### PR TITLE
Reader / Lazy init cells

### DIFF
--- a/src/PhpSpreadsheet/Reader/BaseReader.php
+++ b/src/PhpSpreadsheet/Reader/BaseReader.php
@@ -25,6 +25,14 @@ abstract class BaseReader implements IReader
     protected $readEmptyCells = true;
 
     /**
+     * Lazy init cells by first access or instantly
+     * Identifies when loaded cells will be initialized - instantly or on first access.
+     *
+     * @var bool
+     */
+    protected $lazyInitCells = false;
+
+    /**
      * Read charts that are defined in the workbook?
      * Identifies whether the Reader should read the definitions for any charts that exist in the workbook;.
      *
@@ -101,6 +109,34 @@ abstract class BaseReader implements IReader
     public function setReadEmptyCells($pValue)
     {
         $this->readEmptyCells = (bool) $pValue;
+
+        return $this;
+    }
+
+    /**
+     * Deferred init cells or by first access
+     *        If this is true, then the Reader will create cells internal object for each readed cell.
+     *        If false (the default) it will store readed cells data to create for them internal objects on first access.
+     *
+     * @return bool
+     */
+    public function getLazyInitCells()
+    {
+        return $this->lazyInitCells;
+    }
+
+    /**
+     * Set deferred init cells or by first access
+     *        Set to true to create cells internal object for each readed cell.
+     *        Set to false (the default) to store readed cells data to create for them internal objects on first access.
+     *
+     * @param bool $pValue
+     *
+     * @return IReader
+     */
+    public function setLazyInitCells($pValue)
+    {
+        $this->lazyInitCells = (bool) $pValue;
 
         return $this;
     }

--- a/src/PhpSpreadsheet/Reader/Ods.php
+++ b/src/PhpSpreadsheet/Reader/Ods.php
@@ -658,7 +658,7 @@ class Ods extends BaseReader
                                         if ($type !== DataType::TYPE_NULL) {
                                             for ($rowAdjust = 0; $rowAdjust < $rowRepeats; ++$rowAdjust) {
                                                 $rID = $rowID + $rowAdjust;
-
+                                                /*
                                                 $cell = $spreadsheet->getActiveSheet()
                                                             ->getCell($columnID . $rID);
 
@@ -673,6 +673,21 @@ class Ods extends BaseReader
                                                     $cell->setCalculatedValue($dataValue);
                                                 }
 
+                                                if ($hyperlink !== null) {
+                                                    $cell->getHyperlink()
+                                                        ->setUrl($hyperlink);
+                                                }
+                                                */
+
+                                                $cellData = [
+                                                    'value' => $hasCalculatedValue ? $cellDataFormula : $dataValue,
+                                                    'calculatedValue' => $hasCalculatedValue ? $dataValue : null,
+                                                    'type' => $type,
+                                                    'styleIndex' => null,
+                                                    'hyperlink' => $hyperlink,
+                                                ];
+                                                $spreadsheet->getActiveSheet()->createNewPredefinedCell($columnID . $rID, $cellData);
+
                                                 // Set other properties
                                                 if ($formatting !== null) {
                                                     $spreadsheet->getActiveSheet()
@@ -684,11 +699,6 @@ class Ods extends BaseReader
                                                         ->getStyle($columnID . $rID)
                                                         ->getNumberFormat()
                                                         ->setFormatCode(NumberFormat::FORMAT_GENERAL);
-                                                }
-
-                                                if ($hyperlink !== null) {
-                                                    $cell->getHyperlink()
-                                                        ->setUrl($hyperlink);
                                                 }
                                             }
                                         }

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -944,23 +944,46 @@ class Xlsx extends BaseReader
                                             $value = $value->getPlainText();
                                         }
 
-                                        $cell = $docSheet->getCell($r);
-                                        // Assign value
-                                        if ($cellDataType != '') {
-                                            $cell->setValueExplicit($value, $cellDataType);
-                                        } else {
-                                            $cell->setValue($value);
-                                        }
-                                        if ($calculatedValue !== null) {
-                                            $cell->setCalculatedValue($calculatedValue);
-                                        }
-
                                         // Style information?
