### PR TITLE
Update Border.php

### DIFF
--- a/src/PhpSpreadsheet/Style/Border.php
+++ b/src/PhpSpreadsheet/Style/Border.php
@@ -146,7 +146,7 @@ class Border extends Supervisor implements IComparable
      */
     public function getStyleArray($array)
     {
-        switch ($this->parentPropertyName) {
+        switch (strtolower($this->parentPropertyName)) {
             case 'allborders':
             case 'bottom':
             case 'diagonal':


### PR DESCRIPTION
Changing the switch case to `strtolower` as internally the case is still `allBorders` given the following execution stack.

```php
$this->excel->getActiveSheet()
    ->getStyle($style)
    ->getBorders()
    ->getAllBorders()
    ->setBorderStyle(ExcelStyle\Border::BORDER_THIN);
```

This likely is a hacking change and may not get merged, but it highlights the issue as well. May count this as a bug report ;)

The alternative would likely to fix the occurence of the camelcased `allBorders` and change it to the lowercased `allborders`

This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?
