### PR TITLE
supress iconv error

### DIFF
--- a/src/PhpSpreadsheet/Shared/StringHelper.php
+++ b/src/PhpSpreadsheet/Shared/StringHelper.php
@@ -453,7 +453,7 @@ class StringHelper
     public static function convertEncoding($value, $to, $from)
     {
         if (self::getIsIconvEnabled()) {
-            $result = iconv($from, $to . '//IGNORE//TRANSLIT', $value);
+            $result = @iconv($from, $to . '//IGNORE//TRANSLIT', $value);
             if (false !== $result) {
                 return $result;
             }


### PR DESCRIPTION
This is:
a bug fix

### Why this change is needed?

iconv will yield E_NOTICE error
