### PR TITLE
Change array key from style to borderStyle

### DIFF
--- a/docs/topics/recipes.md
+++ b/docs/topics/recipes.md
@@ -801,10 +801,10 @@ outline           | setOutline()
 
 **\PhpOffice\PhpSpreadsheet\Style\Border**
 
-Array key | Maps to property
-----------|-------------------
-style     | setBorderStyle()
-color     | getColor()
+Array key   | Maps to property
+------------|-------------------
+borderStyle | setBorderStyle()
+color       | getColor()
 
 **\PhpOffice\PhpSpreadsheet\Style\Alignment**
 


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

### Why this change is needed?

This change is needed because 'style' array key was deprecated by 'borderStyle'.