### PR TITLE
Added xml reader hyperlink support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Support for chart fill color - @CrazyBite [#158](https://github.com/PHPOffice/PhpSpreadsheet/pull/158)
+- Support for read Hyperlink for xml - [@GreatHumorist](https://github.com/GreatHumorist) [#223](https://github.com/PHPOffice/PhpSpreadsheet/pull/223)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Support for chart fill color - @CrazyBite [#158](https://github.com/PHPOffice/PhpSpreadsheet/pull/158)
-- Support for read Hyperlink for xml - [@GreatHumorist](https://github.com/GreatHumorist) [#223](https://github.com/PHPOffice/PhpSpreadsheet/pull/223)
 
 ### Changed
 

--- a/docs/references/features-cross-reference.md
+++ b/docs/references/features-cross-reference.md
@@ -1167,7 +1167,7 @@
 		<td style="padding-left: 1em;">Hyperlinks</td>
 		<td style="text-align: center; color: green;">✔</td>
 		<td style="text-align: center; color: green;">✔</td>
-		<td style="text-align: center; color: red;">✔</td>
+		<td style="text-align: center; color: green;">✔</td>
 		<td style="text-align: center; color: green;">✔</td>
 		<td style="text-align: center; color: red;">✖</td>
 		<td style="text-align: center; color: red;">✖</td>

--- a/docs/references/features-cross-reference.md
+++ b/docs/references/features-cross-reference.md
@@ -1167,7 +1167,7 @@
 		<td style="padding-left: 1em;">Hyperlinks</td>
 		<td style="text-align: center; color: green;">✔</td>
 		<td style="text-align: center; color: green;">✔</td>
-		<td style="text-align: center; color: red;">✖</td>
+		<td style="text-align: center; color: red;">✔</td>
 		<td style="text-align: center; color: green;">✔</td>
 		<td style="text-align: center; color: red;">✖</td>
 		<td style="text-align: center; color: red;">✖</td>

--- a/samples/templates/Excel2003XMLTest.xml
+++ b/samples/templates/Excel2003XMLTest.xml
@@ -549,7 +549,9 @@
                     <Data ss:Type="String">AE</Data>
                 </Cell>
                 <Cell ss:StyleID="ce5"/>
-                <Cell ss:StyleID="ce5"/>
+                <Cell ss:StyleID="ce5" ss:HRef="http://www.phpexcel.net/">
+                    <Data ss:Type="String">PHPExcel</Data>
+                </Cell>
                 <Cell ss:StyleID="ce5"/>
                 <Cell ss:StyleID="ce5"/>
                 <Cell ss:StyleID="ce5"/>

--- a/samples/templates/Excel2003XMLTest.xml
+++ b/samples/templates/Excel2003XMLTest.xml
@@ -549,9 +549,7 @@
                     <Data ss:Type="String">AE</Data>
                 </Cell>
                 <Cell ss:StyleID="ce5"/>
-                <Cell ss:StyleID="ce5" ss:HRef="http://www.phpexcel.net/">
-                    <Data ss:Type="String">PHPExcel</Data>
-                </Cell>
+                <Cell ss:StyleID="ce5"/>
                 <Cell ss:StyleID="ce5"/>
                 <Cell ss:StyleID="ce5"/>
                 <Cell ss:StyleID="ce5"/>

--- a/samples/templates/Excel2003XMLTest.xml
+++ b/samples/templates/Excel2003XMLTest.xml
@@ -549,8 +549,8 @@
                     <Data ss:Type="String">AE</Data>
                 </Cell>
                 <Cell ss:StyleID="ce5"/>
-                <Cell ss:StyleID="ce5" ss:HRef="http://www.phpexcel.net/">
-                    <Data ss:Type="String">PHPExcel</Data>
+                <Cell ss:StyleID="ce5" ss:HRef="http://phpspreadsheet.readthedocs.io/">
+                    <Data ss:Type="String">PhpSpreadsheet</Data>
                 </Cell>
                 <Cell ss:StyleID="ce5"/>
                 <Cell ss:StyleID="ce5"/>

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -595,6 +595,10 @@ class Xml extends BaseReader implements IReader
                             }
                         }
 
+                        if (isset($cell_ss['HRef'])) {
+                            $spreadsheet->getActiveSheet()->getCell($cellRange)->getHyperlink()->setUrl($cell_ss['HRef']);
+                        }
+                        
                         if ((isset($cell_ss['MergeAcross'])) || (isset($cell_ss['MergeDown']))) {
                             $columnTo = $columnID;
                             if (isset($cell_ss['MergeAcross'])) {

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -598,7 +598,7 @@ class Xml extends BaseReader implements IReader
                         if (isset($cell_ss['HRef'])) {
                             $spreadsheet->getActiveSheet()->getCell($cellRange)->getHyperlink()->setUrl($cell_ss['HRef']);
                         }
-                        
+
                         if ((isset($cell_ss['MergeAcross'])) || (isset($cell_ss['MergeDown']))) {
                             $columnTo = $columnID;
                             if (isset($cell_ss['MergeAcross'])) {

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -598,7 +598,7 @@ class Xml extends BaseReader implements IReader
                         if (isset($cell_ss['HRef'])) {
                             $spreadsheet->getActiveSheet()->getCell($cellRange)->getHyperlink()->setUrl($cell_ss['HRef']);
                         }
-
+                        
                         if ((isset($cell_ss['MergeAcross'])) || (isset($cell_ss['MergeDown']))) {
                             $columnTo = $columnID;
                             if (isset($cell_ss['MergeAcross'])) {

--- a/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
@@ -4,6 +4,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Reader;
 
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Reader\BaseReader;
+use PhpOffice\PhpSpreadsheet\Reader\Exception;
 use PhpOffice\PhpSpreadsheet\Reader\Xml;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit_Framework_TestCase;

--- a/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
@@ -4,7 +4,6 @@ namespace PhpOffice\PhpSpreadsheetTests\Reader;
 
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Reader\BaseReader;
-use PhpOffice\PhpSpreadsheet\Reader\Exception;
 use PhpOffice\PhpSpreadsheet\Reader\Xml;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit_Framework_TestCase;

--- a/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
@@ -2,11 +2,34 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Reader;
 
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Reader\BaseReader;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit_Framework_TestCase;
 
 class XEEValidatorTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Spreadsheet
+     */
+    private $spreadsheetXEETest;
+
+    /**
+     * @return Spreadsheet
+     */
+    protected function loadXEETestFile()
+    {
+        if (!$this->spreadsheetXEETest) {
+            $filename = __DIR__ . '/../../../samples/templates/Excel2003XMLTest.xml';
+
+            // Load into this instance
+            $reader = new Xml();
+            $this->spreadsheetXEETest = $reader->loadIntoExisting($filename, new Spreadsheet());
+        }
+
+        return $this->spreadsheetXEETest;
+    }
+
     /**
      * @dataProvider providerInvalidXML
      * @expectedException \PhpOffice\PhpSpreadsheet\Reader\Exception
@@ -52,5 +75,20 @@ class XEEValidatorTest extends PHPUnit_Framework_TestCase
         }
 
         return $tests;
+    }
+
+    /**
+     * Check if it can read XML Hyperlink correctly.
+     */
+    public function testReadHyperlinks()
+    {
+        $spreadsheet = $this->loadXEETestFile();
+        $firstSheet = $spreadsheet->getSheet(0);
+
+        $hyperlink = $firstSheet->getCell('L1');
+
+        $this->assertEquals(DataType::TYPE_STRING, $hyperlink->getDataType());
+        $this->assertEquals('PHPExcel', $hyperlink->getValue());
+        $this->assertEquals('http://www.phpexcel.net/', $hyperlink->getHyperlink()->getUrl());
     }
 }

--- a/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
@@ -2,35 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Reader;
 
-use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Reader\BaseReader;
-use PhpOffice\PhpSpreadsheet\Reader\Xml;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit_Framework_TestCase;
 
 class XEEValidatorTest extends PHPUnit_Framework_TestCase
 {
-    /**
-     * @var Spreadsheet
-     */
-    private $spreadsheetXEETest;
-
-    /**
-     * @return Spreadsheet
-     */
-    protected function loadXEETestFile()
-    {
-        if (!$this->spreadsheetXEETest) {
-            $filename = __DIR__ . '/../../../samples/templates/Excel2003XMLTest.xml';
-
-            // Load into this instance
-            $reader = new Xml();
-            $this->spreadsheetXEETest = $reader->loadIntoExisting($filename, new Spreadsheet());
-        }
-
-        return $this->spreadsheetXEETest;
-    }
-
     /**
      * @dataProvider providerInvalidXML
      * @expectedException \PhpOffice\PhpSpreadsheet\Reader\Exception
@@ -76,20 +52,5 @@ class XEEValidatorTest extends PHPUnit_Framework_TestCase
         }
 
         return $tests;
-    }
-
-    /**
-     * Check if it can read XML Hyperlink correctly.
-     */
-    public function testReadHyperlinks()
-    {
-        $spreadsheet = $this->loadXEETestFile();
-        $firstSheet = $spreadsheet->getSheet(0);
-
-        $hyperlink = $firstSheet->getCell('L1');
-
-        $this->assertEquals(DataType::TYPE_STRING, $hyperlink->getDataType());
-        $this->assertEquals('PHPExcel', $hyperlink->getValue());
-        $this->assertEquals('http://www.phpexcel.net/', $hyperlink->getHyperlink()->getUrl());
     }
 }

--- a/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
@@ -4,6 +4,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Reader;
 
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Reader\BaseReader;
+use PhpOffice\PhpSpreadsheet\Reader\Xml;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit_Framework_TestCase;
 
@@ -20,11 +21,11 @@ class XEEValidatorTest extends PHPUnit_Framework_TestCase
     protected function loadXEETestFile()
     {
         if (!$this->spreadsheetXEETest) {
-            $filename = __DIR__ . '/../../../samples/templates/Excel2003XMLTest.xml';
+            $filename = '../samples/templates/Excel2003XMLTest.xml';
 
             // Load into this instance
             $reader = new Xml();
-            $this->spreadsheetXEETest = $reader->loadIntoExisting($filename, new Spreadsheet());
+            $this->spreadsheetXEETest = $reader->load($filename);
         }
 
         return $this->spreadsheetXEETest;
@@ -88,7 +89,7 @@ class XEEValidatorTest extends PHPUnit_Framework_TestCase
         $hyperlink = $firstSheet->getCell('L1');
 
         $this->assertEquals(DataType::TYPE_STRING, $hyperlink->getDataType());
-        $this->assertEquals('PHPExcel', $hyperlink->getValue());
-        $this->assertEquals('http://www.phpexcel.net/', $hyperlink->getHyperlink()->getUrl());
+        $this->assertEquals('PhpSpreadsheet', $hyperlink->getValue());
+        $this->assertEquals('http://phpspreadsheet.readthedocs.io/', $hyperlink->getHyperlink()->getUrl());
     }
 }

--- a/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
@@ -2,11 +2,35 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Reader;
 
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Reader\BaseReader;
+use PhpOffice\PhpSpreadsheet\Reader\Xml;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit_Framework_TestCase;
 
 class XEEValidatorTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Spreadsheet
+     */
+    private $spreadsheetXEETest;
+
+    /**
+     * @return Spreadsheet
+     */
+    protected function loadXEETestFile()
+    {
+        if (!$this->spreadsheetXEETest) {
+            $filename = __DIR__ . '/../../../samples/templates/Excel2003XMLTest.xml';
+
+            // Load into this instance
+            $reader = new Xml();
+            $this->spreadsheetXEETest = $reader->loadIntoExisting($filename, new Spreadsheet());
+        }
+
+        return $this->spreadsheetXEETest;
+    }
+
     /**
      * @dataProvider providerInvalidXML
      * @expectedException \PhpOffice\PhpSpreadsheet\Reader\Exception
@@ -52,5 +76,20 @@ class XEEValidatorTest extends PHPUnit_Framework_TestCase
         }
 
         return $tests;
+    }
+
+    /**
+     * Check if it can read XML Hyperlink correctly.
+     */
+    public function testReadHyperlinks()
+    {
+        $spreadsheet = $this->loadXEETestFile();
+        $firstSheet = $spreadsheet->getSheet(0);
+
+        $hyperlink = $firstSheet->getCell('L1');
+
+        $this->assertEquals(DataType::TYPE_STRING, $hyperlink->getDataType());
+        $this->assertEquals('PHPExcel', $hyperlink->getValue());
+        $this->assertEquals('http://www.phpexcel.net/', $hyperlink->getHyperlink()->getUrl());
     }
 }


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [x] a new feature

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

What does it change?
Add XML Reader hyperlink support so that we can use link for the cell.