### PR TITLE
Uncommented the increment of $imageCounter

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/BaseDrawing.php
+++ b/src/PhpSpreadsheet/Worksheet/BaseDrawing.php
@@ -139,7 +139,8 @@ class BaseDrawing implements IComparable
         $this->rotation = 0;
         $this->shadow = new Drawing\Shadow();
 
-        // Set image index++self::$imageCounter;
+        // Set image index
+        ++self::$imageCounter;
         $this->imageIndex = self::$imageCounter;
     }
 


### PR DESCRIPTION
The static variable $imageCounter previously had a constant value of 0 throughout the program as it was never being modified.
Now it increments every time a new drawing is being instantiated.

This also fixed a problem when multiple images of same name in the same worksheet are incorrectly displayed.
https://github.com/PHPOffice/PhpSpreadsheet/issues/204

This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?
