### PR TITLE
setSize fix

### DIFF
--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -257,9 +257,9 @@ class Font extends Supervisor implements IComparable
      *
      * @return Font
      */
-    public function setSize($pValue)
+    public function setSize(float $pValue = null)
     {
-        if ($pValue == '') {
+        if ($pValue === null) {
             $pValue = 10;
         }
         if ($this->isSupervisor) {


### PR DESCRIPTION
setSize is allowing any type of value
setSize should only allow int or float
Added float `type hinting` for setSize.

In this case if user inputs (`24 pt`) will get a notice.
`Notice: A non well formed numeric value encountered in ../myproject/vendor/phpoffice/phpspreadsheet/src/PhpSpreadsheet/Style/Font.php on line 261`
This will set the size 24. And will not generate a corrupt excel workbook.

> Note: if migrating to PHP `>7.0` return type `: float` can also be added to `getSize()` method

This is:

- [x] a bugfix
- [x] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?
