### PR TITLE
Catch some invalid parameter

### DIFF
--- a/src/PhpSpreadsheet/Shared/OLERead.php
+++ b/src/PhpSpreadsheet/Shared/OLERead.php
@@ -302,6 +302,14 @@ class OLERead
      */
     private static function getInt4d($data, $pos)
     {
+        if (trim($data) == '') {
+            // No data provided
+            throw new \PhpOffice\PhpSpreadsheet\Reader\Exception('Parameter data is empty.');
+        } elseif ($pos < 0) {
+            // Invalid position
+            throw new \PhpOffice\PhpSpreadsheet\Reader\Exception('Parameter pos=' . $pos . ' is invalid.');
+        }
+
         $len = strlen($data);
         if ($len < $pos + 4) {
             $data .= str_repeat("\0", $pos + 4 - $len);


### PR DESCRIPTION
This may happen when the loaded input file is corrupt or damaged (for whatever reason). If this is not being tested, an endless loop may happen.

BTW: Please rename your Exception to e.g. PHPOfficeException to avoid confusion with the generic Exception from SPL.

With trim($data) == '' I wanted to make sure that not just only spaces are being provided. If that is okay, then I can change it to e.g. empty().