### PR TITLE
Infer CSV delimiter if it hasn't been set explicitly

### DIFF
--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -162,7 +162,7 @@ class Csv extends BaseReader implements IReader
         }
 
         $potentialDelimiters = [',', ';', "\t", '|', ':', ' '];
-        $count = [];
+        $counts = [];
         foreach ($potentialDelimiters as $delimiter) {
             $counts[$delimiter] = [];
         }

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -40,7 +40,7 @@ class Csv extends BaseReader implements IReader
      *
      * @var string
      */
-    private $delimiter = ',';
+    private $delimiter = null;
 
     /**
      * Enclosure.
@@ -153,6 +153,82 @@ class Csv extends BaseReader implements IReader
     }
 
     /**
+     * Infer the separator if it isn't explicitly set in the file or specified by the user
+     */
+    protected function inferSeparator()
+    {
+        if ($this->delimiter !== null) {
+            return;
+        }
+
+        $potentialDelimiters = [ ',', ';', "\t", '|', ':', ' ' ];
+        $count = array();
+        foreach ($potentialDelimiters as $delimiter) {
+          $counts[$delimiter] = array();
+        }
+
+        // Count how many times each of the potential delimiters appears in each line
+        $numberLines = 0;
+        while (($line = fgets($this->fileHandle)) !== false && (++$numberLines < 1000)) {
+            $countLine = array();
+            for ($i = strlen($line) - 1; $i >= 0; $i--) {
+                $char = $line[$i];
+                if (isset($counts[$char])) {
+                    if (!isset($countLine[$char])) {
+                        $countLine[$char] = 0;
+                    }
+                    $countLine[$char]++;
+                }
+            }
+            foreach ($potentialDelimiters as $delimiter) {
+                $counts[$delimiter][] = isset($countLine[$delimiter])
+                    ? $countLine[$delimiter]
+                    : 0;
+            }
+        }
+
+        // Calculate the mean square deviations for each delimiter (ignoring delimiters that haven't been found consistently)
+        $meanSquareDeviations = array();
+        $middleIdx = floor(($numberLines - 1) / 2);
+
+        foreach ($potentialDelimiters as $delimiter) {
+            $series = $counts[$delimiter];
+            sort($series);
+
+            $median = ($numberLines % 2)
+                ? $series[$middleIdx]
+                : ($series[$middleIdx] + $series[$middleIdx + 1]) / 2;
+
+            if ($median === 0) {
+                continue;
+            }
+
+            $meanSquareDeviations[$delimiter] = array_reduce($series, function ($sum, $value) use($median) { return $sum + pow($value - $median, 2); })
+                / count($series);
+        }
+
+        // ... and pick the delimiter with the smallest mean square deviation (in case of ties, the order in potentialDelimiters is respected)
+        $min = INF;
+        foreach ($potentialDelimiters as $delimiter) {
+            if (!isset($meanSquareDeviations[$delimiter])) {
+                continue;
+            }
+
+            if ($meanSquareDeviations[$delimiter] < $min) {
+                $min = $meanSquareDeviations[$delimiter];
+                $this->delimiter = $delimiter;
+            }
+        }
+
+        // If no delimiter could be detected, fall back to the default
+        if ($this->delimiter === null) {
+            $this->delimiter = reset($potentialDelimiters);
+        }
+
+        return $this->skipBOM();
+    }
+
+    /**
      * Return worksheet info (Name, Last Column Letter, Last Column Index, Total Rows, Total Columns).
      *
      * @param string $pFilename
@@ -171,6 +247,7 @@ class Csv extends BaseReader implements IReader
         // Skip BOM, if any
         $this->skipBOM();
         $this->checkSeparator();
+        $this->inferSeparator();
 
         $worksheetInfo = [];
         $worksheetInfo[0]['worksheetName'] = 'Worksheet';
@@ -237,6 +314,7 @@ class Csv extends BaseReader implements IReader
         // Skip BOM, if any
         $this->skipBOM();
         $this->checkSeparator();
+        $this->inferSeparator();
 
         // Create new PhpSpreadsheet object
         while ($spreadsheet->getSheetCount() <= $this->sheetIndex) {

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -153,7 +153,7 @@ class Csv extends BaseReader implements IReader
     }
 
     /**
-     * Infer the separator if it isn't explicitly set in the file or specified by the user
+     * Infer the separator if it isn't explicitly set in the file or specified by the user.
      */
     protected function inferSeparator()
     {
@@ -161,23 +161,23 @@ class Csv extends BaseReader implements IReader
             return;
         }
 
