### PR TITLE
Fix cant get right format chinese date format problem

### DIFF
--- a/src/PhpSpreadsheet/Style/NumberFormat.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat.php
@@ -464,7 +464,7 @@ class NumberFormat extends Supervisor implements \PhpOffice\PhpSpreadsheet\IComp
         // strip off first part containing e.g. [$-F800] or [$USD-409]
         // general syntax: [$<Currency string>-<language info>]
         // language info is in hexadecimal
-		// strip off chinese part like [DBNum1][$-804]
+        // strip off chinese part like [DBNum1][$-804]
         $format = preg_replace('/^(\[[0-9A-Za-z]*\])*(\[\$[A-Z]*-[0-9A-F]*\])/i', '', $format);
 
         // OpenOffice.org uses upper-case number formats, e.g. 'YYYY', convert to lower-case;

--- a/src/PhpSpreadsheet/Style/NumberFormat.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat.php
@@ -464,7 +464,8 @@ class NumberFormat extends Supervisor implements \PhpOffice\PhpSpreadsheet\IComp
         // strip off first part containing e.g. [$-F800] or [$USD-409]
         // general syntax: [$<Currency string>-<language info>]
         // language info is in hexadecimal
-        $format = preg_replace('/^(\[\$[A-Z]*-[0-9A-F]*\])/i', '', $format);
+		// strip off chinese part like [DBNum1][$-804]
+        $format = preg_replace('/^(\[[0-9A-Za-z]*\])*(\[\$[A-Z]*-[0-9A-F]*\])/i', '', $format);
 
         // OpenOffice.org uses upper-case number formats, e.g. 'YYYY', convert to lower-case;
         //    but we don't want to change any quoted strings


### PR DESCRIPTION
I found PhpSpread sheet can not get chinese date format properly
so i modify preg expression in NumberFormat.php to fix this problem
below is chinese date format string.
[DBNum1][$-804]yyyy"年"m"月"d"日";@
[DBNum1][$-804]yyyy"年"m"月";@
[DBNum1][$-804]m"月"d"日";@