### PR TITLE
Added SimpleXMLElement Exception check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Control characters in cell values are automatically escaped - [#212](https://github.com/PHPOffice/PhpSpreadsheet/issues/212)
 - Prevent color changing when copy/pasting xls files written by PhpSpreadsheet to another file - @al-lala [#218](https://github.com/PHPOffice/PhpSpreadsheet/issues/218)
+- Check if a XML file is a valid SimpleXML - @GreatHumorist [#222](https://github.com/PHPOffice/PhpSpreadsheet/pull/222)
 
 ### BREAKING CHANGE
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Merge data-validations to reduce written worksheet size - @billblume [#131](https://github.com/PHPOffice/PhpSpreadSheet/issues/131)
+- Throws exception if a XML file is invalid - @GreatHumorist [#222](https://github.com/PHPOffice/PhpSpreadsheet/pull/222)
 
 ### Fixed
 
 - Control characters in cell values are automatically escaped - [#212](https://github.com/PHPOffice/PhpSpreadsheet/issues/212)
 - Prevent color changing when copy/pasting xls files written by PhpSpreadsheet to another file - @al-lala [#218](https://github.com/PHPOffice/PhpSpreadsheet/issues/218)
-- Check if a XML file is a valid SimpleXML - @GreatHumorist [#222](https://github.com/PHPOffice/PhpSpreadsheet/pull/222)
 
 ### BREAKING CHANGE
 

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -139,7 +139,7 @@ class Xml extends BaseReader implements IReader
             Settings::getLibXmlLoaderOptions()
         );
         if (!($xml instanceof \SimpleXMLElement)) {
-            throw new Exception('SimpleXMLElement can not load ' .$pFilename);
+            throw new Exception('SimpleXMLElement can not load ' . $pFilename);
         }
         $namespaces = $xml->getNamespaces(true);
 
@@ -171,7 +171,7 @@ class Xml extends BaseReader implements IReader
             Settings::getLibXmlLoaderOptions()
         );
         if (!($xml instanceof \SimpleXMLElement)) {
-            throw new Exception('SimpleXMLElement can not load ' .$pFilename);
+            throw new Exception('SimpleXMLElement can not load ' . $pFilename);
         }
         $namespaces = $xml->getNamespaces(true);
 
@@ -351,7 +351,7 @@ class Xml extends BaseReader implements IReader
             Settings::getLibXmlLoaderOptions()
         );
         if (!($xml instanceof \SimpleXMLElement)) {
-            throw new Exception('SimpleXMLElement can not load ' .$pFilename);
+            throw new Exception('SimpleXMLElement can not load ' . $pFilename);
         }
         $namespaces = $xml->getNamespaces(true);
 

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheet\Reader;
 use DateTimeZone;
 use PhpOffice\PhpSpreadsheet\Cell;
 use PhpOffice\PhpSpreadsheet\Document\Properties;
+use PhpOffice\PhpSpreadsheet\Reader\Exception;
 use PhpOffice\PhpSpreadsheet\RichText;
 use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
@@ -118,6 +119,28 @@ class Xml extends BaseReader implements IReader
     }
 
     /**
+     * Check if the file is a valid SimpleXML.
+     * @param $pFilename
+     *
+     * @throws Exception
+     *
+     * @return \SimpleXMLElement or false
+     */
+    public function trySimpleXMLLoadString($pFilename)
+    {
+        try{
+            $xml = simplexml_load_string(
+                $this->securityScan(file_get_contents($pFilename)),
+                'SimpleXMLElement',
+                Settings::getLibXmlLoaderOptions()
+            );
+        } catch (\Exception $e) {
+            throw new Exception($pFilename . ' -> ' . $e->getMessage());
+        }
+        return $xml;
+    }
+
+    /**
      * Reads names of the worksheets from a file, without parsing the whole file to a Spreadsheet object.
      *
      * @param string $pFilename
@@ -133,14 +156,8 @@ class Xml extends BaseReader implements IReader
 
         $worksheetNames = [];
 
-        $xml = simplexml_load_string(
-            $this->securityScan(file_get_contents($pFilename)),
-            'SimpleXMLElement',
-            Settings::getLibXmlLoaderOptions()
-        );
-        if ($xml === false) {
-            throw new Exception('SimpleXMLElement can not load ' . $pFilename);
-        }
+        $xml = $this->trySimpleXMLLoadString($pFilename);
+
         $namespaces = $xml->getNamespaces(true);
 
         $xml_ss = $xml->children($namespaces['ss']);
@@ -165,14 +182,8 @@ class Xml extends BaseReader implements IReader
 
         $worksheetInfo = [];
 
-        $xml = simplexml_load_string(
-            $this->securityScan(file_get_contents($pFilename)),
-            'SimpleXMLElement',
-            Settings::getLibXmlLoaderOptions()
-        );
-        if ($xml === false) {
-            throw new Exception('SimpleXMLElement can not load ' . $pFilename);
-        }
+        $xml = $this->trySimpleXMLLoadString($pFilename);
+
         $namespaces = $xml->getNamespaces(true);
 
         $worksheetID = 1;
@@ -345,14 +356,8 @@ class Xml extends BaseReader implements IReader
             throw new Exception($pFilename . ' is an Invalid Spreadsheet file.');
         }
 
-        $xml = simplexml_load_string(
-            $this->securityScan(file_get_contents($pFilename)),
-            'SimpleXMLElement',
-            Settings::getLibXmlLoaderOptions()
-        );
-        if ($xml === false) {
-            throw new Exception('SimpleXMLElement can not load ' . $pFilename);
-        }
+        $xml = $this->trySimpleXMLLoadString($pFilename);
+
         $namespaces = $xml->getNamespaces(true);
 
         $docProps = $spreadsheet->getProperties();

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -119,7 +119,7 @@ class Xml extends BaseReader implements IReader
 
     /**
      * Check if the file is a valid SimpleXML.
-     * 
+     *
      * @param $pFilename
      *
      * @throws Exception

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -138,6 +138,9 @@ class Xml extends BaseReader implements IReader
             'SimpleXMLElement',
             Settings::getLibXmlLoaderOptions()
         );
+        if (!($xml instanceof \SimpleXMLElement)) {
+            throw new Exception('SimpleXMLElement can not load ' .$pFilename);
+        }
         $namespaces = $xml->getNamespaces(true);
 
         $xml_ss = $xml->children($namespaces['ss']);
@@ -167,6 +170,9 @@ class Xml extends BaseReader implements IReader
             'SimpleXMLElement',
             Settings::getLibXmlLoaderOptions()
         );
+        if (!($xml instanceof \SimpleXMLElement)) {
+            throw new Exception('SimpleXMLElement can not load ' .$pFilename);
+        }
         $namespaces = $xml->getNamespaces(true);
 
         $worksheetID = 1;
@@ -344,6 +350,9 @@ class Xml extends BaseReader implements IReader
             'SimpleXMLElement',
             Settings::getLibXmlLoaderOptions()
         );
+        if (!($xml instanceof \SimpleXMLElement)) {
+            throw new Exception('SimpleXMLElement can not load ' .$pFilename);
+        }
         $namespaces = $xml->getNamespaces(true);
 
         $docProps = $spreadsheet->getProperties();

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -138,7 +138,7 @@ class Xml extends BaseReader implements IReader
             'SimpleXMLElement',
             Settings::getLibXmlLoaderOptions()
         );
-        if (!($xml instanceof \SimpleXMLElement)) {
+        if ($xml === false) {
             throw new Exception('SimpleXMLElement can not load ' . $pFilename);
         }
         $namespaces = $xml->getNamespaces(true);
@@ -170,7 +170,7 @@ class Xml extends BaseReader implements IReader
             'SimpleXMLElement',
             Settings::getLibXmlLoaderOptions()
         );
-        if (!($xml instanceof \SimpleXMLElement)) {
+        if ($xml === false) {
             throw new Exception('SimpleXMLElement can not load ' . $pFilename);
         }
         $namespaces = $xml->getNamespaces(true);
@@ -350,7 +350,7 @@ class Xml extends BaseReader implements IReader
             'SimpleXMLElement',
             Settings::getLibXmlLoaderOptions()
         );
-        if (!($xml instanceof \SimpleXMLElement)) {
+        if ($xml === false) {
             throw new Exception('SimpleXMLElement can not load ' . $pFilename);
         }
         $namespaces = $xml->getNamespaces(true);

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -5,7 +5,6 @@ namespace PhpOffice\PhpSpreadsheet\Reader;
 use DateTimeZone;
 use PhpOffice\PhpSpreadsheet\Cell;
 use PhpOffice\PhpSpreadsheet\Document\Properties;
-use PhpOffice\PhpSpreadsheet\Reader\Exception;
 use PhpOffice\PhpSpreadsheet\RichText;
 use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
@@ -120,6 +119,7 @@ class Xml extends BaseReader implements IReader
 
     /**
      * Check if the file is a valid SimpleXML.
+     * 
      * @param $pFilename
      *
      * @throws Exception
@@ -128,7 +128,7 @@ class Xml extends BaseReader implements IReader
      */
     public function trySimpleXMLLoadString($pFilename)
     {
-        try{
+        try {
             $xml = simplexml_load_string(
                 $this->securityScan(file_get_contents($pFilename)),
                 'SimpleXMLElement',
@@ -137,6 +137,7 @@ class Xml extends BaseReader implements IReader
         } catch (\Exception $e) {
             throw new Exception($pFilename . ' -> ' . $e->getMessage());
         }
+
         return $xml;
     }
 

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -120,11 +120,11 @@ class Xml extends BaseReader implements IReader
     /**
      * Check if the file is a valid SimpleXML.
      *
-     * @param $pFilename
+     * @param string $pFilename
      *
      * @throws Exception
      *
-     * @return \SimpleXMLElement or false
+     * @return false|\SimpleXMLElement
      */
     public function trySimpleXMLLoadString($pFilename)
     {
@@ -135,7 +135,7 @@ class Xml extends BaseReader implements IReader
                 Settings::getLibXmlLoaderOptions()
             );
         } catch (\Exception $e) {
-            throw new Exception($pFilename . ' -> ' . $e->getMessage());
+            throw new Exception('Cannot load invalid XML file: ' . $pFilename, 0, $e);
         }
 
         return $xml;

--- a/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
@@ -3,8 +3,8 @@
 namespace PhpOffice\PhpSpreadsheetTests\Reader;
 
 use PhpOffice\PhpSpreadsheet\Reader\BaseReader;
-use PhpOffice\PhpSpreadsheet\Reader\Xml;
 use PhpOffice\PhpSpreadsheet\Reader\Exception;
+use PhpOffice\PhpSpreadsheet\Reader\Xml;
 use PHPUnit_Framework_TestCase;
 
 class XEEValidatorTest extends PHPUnit_Framework_TestCase

--- a/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
@@ -41,7 +41,6 @@ class XEEValidatorTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidSimpleXML($filename)
     {
-        $this->expectException(Exception::class);
         $xmlReader = new Xml();
         $xmlReader->trySimpleXMLLoadString($filename);
     }

--- a/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
@@ -3,6 +3,8 @@
 namespace PhpOffice\PhpSpreadsheetTests\Reader;
 
 use PhpOffice\PhpSpreadsheet\Reader\BaseReader;
+use PhpOffice\PhpSpreadsheet\Reader\Xml;
+use PhpOffice\PhpSpreadsheet\Reader\Exception;
 use PHPUnit_Framework_TestCase;
 
 class XEEValidatorTest extends PHPUnit_Framework_TestCase
@@ -24,7 +26,30 @@ class XEEValidatorTest extends PHPUnit_Framework_TestCase
     public function providerInvalidXML()
     {
         $tests = [];
-        foreach (glob(__DIR__ . '/../../data/Reader/XEE/XEETestInvalid*.xml') as $file) {
+        foreach (glob(__DIR__ . '/../../data/Reader/XEE/XEETestInvalidUTF*.xml') as $file) {
+            $tests[basename($file)] = [realpath($file)];
+        }
+
+        return $tests;
+    }
+
+    /**
+     * @dataProvider providerInvalidSimpleXML
+     * @expectedException \PhpOffice\PhpSpreadsheet\Reader\Exception
+     *
+     * @param $filename
+     */
+    public function testInvalidSimpleXML($filename)
+    {
+        $this->expectException(Exception::class);
+        $xmlReader = new Xml();
+        $xmlReader->trySimpleXMLLoadString($filename);
+    }
+
+    public function providerInvalidSimpleXML()
+    {
+        $tests = [];
+        foreach (glob(__DIR__ . '/../../data/Reader/XEE/XEETestInvalidSimpleXML*.xml') as $file) {
             $tests[basename($file)] = [realpath($file)];
         }
 

--- a/tests/data/Reader/XEE/XEETestInvalidSimpleXML.xml
+++ b/tests/data/Reader/XEE/XEETestInvalidSimpleXML.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<root>
+	<data>R&d</data>
+	<data>R<d</data>
+	<data>R>d</data>
+	<data>R'd</data>
+	<data>R"d</data>
+</root>


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

What does it change?
When the xml file get is not a standard xml file, the simplexml_load_string will return false, this will cause an error on "$xml->getNamespaces(true);" . So, instead of show the error, throw an exception may be better for it.