### PR TITLE
Remove 31-character limit from sheet title

### DIFF
--- a/src/PhpSpreadsheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet.php
@@ -430,11 +430,6 @@ class Worksheet implements IComparable
             throw new Exception('Invalid character found in sheet code name');
         }
 
-        // Maximum 31 characters allowed for sheet title
-        if ($CharCount > 31) {
-            throw new Exception('Maximum 31 characters allowed in sheet code name.');
-        }
-
         return $pValue;
     }
 
@@ -452,11 +447,6 @@ class Worksheet implements IComparable
         // Some of the printable ASCII characters are invalid:  * : / \ ? [ ]
         if (str_replace(self::$invalidCharacters, '', $pValue) !== $pValue) {
             throw new Exception('Invalid character found in sheet title');
-        }
-
-        // Maximum 31 characters allowed for sheet title
-        if (Shared\StringHelper::countCharacters($pValue) > 31) {
-            throw new Exception('Maximum 31 characters allowed in sheet title.');
         }
 
         return $pValue;


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?

There is no documented reason why sheet titles were being limited to 31 characters (this code has been in place since PHPExcel was initially migrated to GitHub 7 years ago). It's possible that some archaic format does have trouble with this, but imposing that limit globally presents problems for parsing all formats.

If this is needed for some format, the restriction should be imposed on save (and only on save) to the affected format, so as not to affect other formats.

Issue #176