### PR TITLE
Remove non-obvious BaseReader's dependency

### DIFF
--- a/src/PhpSpreadsheet/Reader/BaseReader.php
+++ b/src/PhpSpreadsheet/Reader/BaseReader.php
@@ -292,4 +292,19 @@ abstract class BaseReader implements IReader
     {
         return $this->securityScan(file_get_contents($filestream));
     }
+
+    /**
+     * Checks if the file to be read is of a valid format.
+     * Redefined in some readers that inherit from this one.
+     *
+     * It's kind of against OOP and it's only added here because base reader
+     * actually calls this method despite it might be not implemented in
+     * an child class.
+     *
+     * @return bool
+     */
+    protected function isValidFormat()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
[BaseReader calls `isValidFormat`](https://github.com/kamazee/PhpSpreadsheet/blob/fb786e91b0177785ae7964be62ba45c73cdf8a1d/src/PhpSpreadsheet/Reader/BaseReader.php#L263) despite it doesn't require it to be implemented. A stub is added to mitigate it. Not really a good solution but an ad-hoc hack that preserves backward compatibility. Should be rethought and refactored, I guess.
