### PR TITLE
Use assertInstanceOf

### DIFF
--- a/tests/PhpSpreadsheetTests/Cell/HyperlinkTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/HyperlinkTest.php
@@ -24,7 +24,7 @@ class HyperlinkTest extends TestCase
 
         $testInstance = new Hyperlink($initialUrlValue);
         $result = $testInstance->setUrl($newUrlValue);
-        self::assertTrue($result instanceof Hyperlink);
+        self::assertInstanceOf(Hyperlink::class, $result);
 
         $result = $testInstance->getUrl();
         self::assertEquals($newUrlValue, $result);
@@ -47,7 +47,7 @@ class HyperlinkTest extends TestCase
 
         $testInstance = new Hyperlink(null, $initialTooltipValue);
         $result = $testInstance->setTooltip($newTooltipValue);
-        self::assertTrue($result instanceof Hyperlink);
+        self::assertInstanceOf(Hyperlink::class, $result);
 
         $result = $testInstance->getTooltip();
         self::assertEquals($newTooltipValue, $result);

--- a/tests/PhpSpreadsheetTests/Chart/DataSeriesValuesTest.php
+++ b/tests/PhpSpreadsheetTests/Chart/DataSeriesValuesTest.php
@@ -19,7 +19,7 @@ class DataSeriesValuesTest extends TestCase
 
         foreach ($dataTypeValues as $dataTypeValue) {
             $result = $testInstance->setDataType($dataTypeValue);
-            self::assertTrue($result instanceof DataSeriesValues);
+            self::assertInstanceOf(DataSeriesValues::class, $result);
         }
     }
 

--- a/tests/PhpSpreadsheetTests/Chart/LayoutTest.php
+++ b/tests/PhpSpreadsheetTests/Chart/LayoutTest.php
@@ -14,7 +14,7 @@ class LayoutTest extends TestCase
         $testInstance = new Layout();
 
         $result = $testInstance->setLayoutTarget($LayoutTargetValue);
-        self::assertTrue($result instanceof Layout);
+        self::assertInstanceOf(Layout::class, $result);
     }
 
     public function testGetLayoutTarget()


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [x] a new feature

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

What does it change?

Use `assertInstanceOf` instead of `instanceof` operator.
