### PR TITLE
Rewrites: in_array() versus isset()

### DIFF
--- a/src/PhpSpreadsheet/CachedObjectStorageFactory.php
+++ b/src/PhpSpreadsheet/CachedObjectStorageFactory.php
@@ -58,17 +58,17 @@ class CachedObjectStorageFactory
      * @var string[]
      */
     private static $storageMethods = [
-        self::CACHE_IN_MEMORY,
-        self::CACHE_IN_MEMORY_GZIP,
-        self::CACHE_IN_MEMORY_SERIALIZED,
-        self::CACHE_IGBINARY,
-        self::CACHE_TO_PHPTEMP,
-        self::CACHE_TO_DISCISAM,
-        self::CACHE_TO_APC,
-        self::CACHE_TO_MEMCACHE,
-        self::CACHE_TO_WINCACHE,
-        self::CACHE_TO_SQLITE,
-        self::CACHE_TO_SQLITE3,
+        self::CACHE_IN_MEMORY => true,
+        self::CACHE_IN_MEMORY_GZIP => true,
+        self::CACHE_IN_MEMORY_SERIALIZED => true,
+        self::CACHE_IGBINARY => true,
+        self::CACHE_TO_PHPTEMP => true,
+        self::CACHE_TO_DISCISAM => true,
+        self::CACHE_TO_APC => true,
+        self::CACHE_TO_MEMCACHE => true,
+        self::CACHE_TO_WINCACHE => true,
+        self::CACHE_TO_SQLITE => true,
+        self::CACHE_TO_SQLITE3 => true,
     ];
 
     /**
@@ -136,7 +136,7 @@ class CachedObjectStorageFactory
      **/
     public static function getAllCacheStorageMethods()
     {
-        return self::$storageMethods;
+        return array_keys(self::$storageMethods);
     }
 
     /**
@@ -147,7 +147,7 @@ class CachedObjectStorageFactory
     public static function getCacheStorageMethods()
     {
         $activeMethods = [];
-        foreach (self::$storageMethods as $storageMethod) {
+        foreach (self::getAllCacheStorageMethods() as $storageMethod) {
             $cacheStorageClass = '\\PhpOffice\\PhpSpreadsheet\\CachedObjectStorage\\' . $storageMethod;
             if (call_user_func([$cacheStorageClass, 'cacheMethodIsAvailable'])) {
                 $activeMethods[] = $storageMethod;
@@ -168,7 +168,7 @@ class CachedObjectStorageFactory
      **/
     public static function initialize($method = self::CACHE_IN_MEMORY, $arguments = [])
     {
-        if (!in_array($method, self::$storageMethods)) {
+        if (!isset(self::$storageMethods[$method])) {
             return false;
         }
 

--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -547,7 +547,7 @@ class ReferenceHelper
         $autoFilterRange = $autoFilter->getRange();
         if (!empty($autoFilterRange)) {
             if ($pNumCols != 0) {
-                $autoFilterColumns = array_keys($autoFilter->getColumns());
+                $autoFilterColumns = $autoFilter->getColumns();
                 if (count($autoFilterColumns) > 0) {
                     sscanf($pBefore, '%[A-Z]%d', $column, $row);
                     $columnIndex = Cell::columnIndexFromString($column);
@@ -559,7 +559,7 @@ class ReferenceHelper
                             $deleteColumn = $columnIndex + $pNumCols - 1;
                             $deleteCount = abs($pNumCols);
                             for ($i = 1; $i <= $deleteCount; ++$i) {
-                                if (in_array(Cell::stringFromColumnIndex($deleteColumn), $autoFilterColumns)) {
+                                if (isset($autoFilterColumns[Cell::stringFromColumnIndex($deleteColumn)])) {
                                     $autoFilter->clearColumn(Cell::stringFromColumnIndex($deleteColumn));
                                 }
                                 ++$deleteColumn;

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -518,8 +518,10 @@ class Worksheet extends BIFFwriter
                 foreach ($conditionalStyles as $conditional) {
                     if ($conditional->getConditionType() == \PhpOffice\PhpSpreadsheet\Style\Conditional::CONDITION_EXPRESSION
                         || $conditional->getConditionType() == \PhpOffice\PhpSpreadsheet\Style\Conditional::CONDITION_CELLIS) {
-                        if (!in_array($conditional->getHashCode(), $arrConditional)) {
-                            $arrConditional[] = $conditional->getHashCode();
+                        if (!isset($arrConditional[$conditional->getHashCode()])) {
+                            // This hash code has been handled
+                            $arrConditional[$conditional->getHashCode()] = true;
+
                             // Write CFRULE record
                             $this->writeCFRule($conditional);
                         }


### PR DESCRIPTION
As mentioned in #81 in_array() performs slow as it searches the whole array for a value. If you can use isset() because the value is unimportant, only the fact that `$foo` is in `$foos`, then you should use `isset()`. If you need to check on NULL values, use `array_key_exists()` (which we don't need/do here).

So isset() is IMHO really fine and better here.