### PR TITLE
Add feature to get text & background color from inline CSS : td&th

### DIFF
--- a/docs/references/features-cross-reference.md
+++ b/docs/references/features-cross-reference.md
@@ -906,7 +906,7 @@
 		<td></td>
 		<td></td>
 		<td></td>
-		<td></td>
+		<td style="text-align: center; color: orange;">●</td>
 		<td></td>
 		<td></td>
 		<td></td>

--- a/samples/46_ReadHtml.php
+++ b/samples/46_ReadHtml.php
@@ -1,0 +1,19 @@
+<?php
+
+// Turn off error reporting
+error_reporting(0);
+
+use PhpOffice\PhpSpreadsheet\IOFactory;
+
+require __DIR__ . '/Header.php';
+
+$html = __DIR__ . '/templates/46readHtml.html';
+$callStartTime = microtime(true);
+
+$objReader = IOFactory::createReader('Html');
+$objPHPExcel = $objReader->load($html);
+
+$helper->logRead('Html', $html, $callStartTime);
+
+// Save
+$helper->write($objPHPExcel, __FILE__);

--- a/samples/templates/46readHtml.html
+++ b/samples/templates/46readHtml.html
@@ -1,0 +1,130 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<title>Competency List</title>
+</head>
+<body>
+<table class="w3-table-all notranslate">
+    <tr>
+    <th style="background-color: #0000FF;color:#FFFFFF">Color Name</th>
+    <th style="background-color: #FF0000">HEX</th>
+    <th style="background-color: #008000">Color</th>
+    </tr>
+
+    <tr>
+    <td style="color:#000000">Black</td>
+    <td>#000000</td>
+    <td style="background-color:#000000">&nbsp;</td>
+    </tr>
+
+    <tr>
+    <td style="color:#0000FF">Blue</td>
+    <td>#0000FF</td>
+    <td style="background-color:#0000FF">&nbsp;</td>
+    </tr>
+
+
+    <tr>
+    <td style="color:#008000">Green</td>
+    <td>#008000</td>
+    <td style="background-color:#008000">&nbsp;</td>
+    </tr>
+
+    <tr>
+    <td style="color:#00FFFF">Cyan</td>
+    <td>#00FFFF</td>
+    <td style="background-color:#00FFFF">&nbsp;</td>
+    </tr>
+
+    <tr>
+    <td style="color:#800080">Purple</td>
+    <td>#800080</td>
+    <td style="background-color:#800080">&nbsp;</td>
+    </tr>
+
+
+    <tr>
+    <td style="color:#800080">Grey</td>
+    <td>#808080</td>
+    <td style="background-color:#808080">&nbsp;</td>
+    </tr>
+
+    <tr>
+    <td style="color:#87CEEB">SkyBlue</td>
+    <td>#87CEEB</td>
+    <td style="background-color:#87CEEB">&nbsp;</td>
+    </tr>
+
+
+    <tr>
+    <td style="color:#A52A2A">Brown</td>
+    <td>#A52A2A</td>
+    <td style="background-color:#A52A2A">&nbsp;</td>
+    </tr>
+
+    <tr>
+    <td style="color:#C0C0C0;background-color: #000000">Silver</td>
+    <td>#C0C0C0</td>
+    <td style="background-color:#C0C0C0">&nbsp;</td>
+    </tr>
+
+    <tr>
+    <td style="color:#D2691E">Chocolate</td>
+    <td>#D2691E</td>
+    <td style="background-color:#D2691E">&nbsp;</td>
+    </tr>
+
+    <tr>
+    <td style="color:#D2B48C;background-color: #000000">Tan</td>
+    <td>#D2B48C</td>
+    <td style="background-color:#D2B48C">&nbsp;</td>
+    </tr>
+
+
+    <tr>
+    <td style="color:#EE82EE;background-color: #000000">Violet</td>
+    <td>#EE82EE</td>
+    <td style="background-color:#EE82EE">&nbsp;</td>
+    </tr>
+
+
+    <tr>
+    <td style="color:#FF0000;background-color: #000000">Red</td>
+    <td>#FF0000</td>
+    <td style="background-color:#FF0000">&nbsp;</td>
+    </tr>
+
+    <tr>
+    <td style="color:#FFC0CB;background-color: #000000">Pink</td>
+    <td>#FFC0CB</td>
+    <td style="background-color:#FFC0CB">&nbsp;</td>
+    </tr>
+
+    <tr>
+    <td style="color:#FFD700;background-color: #000000">Gold</td>
+    <td>#FFD700</td>
+    <td style="background-color:#FFD700">&nbsp;</td>
+    </tr>
+
+    <tr>
+    <td style="color:#FFFF00;background-color: #000000">Yellow</td>
+    <td>#FFFF00</td>
+    <td style="background-color:#FFFF00">&nbsp;</td>
+    </tr>
+
+    <tr>
+    <td style="color:#FFFFE0;background-color: #000000">LightYellow</td>
+    <td>#FFFFE0</td>
+    <td style="background-color:#FFFFE0">&nbsp;</td>
+    </tr>
+
+    <tr>
+    <td style="color:#FFFFFF;background-color: #000000">White</td>
+    <td>#FFFFFF</td>
+    <td style="background-color:#FFFFFF">&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -443,22 +443,22 @@ class Html extends BaseReader implements IReader
                         $this->processDomElement($child, $sheet, $row, $column, $cellContent);
 
                         // add color styles (background & text) from dom element,currently support : td & th, using ONLY inline css style with RGB color