-        $potentialDelimiters = [ ',', ';', "\t", '|', ':', ' ' ];
-        $count = array();
+        $potentialDelimiters = [',', ';', "\t", '|', ':', ' '];
+        $count = [];
         foreach ($potentialDelimiters as $delimiter) {
-          $counts[$delimiter] = array();
+            $counts[$delimiter] = [];
         }
 
         // Count how many times each of the potential delimiters appears in each line
         $numberLines = 0;
         while (($line = fgets($this->fileHandle)) !== false && (++$numberLines < 1000)) {
-            $countLine = array();
-            for ($i = strlen($line) - 1; $i >= 0; $i--) {
+            $countLine = [];
+            for ($i = strlen($line) - 1; $i >= 0; --$i) {
                 $char = $line[$i];
                 if (isset($counts[$char])) {
                     if (!isset($countLine[$char])) {
                         $countLine[$char] = 0;
                     }
-                    $countLine[$char]++;
+                    ++$countLine[$char];
                 }
             }
             foreach ($potentialDelimiters as $delimiter) {
@@ -188,7 +188,7 @@ class Csv extends BaseReader implements IReader
         }
 
         // Calculate the mean square deviations for each delimiter (ignoring delimiters that haven't been found consistently)
-        $meanSquareDeviations = array();
+        $meanSquareDeviations = [];
         $middleIdx = floor(($numberLines - 1) / 2);
 
         foreach ($potentialDelimiters as $delimiter) {
@@ -203,8 +203,12 @@ class Csv extends BaseReader implements IReader
                 continue;
             }
 
-            $meanSquareDeviations[$delimiter] = array_reduce($series, function ($sum, $value) use($median) { return $sum + pow($value - $median, 2); })
-                / count($series);
+            $meanSquareDeviations[$delimiter] = array_reduce(
+                $series,
+                function ($sum, $value) use ($median) {
+                    return $sum + pow($value - $median, 2);
+                }
+            ) / count($series);
         }
 
         // ... and pick the delimiter with the smallest mean square deviation (in case of ties, the order in potentialDelimiters is respected)

--- a/tests/PhpSpreadsheetTests/Reader/CsvTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/CsvTest.php
@@ -24,4 +24,18 @@ class CsvTest extends \PHPUnit_Framework_TestCase
         $actual = $reloadedSpreadsheet->getActiveSheet()->getCell('A1')->getCalculatedValue();
         $this->assertSame($value, $actual, 'should be able to write and read strings with multiples quotes');
     }
+
+    public function testDelimiterDetection()
+    {
+        $reader = new \PhpOffice\PhpSpreadsheet\Reader\Csv();
+        $this->assertNull($reader->getDelimiter());
+
+        $filename = __DIR__ . '/../../data/Reader/CSV/semicolon_separated.csv';
+        $spreadsheet = $reader->load($filename);
+
+        $this->assertSame(';', $reader->getDelimiter(), 'should be able to infer the delimiter');
+
+        $actual = $spreadsheet->getActiveSheet()->getCell('C2')->getValue();
+        $this->assertSame('25,5', $actual, 'should be able to retrieve values with commas');
+    }
 }

--- a/tests/data/Reader/CSV/semicolon_separated.csv
+++ b/tests/data/Reader/CSV/semicolon_separated.csv
@@ -1,0 +1,3 @@
+This;Are;Headers
+Cell A2;Number with comma;25,5
+Two colons and a comma;B|3;:,:


### PR DESCRIPTION
This change tries to infer the delimiter if it hasn't been explicitly set. It first  counts the number of occurrences of a number of potential delimiters (max. first 1000 lines) of a CSV file and then chooses the one which occurs most regularly (mean square deviation). 