### PR TITLE
Ods writer: add support for basic text styling (Fix #105)

### DIFF
--- a/src/PhpSpreadsheet/Writer/Ods/Content.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Content.php
@@ -2,7 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Writer\Ods;
 
-/**
+/*
  * PhpSpreadsheet.
  *
  * Copyright (c) 2006 - 2015 PhpSpreadsheet
@@ -28,18 +28,19 @@ namespace PhpOffice\PhpSpreadsheet\Writer\Ods;
  */
 
 use PhpOffice\PhpSpreadsheet\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Shared\XMLWriter;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\Font;
 use PhpOffice\PhpSpreadsheet\Worksheet;
-use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Writer\Exception;
 use PhpOffice\PhpSpreadsheet\Writer\Ods;
 use PhpOffice\PhpSpreadsheet\Writer\Ods\Cell\Comment;
 
 /**
  * @category   PhpSpreadsheet
+ *
  * @method Ods getParentWriter
  *
  * @copyright  Copyright (c) 2006 - 2015 PhpSpreadsheet (https://github.com/PHPOffice/PhpSpreadsheet)
@@ -200,7 +201,6 @@ class Content extends WriterPart
         $prevColumn = -1;
         $cells = $row->getCellIterator();
         while ($cells->valid()) {
-
             /** @var Cell $cell */
             $cell = $cells->current();
             $column = Cell::columnIndexFromString($cell->getColumn()) - 1;
@@ -210,8 +210,8 @@ class Content extends WriterPart
 
             // Style XF
             $style = $cell->getXfIndex();
-            if($style !== null){
-                $objWriter->writeAttribute('table:style-name', self::CELL_STYLE_PREFIX.$style);
+            if ($style !== null) {
+                $objWriter->writeAttribute('table:style-name', self::CELL_STYLE_PREFIX . $style);
             }
 
             switch ($cell->getDataType()) {
@@ -288,15 +288,14 @@ class Content extends WriterPart
     }
 
     /**
-     * Write XF cell styles
+     * Write XF cell styles.
      *
      * @param XMLWriter $writer
      * @param Spreadsheet $spreadsheet
      */
     private function writeXfStyles(XMLWriter $writer, Spreadsheet $spreadsheet)
     {
-        foreach($spreadsheet->getCellXfCollection() as $style) {
-
+        foreach ($spreadsheet->getCellXfCollection() as $style) {
             $writer->startElement('style:style');
             $writer->writeAttribute('style:name', self::CELL_STYLE_PREFIX . $style->getIndex());
             $writer->writeAttribute('style:family', 'table-cell');
@@ -311,40 +310,37 @@ class Content extends WriterPart
 
             $font = $style->getFont();
 
-            if($font->getBold()) {
+            if ($font->getBold()) {
                 $writer->writeAttribute('fo:font-weight', 'bold');
                 $writer->writeAttribute('style:font-weight-complex', 'bold');
                 $writer->writeAttribute('style:font-weight-asian', 'bold');
             }
 
-            if($font->getItalic()) {
+            if ($font->getItalic()) {
                 $writer->writeAttribute('fo:font-style', 'italic');
             }
 
-            if($color = $font->getColor()) {
+            if ($color = $font->getColor()) {
                 $writer->writeAttribute('fo:color', sprintf('#%s', $color->getRGB()));
             }
 
-            if($family = $font->getName()) {
+            if ($family = $font->getName()) {
                 $writer->writeAttribute('fo:font-family', $family);
             }
 
-            if($size = $font->getSize()) {
+            if ($size = $font->getSize()) {
                 $writer->writeAttribute('fo:font-size', sprintf('%.1fpt', $size));
             }
 
-            if($font->getUnderline() && $font->getUnderline() != Font::UNDERLINE_NONE) {
-
+            if ($font->getUnderline() && $font->getUnderline() != Font::UNDERLINE_NONE) {
                 $writer->writeAttribute('style:text-underline-style', 'solid');
                 $writer->writeAttribute('style:text-underline-width', 'auto');
                 $writer->writeAttribute('style:text-underline-color', 'font-color');
 
-                switch($font->getUnderline()){
-
+                switch ($font->getUnderline()) {
                     case Font::UNDERLINE_DOUBLE:
                         $writer->writeAttribute('style:text-underline-type', 'double');
                         break;
-
                     case Font::UNDERLINE_SINGLE:
                         $writer->writeAttribute('style:text-underline-type', 'single');
                         break;
@@ -361,20 +357,18 @@ class Content extends WriterPart
             $writer->writeAttribute('style:rotation-align', 'none');
 
             // Fill
-            if($fill = $style->getFill()) {
-                switch($fill->getFillType()) {
-
+            if ($fill = $style->getFill()) {
+                switch ($fill->getFillType()) {
                     case Fill::FILL_SOLID:
-                        $writer->writeAttribute('fo:background-color', sprintf('#%s',
+                        $writer->writeAttribute('fo:background-color', sprintf(
+                            '#%s',
                             strtolower($fill->getStartColor()->getRGB())
                         ));
                         break;
-
                     case Fill::FILL_GRADIENT_LINEAR:
                     case Fill::FILL_GRADIENT_PATH:
                         /// TODO :: To be implemented
                         break;
-
                     case Fill::FILL_NONE:
                     default:
                 }

--- a/src/PhpSpreadsheet/Writer/Ods/Content.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Content.php
@@ -130,8 +130,8 @@ class Content extends WriterPart
     {
         $spreadsheet = $this->getParentWriter()->getSpreadsheet(); /* @var $spreadsheet Spreadsheet */
 
-        $sheet_count = $spreadsheet->getSheetCount();
-        for ($i = 0; $i < $sheet_count; ++$i) {
+        $sheetCount = $spreadsheet->getSheetCount();
+        for ($i = 0; $i < $sheetCount; ++$i) {
             $objWriter->startElement('table:table');
             $objWriter->writeAttribute('table:name', $spreadsheet->getSheet($i)->getTitle());
             $objWriter->writeElement('office:forms');
@@ -151,11 +151,11 @@ class Content extends WriterPart
      */
     private function writeRows(XMLWriter $objWriter, Worksheet $sheet)
     {
-        $number_rows_repeated = self::NUMBER_ROWS_REPEATED_MAX;
+        $numberRowsRepeated = self::NUMBER_ROWS_REPEATED_MAX;
         $span_row = 0;
         $rows = $sheet->getRowIterator();
         while ($rows->valid()) {
-            --$number_rows_repeated;
+            --$numberRowsRepeated;
             $row = $rows->current();
             if ($row->getCellIterator()->valid()) {
                 if ($span_row) {
@@ -189,14 +189,14 @@ class Content extends WriterPart
      */
     private function writeCells(XMLWriter $objWriter, Worksheet\Row $row)
     {
-        $number_cols_repeated = self::NUMBER_COLS_REPEATED_MAX;
-        $prev_column = -1;
+        $numberColsRepeated = self::NUMBER_COLS_REPEATED_MAX;
+        $prevColumn = -1;
         $cells = $row->getCellIterator();
         while ($cells->valid()) {
             $cell = $cells->current();
             $column = Cell::columnIndexFromString($cell->getColumn()) - 1;
 
-            $this->writeCellSpan($objWriter, $column, $prev_column);
+            $this->writeCellSpan($objWriter, $column, $prevColumn);
             $objWriter->startElement('table:table-cell');
 
             switch ($cell->getDataType()) {
@@ -210,18 +210,18 @@ class Content extends WriterPart
                     break;
                 case DataType::TYPE_FORMULA:
                     try {
-                        $formula_value = $cell->getCalculatedValue();
+                        $formulaValue = $cell->getCalculatedValue();
                     } catch (\Exception $e) {
-                        $formula_value = $cell->getValue();
+                        $formulaValue = $cell->getValue();
                     }
                     $objWriter->writeAttribute('table:formula', 'of:' . $cell->getValue());
-                    if (is_numeric($formula_value)) {
+                    if (is_numeric($formulaValue)) {
                         $objWriter->writeAttribute('office:value-type', 'float');
                     } else {
                         $objWriter->writeAttribute('office:value-type', 'string');
                     }
-                    $objWriter->writeAttribute('office:value', $formula_value);
-                    $objWriter->writeElement('text:p', $formula_value);
+                    $objWriter->writeAttribute('office:value', $formulaValue);
+                    $objWriter->writeElement('text:p', $formulaValue);
                     break;
                 case DataType::TYPE_INLINE:
                     throw new Exception('Writing of inline not implemented yet.');
@@ -238,14 +238,14 @@ class Content extends WriterPart
             }
             Comment::write($objWriter, $cell);
             $objWriter->endElement();
-            $prev_column = $column;
+            $prevColumn = $column;
             $cells->next();
         }
-        $number_cols_repeated = $number_cols_repeated - $prev_column - 1;
-        if ($number_cols_repeated > 0) {
-            if ($number_cols_repeated > 1) {
+        $numberColsRepeated = $numberColsRepeated - $prevColumn - 1;
+        if ($numberColsRepeated > 0) {
+            if ($numberColsRepeated > 1) {
                 $objWriter->startElement('table:table-cell');
-                $objWriter->writeAttribute('table:number-columns-repeated', $number_cols_repeated);
+                $objWriter->writeAttribute('table:number-columns-repeated', $numberColsRepeated);
                 $objWriter->endElement();
             } else {
                 $objWriter->writeElement('table:table-cell');

--- a/src/PhpSpreadsheet/Writer/Ods/Content.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Content.php
@@ -33,10 +33,12 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Writer\Exception;
+use PhpOffice\PhpSpreadsheet\Writer\Ods;
 use PhpOffice\PhpSpreadsheet\Writer\Ods\Cell\Comment;
 
 /**
  * @category   PhpSpreadsheet
+ * @method Ods getParentWriter
  *
  * @copyright  Copyright (c) 2006 - 2015 PhpSpreadsheet (https://github.com/PHPOffice/PhpSpreadsheet)
  * @author     Alexander Pervakov <frost-nzcr4@jagmort.com>
@@ -49,18 +51,12 @@ class Content extends WriterPart
     /**
      * Write content.xml to XML format.
      *
-     * @param \PhpOffice\PhpSpreadsheet\Spreadsheet $spreadsheet
-     *
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      *
      * @return string XML Output
      */
-    public function write(Spreadsheet $spreadsheet = null)
+    public function write()
     {
-        if (!$spreadsheet) {
-            $spreadsheet = $this->getParentWriter()->getSpreadsheet(); /* @var $spreadsheet Spreadsheet */
-        }
-
         $objWriter = null;
         if ($this->getParentWriter()->getUseDiskCaching()) {
             $objWriter = new XMLWriter(XMLWriter::STORAGE_DISK, $this->getParentWriter()->getDiskCachingDirectory());
@@ -114,7 +110,9 @@ class Content extends WriterPart
         $objWriter->startElement('office:body');
         $objWriter->startElement('office:spreadsheet');
         $objWriter->writeElement('table:calculation-settings');
+
         $this->writeSheets($objWriter);
+
         $objWriter->writeElement('table:named-expressions');
         $objWriter->endElement();
         $objWriter->endElement();

--- a/tests/PhpSpreadsheetTests/Writer/Ods/ContentTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Ods/ContentTest.php
@@ -11,7 +11,6 @@ use PhpOffice\PhpSpreadsheet\Style\Font;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Writer\Ods;
 use PhpOffice\PhpSpreadsheet\Writer\Ods\Content;
-use PhpOffice\PhpSpreadsheetTests\Worksheet\WorksheetColumnTest;
 
 class ContentTest extends \PHPUnit_Framework_TestCase
 {
@@ -24,7 +23,7 @@ class ContentTest extends \PHPUnit_Framework_TestCase
 
         $xml = $content->write();
 
-        $this->assertXmlStringEqualsXmlFile($this->samplesPath . "/content-empty.xml", $xml);
+        $this->assertXmlStringEqualsXmlFile($this->samplesPath . '/content-empty.xml', $xml);
     }
 
     public function testWriteSpreadsheet()
@@ -35,9 +34,9 @@ class ContentTest extends \PHPUnit_Framework_TestCase
         $worksheet1 = $workbook->getActiveSheet();
         $worksheet1->setCellValue('A1', 1); // Number
         $worksheet1->setCellValue('B1', 12345.6789); // Number
-        $worksheet1->setCellValue('C1', "1"); // Number without cast
-        $worksheet1->setCellValueExplicit('D1', "01234", DataType::TYPE_STRING); // Number casted to string
-        $worksheet1->setCellValue('E1', "Lorem ipsum"); // String
+        $worksheet1->setCellValue('C1', '1'); // Number without cast
+        $worksheet1->setCellValueExplicit('D1', '01234', DataType::TYPE_STRING); // Number casted to string
+        $worksheet1->setCellValue('E1', 'Lorem ipsum'); // String
 
         $worksheet1->setCellValue('A2', true); // Boolean
         $worksheet1->setCellValue('B2', false); // Boolean
@@ -51,7 +50,7 @@ class ContentTest extends \PHPUnit_Framework_TestCase
         // Styles
         $worksheet1->getStyle('A1')->getFont()->setBold(true);
         $worksheet1->getStyle('B1')->getFont()->setItalic(true);
-        $worksheet1->getStyle('C1')->getFont()->setName("Courier");
+        $worksheet1->getStyle('C1')->getFont()->setName('Courier');
         $worksheet1->getStyle('C1')->getFont()->setSize(14);
         $worksheet1->getStyle('C1')->getFont()->setColor(new Color(Color::COLOR_BLUE));
 
@@ -73,6 +72,6 @@ class ContentTest extends \PHPUnit_Framework_TestCase
 
         $xml = $content->write();
 
-        $this->assertXmlStringEqualsXmlFile($this->samplesPath . "/content-with-data.xml", $xml);
+        $this->assertXmlStringEqualsXmlFile($this->samplesPath . '/content-with-data.xml', $xml);
     }
 }

--- a/tests/PhpSpreadsheetTests/Writer/Ods/ContentTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Ods/ContentTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Ods\Content;
+
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Shared\Date;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Color;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+use PhpOffice\PhpSpreadsheet\Writer\Ods;
+use PhpOffice\PhpSpreadsheet\Writer\Ods\Content;
+use PhpOffice\PhpSpreadsheetTests\Worksheet\WorksheetColumnTest;
+
+class ContentTest extends \PHPUnit_Framework_TestCase
+{
+    public $samplesPath = __DIR__ . '/../../../data/Writer/Ods';
+
+    public function testWriteEmptySpreadsheet()
+    {
+        $content = new Content();
+        $content->setParentWriter(new Ods(new Spreadsheet()));
+
+        $xml = $content->write();
+
+        $this->assertXmlStringEqualsXmlFile($this->samplesPath . "/content-empty.xml", $xml);
+    }
+
+    public function testWriteSpreadsheet()
+    {
+        $workbook = new Spreadsheet();
+
+        // Worksheet 1
+        $worksheet1 = $workbook->getActiveSheet();
+        $worksheet1->setCellValue('A1', 1); // Number
+        $worksheet1->setCellValue('B1', 12345.6789); // Number
+        $worksheet1->setCellValue('C1', "1"); // Number without cast
+        $worksheet1->setCellValueExplicit('D1', "01234", DataType::TYPE_STRING); // Number casted to string
+        $worksheet1->setCellValue('E1', "Lorem ipsum"); // String
+
+        $worksheet1->setCellValue('A2', true); // Boolean
+        $worksheet1->setCellValue('B2', false); // Boolean
+        $worksheet1->setCellValue('C2', '=IF(A3, CONCATENATE(A1, " ", A2), CONCATENATE(A2, " ", A1))'); // Formula
+
+        $worksheet1->setCellValue('D2', Date::PHPToExcel(1488635026)); // Date
+        $worksheet1->getStyle('D2')
+            ->getNumberFormat()
+            ->setFormatCode(NumberFormat::FORMAT_DATE_DATETIME);
+
+        // Worksheet 2
+        $worksheet2 = $workbook->createSheet();
+        $worksheet2->setTitle('New Worksheet');
+        $worksheet2->setCellValue('A1', 2);
+
+        // Write
+        $content = new Content();
+        $content->setParentWriter(new Ods($workbook));
+
+        $xml = $content->write();
+
+        $this->assertXmlStringEqualsXmlFile($this->samplesPath . "/content-with-data.xml", $xml);
+    }
+}

--- a/tests/PhpSpreadsheetTests/Writer/Ods/ContentTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Ods/ContentTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Writer\Ods\Content;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
@@ -15,6 +16,25 @@ use PhpOffice\PhpSpreadsheet\Writer\Ods\Content;
 class ContentTest extends \PHPUnit_Framework_TestCase
 {
     public $samplesPath = __DIR__ . '/../../../data/Writer/Ods';
+
+    /**
+     * @var string
+     */
+    protected $compatibilityMode;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->compatibilityMode = Functions::getCompatibilityMode();
+        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        Functions::setCompatibilityMode($this->compatibilityMode);
+    }
 
     public function testWriteEmptySpreadsheet()
     {
@@ -40,7 +60,11 @@ class ContentTest extends \PHPUnit_Framework_TestCase
 
         $worksheet1->setCellValue('A2', true); // Boolean
         $worksheet1->setCellValue('B2', false); // Boolean
-        $worksheet1->setCellValue('C2', '=IF(A3, CONCATENATE(A1, " ", A2), CONCATENATE(A2, " ", A1))'); // Formula
+        $worksheet1->setCellValueExplicit(
+            'C2',
+            '=IF(A3, CONCATENATE(A1, " ", A2), CONCATENATE(A2, " ", A1))',
+            DataType::TYPE_FORMULA
+        ); // Formula
 
         $worksheet1->setCellValue('D2', Date::PHPToExcel(1488635026)); // Date
         $worksheet1->getStyle('D2')

--- a/tests/PhpSpreadsheetTests/Writer/Ods/ContentTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Ods/ContentTest.php
@@ -6,6 +6,8 @@ use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Color;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Style\Font;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Writer\Ods;
 use PhpOffice\PhpSpreadsheet\Writer\Ods\Content;
@@ -45,6 +47,20 @@ class ContentTest extends \PHPUnit_Framework_TestCase
         $worksheet1->getStyle('D2')
             ->getNumberFormat()
             ->setFormatCode(NumberFormat::FORMAT_DATE_DATETIME);
+
+        // Styles
+        $worksheet1->getStyle('A1')->getFont()->setBold(true);
+        $worksheet1->getStyle('B1')->getFont()->setItalic(true);
+        $worksheet1->getStyle('C1')->getFont()->setName("Courier");
+        $worksheet1->getStyle('C1')->getFont()->setSize(14);
+        $worksheet1->getStyle('C1')->getFont()->setColor(new Color(Color::COLOR_BLUE));
+
+        $worksheet1->getStyle('C1')->getFill()->setFillType(Fill::FILL_SOLID);
+        $worksheet1->getStyle('C1')->getFill()->setStartColor(new Color(Color::COLOR_RED));
+
+        $worksheet1->getStyle('C1')->getFont()->setUnderline(Font::UNDERLINE_SINGLE);
+        $worksheet1->getStyle('C2')->getFont()->setUnderline(Font::UNDERLINE_DOUBLE);
+        $worksheet1->getStyle('D2')->getFont()->setUnderline(Font::UNDERLINE_NONE);
 
         // Worksheet 2
         $worksheet2 = $workbook->createSheet();

--- a/tests/data/Writer/Ods/content-empty.xml
+++ b/tests/data/Writer/Ods/content-empty.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2">
+    <office:scripts />
+    <office:font-face-decls />
+    <office:automatic-styles />
+    <office:body>
+        <office:spreadsheet>
+            <table:calculation-settings />
+            <table:table table:name="Worksheet">
+                <office:forms />
+                <table:table-column table:number-columns-repeated="1024" />
+                <table:table-row>
+                    <table:table-cell />
+                    <table:table-cell table:number-columns-repeated="1023" />
+                </table:table-row>
+            </table:table>
+            <table:named-expressions />
+        </office:spreadsheet>
+    </office:body>
+</office:document-content>

--- a/tests/data/Writer/Ods/content-empty.xml
+++ b/tests/data/Writer/Ods/content-empty.xml
@@ -2,7 +2,12 @@
 <office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2">
     <office:scripts />
     <office:font-face-decls />
-    <office:automatic-styles />
+    <office:automatic-styles>
+        <style:style style:name="ce0" style:family="table-cell" style:parent-style-name="Default">
+            <style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt" />
+            <style:table-cell-properties style:rotation-align="none" />
+        </style:style>
+    </office:automatic-styles>
     <office:body>
         <office:spreadsheet>
             <table:calculation-settings />
@@ -10,7 +15,7 @@
                 <office:forms />
                 <table:table-column table:number-columns-repeated="1024" />
                 <table:table-row>
-                    <table:table-cell />
+                    <table:table-cell table:style-name="ce0" />
                     <table:table-cell table:number-columns-repeated="1023" />
                 </table:table-row>
             </table:table>

--- a/tests/data/Writer/Ods/content-with-data.xml
+++ b/tests/data/Writer/Ods/content-with-data.xml
@@ -2,7 +2,52 @@
 <office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2">
     <office:scripts />
     <office:font-face-decls />
-    <office:automatic-styles />
+    <office:automatic-styles>
+        <style:style style:name="ce0" style:family="table-cell" style:parent-style-name="Default">
+            <style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt" />
+            <style:table-cell-properties style:rotation-align="none" />
+        </style:style>
+        <style:style style:name="ce1" style:family="table-cell" style:parent-style-name="Default">
+            <style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt" />
+            <style:table-cell-properties style:rotation-align="none" />
+        </style:style>
+        <style:style style:name="ce2" style:family="table-cell" style:parent-style-name="Default">
+            <style:text-properties fo:font-weight="bold" style:font-weight-complex="bold" style:font-weight-asian="bold" fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt" />
+            <style:table-cell-properties style:rotation-align="none" />
+        </style:style>
+        <style:style style:name="ce3" style:family="table-cell" style:parent-style-name="Default">
+            <style:text-properties fo:font-style="italic" fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt" />
+            <style:table-cell-properties style:rotation-align="none" />
+        </style:style>
+        <style:style style:name="ce4" style:family="table-cell" style:parent-style-name="Default">
+            <style:text-properties fo:color="#000000" fo:font-family="Courier" fo:font-size="11.0pt" />
+            <style:table-cell-properties style:rotation-align="none" />
+        </style:style>
+        <style:style style:name="ce5" style:family="table-cell" style:parent-style-name="Default">
+            <style:text-properties fo:color="#000000" fo:font-family="Courier" fo:font-size="14.0pt" />
+            <style:table-cell-properties style:rotation-align="none" />
+        </style:style>
+        <style:style style:name="ce6" style:family="table-cell" style:parent-style-name="Default">
+            <style:text-properties fo:color="#0000FF" fo:font-family="Courier" fo:font-size="14.0pt" />
+            <style:table-cell-properties style:rotation-align="none" />
+        </style:style>
+        <style:style style:name="ce7" style:family="table-cell" style:parent-style-name="Default">
+            <style:text-properties fo:color="#0000FF" fo:font-family="Courier" fo:font-size="14.0pt" />
+            <style:table-cell-properties style:rotation-align="none" fo:background-color="#ffffff" />
+        </style:style>
+        <style:style style:name="ce8" style:family="table-cell" style:parent-style-name="Default">
+            <style:text-properties fo:color="#0000FF" fo:font-family="Courier" fo:font-size="14.0pt" />
+            <style:table-cell-properties style:rotation-align="none" fo:background-color="#ff0000" />
+        </style:style>
+        <style:style style:name="ce9" style:family="table-cell" style:parent-style-name="Default">
+            <style:text-properties fo:color="#0000FF" fo:font-family="Courier" fo:font-size="14.0pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" style:text-underline-type="single" />
+            <style:table-cell-properties style:rotation-align="none" fo:background-color="#ff0000" />
+        </style:style>
+        <style:style style:name="ce10" style:family="table-cell" style:parent-style-name="Default">
+            <style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" style:text-underline-type="double" />
+            <style:table-cell-properties style:rotation-align="none" />
+        </style:style>
+    </office:automatic-styles>
     <office:body>
         <office:spreadsheet>
             <table:calculation-settings />
@@ -10,37 +55,37 @@
                 <office:forms />
                 <table:table-column table:number-columns-repeated="1024" />
                 <table:table-row>
-                    <table:table-cell office:value-type="float" office:value="1">
+                    <table:table-cell table:style-name="ce2" office:value-type="float" office:value="1">
                         <text:p>1</text:p>
                     </table:table-cell>
-                    <table:table-cell office:value-type="float" office:value="12345.6789">
+                    <table:table-cell table:style-name="ce3" office:value-type="float" office:value="12345.6789">
                         <text:p>12345.6789</text:p>
                     </table:table-cell>
-                    <table:table-cell office:value-type="float" office:value="1">
+                    <table:table-cell table:style-name="ce9" office:value-type="float" office:value="1">
                         <text:p>1</text:p>
                     </table:table-cell>
-                    <table:table-cell office:value-type="string">
+                    <table:table-cell table:style-name="ce0" office:value-type="string">
                         <text:p>01234</text:p>
                     </table:table-cell>
-                    <table:table-cell office:value-type="string">
+                    <table:table-cell table:style-name="ce0" office:value-type="string">
                         <text:p>Lorem ipsum</text:p>
                     </table:table-cell>
                     <table:table-cell table:number-columns-repeated="1019" />
                 </table:table-row>
                 <table:table-row>
-                    <table:table-cell office:value-type="boolean" office:value="1">
+                    <table:table-cell table:style-name="ce0" office:value-type="boolean" office:value="1">
                         <text:p>1</text:p>
                     </table:table-cell>
-                    <table:table-cell office:value-type="boolean" office:value="">
+                    <table:table-cell table:style-name="ce0" office:value-type="boolean" office:value="">
                         <text:p></text:p>
                     </table:table-cell>
-                    <table:table-cell table:formula="of:=IF(A3, CONCATENATE(A1, &quot; &quot;, A2), CONCATENATE(A2, &quot; &quot;, A1))" office:value-type="string" office:value="1 TRUE">
+                    <table:table-cell table:style-name="ce10" table:formula="of:=IF(A3, CONCATENATE(A1, &quot; &quot;, A2), CONCATENATE(A2, &quot; &quot;, A1))" office:value-type="string" office:value="1 TRUE">
                         <text:p>1 TRUE</text:p>
                     </table:table-cell>
-                    <table:table-cell office:value-type="float" office:value="42798.572060185">
+                    <table:table-cell table:style-name="ce1" office:value-type="float" office:value="42798.572060185">
                         <text:p>42798.572060185</text:p>
                     </table:table-cell>
-                    <table:table-cell />
+                    <table:table-cell table:style-name="ce0" />
                     <table:table-cell table:number-columns-repeated="1019" />
                 </table:table-row>
             </table:table>
@@ -48,7 +93,7 @@
                 <office:forms />
                 <table:table-column table:number-columns-repeated="1024" />
                 <table:table-row>
-                    <table:table-cell office:value-type="float" office:value="2">
+                    <table:table-cell table:style-name="ce0" office:value-type="float" office:value="2">
                         <text:p>2</text:p>
                     </table:table-cell>
                     <table:table-cell table:number-columns-repeated="1023" />

--- a/tests/data/Writer/Ods/content-with-data.xml
+++ b/tests/data/Writer/Ods/content-with-data.xml
@@ -79,8 +79,8 @@
                     <table:table-cell table:style-name="ce0" office:value-type="boolean" office:value="">
                         <text:p></text:p>
                     </table:table-cell>
-                    <table:table-cell table:style-name="ce10" table:formula="of:=IF(A3, CONCATENATE(A1, &quot; &quot;, A2), CONCATENATE(A2, &quot; &quot;, A1))" office:value-type="string" office:value="1 TRUE">
-                        <text:p>1 TRUE</text:p>
+                    <table:table-cell table:style-name="ce10" table:formula="of:=IF(A3, CONCATENATE(A1, &quot; &quot;, A2), CONCATENATE(A2, &quot; &quot;, A1))" office:value-type="string" office:value="1 1">
+                        <text:p>1 1</text:p>
                     </table:table-cell>
                     <table:table-cell table:style-name="ce1" office:value-type="float" office:value="42798.572060185">
                         <text:p>42798.572060185</text:p>

--- a/tests/data/Writer/Ods/content-with-data.xml
+++ b/tests/data/Writer/Ods/content-with-data.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2">
+    <office:scripts />
+    <office:font-face-decls />
+    <office:automatic-styles />
+    <office:body>
+        <office:spreadsheet>
+            <table:calculation-settings />
+            <table:table table:name="Worksheet">
+                <office:forms />
+                <table:table-column table:number-columns-repeated="1024" />
+                <table:table-row>
+                    <table:table-cell office:value-type="float" office:value="1">
+                        <text:p>1</text:p>
+                    </table:table-cell>
+                    <table:table-cell office:value-type="float" office:value="12345.6789">
+                        <text:p>12345.6789</text:p>
+                    </table:table-cell>
+                    <table:table-cell office:value-type="float" office:value="1">
+                        <text:p>1</text:p>
+                    </table:table-cell>
+                    <table:table-cell office:value-type="string">
+                        <text:p>01234</text:p>
+                    </table:table-cell>
+                    <table:table-cell office:value-type="string">
+                        <text:p>Lorem ipsum</text:p>
+                    </table:table-cell>
+                    <table:table-cell table:number-columns-repeated="1019" />
+                </table:table-row>
+                <table:table-row>
+                    <table:table-cell office:value-type="boolean" office:value="1">
+                        <text:p>1</text:p>
+                    </table:table-cell>
+                    <table:table-cell office:value-type="boolean" office:value="">
+                        <text:p></text:p>
+                    </table:table-cell>
+                    <table:table-cell table:formula="of:=IF(A3, CONCATENATE(A1, &quot; &quot;, A2), CONCATENATE(A2, &quot; &quot;, A1))" office:value-type="string" office:value="1 TRUE">
+                        <text:p>1 TRUE</text:p>
+                    </table:table-cell>
+                    <table:table-cell office:value-type="float" office:value="42798.572060185">
+                        <text:p>42798.572060185</text:p>
+                    </table:table-cell>
+                    <table:table-cell />
+                    <table:table-cell table:number-columns-repeated="1019" />
+                </table:table-row>
+            </table:table>
+            <table:table table:name="New Worksheet">
+                <office:forms />
+                <table:table-column table:number-columns-repeated="1024" />
+                <table:table-row>
+                    <table:table-cell office:value-type="float" office:value="2">
+                        <text:p>2</text:p>
+                    </table:table-cell>
+                    <table:table-cell table:number-columns-repeated="1023" />
+                </table:table-row>
+            </table:table>
+            <table:named-expressions />
+        </office:spreadsheet>
+    </office:body>
+</office:document-content>


### PR DESCRIPTION
With this PR the Ods writer now supports cross-referenced (XF) styles. 

Styles supported at the moment:

- bold
- italic
- font family
- font size
- underline
- bg color

Closes https://github.com/PHPOffice/PhpSpreadsheet/issues/105