### PR TITLE
Set column data type

### DIFF
--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -71,6 +71,14 @@ class Csv extends BaseReader implements IReader
     private $contiguousRow = -1;
 
     /**
+	 * Col Data Type 
+	 *
+	 * @access private
+	 * @array PHPExcel_Cell_DataType
+	*/
+	private $_colDataType = array();
+
+    /**
      * Create a new CSV Reader instance.
      */
     public function __construct()
@@ -271,7 +279,11 @@ class Csv extends BaseReader implements IReader
                     }
 
                     // Set cell value
-                    $sheet->getCell($columnLetter . $currentRow)->setValue($rowDatum);
+					if (isset($this->_colDataType[$columnLetter])) {
+						$sheet->setCellValueExplicit($columnLetter . $currentRow, $rowDatum, $this->_colDataType[$columnLetter]);
+					} else {
+						$sheet->getCell($columnLetter . $currentRow)->setValue($rowDatum);
+					}
                 }
                 ++$columnLetter;
             }
@@ -413,4 +425,29 @@ class Csv extends BaseReader implements IReader
 
         return true;
     }
+    
+    /**
+	 * Get col data Type
+	 *
+	 * @param string
+	 * @return mixed
+	 */
+	public function getColDataType($colLetter) {
+		if (isset($this->_colDataType[$colLetter]))
+			return $this->_colDataType[$colLetter];
+		else
+			return FALSE;
+	}
+
+	/**
+	 * Set col data Type
+	 *
+	 * @param string, PHPExcel_Cell_DataType
+	 * @return PHPExcel_Reader_CSV
+	 */
+	public function setColDataType($colLetter = 'A', $dateType = PHPExcel_Cell_DataType::TYPE_STRING) {
+		$this->_colDataType[$colLetter] = $dateType;
+		return $this;
+	}
+
 }

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -71,7 +71,7 @@ class Csv extends BaseReader implements IReader
     private $contiguousRow = -1;
 
     /**
-     * Col Data Type 
+     * Col Data Type
      *
      * @access private
      * @array PHPExcel_Cell_DataType
@@ -284,7 +284,6 @@ class Csv extends BaseReader implements IReader
                     } else {
                         $sheet->getCell($columnLetter . $currentRow)->setValue($rowDatum);
                     }
-
                 }
                 ++$columnLetter;
             }

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -401,6 +401,7 @@ class Csv extends BaseReader implements IReader
     {
         return $this->contiguous;
     }
+
     /**
      * Can the current IReader read the file?
      *
@@ -446,9 +447,9 @@ class Csv extends BaseReader implements IReader
      * @param string $colLetter
      * @param mixed $dataType
      */
-    public function setColDataType($colLetter = 'A', $dateType = PHPExcel_Cell_DataType::TYPE_STRING)
+    public function setColDataType($colLetter = 'A', $dataType = PHPExcel_Cell_DataType::TYPE_STRING)
     {
-        $this->_colDataType[$colLetter] = $dateType;
+        $this->_colDataType[$colLetter] = $dataType;
 
         return $this;
     }

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -428,7 +428,7 @@ class Csv extends BaseReader implements IReader
     /**
      * Get col data Type.
      *
-     * @param string
+     * @param string $colLetter
      *
      * @return mixed
      */
@@ -444,7 +444,8 @@ class Csv extends BaseReader implements IReader
     /**
      * Set col data Type.
      *
-     * @param string, PHPExcel_Cell_DataType
+     * @param string $colletter
+     * @param PHPExcel_Cell_DataType $dataType
      */
     public function setColDataType($colLetter = 'A', $dateType = PHPExcel_Cell_DataType::TYPE_STRING)
     {

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -437,9 +437,9 @@ class Csv extends BaseReader implements IReader
     {
         if (isset($this->_colDataType[$colLetter])) {
             return $this->_colDataType[$colLetter];
-        } else {
-            return false;
         }
+        
+        return false;
     }
     
     /**

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -71,10 +71,9 @@ class Csv extends BaseReader implements IReader
     private $contiguousRow = -1;
 
     /**
-     * Col Data Type
+     * Col Data Type.
      *
-     * @access private
-     * @array PHPExcel_Cell_DataType
+     * @var PHPExcel_Cell_DataType
      */
     private $_colDataType = [];
 
@@ -427,9 +426,10 @@ class Csv extends BaseReader implements IReader
     }
     
     /**
-     * Get col data Type
+     * Get col data Type.
      *
      * @param string
+     *
      * @return mixed
      */
     public function getColDataType($colLetter)
