### PR TITLE
Fixed #201 when no 'r' attribute in node c in xlsx's xml

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -848,6 +848,7 @@ class Xlsx extends BaseReader implements IReader
                             }
 
                             if ($xmlSheet && $xmlSheet->sheetData && $xmlSheet->sheetData->row) {
+                                $cIndex = 1; // Cell Start from 1
                                 foreach ($xmlSheet->sheetData->row as $row) {
                                     if ($row['ht'] && !$this->readDataOnly) {
                                         $docSheet->getRowDimension((int) ($row['r']))->setRowHeight((float) ($row['ht']));
@@ -864,9 +865,13 @@ class Xlsx extends BaseReader implements IReader
                                     if ($row['s'] && !$this->readDataOnly) {
                                         $docSheet->getRowDimension((int) ($row['r']))->setXfIndex((int) ($row['s']));
                                     }
-
+                                    
+                                    $rowIndex = 0; // Start form zero because Cell::stringFromColumnIndex start from A default, actually is 1
                                     foreach ($row->c as $c) {
                                         $r = (string) $c['r'];
+                                        if ($r == '') {
+                                            $r = Cell::stringFromColumnIndex($rowIndex) . $cIndex;
+                                        }
                                         $cellDataType = (string) $c['t'];
                                         $value = null;
                                         $calculatedValue = null;
@@ -963,7 +968,9 @@ class Xlsx extends BaseReader implements IReader
                                             $cell->setXfIndex(isset($styles[(int) ($c['s'])]) ?
                                                 (int) ($c['s']) : 0);
                                         }
+                                        $rowIndex += 1;
                                     }
+                                    $cIndex += 1;
                                 }
                             }
 

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -864,8 +864,7 @@ class Xlsx extends BaseReader implements IReader
                                     }
                                     if ($row['s'] && !$this->readDataOnly) {
                                         $docSheet->getRowDimension((int) ($row['r']))->setXfIndex((int) ($row['s']));
-                                    }
-                                    
+                                    }     
                                     $rowIndex = 0; // Start form zero because Cell::stringFromColumnIndex start from A default, actually is 1
                                     foreach ($row->c as $c) {
                                         $r = (string) $c['r'];


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?
Fixed #201 when no 'r' attribute in node c in xlsx's xml