### PR TITLE
Use dynamic spreadsheet class

### DIFF
--- a/src/PhpSpreadsheet/IOFactory.php
+++ b/src/PhpSpreadsheet/IOFactory.php
@@ -34,6 +34,8 @@ abstract class IOFactory
         'Mpdf' => Writer\Pdf\Mpdf::class,
     ];
 
+    private static $spreadSheetClass = Spreadsheet::class;
+
     /**
      * Create Writer\IWriter.
      *
@@ -226,5 +228,23 @@ abstract class IOFactory
         }
 
         self::$readers[$readerType] = $readerClass;
+    }
+
+    /**
+     * @return Spreadsheet
+     */
+    public static function getSpreadsheetInstance()
+    {
+      $spreadSheetClass = static::$spreadSheetClass;
+      return new $spreadSheetClass();
+    }
+
+    /**
+     * Use another spread sheet class than Spreadsheet.
+     * @param string $spreadSheetClass
+     */
+    public static function setSpreadsheetClass($spreadSheetClass)
+    {
+        static::$spreadSheetClass = $spreadSheetClass;
     }
 }

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheet\Reader;
 
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
@@ -280,7 +281,7 @@ class Csv extends BaseReader
     public function load($pFilename)
     {
         // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = IOFactory::getSpreadsheetInstance();
 
         // Load into this instance
         return $this->loadIntoExisting($pFilename, $spreadsheet);

--- a/src/PhpSpreadsheet/Reader/Gnumeric.php
+++ b/src/PhpSpreadsheet/Reader/Gnumeric.php
@@ -4,6 +4,7 @@ namespace PhpOffice\PhpSpreadsheet\Reader;
 
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\ReferenceHelper;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
@@ -173,7 +174,7 @@ class Gnumeric extends BaseReader
     public function load($pFilename)
     {
         // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = IOFactory::getSpreadsheetInstance();
 
         // Load into this instance
         return $this->loadIntoExisting($pFilename, $spreadsheet);

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -7,6 +7,7 @@ use DOMElement;
 use DOMNode;
 use DOMText;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Border;
 use PhpOffice\PhpSpreadsheet\Style\Color;
@@ -187,7 +188,7 @@ class Html extends BaseReader
     public function load($pFilename)
     {
         // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = IOFactory::getSpreadsheetInstance();
 
         // Load into this instance
         return $this->loadIntoExisting($pFilename, $spreadsheet);

--- a/src/PhpSpreadsheet/Reader/Ods.php
+++ b/src/PhpSpreadsheet/Reader/Ods.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Document\Properties;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
@@ -236,7 +237,7 @@ class Ods extends BaseReader
     public function load($pFilename)
     {
         // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = IOFactory::getSpreadsheetInstance();
 
         // Load into this instance
         return $this->loadIntoExisting($pFilename, $spreadsheet);

--- a/src/PhpSpreadsheet/Reader/Slk.php
+++ b/src/PhpSpreadsheet/Reader/Slk.php
@@ -4,6 +4,7 @@ namespace PhpOffice\PhpSpreadsheet\Reader;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Border;
@@ -184,7 +185,7 @@ class Slk extends BaseReader
     public function load($pFilename)
     {
         // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = IOFactory::getSpreadsheetInstance();
 
         // Load into this instance
         return $this->loadIntoExisting($pFilename, $spreadsheet);

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -6,6 +6,7 @@ use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Cell\DataValidation;
 use PhpOffice\PhpSpreadsheet\Exception as PhpSpreadsheetException;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Shared\CodePage;
@@ -628,7 +629,7 @@ class Xls extends BaseReader
         $this->loadOLE($pFilename);
 
         // Initialisations
-        $this->spreadsheet = new Spreadsheet();
+        $this->spreadsheet = IOFactory::getSpreadsheetInstance();
         $this->spreadsheet->removeSheetByIndex(0); // remove 1st sheet
         if (!$this->readDataOnly) {
             $this->spreadsheet->removeCellStyleXfByIndex(0); // remove the default style

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -4,6 +4,7 @@ namespace PhpOffice\PhpSpreadsheet\Reader;
 
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Document\Properties;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx\Chart;
 use PhpOffice\PhpSpreadsheet\ReferenceHelper;
@@ -330,7 +331,7 @@ class Xlsx extends BaseReader
         File::assertFile($pFilename);
 
         // Initialisations
-        $excel = new Spreadsheet();
+        $excel = IOFactory::getSpreadsheetInstance();
         $excel->removeSheetByIndex(0);
         if (!$this->readDataOnly) {
             $excel->removeCellStyleXfByIndex(0); // remove the default style

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheet\Reader;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Document\Properties;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
@@ -234,7 +235,7 @@ class Xml extends BaseReader
     public function load($pFilename)
     {
         // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = IOFactory::getSpreadsheetInstance();
         $spreadsheet->removeSheetByIndex(0);
 
         // Load into this instance


### PR DESCRIPTION
See issue #348 

This is:

```
- [ ] a bug report
- [ x ] a feature request
```

### What is the expected behavior?
I have some problems with formulas referencing columns in a table in excel. The formula looks like this: ```@[FirstName] & @[LastName]```.

I also have another problem where an Excel document exported from another system have invalid data zoomScaleNormal="0".

I have fixed both problems in an inherited class of Spreadsheet - but it is hard to implement, because the load() method for instance creates a ```new Spreadsheet()```. In simplexml_load_string() it is possible to specify classname. Is it possible to implement something like this? Or maybe a ```public static fuction setSpreadsheetClass(string $className)```