+                                        $styleIndex = 0;
                                         if ($c['s'] && !$this->readDataOnly) {
                                             // no style index means 0, it seems
-                                            $cell->setXfIndex(isset($styles[(int) ($c['s'])]) ?
+                                            $styleIndex = (isset($styles[(int) ($c['s'])]) ?
                                                 (int) ($c['s']) : 0);
                                         }
+
+                                        if ($this->lazyInitCells) {
+                                            $docSheet->lazyCreateNewCell($r, $value, $calculatedValue, $cellDataType, $styleIndex);
+                                        } else {
+                                            /*
+                                            $cell = $docSheet->getCell($r);
+
+                                            // Assign value
+                                            if ($cellDataType != '') {
+                                                $cell->setValueExplicit($value, $cellDataType);
+                                            } else {
+                                                $cell->setValue($value);
+                                            }
+                                            if ($calculatedValue !== null) {
+                                                $cell->setCalculatedValue($calculatedValue);
+                                            }
+
+                                            // Style information?
+                                            if ($c['s'] && !$this->readDataOnly) {
+                                                // no style index means 0, it seems
+                                                $cell->setXfIndex(isset($styles[(int) ($c['s'])]) ?
+                                                    (int) ($c['s']) : 0);
+                                            }
+                                            */
+                                            $cellData = [
+                                                'value' => $value,
+                                                'calculatedValue' => $calculatedValue,
+                                                'type' => $cellDataType,
+                                                'styleIndex' => $styleIndex,
+                                            ];
+                                            $docSheet->createNewPredefinedCell($r, $cellData);
+                                        }
+
                                         $rowIndex += 1;
                                     }
                                     $cIndex += 1;

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1242,6 +1242,62 @@ class Worksheet implements IComparable
     }
 
     /**
+     * Store new cell at the specified coordinate to create it on first access.
+     *
+     * @param string $pCoordinate Coordinate of the cell
+     * @param mixed $pValue Value of the cell
+     * @param mixed $calculatedValue Value of the cell
+     * @param string $cellDataType Explicit data type, see DataType::TYPE_*
+     * @param int $styleIndex Style index of cell
+     * @param string $hyperlink Hyperlink string
+     */
+    public function lazyCreateNewCell($pCoordinate, $pValue, $calculatedValue, $cellDataType, $styleIndex = 0, $hyperlink = null)
+    {
+        $cellData = [
+            'value' => $pValue,
+            'calculatedValue' => $calculatedValue,
+            'type' => $cellDataType,
+            'styleIndex' => $styleIndex,
+            'hyperlink' => $hyperlink,
+        ];
+        $this->cellCollection->addLazyCellData($pCoordinate, $cellData);
+        $this->cellCollectionIsSorted = false;
+    }
+
+    /**
+     * Create a new cell with predefined attributes at the specified coordinate.
+     *
+     * @param string $pCoordinate Coordinate of the cell
+     * @param array $cellData Cell predefined attributes
+     *
+     * @return Cell Cell that was created
+     */
+    public function createNewPredefinedCell($pCoordinate, $cellData)
+    {
+        $cell = $this->createNewCell($pCoordinate);
+
+        // Assign value
+        if (!empty($cellData['type'])) {    // type can be empty string
+            $cell->setValueExplicit($cellData['value'], $cellData['type']);
+        } else {
+            $cell->setValue($cellData['value']);
+        }
+        if (isset($cellData['calculatedValue'])) {
+            $cell->setCalculatedValue($cellData['calculatedValue']);
+        }
+        // Style information?
+        if (isset($cellData['styleIndex'])) {
+            $cell->setXfIndex($cellData['styleIndex']);
+        }
+        if (isset($cellData['hyperlink'])) {
+            $cell->getHyperlink()
+                ->setUrl($cellData['hyperlink']);
+        }
+
+        return $cell;
+    }
+
+    /**
      * Create a new cell at the specified coordinate.
      *
      * @param string $pCoordinate Coordinate of the cell

--- a/tests/PhpSpreadsheetTests/Reader/OdsLazyTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/OdsLazyTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader;
+
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Reader\Ods;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Font;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @todo The class doesn't read the bold/italic/underline properties (rich text)
+ */
+class OdsLazyTest extends TestCase
+{
+    /**
+     * @var Spreadsheet
+     */
+    private $spreadsheetOOCalcTest;
+
+    /**
+     * @var Spreadsheet
+     */
+    private $spreadsheetData;
+
+    /**
+     * @return Spreadsheet
+     */
+    protected function loadOOCalcTestFile()
+    {
+        if (!$this->spreadsheetOOCalcTest) {
+            $filename = __DIR__ . '/../../../samples/templates/OOCalcTest.ods';
+
+            // Load into this instance
+            $reader = new Ods();
+            $reader->setLazyInitCells(true);
+            $this->spreadsheetOOCalcTest = $reader->loadIntoExisting($filename, new Spreadsheet());
+        }
+
+        return $this->spreadsheetOOCalcTest;
+    }
+
+    /**
+     * @return Spreadsheet
+     */
+    protected function loadDataFile()
+    {
+        if (!$this->spreadsheetData) {
+            $filename = __DIR__ . '/../../data/Reader/Ods/data.ods';
+
+            // Load into this instance
+            $reader = new Ods();
+            $reader->setLazyInitCells(true);
+            $this->spreadsheetData = $reader->loadIntoExisting($filename, new Spreadsheet());
+        }
+
+        return $this->spreadsheetData;
+    }
+
+    public function testReadFileProperties()
+    {
+        $filename = __DIR__ . '/../../data/Reader/Ods/data.ods';
+
+        // Load into this instance
+        $reader = new Ods();
+        $reader->setLazyInitCells(true);
+
+        // Test "listWorksheetNames" method
+
+        self::assertEquals([
+            'Sheet1',
+            'Second Sheet',
+        ], $reader->listWorksheetNames($filename));
+    }
+
+    public function testLoadWorksheets()
+    {
+        $spreadsheet = $this->loadDataFile();
+
+        self::assertInstanceOf('PhpOffice\PhpSpreadsheet\Spreadsheet', $spreadsheet);
+
+        self::assertEquals(2, $spreadsheet->getSheetCount());
+
+        $firstSheet = $spreadsheet->getSheet(0);
+        self::assertInstanceOf('PhpOffice\PhpSpreadsheet\Worksheet\Worksheet', $firstSheet);
+
+        $secondSheet = $spreadsheet->getSheet(1);
+        self::assertInstanceOf('PhpOffice\PhpSpreadsheet\Worksheet\Worksheet', $secondSheet);
+    }
+
+    public function testReadValueAndComments()
+    {
+        $spreadsheet = $this->loadOOCalcTestFile();
+
+        $firstSheet = $spreadsheet->getSheet(0);
+
+        self::assertEquals(29, $firstSheet->getHighestRow());
+        self::assertEquals('N', $firstSheet->getHighestColumn());
+
+        // Simple cell value
+        self::assertEquals('Test String 1', $firstSheet->getCell('A1')->getValue());
+
+        // Merged cell
+        self::assertEquals('BOX', $firstSheet->getCell('B18')->getValue());
+
+        // Comments/Annotations
+        self::assertEquals(
+            'Test for a simple colour-formatted string',
+            $firstSheet->getComment('A1')->getText()->getPlainText()
+        );
+
+        // Data types
+        self::assertEquals(DataType::TYPE_STRING, $firstSheet->getCell('A1')->getDataType());
+        self::assertEquals(DataType::TYPE_NUMERIC, $firstSheet->getCell('B1')->getDataType()); // Int
+
+        self::assertEquals(DataType::TYPE_NUMERIC, $firstSheet->getCell('B6')->getDataType()); // Float
+        self::assertEquals(1.23, $firstSheet->getCell('B6')->getValue());
+        self::assertEquals(0, $firstSheet->getCell('G10')->getValue());
+
+        self::assertEquals(DataType::TYPE_NUMERIC, $firstSheet->getCell('A10')->getDataType()); // Date
+        self::assertEquals(22269.0, $firstSheet->getCell('A10')->getValue());
+
+        self::assertEquals(DataType::TYPE_NUMERIC, $firstSheet->getCell('A13')->getDataType()); // Time
+        self::assertEquals(25569.0625, $firstSheet->getCell('A13')->getValue());
+
+        self::assertEquals(DataType::TYPE_NUMERIC, $firstSheet->getCell('A15')->getDataType()); // Date + Time
+        self::assertEquals(22269.0625, $firstSheet->getCell('A15')->getValue());
+
+        self::assertEquals(DataType::TYPE_NUMERIC, $firstSheet->getCell('A11')->getDataType()); // Fraction
+
+        self::assertEquals(DataType::TYPE_BOOL, $firstSheet->getCell('D6')->getDataType());
+        self::assertTrue($firstSheet->getCell('D6')->getValue());
+
+        self::assertEquals(DataType::TYPE_FORMULA, $firstSheet->getCell('C6')->getDataType()); // Formula
+        self::assertEquals('=TRUE()', $firstSheet->getCell('C6')->getValue()); // Formula
+
+        // Percentage, Currency
+
+        $spreadsheet = $this->loadDataFile();
+
+        $firstSheet = $spreadsheet->getSheet(0);
+
+        self::assertEquals(DataType::TYPE_NUMERIC, $firstSheet->getCell('A1')->getDataType()); // Percentage (10%)
+        self::assertEquals(0.1, $firstSheet->getCell('A1')->getValue());
+
+        self::assertEquals(DataType::TYPE_NUMERIC, $firstSheet->getCell('A2')->getDataType()); // Percentage (10.00%)
+        self::assertEquals(0.1, $firstSheet->getCell('A2')->getValue());
+
+        self::assertEquals(DataType::TYPE_NUMERIC, $firstSheet->getCell('A4')->getDataType()); // Currency (€10.00)
+        self::assertEquals(10, $firstSheet->getCell('A4')->getValue());
+
+        self::assertEquals(DataType::TYPE_NUMERIC, $firstSheet->getCell('A5')->getDataType()); // Currency ($20)
+        self::assertEquals(20, $firstSheet->getCell('A5')->getValue());
+    }
+
+    public function testReadColors()
+    {
+        $spreadsheet = $this->loadOOCalcTestFile();
+        $firstSheet = $spreadsheet->getSheet(0);
+
+        // Background color
+
+        $style = $firstSheet->getCell('K3')->getStyle();
+
+        self::assertEquals('none', $style->getFill()->getFillType());
+        self::assertEquals('FFFFFFFF', $style->getFill()->getStartColor()->getARGB());
+        self::assertEquals('FF000000', $style->getFill()->getEndColor()->getARGB());
+    }
+
+    public function testReadRichText()
+    {
+        $spreadsheet = $this->loadOOCalcTestFile();
+        $firstSheet = $spreadsheet->getSheet(0);
+
+        self::assertEquals(
+            "I don't know if OOCalc supports Rich Text in the same way as Excel, " .
+            'And this row should be autofit height with text wrap',
+            $firstSheet->getCell('A28')->getValue()
+        );
+    }
+
+    public function testReadCellsWithRepeatedSpaces()
+    {
+        $spreadsheet = $this->loadDataFile();
+        $firstSheet = $spreadsheet->getSheet(0);
+
+        self::assertEquals('This has    4 spaces before and 2 after  ', $firstSheet->getCell('A8')->getValue());
+        self::assertEquals('This only one after ', $firstSheet->getCell('A9')->getValue());
+        self::assertEquals('Test with DIFFERENT styles     and multiple spaces:  ', $firstSheet->getCell('A10')->getValue());
+        self::assertEquals("test with new \nLines", $firstSheet->getCell('A11')->getValue());
+    }
+
+    public function testReadHyperlinks()
+    {
+        $spreadsheet = $this->loadOOCalcTestFile();
+        $firstSheet = $spreadsheet->getSheet(0);
+
+        $hyperlink = $firstSheet->getCell('A29');
+
+        self::assertEquals(DataType::TYPE_STRING, $hyperlink->getDataType());
+        self::assertEquals('PHPExcel', $hyperlink->getValue());
+        self::assertEquals('http://www.phpexcel.net/', $hyperlink->getHyperlink()->getUrl());
+    }
+
+    // Below some test for features not implemented yet
+
+    public function testReadBoldItalicUnderline()
+    {
+        $this->markTestIncomplete('Features not implemented yet');
+
+        $spreadsheet = $this->loadOOCalcTestFile();
+        $firstSheet = $spreadsheet->getSheet(0);
+
+        // Font styles
+
+        $style = $firstSheet->getCell('A1')->getStyle();
+        self::assertEquals('FF000000', $style->getFont()->getColor()->getARGB());
+        self::assertEquals(11, $style->getFont()->getSize());
+        self::assertEquals(Font::UNDERLINE_NONE, $style->getFont()->getUnderline());
+
+        $style = $firstSheet->getCell('E3')->getStyle();
+        self::assertEquals(Font::UNDERLINE_SINGLE, $style->getFont()->getUnderline());
+
+        $style = $firstSheet->getCell('E1')->getStyle();
+        self::assertTrue($style->getFont()->getBold());
+        self::assertTrue($style->getFont()->getItalic());
+    }
+}

--- a/tests/PhpSpreadsheetTests/Reader/XlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XlsxTest.php
@@ -14,6 +14,15 @@ class XlsxTest extends TestCase
     {
         $filename = './data/Reader/XLSX/without_cell_reference.xlsx';
         $reader = new Xlsx();
-        $reader->load($filename);
+
+        $reader->setLazyInitCells(false);
+        $spreadsheet = $reader->load($filename);
+        $firstSheet = $spreadsheet->getSheet(0);
+        self::assertEquals('2', $firstSheet->getCell('B2')->getValue());
+
+        $reader->setLazyInitCells(true);
+        $spreadsheet = $reader->load($filename);
+        $firstSheet = $spreadsheet->getSheet(0);
+        self::assertEquals('2', $firstSheet->getCell('B2')->getValue());
     }
 }


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?
  Add to Xlsx and Ods readers `lazyInitCells` option. It allow faster (30%) read large documents, because do not initialize each cell as internal object. Internal object will create on first access to the cell.
  This method can be helpful in cases when need to read few cells from large documents.