### PR TITLE
Properly format non-integer font sizes

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/Style.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Style.php
@@ -323,7 +323,7 @@ class Style extends WriterPart
         // Size
         if ($pFont->getSize() !== null) {
             $objWriter->startElement('sz');
-            $objWriter->writeAttribute('val', $pFont->getSize());
+            $objWriter->writeAttribute('val', \PhpOffice\PhpSpreadsheet\Shared\StringHelper::formatNumber($pFont->getSize()));
             $objWriter->endElement();
         }
 


### PR DESCRIPTION
The OOXML spec defines the font sizes (the `sz` element) as a double, so the value needs to be wrapped in `PHPExcel_Shared_String::FormatNumber()` to avoid breaking in non-English locales.