### PR TITLE
allow to use customized pdf library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support for chart fill color - @CrazyBite [#158](https://github.com/PHPOffice/PhpSpreadsheet/pull/158)
 - Support for read Hyperlink for xml - [@GreatHumorist](https://github.com/GreatHumorist) [#223](https://github.com/PHPOffice/PhpSpreadsheet/pull/223)
+- Support for easer use extended classes of PDF libraries - [#266](https://github.com/PHPOffice/PhpSpreadsheet/pull/266)
 
 ### Changed
 
@@ -31,12 +32,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Easier usage of chart renderers, see the [migration guide](./docs/topics/migration-from-PHPExcel.md).
 - Rename a few more classes to keep them in their related namespaces:
     - `CalcEngine` => `Calculation\Engine`
-    - `PhpSpreadsheet\Calculation` => `PhpSpreadsheet\Calculation\Calculation` 
-    - `PhpSpreadsheet\Cell` => `PhpSpreadsheet\Cell\Cell` 
-    - `PhpSpreadsheet\Chart` => `PhpSpreadsheet\Chart\Chart` 
-    - `PhpSpreadsheet\RichText` => `PhpSpreadsheet\RichText\RichText` 
-    - `PhpSpreadsheet\Style` => `PhpSpreadsheet\Style\Style` 
-    - `PhpSpreadsheet\Worksheet` => `PhpSpreadsheet\Worksheet\Worksheet` 
+    - `PhpSpreadsheet\Calculation` => `PhpSpreadsheet\Calculation\Calculation`
+    - `PhpSpreadsheet\Cell` => `PhpSpreadsheet\Cell\Cell`
+    - `PhpSpreadsheet\Chart` => `PhpSpreadsheet\Chart\Chart`
+    - `PhpSpreadsheet\RichText` => `PhpSpreadsheet\RichText\RichText`
+    - `PhpSpreadsheet\Style` => `PhpSpreadsheet\Style\Style`
+    - `PhpSpreadsheet\Worksheet` => `PhpSpreadsheet\Worksheet\Worksheet`
 
 ## [1.0.0-beta] - 2017-08-17
 

--- a/docs/topics/reading-and-writing-to-file.md
+++ b/docs/topics/reading-and-writing-to-file.md
@@ -779,6 +779,25 @@ Or you can instantiate directly the writer of your choice like so:
 $writer = \PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf($spreadsheet);
 ```
 
+You can also use extended classes, based on supported libraries:
+
+``` php
+class MY_TCPDF extends TCPDF
+{
+	// ...
+}
+
+class MY_TCPDF_WRITER extends \PhpOffice\PhpSpreadsheet\Writer\Pdf\Tcpdf implements \PhpOffice\PhpSpreadsheet\Writer\IWriter
+{
+	protected function createExternalWriterInstance($orientation, $unit, $paperSize)
+	{
+		return new MY_TCPDF($orientation, $unit, $paperSize);
+	}
+}
+
+\PhpOffice\PhpSpreadsheet\IOFactory::registerWriter('Pdf', MY_TCPDF_WRITER::class);
+```
+
 #### Writing a spreadsheet
 
 Once you have identified the Renderer that you wish to use for PDF

--- a/src/PhpSpreadsheet/Writer/Pdf/Dompdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Dompdf.php
@@ -11,11 +11,9 @@ class Dompdf extends Pdf implements IWriter
     /**
      * Gets the implementation of external PDF library that should be used.
      *
-     * @param array $config Configuration array
-     *
-     * @return Dompdf implementation
+     * @return \Dompdf\Dompdf implementation
      */
-    protected function getExternalWriter()
+    protected function createExternalWriterInstance()
     {
         return new \Dompdf\Dompdf();
     }
@@ -63,7 +61,7 @@ class Dompdf extends Pdf implements IWriter
         }
 
         //  Create PDF
-        $pdf = $this->getExternalWriter();
+        $pdf = $this->createExternalWriterInstance();
         $pdf->setPaper(strtolower($paperSize), $orientation);
 
         $pdf->loadHtml(

--- a/src/PhpSpreadsheet/Writer/Pdf/Dompdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Dompdf.php
@@ -9,6 +9,18 @@ use PhpOffice\PhpSpreadsheet\Writer\Pdf;
 class Dompdf extends Pdf implements IWriter
 {
     /**
+     * Gets the implementation of external PDF library that should be used.
+     *
+     * @param array $config Configuration array
+     *
+     * @return Dompdf implementation
+     */
+    protected function getExternalWriter()
+    {
+        return new \Dompdf\Dompdf();
+    }
+
+    /**
      * Save Spreadsheet to file.
      *
      * @param string $pFilename Name of the file to save as
@@ -51,7 +63,7 @@ class Dompdf extends Pdf implements IWriter
         }
 
         //  Create PDF
-        $pdf = new \Dompdf\Dompdf();
+        $pdf = $this->getExternalWriter();
         $pdf->setPaper(strtolower($paperSize), $orientation);
 
         $pdf->loadHtml(

--- a/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
@@ -14,9 +14,9 @@ class Mpdf extends Pdf implements IWriter
      *
      * @param array $config Configuration array
      *
-     * @return Mpdf implementation
+     * @return \Mpdf\Mpdf implementation
      */
-    protected function getExternalWriter($config)
+    protected function createExternalWriterInstance($config)
     {
         return new \Mpdf\Mpdf($config);
     }
@@ -67,7 +67,7 @@ class Mpdf extends Pdf implements IWriter
 
         //  Create PDF
         $config = ['tempDir' => $this->tempDir];
-        $pdf = $this->getExternalWriter($config);
+        $pdf = $this->createExternalWriterInstance($config);
         $ortmp = $orientation;
         $pdf->_setPageSize(strtoupper($paperSize), $ortmp);
         $pdf->DefOrientation = $orientation;

--- a/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
@@ -10,6 +10,18 @@ use PhpOffice\PhpSpreadsheet\Writer\Pdf;
 class Mpdf extends Pdf implements IWriter
 {
     /**
+     * Gets the implementation of external PDF library that should be used.
+     *
+     * @param array $config Configuration array
+     *
+     * @return Mpdf implementation
+     */
+    protected function getExternalWriter($config)
+    {
+        return new \Mpdf\Mpdf($config);
+    }
+
+    /**
      * Save Spreadsheet to file.
      *
      * @param string $pFilename Name of the file to save as
@@ -55,7 +67,7 @@ class Mpdf extends Pdf implements IWriter
 
         //  Create PDF
         $config = ['tempDir' => $this->tempDir];
-        $pdf = new \Mpdf\Mpdf($config);
+        $pdf = $this->getExternalWriter($config);
         $ortmp = $orientation;
         $pdf->_setPageSize(strtoupper($paperSize), $ortmp);
         $pdf->DefOrientation = $orientation;

--- a/src/PhpSpreadsheet/Writer/Pdf/Tcpdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Tcpdf.php
@@ -9,6 +9,20 @@ use PhpOffice\PhpSpreadsheet\Writer\Pdf;
 class Tcpdf extends Pdf implements IWriter
 {
     /**
+     * Gets the implementation of external PDF library that should be used.
+     *
+     * @param string $orientation Page orientation
+     * @param string $unit Unit measure
+     * @param string $paperSize Paper size
+     *
+     * @return TCPDF implementation
+     */
+    protected function getExternalWriter($orientation, $unit, $paperSize)
+    {
+        return new \TCPDF($orientation, $unit, $paperSize);
+    }
+
+    /**
      * Save Spreadsheet to file.
      *
      * @param string $pFilename Name of the file to save as
@@ -51,7 +65,7 @@ class Tcpdf extends Pdf implements IWriter
         }
 
         //  Create PDF
-        $pdf = new \TCPDF($orientation, 'pt', $paperSize);
+        $pdf = $this->getExternalWriter($orientation, 'pt', $paperSize);
         $pdf->setFontSubsetting(false);
         //    Set margins, converting inches to points (using 72 dpi)
         $pdf->SetMargins($printMargins->getLeft() * 72, $printMargins->getTop() * 72, $printMargins->getRight() * 72);

--- a/src/PhpSpreadsheet/Writer/Pdf/Tcpdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Tcpdf.php
@@ -17,7 +17,7 @@ class Tcpdf extends Pdf implements IWriter
      *
      * @return TCPDF implementation
      */
-    protected function getExternalWriter($orientation, $unit, $paperSize)
+    protected function createExternalWriterInstance($orientation, $unit, $paperSize)
     {
         return new \TCPDF($orientation, $unit, $paperSize);
     }
@@ -65,7 +65,7 @@ class Tcpdf extends Pdf implements IWriter
         }
 
         //  Create PDF
-        $pdf = $this->getExternalWriter($orientation, 'pt', $paperSize);
+        $pdf = $this->createExternalWriterInstance($orientation, 'pt', $paperSize);
         $pdf->setFontSubsetting(false);
         //    Set margins, converting inches to points (using 72 dpi)
         $pdf->SetMargins($printMargins->getLeft() * 72, $printMargins->getTop() * 72, $printMargins->getRight() * 72);


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [x] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?
  Allow to use customized PDF library without rewriting save() method.
  Customized PDF libray sample: https://tcpdf.org/examples/example_003/