-                        if (isset($attributeArray['style'])){
-                            $styles = explode(';',$attributeArray['style']);
+                        if (isset($attributeArray['style'])) {
+                            $styles = explode(';', $attributeArray['style']);
                             foreach ($styles as $st) {
                                 $value = explode(':', $st);
                                 if (!empty($value[0])) {
-                                    if(trim($value[0])=="background-color" || trim($value[0])=="color" ) {
+                                    if (trim($value[0]) == 'background-color' || trim($value[0]) == 'color') {
                                         $style_color = null;
                                         //check if has #, so we can get clean hex
-                                        if ( substr(trim($value[1]), 0, 1) == "#" ) {
+                                        if (substr(trim($value[1]), 0, 1) == '#') {
                                             $style_color = substr(trim($value[1]), 1);
                                         }
-                                        if($style_color) {
-                                            if (trim($value[0]) == "background-color") {
-                                                    $sheet->getStyle($column . $row)->applyFromArray( ['fill' => ['type' => \PhpOffice\PhpSpreadsheet\Style\Fill::FILL_SOLID,'color' => ['rgb' => "{$style_color}" ],], ] );
-                                            } elseif (trim($value[0]) == "color") {
-                                                    $sheet->getStyle($column . $row)->applyFromArray( ['font' => ['color' => [ 'rgb' => "$style_color}" ]], ]);
+                                        if ($style_color) {
+                                            if (trim($value[0]) == 'background-color') {
+                                                $sheet->getStyle($column . $row)->applyFromArray(['fill' => ['type' => \PhpOffice\PhpSpreadsheet\Style\Fill::FILL_SOLID, 'color' => ['rgb' => "{$style_color}"]]]);
+                                            } elseif (trim($value[0]) == 'color') {
+                                                $sheet->getStyle($column . $row)->applyFromArray(['font' => ['color' => ['rgb' => "$style_color}"]]]);
                                             }
                                         }
                                     }

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -442,6 +442,30 @@ class Html extends BaseReader implements IReader
                     case 'td':
                         $this->processDomElement($child, $sheet, $row, $column, $cellContent);
 
+                        // add color styles (background & text) from dom element,currently support : td & th, using ONLY inline css style with RGB color
+                        if (isset($attributeArray['style'])){
+                            $styles = explode(';',$attributeArray['style']);
+                            foreach ($styles as $st) {
+                                $value = explode(':', $st);
+                                if (!empty($value[0])) {
+                                    if(trim($value[0])=="background-color" || trim($value[0])=="color" ) {
+                                        $style_color = null;
+                                        //check if has #, so we can get clean hex
+                                        if ( substr(trim($value[1]), 0, 1) == "#" ) {
+                                            $style_color = substr(trim($value[1]), 1);
+                                        }
+                                        if($style_color) {
+                                            if (trim($value[0]) == "background-color") {
+                                                    $sheet->getStyle($column . $row)->applyFromArray( ['fill' => ['type' => \PhpOffice\PhpSpreadsheet\Style\Fill::FILL_SOLID,'color' => ['rgb' => "{$style_color}" ],], ] );
+                                            } elseif (trim($value[0]) == "color") {
+                                                    $sheet->getStyle($column . $row)->applyFromArray( ['font' => ['color' => [ 'rgb' => "$style_color}" ]], ]);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
                         while (isset($this->rowspan[$column . $row])) {
                             ++$column;
                         }

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -605,29 +605,37 @@ class Html extends BaseReader implements IReader
      */
     private function applyInlineStyle(&$sheet, $row, $column, $attributeArray)
     {
+        if (!isset($attributeArray['style'])) {
+            return;
+        }
+
         $supported_styles = ['background-color', 'color'];
 
         // add color styles (background & text) from dom element,currently support : td & th, using ONLY inline css style with RGB color
-        if (isset($attributeArray['style'])) {
-            $styles = explode(';', $attributeArray['style']);
-            foreach ($styles as $st) {
-                $value = explode(':', $st);
-                if (!empty(trim($value[0]))) {
-                    if (in_array(trim($value[0]), $supported_styles)) {
-                        $style_color = null;
-                        //check if has #, so we can get clean hex
-                        if (substr(trim($value[1]), 0, 1) == '#') {
-                            $style_color = substr(trim($value[1]), 1);
-                        }
-                        if ($style_color) {
-                            if (trim($value[0]) == 'background-color') {
-                                $sheet->getStyle($column . $row)->applyFromArray(['fill' => ['type' => Fill::FILL_SOLID, 'color' => ['rgb' => "{$style_color}"]]]);
-                            } elseif (trim($value[0]) == 'color') {
-                                $sheet->getStyle($column . $row)->applyFromArray(['font' => ['color' => ['rgb' => "$style_color}"]]]);
-                            }
-                        }
-                    }
-                }
+        $styles = explode(';', $attributeArray['style']);
+        foreach ($styles as $st) {
+            $value = explode(':', $st);
+
+            if (empty(trim($value[0])) || !in_array(trim($value[0]), $supported_styles)) {
+                continue;
+            }
+
+            //check if has #, so we can get clean hex
+            if (substr(trim($value[1]), 0, 1) == '#') {
+                $style_color = substr(trim($value[1]), 1);
+            }
+
+            if (empty($style_color)) {
+                continue;
+            }
+
+            switch (trim($value[0])) {
+                case 'background-color':
+                    $sheet->getStyle($column . $row)->applyFromArray(['fill' => ['type' => Fill::FILL_SOLID, 'color' => ['rgb' => "{$style_color}"]]]);
+                    break;
+                case 'color':
+                    $sheet->getStyle($column . $row)->applyFromArray(['font' => ['color' => ['rgb' => "$style_color}"]]]);
+                    break;
             }
         }
     }


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [x] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

What does it change?

> Updated Pull Request from https://github.com/PHPOffice/PhpSpreadsheet/pull/178 , forgot to create new branch

I'm not sure if others need this feature, but this feature is quite handy for me and my team to directly generate excel file from html text, usually our client want specific coloring for the excel file and usually we already have the html for that.

This is limited for inline css inside and tag.