### PR TITLE
Use getFromName instead of getFromIndex and locateName

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -308,13 +308,9 @@ class Xlsx extends BaseReader
         //    so we need to load case-insensitively from the zip file
 
         // Apache POI fixes
-        $contents = $archive->getFromIndex(
-            $archive->locateName($fileName, ZipArchive::FL_NOCASE)
-        );
+        $contents = $archive->getFromName($fileName, 0, ZipArchive::FL_NOCASE);
         if ($contents === false) {
-            $contents = $archive->getFromIndex(
-                $archive->locateName(substr($fileName, 1), ZipArchive::FL_NOCASE)
-            );
+            $contents = $archive->getFromName(substr($fileName, 1), 0, ZipArchive::FL_NOCASE);
         }
 
         return $contents;


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

What does it change?

Fixes #262. Let me know if you need me to check more of the above boxes.