### PR TITLE
Added support for custom indexed colors in Xlsx reader

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -546,6 +546,13 @@ class Xlsx extends BaseReader implements IReader
                         'SimpleXMLElement',
                         Settings::getLibXmlLoaderOptions()
                     );
+                    if ($xmlStyles->colors->indexedColors) {
+                        $colors = [];
+                        foreach ($xmlStyles->colors->indexedColors as $rgbColor) {
+                            $colors[] = (string) $rgbColor['rgb'];
+                        }
+                        Style\Color::setIndexedColors($colors);
+                    }
                     $numFmts = null;
                     if ($xmlStyles && $xmlStyles->numFmts[0]) {
                         $numFmts = $xmlStyles->numFmts[0];

--- a/src/PhpSpreadsheet/Style/Color.php
+++ b/src/PhpSpreadsheet/Style/Color.php
@@ -357,6 +357,16 @@ class Color extends Supervisor implements IComparable
     }
 
     /**
+     * Set all indexed colors.
+     *
+     * @param array $colors Colors to be set
+     */
+    public static function setIndexedColors(array $colors)
+    {
+        self::$indexedColors = $colors;
+    }
+
+    /**
      * Get indexed color.
      *
      * @param int $pIndex Index entry point into the colour array


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [x] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?

Added support for custom indexed colors in Xlsx reader. Previously the built-in index was always used, which resulted in wrong colors in the cells.

The fix was made for my own use, please be free to include it if you find the change useful.