### PR TITLE
Settings: deleted libxml_disable_entity_loader() calls

### DIFF
--- a/docs/topics/reading-files.md
+++ b/docs/topics/reading-files.md
@@ -12,8 +12,7 @@ spreadsheet files. This can lead to:
 -   Server Side Request Forgery
 -   Command Execution (depending on the installed PHP wrappers)
 
-To prevent this, PhpSpreadsheet sets `libxml_disable_entity_loader` to
-`true` for the XML-based Readers by default.
+To prevent this, by default every XML-based Reader looks for XML entities declared inside the DOCTYPE and if any is found an exception is raised.
 
 ## Loading a Spreadsheet File
 

--- a/src/PhpSpreadsheet/Settings.php
+++ b/src/PhpSpreadsheet/Settings.php
@@ -237,7 +237,6 @@ class Settings
         if (is_null($options) && defined('LIBXML_DTDLOAD')) {
             $options = LIBXML_DTDLOAD | LIBXML_DTDATTR;
         }
-        @libxml_disable_entity_loader((bool) $options);
         self::$libXmlLoaderOptions = $options;
     }
 
@@ -254,7 +253,6 @@ class Settings
         } elseif (is_null(self::$libXmlLoaderOptions)) {
             self::$libXmlLoaderOptions = true;
         }
-        @libxml_disable_entity_loader((bool) self::$libXmlLoaderOptions);
 
         return self::$libXmlLoaderOptions;
     }

--- a/tests/PhpSpreadsheetTests/SettingsTest.php
+++ b/tests/PhpSpreadsheetTests/SettingsTest.php
@@ -4,14 +4,27 @@ namespace PhpOffice\PhpSpreadsheetTests;
 
 class SettingsTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var string
+     */
+    protected $prevValue;
+
     public function setUp()
     {
+        $this->prevValue = libxml_disable_entity_loader();
+        libxml_disable_entity_loader(false); // Enable entity loader
+    }
+
+    protected function tearDown()
+    {
+        libxml_disable_entity_loader($this->prevValue);
     }
 
     public function testGetXMLSettings()
     {
         $result = \PhpOffice\PhpSpreadsheet\Settings::getLibXmlLoaderOptions();
         $this->assertTrue((bool) ((LIBXML_DTDLOAD | LIBXML_DTDATTR) & $result));
+        $this->assertFalse(libxml_disable_entity_loader());
     }
 
     public function testSetXMLSettings()
@@ -19,5 +32,6 @@ class SettingsTest extends \PHPUnit_Framework_TestCase
         \PhpOffice\PhpSpreadsheet\Settings::setLibXmlLoaderOptions(LIBXML_DTDLOAD | LIBXML_DTDATTR | LIBXML_DTDVALID);
         $result = \PhpOffice\PhpSpreadsheet\Settings::getLibXmlLoaderOptions();
         $this->assertTrue((bool) ((LIBXML_DTDLOAD | LIBXML_DTDATTR | LIBXML_DTDVALID) & $result));
+        $this->assertFalse(libxml_disable_entity_loader());
     }
 }


### PR DESCRIPTION
Delete the calls since they're not necessary.

Prevent setLibXmlLoaderOptions() and getLibXmlLoaderOptions() to call the libxml_disable_entity_loader() function which alter the global state of libxml.

See the discussion here https://github.com/PHPOffice/PhpSpreadsheet/issues/74

Can confirm that every time that XML data is parsed the `BaseReader::securityScanFile()` method is called beforehand, so we're good to go.