### PR TITLE
MemoryDrawing bug fix for Issue #92

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 /tests/codeCoverage
 /analysis
 /vendor/
-/square/
-/public/
 /phpunit.xml
 /.php_cs.cache
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /tests/codeCoverage
 /analysis
 /vendor/
+/square/
+/public/
 /phpunit.xml
 /.php_cs.cache
 

--- a/src/PhpSpreadsheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet.php
@@ -2974,9 +2974,6 @@ class Worksheet implements IComparable
                     $newCollection = clone $this->cellCollection;
                     $newCollection->copyCellCollection($this);
                     $this->cellCollection = $newCollection;
-                } elseif ($key == 'drawingCollection') {
-                    $newCollection = clone $this->drawingCollection;
-                    $this->drawingCollection = $newCollection;
                 } elseif (($key == 'autoFilter') && ($this->autoFilter instanceof Worksheet\AutoFilter)) {
                     $newAutoFilter = clone $this->autoFilter;
                     $this->autoFilter = $newAutoFilter;

--- a/src/PhpSpreadsheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheet;
 
+use ArrayObject;
+
 /**
  * Copyright (c) 2006 - 2016 PhpSpreadsheet.
  *
@@ -2974,6 +2976,14 @@ class Worksheet implements IComparable
                     $newCollection = clone $this->cellCollection;
                     $newCollection->copyCellCollection($this);
                     $this->cellCollection = $newCollection;
+                } elseif ($key == 'drawingCollection') {
+                    $newCollection = new ArrayObject();
+                    foreach ($this->drawingCollection as $id => $item) {
+                        if (is_object($item)) {
+                            $newCollection[$id] = clone $this->drawingCollection[$id];
+                        }
+                    }
+                    $this->drawingCollection = $newCollection;
                 } elseif (($key == 'autoFilter') && ($this->autoFilter instanceof Worksheet\AutoFilter)) {
                     $newAutoFilter = clone $this->autoFilter;
                     $this->autoFilter = $newAutoFilter;

--- a/src/PhpSpreadsheet/Worksheet/MemoryDrawing.php
+++ b/src/PhpSpreadsheet/Worksheet/MemoryDrawing.php
@@ -197,7 +197,7 @@ class MemoryDrawing extends BaseDrawing implements \PhpOffice\PhpSpreadsheet\ICo
         $vars = get_object_vars($this);
         foreach ($vars as $key => $value) {
             if (is_object($value)) {
-                $this->$key = clone $value;
+                $this->$key = unserialize(serialize($value));
             } else {
                 $this->$key = $value;
             }


### PR DESCRIPTION
Fix for Cloned worksheet updates reflected on original (Drawing) #92
We need to make note of two things:

- The old code was trying to clone an objectArray, and hence was performing a shallow copy of memoryDrawing objects (the __clone magic function was not getting invoked).
Instead, if one loops over the objectArray, and then clones the individual memory drawing objects, then the __clone function for the MemoryDrawing object is invoked.

- The __clone function for memory drawing was using the clone keyword which does not deal with circular references (Since memoryDrawing object had references to worksheet object, it was encountering an infinite loop). However, serializing and unserializing objects deals with circular references pretty well. 