@@ -442,10 +442,9 @@ class Csv extends BaseReader implements IReader
     }
     
     /**
-     * Set col data Type
+     * Set col data Type.
      *
      * @param string, PHPExcel_Cell_DataType
-     * @return PHPExcel_Reader_CSV
      */
     public function setColDataType($colLetter = 'A', $dateType = PHPExcel_Cell_DataType::TYPE_STRING)
     {

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -71,12 +71,12 @@ class Csv extends BaseReader implements IReader
     private $contiguousRow = -1;
 
     /**
-	 * Col Data Type 
-	 *
-	 * @access private
-	 * @array PHPExcel_Cell_DataType
-	*/
-	private $_colDataType = array();
+    * Col Data Type 
+    *
+    * @access private
+    * @array PHPExcel_Cell_DataType
+    */
+    private $_colDataType = array();
 
     /**
      * Create a new CSV Reader instance.
@@ -279,11 +279,11 @@ class Csv extends BaseReader implements IReader
                     }
 
                     // Set cell value
-					if (isset($this->_colDataType[$columnLetter])) {
-						$sheet->setCellValueExplicit($columnLetter . $currentRow, $rowDatum, $this->_colDataType[$columnLetter]);
-					} else {
-						$sheet->getCell($columnLetter . $currentRow)->setValue($rowDatum);
-					}
+                    if (isset($this->_colDataType[$columnLetter])) {
+                        $sheet->setCellValueExplicit($columnLetter . $currentRow, $rowDatum, $this->_colDataType[$columnLetter]);
+                    } else {
+                        $sheet->getCell($columnLetter . $currentRow)->setValue($rowDatum);
+                    }
                 }
                 ++$columnLetter;
             }
@@ -427,27 +427,29 @@ class Csv extends BaseReader implements IReader
     }
     
     /**
-	 * Get col data Type
-	 *
-	 * @param string
-	 * @return mixed
-	 */
-	public function getColDataType($colLetter) {
-		if (isset($this->_colDataType[$colLetter]))
-			return $this->_colDataType[$colLetter];
-		else
-			return FALSE;
-	}
-
-	/**
-	 * Set col data Type
-	 *
-	 * @param string, PHPExcel_Cell_DataType
-	 * @return PHPExcel_Reader_CSV
-	 */
-	public function setColDataType($colLetter = 'A', $dateType = PHPExcel_Cell_DataType::TYPE_STRING) {
-		$this->_colDataType[$colLetter] = $dateType;
-		return $this;
-	}
-
+    * Get col data Type
+    *
+    * @param string
+    * @return mixed
+    */
+	public function getColDataType($colLetter)
+    {
+        if (isset($this->_colDataType[$colLetter])) {
+            return $this->_colDataType[$colLetter];
+        } else {
+            return false;
+        }
+    }
+    
+    /**
+    * Set col data Type
+    *
+    * @param string, PHPExcel_Cell_DataType
+    * @return PHPExcel_Reader_CSV
+    */
+    public function setColDataType($colLetter = 'A', $dateType = PHPExcel_Cell_DataType::TYPE_STRING)
+    {
+        $this->_colDataType[$colLetter] = $dateType;
+        return $this;
+    }
 }

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -401,7 +401,6 @@ class Csv extends BaseReader implements IReader
     {
         return $this->contiguous;
     }
-
     /**
      * Can the current IReader read the file?
      *
@@ -444,8 +443,8 @@ class Csv extends BaseReader implements IReader
     /**
      * Set col data Type.
      *
-     * @param string $colletter
-     * @param PHPExcel_Cell_DataType $dataType
+     * @param string $colLetter
+     * @param mixed $dataType
      */
     public function setColDataType($colLetter = 'A', $dateType = PHPExcel_Cell_DataType::TYPE_STRING)
     {

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -71,12 +71,12 @@ class Csv extends BaseReader implements IReader
     private $contiguousRow = -1;
 
     /**
-    * Col Data Type 
-    *
-    * @access private
-    * @array PHPExcel_Cell_DataType
-    */
-    private $_colDataType = array();
+     * Col Data Type 
+     *
+     * @access private
+     * @array PHPExcel_Cell_DataType
+     */
+    private $_colDataType = [];
 
     /**
      * Create a new CSV Reader instance.
@@ -284,6 +284,7 @@ class Csv extends BaseReader implements IReader
                     } else {
                         $sheet->getCell($columnLetter . $currentRow)->setValue($rowDatum);
                     }
+
                 }
                 ++$columnLetter;
             }
@@ -427,12 +428,12 @@ class Csv extends BaseReader implements IReader
     }
     
     /**
-    * Get col data Type
-    *
-    * @param string
-    * @return mixed
-    */
-	public function getColDataType($colLetter)
+     * Get col data Type
+     *
+     * @param string
+     * @return mixed
+     */
+    public function getColDataType($colLetter)
     {
         if (isset($this->_colDataType[$colLetter])) {
             return $this->_colDataType[$colLetter];
@@ -442,14 +443,15 @@ class Csv extends BaseReader implements IReader
     }
     
     /**
-    * Set col data Type
-    *
-    * @param string, PHPExcel_Cell_DataType
-    * @return PHPExcel_Reader_CSV
-    */
+     * Set col data Type
+     *
+     * @param string, PHPExcel_Cell_DataType
+     * @return PHPExcel_Reader_CSV
+     */
     public function setColDataType($colLetter = 'A', $dateType = PHPExcel_Cell_DataType::TYPE_STRING)
     {
         $this->_colDataType[$colLetter] = $dateType;
+
         return $this;
     }
 }

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -423,7 +423,7 @@ class Csv extends BaseReader implements IReader
 
         return true;
     }
-    
+
     /**
      * Get col data Type.
      *
@@ -436,10 +436,10 @@ class Csv extends BaseReader implements IReader
         if (isset($this->_colDataType[$colLetter])) {
             return $this->_colDataType[$colLetter];
         }
-        
+
         return false;
     }
-    
+
     /**
      * Set col data Type.
      *


### PR DESCRIPTION
You can set column data type before import it.

How to use it:

```php
$objReader = new PHPExcel_Reader_CSV();
$objReader->setColDataType($columnLetter,PHPExcel_Cell_DataType::TYPE_STRING);
$objPHPExcel = $objReader->load("sample.csv");
````