### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -4,9 +4,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CalculationTest extends PHPUnit_Framework_TestCase
+class CalculationTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/PhpSpreadsheetTests/Calculation/DateTimeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/DateTimeTest.php
@@ -5,12 +5,12 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class DateTimeTest.
  */
-class DateTimeTest extends PHPUnit_Framework_TestCase
+class DateTimeTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/PhpSpreadsheetTests/Calculation/EngineeringTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/EngineeringTest.php
@@ -5,9 +5,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class EngineeringTest extends PHPUnit_Framework_TestCase
+class EngineeringTest extends TestCase
 {
     /**
      * @var ComplexAssert

--- a/tests/PhpSpreadsheetTests/Calculation/FinancialTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/FinancialTest.php
@@ -4,9 +4,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Financial;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class FinancialTest extends PHPUnit_Framework_TestCase
+class FinancialTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/PhpSpreadsheetTests/Calculation/FunctionsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/FunctionsTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class FunctionsTest extends PHPUnit_Framework_TestCase
+class FunctionsTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/PhpSpreadsheetTests/Calculation/LogicalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/LogicalTest.php
@@ -4,9 +4,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\Logical;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class LogicalTest extends PHPUnit_Framework_TestCase
+class LogicalTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/PhpSpreadsheetTests/Calculation/LookupRefTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/LookupRefTest.php
@@ -4,12 +4,12 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\LookupRef;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class LookupRefTest.
  */
-class LookupRefTest extends PHPUnit_Framework_TestCase
+class LookupRefTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/PhpSpreadsheetTests/Calculation/MathTrigTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/MathTrigTest.php
@@ -5,9 +5,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\MathTrig;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class MathTrigTest extends PHPUnit_Framework_TestCase
+class MathTrigTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/PhpSpreadsheetTests/Calculation/TextDataTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/TextDataTest.php
@@ -6,9 +6,9 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class TextDataTest extends PHPUnit_Framework_TestCase
+class TextDataTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
@@ -9,9 +9,9 @@ use PhpOffice\PhpSpreadsheet\Collection\Cells;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class AdvancedValueBinderTest extends PHPUnit_Framework_TestCase
+class AdvancedValueBinderTest extends TestCase
 {
     public function provider()
     {

--- a/tests/PhpSpreadsheetTests/Cell/CellTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CellTest.php
@@ -4,9 +4,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Cell;
 
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CellTest extends PHPUnit_Framework_TestCase
+class CellTest extends TestCase
 {
     /**
      * @dataProvider providerColumnString

--- a/tests/PhpSpreadsheetTests/Cell/DataTypeTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/DataTypeTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Cell;
 
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class DataTypeTest extends PHPUnit_Framework_TestCase
+class DataTypeTest extends TestCase
 {
     public function testGetErrorCodes()
     {

--- a/tests/PhpSpreadsheetTests/Cell/DataValidatorTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/DataValidatorTest.php
@@ -4,9 +4,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Cell;
 
 use PhpOffice\PhpSpreadsheet\Cell\DataValidation;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class DataValidatorTest extends PHPUnit_Framework_TestCase
+class DataValidatorTest extends TestCase
 {
     public function testNoValidation()
     {

--- a/tests/PhpSpreadsheetTests/Cell/DefaultValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/DefaultValueBinderTest.php
@@ -7,9 +7,9 @@ use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class DefaultValueBinderTest extends PHPUnit_Framework_TestCase
+class DefaultValueBinderTest extends TestCase
 {
     protected $cellStub;
 

--- a/tests/PhpSpreadsheetTests/Cell/HyperlinkTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/HyperlinkTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Cell;
 
 use PhpOffice\PhpSpreadsheet\Cell\Hyperlink;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class HyperlinkTest extends PHPUnit_Framework_TestCase
+class HyperlinkTest extends TestCase
 {
     public function testGetUrl()
     {

--- a/tests/PhpSpreadsheetTests/Chart/DataSeriesValuesTest.php
+++ b/tests/PhpSpreadsheetTests/Chart/DataSeriesValuesTest.php
@@ -4,9 +4,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Chart;
 
 use PhpOffice\PhpSpreadsheet\Chart\DataSeriesValues;
 use PhpOffice\PhpSpreadsheet\Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class DataSeriesValuesTest extends PHPUnit_Framework_TestCase
+class DataSeriesValuesTest extends TestCase
 {
     public function testSetDataType()
     {

--- a/tests/PhpSpreadsheetTests/Chart/LayoutTest.php
+++ b/tests/PhpSpreadsheetTests/Chart/LayoutTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Chart;
 
 use PhpOffice\PhpSpreadsheet\Chart\Layout;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class LayoutTest extends PHPUnit_Framework_TestCase
+class LayoutTest extends TestCase
 {
     public function testSetLayoutTarget()
     {

--- a/tests/PhpSpreadsheetTests/Chart/LegendTest.php
+++ b/tests/PhpSpreadsheetTests/Chart/LegendTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Chart;
 
 use PhpOffice\PhpSpreadsheet\Chart\Legend;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class LegendTest extends PHPUnit_Framework_TestCase
+class LegendTest extends TestCase
 {
     public function testSetPosition()
     {

--- a/tests/PhpSpreadsheetTests/Collection/CellsTest.php
+++ b/tests/PhpSpreadsheetTests/Collection/CellsTest.php
@@ -7,9 +7,9 @@ use PhpOffice\PhpSpreadsheet\Collection\Cells;
 use PhpOffice\PhpSpreadsheet\Collection\Memory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CellsTest extends PHPUnit_Framework_TestCase
+class CellsTest extends TestCase
 {
     public function testCollectionCell()
     {

--- a/tests/PhpSpreadsheetTests/Helper/MigratorTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/MigratorTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Helper;
 
 use PhpOffice\PhpSpreadsheet\Helper\Migrator;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class MigratorTest extends PHPUnit_Framework_TestCase
+class MigratorTest extends TestCase
 {
     public function testMappingOnlyContainExistingClasses()
     {

--- a/tests/PhpSpreadsheetTests/Helper/SampleTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/SampleTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Sample;
 
 use PhpOffice\PhpSpreadsheet\Helper\Sample;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class SampleTest extends PHPUnit_Framework_TestCase
+class SampleTest extends TestCase
 {
     /**
      * @runInSeparateProcess

--- a/tests/PhpSpreadsheetTests/IOFactoryTest.php
+++ b/tests/PhpSpreadsheetTests/IOFactoryTest.php
@@ -6,9 +6,9 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IOFactoryTest extends PHPUnit_Framework_TestCase
+class IOFactoryTest extends TestCase
 {
     /**
      * @dataProvider providerCreateWriter

--- a/tests/PhpSpreadsheetTests/Reader/CsvTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/CsvTest.php
@@ -6,9 +6,9 @@ use PhpOffice\PhpSpreadsheet\Reader\Csv as ReaderCsv;
 use PhpOffice\PhpSpreadsheet\Shared\File;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Csv as WriterCsv;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CsvTest extends PHPUnit_Framework_TestCase
+class CsvTest extends TestCase
 {
     public function testEnclosure()
     {

--- a/tests/PhpSpreadsheetTests/Reader/HtmlTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/HtmlTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Reader;
 
 use PhpOffice\PhpSpreadsheet\Reader\Html;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class HtmlTest extends PHPUnit_Framework_TestCase
+class HtmlTest extends TestCase
 {
     public function testCsvWithAngleBracket()
     {

--- a/tests/PhpSpreadsheetTests/Reader/OdsTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/OdsTest.php
@@ -6,12 +6,12 @@ use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Reader\Ods;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Font;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @todo The class doesn't read the bold/italic/underline properties (rich text)
  */
-class OdsTest extends PHPUnit_Framework_TestCase
+class OdsTest extends TestCase
 {
     /**
      * @var Spreadsheet

--- a/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XEEValidatorTest.php
@@ -6,9 +6,9 @@ use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Reader\BaseReader;
 use PhpOffice\PhpSpreadsheet\Reader\Xml;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class XEEValidatorTest extends PHPUnit_Framework_TestCase
+class XEEValidatorTest extends TestCase
 {
     /**
      * @var Spreadsheet

--- a/tests/PhpSpreadsheetTests/Reader/XlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XlsxTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Reader;
 
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class XlsxTest extends PHPUnit_Framework_TestCase
+class XlsxTest extends TestCase
 {
     /**
      * Test load Xlsx file without cell reference.

--- a/tests/PhpSpreadsheetTests/ReferenceHelperTest.php
+++ b/tests/PhpSpreadsheetTests/ReferenceHelperTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests;
 
 use PhpOffice\PhpSpreadsheet\ReferenceHelper;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ReferenceHelperTest extends PHPUnit_Framework_TestCase
+class ReferenceHelperTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/PhpSpreadsheetTests/SettingsTest.php
+++ b/tests/PhpSpreadsheetTests/SettingsTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests;
 
 use PhpOffice\PhpSpreadsheet\Settings;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class SettingsTest extends PHPUnit_Framework_TestCase
+class SettingsTest extends TestCase
 {
     /**
      * @var string

--- a/tests/PhpSpreadsheetTests/Shared/CodePageTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/CodePageTest.php
@@ -4,9 +4,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Shared;
 
 use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\Shared\CodePage;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CodePageTest extends PHPUnit_Framework_TestCase
+class CodePageTest extends TestCase
 {
     /**
      * @dataProvider providerCodePage

--- a/tests/PhpSpreadsheetTests/Shared/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/DateTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Shared;
 
 use PhpOffice\PhpSpreadsheet\Shared\Date;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class DateTest extends PHPUnit_Framework_TestCase
+class DateTest extends TestCase
 {
     public function testSetExcelCalendar()
     {

--- a/tests/PhpSpreadsheetTests/Shared/FileTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/FileTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Shared;
 
 use PhpOffice\PhpSpreadsheet\Shared\File;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class FileTest extends PHPUnit_Framework_TestCase
+class FileTest extends TestCase
 {
     public function testGetUseUploadTempDirectory()
     {

--- a/tests/PhpSpreadsheetTests/Shared/FontTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/FontTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Shared;
 
 use PhpOffice\PhpSpreadsheet\Shared\Font;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class FontTest extends PHPUnit_Framework_TestCase
+class FontTest extends TestCase
 {
     public function testGetAutoSizeMethod()
     {

--- a/tests/PhpSpreadsheetTests/Shared/PasswordHasherTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/PasswordHasherTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Shared;
 
 use PhpOffice\PhpSpreadsheet\Shared\PasswordHasher;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class PasswordHasherTest extends PHPUnit_Framework_TestCase
+class PasswordHasherTest extends TestCase
 {
     /**
      * @dataProvider providerHashPassword

--- a/tests/PhpSpreadsheetTests/Shared/StringHelperTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/StringHelperTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Shared;
 
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class StringHelperTest extends PHPUnit_Framework_TestCase
+class StringHelperTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/PhpSpreadsheetTests/Shared/TimeZoneTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/TimeZoneTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Shared;
 
 use PhpOffice\PhpSpreadsheet\Shared\TimeZone;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class TimeZoneTest extends PHPUnit_Framework_TestCase
+class TimeZoneTest extends TestCase
 {
     public function testSetTimezone()
     {

--- a/tests/PhpSpreadsheetTests/Style/BorderTest.php
+++ b/tests/PhpSpreadsheetTests/Style/BorderTest.php
@@ -4,9 +4,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Style;
 
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Border;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BorderTest extends PHPUnit_Framework_TestCase
+class BorderTest extends TestCase
 {
     public function testCase()
     {

--- a/tests/PhpSpreadsheetTests/Style/ColorTest.php
+++ b/tests/PhpSpreadsheetTests/Style/ColorTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Style;
 
 use PhpOffice\PhpSpreadsheet\Style\Color;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ColorTest extends PHPUnit_Framework_TestCase
+class ColorTest extends TestCase
 {
     /**
      * @dataProvider providerColorGetRed

--- a/tests/PhpSpreadsheetTests/Style/NumberFormatTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormatTest.php
@@ -4,9 +4,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Style;
 
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class NumberFormatTest extends PHPUnit_Framework_TestCase
+class NumberFormatTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/Column/RuleTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/Column/RuleTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Worksheet\AutoFilter\Column;
 
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class RuleTest extends PHPUnit_Framework_TestCase
+class RuleTest extends TestCase
 {
     private $testAutoFilterRuleObject;
     private $mockAutoFilterColumnObject;

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/ColumnTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/ColumnTest.php
@@ -3,9 +3,9 @@
 namespace PhpOffice\PhpSpreadsheetTests\Worksheet\AutoFilter;
 
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ColumnTest extends PHPUnit_Framework_TestCase
+class ColumnTest extends TestCase
 {
     private $testInitialColumn = 'H';
     private $testAutoFilterColumnObject;

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilterTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilterTest.php
@@ -6,9 +6,9 @@ use PhpOffice\PhpSpreadsheet\Collection\Cells;
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter;
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class AutoFilterTest extends PHPUnit_Framework_TestCase
+class AutoFilterTest extends TestCase
 {
     private $testInitialRange = 'H2:O256';
     /**

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnCellIteratorTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnCellIteratorTest.php
@@ -5,9 +5,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Worksheet\ColumnCellIterator;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ColumnCellIteratorTest extends PHPUnit_Framework_TestCase
+class ColumnCellIteratorTest extends TestCase
 {
     public $mockWorksheet;
     public $mockCell;

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnIteratorTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnIteratorTest.php
@@ -5,9 +5,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Column;
 use PhpOffice\PhpSpreadsheet\Worksheet\ColumnIterator;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ColumnIteratorTest extends PHPUnit_Framework_TestCase
+class ColumnIteratorTest extends TestCase
 {
     public $mockWorksheet;
     public $mockColumn;

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnTest.php
@@ -5,9 +5,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Column;
 use PhpOffice\PhpSpreadsheet\Worksheet\ColumnCellIterator;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ColumnTest extends PHPUnit_Framework_TestCase
+class ColumnTest extends TestCase
 {
     public $mockWorksheet;
     public $mockColumn;

--- a/tests/PhpSpreadsheetTests/Worksheet/RowCellIteratorTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/RowCellIteratorTest.php
@@ -5,9 +5,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Worksheet\RowCellIterator;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class RowCellIteratorTest extends PHPUnit_Framework_TestCase
+class RowCellIteratorTest extends TestCase
 {
     public $mockWorksheet;
     public $mockCell;

--- a/tests/PhpSpreadsheetTests/Worksheet/RowIteratorTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/RowIteratorTest.php
@@ -5,9 +5,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Row;
 use PhpOffice\PhpSpreadsheet\Worksheet\RowIterator;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class RowIteratorTest extends PHPUnit_Framework_TestCase
+class RowIteratorTest extends TestCase
 {
     public $mockWorksheet;
     public $mockRow;

--- a/tests/PhpSpreadsheetTests/Worksheet/RowTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/RowTest.php
@@ -5,9 +5,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Row;
 use PhpOffice\PhpSpreadsheet\Worksheet\RowCellIterator;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class RowTest extends PHPUnit_Framework_TestCase
+class RowTest extends TestCase
 {
     public $mockWorksheet;
     public $mockRow;

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -4,9 +4,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class WorksheetTest extends PHPUnit_Framework_TestCase
+class WorksheetTest extends TestCase
 {
     public function testSetTitle()
     {

--- a/tests/PhpSpreadsheetTests/Writer/Ods/ContentTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Ods/ContentTest.php
@@ -12,9 +12,9 @@ use PhpOffice\PhpSpreadsheet\Style\Font;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Writer\Ods;
 use PhpOffice\PhpSpreadsheet\Writer\Ods\Content;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ContentTest extends PHPUnit_Framework_TestCase
+class ContentTest extends TestCase
 {
     private $samplesPath = __DIR__ . '/../../../data/Writer/Ods';
 

--- a/tests/PhpSpreadsheetTests/Writer/Xls/WorkbookTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/WorkbookTest.php
@@ -5,9 +5,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Writer\Xls\Workbook;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xls\Parser;
 use PhpOffice\PhpSpreadsheet\Writer\Xls\Workbook;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class WorkbookTest extends PHPUnit_Framework_TestCase
+class WorkbookTest extends TestCase
 {
     /**
      * @var Workbook


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).