### PR TITLE
Require GD for saving images in xls

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xls.php
+++ b/src/PhpSpreadsheet/Writer/Xls.php
@@ -454,6 +454,9 @@ class Xls extends BaseWriter implements IWriter
         // the BSE's (all the images)
         foreach ($this->spreadsheet->getAllsheets() as $sheet) {
             foreach ($sheet->getDrawingCollection() as $drawing) {
+                if (!extension_loaded('gd')) {
+                    throw new \RuntimeException('Saving images in xls requires gd extension');
+                }
                 if ($drawing instanceof \PhpOffice\PhpSpreadsheet\Worksheet\Drawing) {
                     $filename = $drawing->getPath();
 


### PR DESCRIPTION
GD is implicitly required for saving images anyway, this exception when it's not loaded simply gives more information on what to do if the execution flow reaches a places that depends on a function from GD.
