### PR TITLE
Add failing test for getting settings globally affecting external xml reading

### DIFF
--- a/tests/PhpSpreadsheetTests/SettingsTest.php
+++ b/tests/PhpSpreadsheetTests/SettingsTest.php
@@ -20,4 +20,10 @@ class SettingsTest extends \PHPUnit_Framework_TestCase
         $result = \PhpOffice\PhpSpreadsheet\Settings::getLibXmlLoaderOptions();
         $this->assertTrue((bool) ((LIBXML_DTDLOAD | LIBXML_DTDATTR | LIBXML_DTDVALID) & $result));
     }
+
+    public function testReadingExternalXMLAfterGettingSettings()
+    {
+        \PhpOffice\PhpSpreadsheet\Settings::getLibXmlLoaderOptions();
+        $this->assertInstanceOf(\SimpleXMLElement::class, simplexml_load_file('http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl'));
+    }
 }


### PR DESCRIPTION
It appears that when `getLibXmlLoaderOptions()` is called, it globally affects external xml reading.
This is bad, because just reading excel files with this library has a global side effect, and it breaks Soap.

If you remove the row with `\PhpOffice\PhpSpreadsheet\Settings::getLibXmlLoaderOptions();`, you can see that the test passes

Otherwise in my PR I only added a failing test. I don't have a fix.