### PR TITLE
Added method Worksheet::cleanRowDimensions()

### DIFF
--- a/src/PhpSpreadsheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet.php
@@ -493,6 +493,31 @@ class Worksheet implements IComparable
     }
 
     /**
+     * Clean up row dimensions.
+     *
+     * @param int $maxRow Maximum row to keep. Defaults to highest data row.
+     *
+     * @return $this
+     */
+    public function cleanRowDimensions($maxRow = null)
+    {
+        if ($maxRow === null) {
+            $maxRow = $this->getHighestDataRow();
+        }
+
+        foreach ($this->rowDimensions as $i => $dimension) {
+            if ($dimension->getRowIndex() > $maxRow) {
+                unset($this->rowDimensions[$i]);
+            }
+        }
+
+        // Garbage collect...
+        $this->garbageCollect();
+
+        return $this;
+    }
+
+    /**
      * Get default row dimension.
      *
      * @return Worksheet\RowDimension


### PR DESCRIPTION
This is:

- [x] a bugfix
- [x] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?

Added method Worksheet::cleanRowDimensions() to work around memory running out with LibreOffice files having useless dimensions over 1M+. Also good for cleaning up the document after loading or removing a bunch of rows.

Fix was made for my own use, please be free to include it if you find the change useful.