### PR TITLE
Add feature to get text & background color from inline css, for td & …

### DIFF
--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -442,6 +442,30 @@ class Html extends BaseReader implements IReader
                     case 'td':
                         $this->processDomElement($child, $sheet, $row, $column, $cellContent);
 
+                        // add color styles (background & text) from dom element,currently support : td & th, using ONLY inline css style with RGB color
+                        if (isset($attributeArray['style'])){
+                            $styles = explode(';',$attributeArray['style']);
+                            foreach ($styles as $st) {
+                                $value = explode(':', $st);
+                                if (!empty($value[0])) {
+                                    if(trim($value[0])=="background-color" || trim($value[0])=="color" ) {
+                                        $style_color = null;
+                                        //check if has #, so we can get clean hex
+                                        if ( substr(trim($value[1]), 0, 1) == "#" ) {
+                                            $style_color = substr(trim($value[1]), 1);
+                                        }
+                                        if($style_color) {
+                                            if (trim($value[0]) == "background-color") {
+                                                    $sheet->getStyle($column . $row)->applyFromArray( ['fill' => ['type' => \PhpOffice\PhpSpreadsheet\Style\Fill::FILL_SOLID,'color' => ['rgb' => "{$style_color}" ],], ] );
+                                            } elseif (trim($value[0]) == "color") {
+                                                    $sheet->getStyle($column . $row)->applyFromArray( ['font' => ['color' => [ 'rgb' => "$style_color}" ]], ]);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
                         while (isset($this->rowspan[$column . $row])) {
                             ++$column;
                         }


### PR DESCRIPTION
…th element

This is:

- [ ] a bugfix
- [x] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

What does it change?

I'm not sure if others need this feature, but this feature is quite handy for me and my team to directly generate excel file from html text, usually our client want specific coloring for the excel file and usually we already have the html for that. 

This is limited for inline css inside <td> and <th> tag.

