### PR TITLE
fix countifs definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix to getCell() method when cell reference includes a worksheet reference - @MarkBaker
 - Ignore inlineStr type if formula element exists - @ncrypthic [#570](https://github.com/PHPOffice/PHPExcel/issues/570)
 - Excel 2007 Reader freezes because of conditional formatting - @rentalhost [#575](https://github.com/PHPOffice/PHPExcel/issues/575)
+- Fix definition of countifs function that made it impossible to import files where this function is used with more than 2 parameters
 
 ### General
 

--- a/src/PhpSpreadsheet/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation.php
@@ -516,7 +516,7 @@ class Calculation
         'COUNTIFS' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Functions::class, 'DUMMY'],
-            'argumentCount' => '2',
+            'argumentCount' => '2+',
         ],
         'COUPDAYBS' => [
             'category' => Category::CATEGORY_FINANCIAL,


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

The countifs function can have more than 2 parameters, it's defined as `COUNTIFS(criteria_range1, criteria1, [criteria_range2, criteria2]…)`, see here: https://support.office.com/en-us/article/COUNTIFS-function-dda3dc6e-f74e-4aee-88bc-aa8c2a866842

I'm not sure how you guys want to cover something like this in a unit test. Should I add a new file and test whether we can read it? Shall I modify an existing one? 
