### PR TITLE
Temporary directory is passed to mPDF

### DIFF
--- a/src/PhpSpreadsheet/Helper/Sample.php
+++ b/src/PhpSpreadsheet/Helper/Sample.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheet\Helper;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\IWriter;
+use PhpOffice\PhpSpreadsheet\Writer\Pdf;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RecursiveRegexIterator;
@@ -118,6 +119,11 @@ class Sample
         foreach ($writers as $writerType) {
             $path = $this->getFilename($filename, mb_strtolower($writerType));
             $writer = IOFactory::createWriter($spreadsheet, $writerType);
+            if ($writer instanceof Pdf) {
+                // PDF writer needs temporary directory
+                $tempDir = $this->getTemporaryFolder();
+                $writer->setTempDir($tempDir);
+            }
             $callStartTime = microtime(true);
             $writer->save($path);
             $this->logWrite($writer, $path, $callStartTime);

--- a/src/PhpSpreadsheet/Writer/Pdf/MPDF.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/MPDF.php
@@ -55,7 +55,8 @@ class MPDF extends Core implements IWriter
         }
 
         //  Create PDF
-        $pdf = new \Mpdf\Mpdf();
+        $config = ['tempDir' => $this->tempDir];
+        $pdf = new \Mpdf\Mpdf($config);
         $ortmp = $orientation;
         $pdf->_setPageSize(strtoupper($paperSize), $ortmp);
         $pdf->DefOrientation = $orientation;


### PR DESCRIPTION
This is:

- [X] a bugfix
- [ ] a new feature

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?
Temporary directory set to PDF writer is passed to mPDF object in constructor.
mPDF 7.0 changed temporary directory configuration from constant to constructor parameter.
Without this change it is not possible to change default temporary directory.
See: https://mpdf.github.io/installation-setup/folders-for-temporary-files.html