### PR TITLE
Include comments in HTML writer (#308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Include spreadsheet comments in HTML writer - [#308](https://github.com/PHPOffice/PhpSpreadsheet/issues/308)
+
 ### Fixed
 
 - Better auto-detection of CSV separators - [#305](https://github.com/PHPOffice/PhpSpreadsheet/issues/305)

--- a/docs/references/features-cross-reference.md
+++ b/docs/references/features-cross-reference.md
@@ -1231,14 +1231,14 @@
         <td style="text-align: center; color: orange;">●</td>
         <td style="text-align: center; color: orange;">●</td>
         <td style="text-align: center;">N/A</td>
-        <td></td>
+        <td style="text-align: center; color: orange;">● <sup>1</sup></td>
         <td style="text-align: center;">N/A</td>
         <td></td>
         <td></td>
     </tr>
     <tr>
         <td style="padding-left: 1em;">Rich Text</td>
-        <td style="text-align: center; color: red;">✖ <sup>1</sup></td>
+        <td style="text-align: center; color: red;">✖ <sup>2</sup></td>
         <td style="text-align: center; color: green;">✔</td>
         <td style="text-align: center; color: red;">✖</td>
         <td style="text-align: center; color: red;">✖</td>
@@ -1256,7 +1256,7 @@
     </tr>
     <tr>
         <td style="padding-left: 1em;">Alignment</td>
-        <td style="text-align: center; color: red;">✖ <sup>2</sup></td>
+        <td style="text-align: center; color: red;">✖ <sup>3</sup></td>
         <td style="text-align: center; color: red;">✖</td>
         <td style="text-align: center; color: red;">✖</td>
         <td style="text-align: center; color: red;">✖</td>
@@ -1568,5 +1568,6 @@
     </tr>
 </table>
 
-1. Only BIFF8 files support Rich Text. Prior to that, comments could only be plain text
-2. Only BIFF8 files support alignment and rotation. Prior to that, comments could only be unformatted text
+1. Only text contents
+2. Only BIFF8 files support Rich Text. Prior to that, comments could only be plain text
+3. Only BIFF8 files support alignment and rotation. Prior to that, comments could only be unformatted text

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -312,6 +312,14 @@ class Html extends BaseReader
                     case 'em':
                     case 'strong':
                     case 'b':
+                        if (isset($attributeArray['class']) && $attributeArray['class'] == 'comment') {
+                            $sheet->getComment($column . $row)
+                                ->getText()
+                                ->createTextRun($child->textContent);
+
+                            break;
+                        }
+
                         if ($cellContent > '') {
                             $cellContent .= ' ';
                         }
@@ -354,6 +362,11 @@ class Html extends BaseReader
                                     }
 
                                     break;
+                                case 'class':
+                                    if ($attributeValue == 'comment-indicator') {
+                                        break; // Ignore - it's just a red square.
+                                    }
+                                    //else fall through
                             }
                         }
                         $cellContent .= ' ';

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -835,7 +835,7 @@ class Html extends BaseWriter
         // sc/source/filter/html/htmlexp.cxx cHTMLExport::WriteHeader()
         //
 
