### PR TITLE
Don't truncate to 64k in mb_str_replace

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Functions.php
+++ b/src/PhpSpreadsheet/Calculation/Functions.php
@@ -703,7 +703,7 @@ if ((!function_exists('mb_str_replace')) &&
             $r = !is_array($replace) ? $replace : (array_key_exists($key, $replace) ? $replace[$key] : '');
             $pos = mb_strpos($subject, $s, 0, 'UTF-8');
             while ($pos !== false) {
-                $subject = mb_substr($subject, 0, $pos, 'UTF-8') . $r . mb_substr($subject, $pos + mb_strlen($s, 'UTF-8'), 65535, 'UTF-8');
+                $subject = mb_substr($subject, 0, $pos, 'UTF-8') . $r . mb_substr($subject, $pos + mb_strlen($s, 'UTF-8'), null, 'UTF-8');
                 $pos = mb_strpos($subject, $s, $pos + mb_strlen($r, 'UTF-8'), 'UTF-8');
             }
         }


### PR DESCRIPTION
I ran into this is a non-PhpSpreadsheet context, but using this code. The idea behind this function is that it's a multibyte-aware version of `str_replace`, but unlike that function, it imposes a 64k limit on strings, and it will unexpectedly truncate when handling strings longer than that. All that's required to fix it is remove the length limit by setting it to `null` instead, which is all this PR does. In case this limit was imposed for memory reasons, it could perhaps instead be raised to a larger value, but that would still break technical compatibility with str_replace.