### PR TITLE
Brand logo added to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# PhpSpreadsheet
+<p align="center">
+    <a href="https://phpspreadsheet.readthedocs.io/" target="_blank">
+        <img src="https://phpspreadsheet.readthedocs.io/en/develop/assets/logo.svg" width="500" alt="PhpSpreadsheet">
+    </a>
+</p>
 
 Master:
 [![Build Status](https://travis-ci.org/PHPOffice/PhpSpreadsheet.svg?branch=master)](https://travis-ci.org/PHPOffice/PhpSpreadsheet)


### PR DESCRIPTION
This is minor cosmetic change, which adds brand logo to README.md
Logo has been picked up from https://phpspreadsheet.readthedocs.io

### Why this change is needed?

Having brand logo makes repository appearance to be more prestigious and easy to recognize.