### PR TITLE
Fix formula string truncated at the end.

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xls/Parser.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Parser.php
@@ -563,7 +563,7 @@ class Parser
     private function convertString($string)
     {
         // chop away beggining and ending quotes
-        $string = substr($string, 1, -2);
+        $string = substr($string, 1, -1);
         if (strlen($string) > 255) {
             throw new WriterException('String is too long');
         }


### PR DESCRIPTION
Wrong use of substr() in commit 453f8f182140930f18fe9edaf8dc84cd5560c9a3 makes
formula string truncated at the end.

Signed-off-by: Toha <tohenk@yahoo.com>

This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
