### PR TITLE
fix return format of INDEX() function

### DIFF
--- a/src/PhpSpreadsheet/Calculation/DateTime.php
+++ b/src/PhpSpreadsheet/Calculation/DateTime.php
@@ -1147,7 +1147,7 @@ class DateTime
             $dateValue = 1;
         } elseif (is_string($dateValue = self::getDateValue($dateValue))) {
             return Functions::VALUE();
-        } elseif ($dateValue == 0.0) {
+        } elseif ($dateValue < 1.0) {
             return 0;
         } elseif ($dateValue < 0.0) {
             return Functions::NAN();

--- a/src/PhpSpreadsheet/Calculation/DateTime.php
+++ b/src/PhpSpreadsheet/Calculation/DateTime.php
@@ -1149,15 +1149,15 @@ class DateTime
             return Functions::VALUE();
         }
 
-		if (Functions::getCompatibilityMode() == Functions::COMPATIBILITY_EXCEL) {
-			if ($dateValue < 1.0) {
-				return 0;
-			} elseif ($dateValue < 0.0) {
-				return Functions::NAN();
-			}
-		}
+        if (Functions::getCompatibilityMode() == Functions::COMPATIBILITY_EXCEL) {
+            if ($dateValue < 1.0) {
+                return 0;
+            } elseif ($dateValue < 0.0) {
+                return Functions::NAN();
+            }
+        }
 
-		// Execute function
+        // Execute function
         $PHPDateObject = Date::excelToDateTimeObject($dateValue);
 
         return (int) $PHPDateObject->format('j');

--- a/src/PhpSpreadsheet/Calculation/DateTime.php
+++ b/src/PhpSpreadsheet/Calculation/DateTime.php
@@ -1147,13 +1147,17 @@ class DateTime
             $dateValue = 1;
         } elseif (is_string($dateValue = self::getDateValue($dateValue))) {
             return Functions::VALUE();
-        } elseif ($dateValue < 1.0) {
-            return 0;
-        } elseif ($dateValue < 0.0) {
-            return Functions::NAN();
         }
 
-        // Execute function
+		if (Functions::getCompatibilityMode() == Functions::COMPATIBILITY_EXCEL) {
+			if ($dateValue < 1.0) {
+				return 0;
+			} elseif ($dateValue < 0.0) {
+				return Functions::NAN();
+			}
+		}
+
+		// Execute function
         $PHPDateObject = Date::excelToDateTimeObject($dateValue);
 
         return (int) $PHPDateObject->format('j');

--- a/src/PhpSpreadsheet/Calculation/LookupRef.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef.php
@@ -647,7 +647,7 @@ class LookupRef
                     if (isset($arrayColumn[$rowNum])) {
                         $returnArray[] = $arrayColumn[$rowNum];
                     } else {
-                        return $arrayValues[$rowNum];
+                        return array( $rowNum => $arrayValues[$rowNum] );
                     }
                 } else {
                     return $arrayValues[$rowNum];

--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -186,23 +186,22 @@ class Date
     public static function excelToDateTimeObject($excelTimestamp, $timeZone = null)
     {
         $timeZone = ($timeZone === null) ? self::getDefaultTimezone() : self::validateTimeZone($timeZone);
-		if (Functions::getCompatibilityMode() == Functions::COMPATIBILITY_EXCEL) {
-			if ($excelTimestamp < 1.0) {
-				// Unix timestamp base date
-				$baseDate = new \DateTime('1970-01-01', $timeZone);
-			} else {
-				// MS Excel calendar base dates
-				if (self::$excelCalendar == self::CALENDAR_WINDOWS_1900) {
-					// Allow adjustment for 1900 Leap Year in MS Excel
-					$baseDate = ($excelTimestamp < 60) ? new \DateTime('1899-12-31', $timeZone) : new \DateTime('1899-12-30', $timeZone);
-				} else {
-					$baseDate = new \DateTime('1904-01-01', $timeZone);
-				}
-			}
-		}
-		else {
-			$baseDate = new \DateTime('1899-12-30', $timeZone);
-		}
+        if (Functions::getCompatibilityMode() == Functions::COMPATIBILITY_EXCEL) {
+            if ($excelTimestamp < 1.0) {
+                // Unix timestamp base date
+                $baseDate = new \DateTime('1970-01-01', $timeZone);
+            } else {
+                // MS Excel calendar base dates
+                if (self::$excelCalendar == self::CALENDAR_WINDOWS_1900) {
+                    // Allow adjustment for 1900 Leap Year in MS Excel
+                    $baseDate = ($excelTimestamp < 60) ? new \DateTime('1899-12-31', $timeZone) : new \DateTime('1899-12-30', $timeZone);
+                } else {
+                    $baseDate = new \DateTime('1904-01-01', $timeZone);
+                }
+            }
+        } else {
+            $baseDate = new \DateTime('1899-12-30', $timeZone);
+        }
 
         $days = floor($excelTimestamp);
         $partDay = $excelTimestamp - $days;
@@ -212,9 +211,9 @@ class Date
         $partDay = $partDay * 60 - $minutes;
         $seconds = round($partDay * 60);
 
-		if ($days >= 0) {
-	        $days = '+' . $days;
-		}
+        if ($days >= 0) {
+            $days = '+' . $days;
+        }
         $interval = $days . ' days';
 
         return $baseDate->modify($interval)

--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -213,7 +213,7 @@ class Date
         $seconds = round($partDay * 60);
 
 		if ($days >= 0) {
-	        $interval = '+' . $days;
+	        $days = '+' . $days;
 		}
         $interval = $days . ' days';
 


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?
  INDEX(...) in result lost row index => users got errors:
```
Calculation.php: dataTestReference() at 3417
 array_keys() expects parameter 1 to be array, float given
Calculation.php: getMatrixDimensions() at 2824
 count(): Parameter must be an array or an object that implements Countable
```