### PR TITLE
#333 Autofit the rows height in the interval based on the largest cell

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -3076,7 +3076,7 @@ class Worksheet implements IComparable
      *
      * @param int $startRow
      * @param int $endRow
-     * @return Alignment
+     * @return Worksheet
      */
     public function autofitRowsHeight($startRow, $endRow, $rowPadding = null)
     {

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -37,6 +37,9 @@ class Worksheet implements IComparable
     const SHEETSTATE_HIDDEN = 'hidden';
     const SHEETSTATE_VERYHIDDEN = 'veryHidden';
 
+    // Row consts
+    const ROW_PADDING = 5;
+
     /**
      * Invalid characters in sheet title.
      *
@@ -3066,5 +3069,42 @@ class Worksheet implements IComparable
     public function hasCodeName()
     {
         return !($this->codeName === null);
+    }
+
+    /**
+     * Autofit the rows height in the interval based on the largest cell
+     *
+     * @param int $startRow
+     * @param int $endRow
+     * @return Alignment
+     */
+    public function autofitRowsHeight($startRow, $endRow, $rowPadding = null)
+    {
+        $rowPadding = $rowPadding ?? self::ROW_PADDING;
+
+        foreach ($this->getRowIterator($startRow, $endRow) as $row) {
+            $cellIterator = $row->getCellIterator();
+            $cellIterator->setIterateOnlyExistingCells(true);
+
+            $maxCellLength = 0;
+            $maxColumnWidth = 0;
+            foreach ($cellIterator as $cell) {
+                $cellLength = strlen($cell->getValue());
+                $columnWidth = $this->getColumnDimension($cell->getParent()->getCurrentColumn())->getWidth();
+
+                $maxCellLength = $cellLength > $maxCellLength ? $cellLength : $maxCellLength;
+                $maxColumnWidth = $columnWidth > $maxColumnWidth ? $columnWidth : $maxColumnWidth;
+            }
+
+            $rowDimension = $this->getRowDimension($row->getRowIndex());
+            $rowHeight = $rowDimension->getRowHeight();
+
+            $cellValuesOnColumn = ceil($maxCellLength / $maxColumnWidth);
+            $cellValuesOnColumn = $cellValuesOnColumn <= 0 ? 1 : $cellValuesOnColumn;
+
+            $rowDimension->setRowHeight( ($rowHeight * $cellValuesOnColumn) + $rowPadding);
+        }
+
+        return $this;
     }
 }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

I'm not sure if it only happens on Libre Office Calc but if I have a text that has been wrapped before using getAlignment()->setWrapText(true) I'm was not able to fit the rows based on the new height of the cells, like when we double click excel/calc rows.