### PR TITLE
Add more entries to gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,10 @@
-/tests export-ignore
-README.md export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs.dist export-ignore
+/.travis.yml export-ignore
+/README.md export-ignore
+/composer.lock export-ignore
+/docs/ export-ignore
+/phpunit.xml.dist export-ignore
+/samples/ export-ignore
+/tests/ export-ignore


### PR DESCRIPTION
Used by composer to ignore tests and other development files in the
distribution of a release.

For more details, see information in the article:

https://blog.madewithlove.be/post/gitattributes/