### PR TITLE
Avoid array_key_exists()

### DIFF
--- a/src/PhpSpreadsheet/CachedObjectStorageFactory.php
+++ b/src/PhpSpreadsheet/CachedObjectStorageFactory.php
@@ -178,7 +178,7 @@ class CachedObjectStorageFactory
 
         self::$storageMethodParameters[$method] = self::$storageMethodDefaultParameters[$method];
         foreach ($arguments as $argument => $value) {
-            if (array_key_exists($argument, self::$storageMethodParameters[$method])) {
+            if (isset(self::$storageMethodParameters[$method][$argument])) {
                 self::$storageMethodParameters[$method][$argument] = $value;
             }
         }

--- a/src/PhpSpreadsheet/Calculation/Functions.php
+++ b/src/PhpSpreadsheet/Calculation/Functions.php
@@ -700,7 +700,7 @@ if ((!function_exists('mb_str_replace')) &&
             if ($s == '' && $s !== 0) {
                 continue;
             }
-            $r = !is_array($replace) ? $replace : (array_key_exists($key, $replace) ? $replace[$key] : '');
+            $r = !is_array($replace) ? $replace : (isset($replace[$key]) ? $replace[$key] : '');
             $pos = mb_strpos($subject, $s, 0, 'UTF-8');
             while ($pos !== false) {
                 $subject = mb_substr($subject, 0, $pos, 'UTF-8') . $r . mb_substr($subject, $pos + mb_strlen($s, 'UTF-8'), null, 'UTF-8');

--- a/src/PhpSpreadsheet/Calculation/MathTrig.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig.php
@@ -458,7 +458,7 @@ class MathTrig
                 $myPoweredFactors[$myCountedFactor] = pow($myCountedFactor, $myCountedPower);
             }
             foreach ($myPoweredFactors as $myPoweredValue => $myPoweredFactor) {
-                if (array_key_exists($myPoweredValue, $allPoweredFactors)) {
+                if (isset($allPoweredFactors[$myPoweredValue])) {
                     if ($allPoweredFactors[$myPoweredValue] < $myPoweredFactor) {
                         $allPoweredFactors[$myPoweredValue] = $myPoweredFactor;
                     }

--- a/src/PhpSpreadsheet/Cell/DataType.php
+++ b/src/PhpSpreadsheet/Cell/DataType.php
@@ -105,7 +105,7 @@ class DataType
     {
         $pValue = (string) $pValue;
 
-        if (!array_key_exists($pValue, self::$errorCodes)) {
+        if (!isset(self::$errorCodes[$pValue])) {
             $pValue = '#NULL!';
         }
 

--- a/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
@@ -84,8 +84,11 @@ class DefaultValueBinder implements IValueBinder
             }
 
             return DataType::TYPE_NUMERIC;
-        } elseif (is_string($pValue) && array_key_exists($pValue, DataType::getErrorCodes())) {
-            return DataType::TYPE_ERROR;
+        } elseif (is_string($pValue)) {
+            $errorCodes = DataType::getErrorCodes();
+            if (isset($errorCodes[$pValue])) {
+                return DataType::TYPE_ERROR;
+            }
         }
 
         return DataType::TYPE_STRING;

--- a/src/PhpSpreadsheet/Chart/Legend.php
+++ b/src/PhpSpreadsheet/Chart/Legend.php
@@ -123,7 +123,7 @@ class Legend
      */
     public function setPositionXL($positionXL = self::XL_LEGEND_POSITION_RIGHT)
     {
-        if (!array_key_exists($positionXL, self::$positionXLref)) {
+        if (!isset(self::$positionXLref[$positionXL])) {
             return false;
         }
 

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -242,7 +242,7 @@ class Spreadsheet
                 break;
             case 'target':
             case 'data':
-                if (is_array($this->ribbonXMLData) && array_key_exists($what, $this->ribbonXMLData)) {
+                if (is_array($this->ribbonXMLData) && isset($this->ribbonXMLData[$what])) {
                     $returnData = $this->ribbonXMLData[$what];
                 }
                 break;
@@ -283,13 +283,13 @@ class Spreadsheet
                 break;
             case 'names':
             case 'data':
-                if (is_array($this->ribbonBinObjects) && array_key_exists($What, $this->ribbonBinObjects)) {
+                if (is_array($this->ribbonBinObjects) && isset($this->ribbonBinObjects[$What])) {
                     $ReturnData = $this->ribbonBinObjects[$What];
                 }
                 break;
             case 'types':
                 if (is_array($this->ribbonBinObjects) &&
-                    array_key_exists('data', $this->ribbonBinObjects) && is_array($this->ribbonBinObjects['data'])) {
+                    isset($this->ribbonBinObjects['data']) && is_array($this->ribbonBinObjects['data'])) {
                     $tmpTypes = array_keys($this->ribbonBinObjects['data']);
                     $ReturnData = array_unique(array_map([$this, 'getExtensionOnly'], $tmpTypes));
                 } else {

--- a/src/PhpSpreadsheet/Style.php
+++ b/src/PhpSpreadsheet/Style.php
@@ -440,25 +440,25 @@ class Style extends Style\Supervisor implements IComparable
                 }
             } else {
                 // not a supervisor, just apply the style array directly on style object
-                if (array_key_exists('fill', $pStyles)) {
+                if (isset($pStyles['fill'])) {
                     $this->getFill()->applyFromArray($pStyles['fill']);
                 }
-                if (array_key_exists('font', $pStyles)) {
+                if (isset($pStyles['font'])) {
                     $this->getFont()->applyFromArray($pStyles['font']);
                 }
-                if (array_key_exists('borders', $pStyles)) {
+                if (isset($pStyles['borders'])) {
                     $this->getBorders()->applyFromArray($pStyles['borders']);
                 }
-                if (array_key_exists('alignment', $pStyles)) {
+                if (isset($pStyles['alignment'])) {
                     $this->getAlignment()->applyFromArray($pStyles['alignment']);
                 }
-                if (array_key_exists('numberformat', $pStyles)) {
+                if (isset($pStyles['numberformat'])) {
                     $this->getNumberFormat()->applyFromArray($pStyles['numberformat']);
                 }
-                if (array_key_exists('protection', $pStyles)) {
+                if (isset($pStyles['protection'])) {
                     $this->getProtection()->applyFromArray($pStyles['protection']);
                 }
-                if (array_key_exists('quotePrefix', $pStyles)) {
+                if (isset($pStyles['quotePrefix'])) {
                     $this->quotePrefix = $pStyles['quotePrefix'];
                 }
             }

--- a/src/PhpSpreadsheet/Style/Borders.php
+++ b/src/PhpSpreadsheet/Style/Borders.php
@@ -221,25 +221,25 @@ class Borders extends Supervisor implements \PhpOffice\PhpSpreadsheet\IComparabl
             if ($this->isSupervisor) {
                 $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($this->getStyleArray($pStyles));
             } else {
-                if (array_key_exists('left', $pStyles)) {
+                if (isset($pStyles['left'])) {
                     $this->getLeft()->applyFromArray($pStyles['left']);
                 }
-                if (array_key_exists('right', $pStyles)) {
+                if (isset($pStyles['right'])) {
                     $this->getRight()->applyFromArray($pStyles['right']);
                 }
-                if (array_key_exists('top', $pStyles)) {
+                if (isset($pStyles['top'])) {
                     $this->getTop()->applyFromArray($pStyles['top']);
                 }
-                if (array_key_exists('bottom', $pStyles)) {
+                if (isset($pStyles['bottom'])) {
                     $this->getBottom()->applyFromArray($pStyles['bottom']);
                 }
-                if (array_key_exists('diagonal', $pStyles)) {
+                if (isset($pStyles['diagonal'])) {
                     $this->getDiagonal()->applyFromArray($pStyles['diagonal']);
                 }
-                if (array_key_exists('diagonaldirection', $pStyles)) {
+                if (isset($pStyles['diagonaldirection'])) {
                     $this->setDiagonalDirection($pStyles['diagonaldirection']);
                 }
-                if (array_key_exists('allborders', $pStyles)) {
+                if (isset($pStyles['allborders'])) {
                     $this->getLeft()->applyFromArray($pStyles['allborders']);
                     $this->getRight()->applyFromArray($pStyles['allborders']);
                     $this->getTop()->applyFromArray($pStyles['allborders']);

--- a/src/PhpSpreadsheet/Style/Color.php
+++ b/src/PhpSpreadsheet/Style/Color.php
@@ -154,10 +154,10 @@ class Color extends Supervisor implements \PhpOffice\PhpSpreadsheet\IComparable
             if ($this->isSupervisor) {
                 $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($this->getStyleArray($pStyles));
             } else {
-                if (array_key_exists('rgb', $pStyles)) {
+                if (isset($pStyles['rgb'])) {
                     $this->setRGB($pStyles['rgb']);
                 }
-                if (array_key_exists('argb', $pStyles)) {
+                if (isset($pStyles['argb'])) {
                     $this->setARGB($pStyles['argb']);
                 }
             }
@@ -421,7 +421,7 @@ class Color extends Supervisor implements \PhpOffice\PhpSpreadsheet\IComparable
             ];
         }
 
-        if (array_key_exists($pIndex, self::$indexedColors)) {
+        if (isset(self::$indexedColors[$pIndex])) {
             return new self(self::$indexedColors[$pIndex]);
         }
 

--- a/src/PhpSpreadsheet/Style/Fill.php
+++ b/src/PhpSpreadsheet/Style/Fill.php
@@ -156,19 +156,19 @@ class Fill extends Supervisor implements \PhpOffice\PhpSpreadsheet\IComparable
             if ($this->isSupervisor) {
                 $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($this->getStyleArray($pStyles));
             } else {
-                if (array_key_exists('type', $pStyles)) {
+                if (isset($pStyles['type'])) {
                     $this->setFillType($pStyles['type']);
                 }
-                if (array_key_exists('rotation', $pStyles)) {
+                if (isset($pStyles['rotation'])) {
                     $this->setRotation($pStyles['rotation']);
                 }
-                if (array_key_exists('startcolor', $pStyles)) {
+                if (isset($pStyles['startcolor'])) {
                     $this->getStartColor()->applyFromArray($pStyles['startcolor']);
                 }
-                if (array_key_exists('endcolor', $pStyles)) {
+                if (isset($pStyles['endcolor'])) {
                     $this->getEndColor()->applyFromArray($pStyles['endcolor']);
                 }
-                if (array_key_exists('color', $pStyles)) {
+                if (isset($pStyles['color'])) {
                     $this->getStartColor()->applyFromArray($pStyles['color']);
                 }
             }

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -181,31 +181,31 @@ class Font extends Supervisor implements \PhpOffice\PhpSpreadsheet\IComparable
             if ($this->isSupervisor) {
                 $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($this->getStyleArray($pStyles));
             } else {
-                if (array_key_exists('name', $pStyles)) {
+                if (isset($pStyles['name'])) {
                     $this->setName($pStyles['name']);
                 }
-                if (array_key_exists('bold', $pStyles)) {
+                if (isset($pStyles['bold'])) {
                     $this->setBold($pStyles['bold']);
                 }
-                if (array_key_exists('italic', $pStyles)) {
+                if (isset($pStyles['italic'])) {
                     $this->setItalic($pStyles['italic']);
                 }
-                if (array_key_exists('superScript', $pStyles)) {
+                if (isset($pStyles['superScript'])) {
                     $this->setSuperScript($pStyles['superScript']);
                 }
-                if (array_key_exists('subScript', $pStyles)) {
+                if (isset($pStyles['subScript'])) {
                     $this->setSubScript($pStyles['subScript']);
                 }
-                if (array_key_exists('underline', $pStyles)) {
+                if (isset($pStyles['underline'])) {
                     $this->setUnderline($pStyles['underline']);
                 }
-                if (array_key_exists('strike', $pStyles)) {
+                if (isset($pStyles['strike'])) {
                     $this->setStrikethrough($pStyles['strike']);
                 }
-                if (array_key_exists('color', $pStyles)) {
+                if (isset($pStyles['color'])) {
                     $this->getColor()->applyFromArray($pStyles['color']);
                 }
-                if (array_key_exists('size', $pStyles)) {
+                if (isset($pStyles['size'])) {
                     $this->setSize($pStyles['size']);
                 }
             }

--- a/src/PhpSpreadsheet/Style/NumberFormat.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat.php
@@ -158,7 +158,7 @@ class NumberFormat extends Supervisor implements \PhpOffice\PhpSpreadsheet\IComp
             if ($this->isSupervisor) {
                 $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($this->getStyleArray($pStyles));
             } else {
-                if (array_key_exists('code', $pStyles)) {
+                if (isset($pStyles['code'])) {
                     $this->setFormatCode($pStyles['code']);
                 }
             }

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -842,7 +842,8 @@ class Worksheet extends BIFFwriter
                 // Numeric value
                 $num = pack('d', $calculatedValue);
             } elseif (is_string($calculatedValue)) {
-                if (array_key_exists($calculatedValue, \PhpOffice\PhpSpreadsheet\Cell\DataType::getErrorCodes())) {
+                $errorCodes = \PhpOffice\PhpSpreadsheet\Cell\DataType::getErrorCodes();
+                if (isset($errorCodes[$calculatedValue])) {
                     // Error value
                     $num = pack('CCCvCv', 0x02, 0x00, self::mapErrorCode($calculatedValue), 0x00, 0x00, 0xFFFF);
                 } elseif ($calculatedValue === '') {

--- a/src/PhpSpreadsheet/Writer/Xlsx/Style.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Style.php
@@ -620,7 +620,7 @@ class Style extends WriterPart
         $aStyles = $this->allStyles($spreadsheet);
         /** @var \PhpOffice\PhpSpreadsheet\Style $style */
         foreach ($aStyles as $style) {
-            if (!array_key_exists($style->getFill()->getHashCode(), $aFills)) {
+            if (!isset($aFills[$style->getFill()->getHashCode()])) {
                 $aFills[$style->getFill()->getHashCode()] = $style->getFill();
             }
         }
@@ -643,7 +643,7 @@ class Style extends WriterPart
 
         /** @var \PhpOffice\PhpSpreadsheet\Style $style */
         foreach ($aStyles as $style) {
-            if (!array_key_exists($style->getFont()->getHashCode(), $aFonts)) {
+            if (!isset($aFonts[$style->getFont()->getHashCode()])) {
                 $aFonts[$style->getFont()->getHashCode()] = $style->getFont();
             }
         }
@@ -666,7 +666,7 @@ class Style extends WriterPart
 
         /** @var \PhpOffice\PhpSpreadsheet\Style $style */
         foreach ($aStyles as $style) {
-            if (!array_key_exists($style->getBorders()->getHashCode(), $aBorders)) {
+            if (!isset($aBorders[$style->getBorders()->getHashCode()])) {
                 $aBorders[$style->getBorders()->getHashCode()] = $style->getBorders();
             }
         }
@@ -689,7 +689,7 @@ class Style extends WriterPart
 
         /** @var \PhpOffice\PhpSpreadsheet\Style $style */
         foreach ($aStyles as $style) {
-            if ($style->getNumberFormat()->getBuiltInFormatCode() === false && !array_key_exists($style->getNumberFormat()->getHashCode(), $aNumFmts)) {
+            if ($style->getNumberFormat()->getBuiltInFormatCode() === false && !isset($aNumFmts[$style->getNumberFormat()->getHashCode()])) {
                 $aNumFmts[$style->getNumberFormat()->getHashCode()] = $style->getNumberFormat();
             }
         }


### PR DESCRIPTION
Compared to isset() it is much slower (there are tons of benchmarks out there) and should be avoided where posible (due to the slow performance). Only if you have keys that have NULL as value and you need to check if they are there (with NULL value) then and only then you need array_key_exists().