-        $css['a.comment-indicator:hover + comment'] = [
+        $css['a.comment-indicator:hover + div.comment'] = [
             'background' => '#ffd',
             'position' => 'absolute',
             'display' => 'block',
@@ -851,7 +851,7 @@ class Html extends BaseWriter
             'height' => '0.5em',
         ];
 
-        $css['comment']['display'] = 'none';
+        $css['div.comment']['display'] = 'none';
 
         // table { }
         $css['table']['border-collapse'] = 'collapse';
@@ -1413,7 +1413,7 @@ class Html extends BaseWriter
 
                 if (isset($pSheet->getComments()[$coordinate])) {
                     $html .= '<a class="comment-indicator"></a>';
-                    $html .= '<comment>' . nl2br($pSheet->getComment($coordinate)) . '</comment>';
+                    $html .= '<div class="comment">' . nl2br($pSheet->getComment($coordinate)->getText()->getPlainText()) . '</div>';
                     $html .= PHP_EOL;
                 }
 

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -1412,7 +1412,7 @@ class Html extends BaseWriter
                 // https://github.com/LibreOffice/core/blob/9fc9bf3240f8c62ad7859947ab8a033ac1fe93fa/sc/source/filter/html/htmlexp.cxx#L1073-L1092
 
                 if(isset($pSheet->getComments()[$coordinate])) {
-                    $html .= '<a class="comment-indicator"></a><comment>' . nl2br($comment) . '</comment>' . PHP_EOL;
+                    $html .= '<a class="comment-indicator"></a><comment>' . nl2br($pSheet->getComment($coordinate)) . '</comment>' . PHP_EOL;
                 }
 
                 // Image?

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -1411,7 +1411,7 @@ class Html extends BaseWriter
                 // Taken from LibreOffice core
                 // https://github.com/LibreOffice/core/blob/9fc9bf3240f8c62ad7859947ab8a033ac1fe93fa/sc/source/filter/html/htmlexp.cxx#L1073-L1092
 
-                if (isset($pSheet->getComments()[$coordinate])) {
+                if (!$this->isPdf && isset($pSheet->getComments()[$coordinate])) {
                     $html .= '<a class="comment-indicator"></a>';
                     $html .= '<div class="comment">' . nl2br($pSheet->getComment($coordinate)->getText()->getPlainText()) . '</div>';
                     $html .= PHP_EOL;

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -836,19 +836,19 @@ class Html extends BaseWriter
         //
 
         $css['a.comment-indicator:hover + comment'] = [
-            "background" => "#ffd",
-            "position" => "absolute",
-            "display" => "block",
-            "border" => "1px solid black",
-            "padding" => "0.5em"
+            'background' => '#ffd',
+            'position' => 'absolute',
+            'display' => 'block',
+            'border' => '1px solid black',
+            'padding' => '0.5em'
         ];
 
         $css['a.comment-indicator'] = [
-            "background" => "red",
-            "display" => "inline-block",
-            "border" => "1px solid black",
-            "width" => "0.5em",
-            "height" => "0.5em"
+            'background' => 'red',
+            'display' => 'inline-block',
+            'border' => '1px solid black',
+            'width' => '0.5em',
+            'height' => '0.5em'
         ];
 
         $css['comment']['display'] = 'none';
@@ -1411,8 +1411,10 @@ class Html extends BaseWriter
                 // Taken from LibreOffice core
                 // https://github.com/LibreOffice/core/blob/9fc9bf3240f8c62ad7859947ab8a033ac1fe93fa/sc/source/filter/html/htmlexp.cxx#L1073-L1092
 
-                if(isset($pSheet->getComments()[$coordinate])) {
-                    $html .= '<a class="comment-indicator"></a><comment>' . nl2br($pSheet->getComment($coordinate)) . '</comment>' . PHP_EOL;
+                if (isset($pSheet->getComments()[$coordinate])) {
+                    $html .= '<a class="comment-indicator"></a>';
+                    $html .= '<comment>' . nl2br($pSheet->getComment($coordinate)) . '</comment>';
+                    $html .= PHP_EOL;
                 }
 
                 // Image?

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -830,6 +830,29 @@ class Html extends BaseWriter
             $css['html']['background-color'] = 'white';
         }
 
+        //
+        // Comment CSS taken from LibreOffice (core)
+        // sc/source/filter/html/htmlexp.cxx cHTMLExport::WriteHeader()
+        //
+
+        $css['a.comment-indicator:hover + comment'] = [
+            "background" => "#ffd",
+            "position" => "absolute",
+            "display" => "block",
+            "border" => "1px solid black",
+            "padding" => "0.5em"
+        ];
+
+        $css['a.comment-indicator'] = [
+            "background" => "red",
+            "display" => "inline-block",
+            "border" => "1px solid black",
+            "width" => "0.5em",
+            "height" => "0.5em"
+        ];
+
+        $css['comment']['display'] = 'none';
+
         // table { }
         $css['table']['border-collapse'] = 'collapse';
         if (!$this->isPdf) {
@@ -1384,6 +1407,13 @@ class Html extends BaseWriter
                     $html .= ' rowspan="' . $rowSpan . '"';
                 }
                 $html .= '>';
+
+                // Taken from LibreOffice core
+                // https://github.com/LibreOffice/core/blob/9fc9bf3240f8c62ad7859947ab8a033ac1fe93fa/sc/source/filter/html/htmlexp.cxx#L1073-L1092
+
+                if(isset($pSheet->getComments()[$coordinate])) {
+                    $html .= '<a class="comment-indicator"></a><comment>' . nl2br($comment) . '</comment>' . PHP_EOL;
+                }
 
                 // Image?
                 $html .= $this->writeImageInCell($pSheet, $coordinate);

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -840,7 +840,7 @@ class Html extends BaseWriter
             'position' => 'absolute',
             'display' => 'block',
             'border' => '1px solid black',
-            'padding' => '0.5em'
+            'padding' => '0.5em',
         ];
 
         $css['a.comment-indicator'] = [
@@ -848,7 +848,7 @@ class Html extends BaseWriter
             'display' => 'inline-block',
             'border' => '1px solid black',
             'width' => '0.5em',
-            'height' => '0.5em'
+            'height' => '0.5em',
         ];
 
         $css['comment']['display'] = 'none';

--- a/tests/PhpSpreadsheetTests/Functional/HtmlCommentsTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/HtmlCommentsTest.php
@@ -2,8 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Functional;
 
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class HtmlCommentsTest extends AbstractFunctional
 {
@@ -12,7 +12,7 @@ class HtmlCommentsTest extends AbstractFunctional
     public function providerCommentRichText()
     {
         $valueSingle = 'I am comment.';
-        $valueMulti= 'I am ' . PHP_EOL . 'multi-line' . PHP_EOL . 'comment.';
+        $valueMulti = 'I am ' . PHP_EOL . 'multi-line' . PHP_EOL . 'comment.';
 
         $plainSingle = new RichText();
         $plainSingle->createText($valueSingle);
@@ -36,12 +36,14 @@ class HtmlCommentsTest extends AbstractFunctional
             'multi-line plain text' => [$plainMulti],
             'single line simple rich text' => [$richSingle],
             'multi-line simple rich text' => [$richMultiSimple],
-            'multi-line mixed rich text' =>  [$richMultiMixed],
+            'multi-line mixed rich text' => [$richMultiMixed],
         ];
     }
 
     /**
      * @dataProvider providerCommentRichText
+     *
+     * @param mixed $richText
      */
     public function testComments($richText)
     {
@@ -58,5 +60,4 @@ class HtmlCommentsTest extends AbstractFunctional
         $actual = $reloadedSpreadsheet->getActiveSheet()->getComment('A1')->getText()->getPlainText();
         self::assertSame($richText->getPlainText(), $actual);
     }
-
 }

--- a/tests/PhpSpreadsheetTests/Functional/HtmlCommentsTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/HtmlCommentsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Functional;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+
+class HtmlCommentsTest extends AbstractFunctional
+{
+    private $value = 'I am comment.';
+    private $spreadsheet;
+
+    private function createComment()
+    {
+        $this->spreadsheet = new Spreadsheet();
+
+        $this->spreadsheet->getActiveSheet()->getCell('A1')->setValue('Comment');
+
+        return $this->spreadsheet->getActiveSheet()
+            ->getComment('A1')
+            ->getText()->createTextRun($this->value);
+    }
+
+    private function doTheTest($string)
+    {
+        $reloadedSpreadsheet = $this->writeAndReload($this->spreadsheet, 'Html');
+
+        $actual = (string) $reloadedSpreadsheet->getActiveSheet()->getComment('A1')->getText()->getPlainText();
+        self::assertSame($this->value, $actual, $string);
+    }
+
+    public function testPlainTextComment()
+    {
+        $this->createComment();
+        $this->doTheTest('should be able to read and write plain text comments from and to html as plain text');
+    }
+
+    public function testRichTextComment()
+    {
+        $this->createComment()->getFont()->setBold(true);
+        $this->doTheTest('should be able to read and write rich text comments from and to html as plain text');
+    }
+}


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:
- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

- To allow users to have Spreadsheet comments included in the HTML file generated by PhpSpreadsheet.
- #308

Submitted early to allow discussion.

HTML and CSS taken from LibreOffice HTML exporter.