### PR TITLE
Simplify mbStrReplace()

### DIFF
--- a/src/PhpSpreadsheet/Shared/StringHelper.php
+++ b/src/PhpSpreadsheet/Shared/StringHelper.php
@@ -553,9 +553,6 @@ class StringHelper
     /**
      * Replace into multi-bytes string.
      *
-     * Strangely, PHP doesn't have a mb_str_replace multibyte function
-     * As we'll only ever use this function with UTF-8 characters, we can simply "hard-code" the character set
-     *
      * @param string|string[] $search
      * @param string|string[] $replace
      * @param string $subject
@@ -564,28 +561,7 @@ class StringHelper
      */
     public static function mbStrReplace($search, $replace, $subject)
     {
-        if (is_array($subject)) {
-            $ret = [];
-            foreach ($subject as $key => $val) {
-                $ret[$key] = self::mbStrReplace($search, $replace, $val);
-            }
-
-            return $ret;
-        }
-
-        foreach ((array) $search as $key => $s) {
-            if ($s == '' && $s !== 0) {
-                continue;
-            }
-            $r = !is_array($replace) ? $replace : (isset($replace[$key]) ? $replace[$key] : '');
-            $pos = mb_strpos($subject, $s, 0, 'UTF-8');
-            while ($pos !== false) {
-                $subject = mb_substr($subject, 0, $pos, 'UTF-8') . $r . mb_substr($subject, $pos + mb_strlen($s, 'UTF-8'), null, 'UTF-8');
-                $pos = mb_strpos($subject, $s, $pos + mb_strlen($r, 'UTF-8'), 'UTF-8');
-            }
-        }
-
-        return $subject;
+        return str_replace($search, $replace, $subject);
     }
 
     /**


### PR DESCRIPTION
By design, UTF-8 allows any byte-oriented substring searching algorithm, since the sequence of bytes for a character cannot occur anywhere else ([source](https://en.wikipedia.org/wiki/UTF-8#Advantages_3)).

So `str_replace()` also works for UTF-8-encoded strings, assuming that the input strings are valid UTF-8 strings. AFAICT the previous implementation of mbStrReplace() did nothing to detect invalid strings.

Also, `str_replace()` does not support [Unicode equivalence](https://en.wikipedia.org/wiki/Unicode_equivalence), but nor do the other `mb_string` functions, and nor does `=SUBSTITUTE()` in Excel (tested on Excel for Mac version 15.19.1).