### PR TITLE
[docs] array short syntax

### DIFF
--- a/docs/topics/accessing-cells.md
+++ b/docs/topics/accessing-cells.md
@@ -178,13 +178,13 @@ It is also possible to set a range of cell values in a single call by
 passing an array of values to the `fromArray()` method.
 
 ``` php
-$arrayData = array(
-    array(NULL, 2010, 2011, 2012),
-    array('Q1',   12,   15,   21),
-    array('Q2',   56,   73,   86),
-    array('Q3',   52,   61,   69),
-    array('Q4',   30,   32,    0),
-);
+$arrayData = [
+    [NULL, 2010, 2011, 2012],
+    ['Q1',   12,   15,   21],
+    ['Q2',   56,   73,   86],
+    ['Q3',   52,   61,   69],
+    ['Q4',   30,   32,    0],
+];
 $spreadsheet->getActiveSheet()
     ->fromArray(
         $arrayData,  // The data to set
@@ -201,7 +201,7 @@ and columns. A 1-d array will be treated as a single row, which is
 particularly useful if you're fetching an array of data from a database.
 
 ``` php
-$rowArray = array('Value1', 'Value2', 'Value3', 'Value4');
+$rowArray = ['Value1', 'Value2', 'Value3', 'Value4'];
 $spreadsheet->getActiveSheet()
     ->fromArray(
         $rowArray,   // The data to set
@@ -218,7 +218,7 @@ the following will convert it into an appropriately structured 2-d array
 that can be fed to the `fromArray()` method:
 
 ``` php
-$rowArray = array('Value1', 'Value2', 'Value3', 'Value4');
+$rowArray = ['Value1', 'Value2', 'Value3', 'Value4'];
 $columnArray = array_chunk($rowArray, 1);
 $spreadsheet->getActiveSheet()
     ->fromArray(

--- a/docs/topics/autofilters.md
+++ b/docs/topics/autofilters.md
@@ -185,10 +185,10 @@ DateGroup rule identifying the selected year and month:
 $columnFilter->createRule()
     ->setRule(
         \PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column\Rule::AUTOFILTER_COLUMN_RULE_EQUAL,
-        array(
+        [
             'year' => 2012,
             'month' => 1
-        )
+        ]
     )
     ->setRuleType(
         \PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column\Rule::AUTOFILTER_RULETYPE_DATEGROUP

--- a/docs/topics/calculation-engine.md
+++ b/docs/topics/calculation-engine.md
@@ -308,21 +308,21 @@ This is the statistical mean.
 ##### Examples
 
 ``` php
-$database = array(
-    array( 'Tree',  'Height', 'Age', 'Yield', 'Profit' ),
-    array( 'Apple',  18,       20,    14,      105.00  ),
-    array( 'Pear',   12,       12,    10,       96.00  ),
-    array( 'Cherry', 13,       14,     9,      105.00  ),
-    array( 'Apple',  14,       15,    10,       75.00  ),
-    array( 'Pear',    9,        8,     8,       76.80  ),
-    array( 'Apple',   8,        9,     6,       45.00  ),
-);
+$database = [
+    [ 'Tree',  'Height', 'Age', 'Yield', 'Profit' ],
+    [ 'Apple',  18,       20,    14,      105.00  ],
+    [ 'Pear',   12,       12,    10,       96.00  ],
+    [ 'Cherry', 13,       14,     9,      105.00  ],
+    [ 'Apple',  14,       15,    10,       75.00  ],
+    [ 'Pear',    9,        8,     8,       76.80  ],
+    [ 'Apple',   8,        9,     6,       45.00  ],
+];
 
-$criteria = array(
-    array( 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ),
-    array( '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ),
-    array( '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ),
-);
+$criteria = [
+    [ 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ],
+    [ '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ],
+    [ '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ],
+];
 
 $worksheet->fromArray( $criteria, NULL, 'A1' )
     ->fromArray( $database, NULL, 'A4' );
@@ -376,21 +376,21 @@ in which you specify a condition for the column.
 ##### Examples
 
 ``` php
-$database = array(
-    array( 'Tree',  'Height', 'Age', 'Yield', 'Profit' ),
-    array( 'Apple',  18,       20,    14,      105.00  ),
-    array( 'Pear',   12,       12,    10,       96.00  ),
-    array( 'Cherry', 13,       14,     9,      105.00  ),
-    array( 'Apple',  14,       15,    10,       75.00  ),
-    array( 'Pear',    9,        8,     8,       76.80  ),
-    array( 'Apple',   8,        9,     6,       45.00  ),
-);
+$database = [
+    [ 'Tree',  'Height', 'Age', 'Yield', 'Profit' ],
+    [ 'Apple',  18,       20,    14,      105.00  ],
+    [ 'Pear',   12,       12,    10,       96.00  ],
+    [ 'Cherry', 13,       14,     9,      105.00  ],
+    [ 'Apple',  14,       15,    10,       75.00  ],
+    [ 'Pear',    9,        8,     8,       76.80  ],
+    [ 'Apple',   8,        9,     6,       45.00  ],
+];
 
-$criteria = array(
-    array( 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ),
-    array( '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ),
-    array( '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ),
-);
+$criteria = [
+    [ 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ],
+    [ '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ],
+    [ '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ],
+];
 
 $worksheet->fromArray( $criteria, NULL, 'A1' )
     ->fromArray( $database, NULL, 'A4' );
@@ -447,21 +447,21 @@ in which you specify a condition for the column.
 ##### Examples
 
 ``` php
-$database = array(
-    array( 'Tree',  'Height', 'Age', 'Yield', 'Profit' ),
-    array( 'Apple',  18,       20,    14,      105.00  ),
-    array( 'Pear',   12,       12,    10,       96.00  ),
-    array( 'Cherry', 13,       14,     9,      105.00  ),
-    array( 'Apple',  14,       15,    10,       75.00  ),
-    array( 'Pear',    9,        8,     8,       76.80  ),
-    array( 'Apple',   8,        9,     6,       45.00  ),
-);
+$database = [
+    [ 'Tree',  'Height', 'Age', 'Yield', 'Profit' ],
+    [ 'Apple',  18,       20,    14,      105.00  ],
+    [ 'Pear',   12,       12,    10,       96.00  ],
+    [ 'Cherry', 13,       14,     9,      105.00  ],
+    [ 'Apple',  14,       15,    10,       75.00  ],
+    [ 'Pear',    9,        8,     8,       76.80  ],
+    [ 'Apple',   8,        9,     6,       45.00  ],
+];
 
-$criteria = array(
-    array( 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ),
-    array( '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ),
-    array( '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ),
-);
+$criteria = [
+    [ 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ],
+    [ '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ],
+    [ '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ],
+];
 
 $worksheet->fromArray( $criteria, NULL, 'A1' )
     ->fromArray( $database, NULL, 'A4' );
@@ -518,21 +518,21 @@ in which you specify a condition for the column.
 #### Examples
 
 ``` php
-$database = array(
-    array( 'Tree',  'Height', 'Age', 'Yield', 'Profit' ),
-    array( 'Apple',  18,       20,    14,      105.00  ),
-    array( 'Pear',   12,       12,    10,       96.00  ),
-    array( 'Cherry', 13,       14,     9,      105.00  ),
-    array( 'Apple',  14,       15,    10,       75.00  ),
-    array( 'Pear',    9,        8,     8,       76.80  ),
-    array( 'Apple',   8,        9,     6,       45.00  ),
-);
+$database = [
+    [ 'Tree',  'Height', 'Age', 'Yield', 'Profit' ],
+    [ 'Apple',  18,       20,    14,      105.00  ],
+    [ 'Pear',   12,       12,    10,       96.00  ],
+    [ 'Cherry', 13,       14,     9,      105.00  ],
+    [ 'Apple',  14,       15,    10,       75.00  ],
+    [ 'Pear',    9,        8,     8,       76.80  ],
+    [ 'Apple',   8,        9,     6,       45.00  ],
+];
 
-$criteria = array(
-    array( 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ),
-    array( '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ),
-    array( '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ),
-);
+$criteria = [
+    [ 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ],
+    [ '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ],
+    [ '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ],
+];
 
 $worksheet->fromArray( $criteria, NULL, 'A1' )
     ->fromArray( $database, NULL, 'A4' );
@@ -586,21 +586,21 @@ in which you specify a condition for the column.
 ##### Examples
 
 ``` php
-$database = array(
-    array( 'Tree',  'Height', 'Age', 'Yield', 'Profit' ),
-    array( 'Apple',  18,       20,    14,      105.00  ),
-    array( 'Pear',   12,       12,    10,       96.00  ),
-    array( 'Cherry', 13,       14,     9,      105.00  ),
-    array( 'Apple',  14,       15,    10,       75.00  ),
-    array( 'Pear',    9,        8,     8,       76.80  ),
-    array( 'Apple',   8,        9,     6,       45.00  ),
-);
+$database = [
+    [ 'Tree',  'Height', 'Age', 'Yield', 'Profit' ],
+    [ 'Apple',  18,       20,    14,      105.00  ],
+    [ 'Pear',   12,       12,    10,       96.00  ],
+    [ 'Cherry', 13,       14,     9,      105.00  ],
+    [ 'Apple',  14,       15,    10,       75.00  ],
+    [ 'Pear',    9,        8,     8,       76.80  ],
+    [ 'Apple',   8,        9,     6,       45.00  ],
+];
 
-$criteria = array(
-    array( 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ),
-    array( '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ),
-    array( '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ),
-);
+$criteria = [
+    [ 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ],
+    [ '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ],
+    [ '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ],
+];
 
 $worksheet->fromArray( $criteria, NULL, 'A1' )
     ->fromArray( $database, NULL, 'A4' );
@@ -654,21 +654,21 @@ in which you specify a condition for the column.
 ##### Examples
 
 ``` php
-$database = array(
-    array( 'Tree',  'Height', 'Age', 'Yield', 'Profit' ),
-    array( 'Apple',  18,       20,    14,      105.00  ),
-    array( 'Pear',   12,       12,    10,       96.00  ),
-    array( 'Cherry', 13,       14,     9,      105.00  ),
-    array( 'Apple',  14,       15,    10,       75.00  ),
-    array( 'Pear',    9,        8,     8,       76.80  ),
-    array( 'Apple',   8,        9,     6,       45.00  ),
-);
+$database = [
+    [ 'Tree',  'Height', 'Age', 'Yield', 'Profit' ],
+    [ 'Apple',  18,       20,    14,      105.00  ],
+    [ 'Pear',   12,       12,    10,       96.00  ],
+    [ 'Cherry', 13,       14,     9,      105.00  ],
+    [ 'Apple',  14,       15,    10,       75.00  ],
+    [ 'Pear',    9,        8,     8,       76.80  ],
+    [ 'Apple',   8,        9,     6,       45.00  ],
+];
 
-$criteria = array(
-    array( 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ),
-    array( '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ),
-    array( '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ),
-);
+$criteria = [
+    [ 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ],
+    [ '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ],
+    [ '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ],
+];
 
 $worksheet->fromArray( $criteria, NULL, 'A1' )
     ->fromArray( $database, NULL, 'A4' );
@@ -722,21 +722,21 @@ in which you specify a condition for the column.
 ##### Examples
 
 ``` php
-$database = array(
-    array( 'Tree',  'Height', 'Age', 'Yield', 'Profit' ),
-    array( 'Apple',  18,       20,    14,      105.00  ),
-    array( 'Pear',   12,       12,    10,       96.00  ),
-    array( 'Cherry', 13,       14,     9,      105.00  ),
-    array( 'Apple',  14,       15,    10,       75.00  ),
-    array( 'Pear',    9,        8,     8,       76.80  ),
-    array( 'Apple',   8,        9,     6,       45.00  ),
-);
+$database = [
+    [ 'Tree',  'Height', 'Age', 'Yield', 'Profit' ],
+    [ 'Apple',  18,       20,    14,      105.00  ],
+    [ 'Pear',   12,       12,    10,       96.00  ],
+    [ 'Cherry', 13,       14,     9,      105.00  ],
+    [ 'Apple',  14,       15,    10,       75.00  ],
+    [ 'Pear',    9,        8,     8,       76.80  ],
+    [ 'Apple',   8,        9,     6,       45.00  ],
+];
 
-$criteria = array(
-    array( 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ),
-    array( '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ),
-    array( '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ),
-);
+$criteria = [
+    [ 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ],
+    [ '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ],
+    [ '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ],
+];
 
 $worksheet->fromArray( $criteria, NULL, 'A1' )
     ->fromArray( $database, NULL, 'A4' );
@@ -791,21 +791,21 @@ in which you specify a condition for the column.
 ##### Examples
 
 ``` php
-$database = array(
-    array( 'Tree',  'Height', 'Age', 'Yield', 'Profit' ),
-    array( 'Apple',  18,       20,    14,      105.00  ),
-    array( 'Pear',   12,       12,    10,       96.00  ),
-    array( 'Cherry', 13,       14,     9,      105.00  ),
-    array( 'Apple',  14,       15,    10,       75.00  ),
-    array( 'Pear',    9,        8,     8,       76.80  ),
-    array( 'Apple',   8,        9,     6,       45.00  ),
-);
+$database = [
+    [ 'Tree',  'Height', 'Age', 'Yield', 'Profit' ],
+    [ 'Apple',  18,       20,    14,      105.00  ],
+    [ 'Pear',   12,       12,    10,       96.00  ],
+    [ 'Cherry', 13,       14,     9,      105.00  ],
+    [ 'Apple',  14,       15,    10,       75.00  ],
+    [ 'Pear',    9,        8,     8,       76.80  ],
+    [ 'Apple',   8,        9,     6,       45.00  ],
+];
 
-$criteria = array(
-    array( 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ),
-    array( '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ),
-    array( '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ),
-);
+$criteria = [
+    [ 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ],
+    [ '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ],
+    [ '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ],
+];
 
 $worksheet->fromArray( $criteria, NULL, 'A1' )
     ->fromArray( $database, NULL, 'A4' );
@@ -860,21 +860,21 @@ in which you specify a condition for the column.
 ##### Examples
 
 ``` php
-$database = array(
-    array( 'Tree',  'Height', 'Age', 'Yield', 'Profit' ),
-    array( 'Apple',  18,       20,    14,      105.00  ),
-    array( 'Pear',   12,       12,    10,       96.00  ),
-    array( 'Cherry', 13,       14,     9,      105.00  ),
-    array( 'Apple',  14,       15,    10,       75.00  ),
-    array( 'Pear',    9,        8,     8,       76.80  ),
-    array( 'Apple',   8,        9,     6,       45.00  ),
-);
+$database = [
+    [ 'Tree',  'Height', 'Age', 'Yield', 'Profit' ],
+    [ 'Apple',  18,       20,    14,      105.00  ],
+    [ 'Pear',   12,       12,    10,       96.00  ],
+    [ 'Cherry', 13,       14,     9,      105.00  ],
+    [ 'Apple',  14,       15,    10,       75.00  ],
+    [ 'Pear',    9,        8,     8,       76.80  ],
+    [ 'Apple',   8,        9,     6,       45.00  ],
+];
 
-$criteria = array(
-    array( 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ),
-    array( '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ),
-    array( '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ),
-);
+$criteria = [
+    [ 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ],
+    [ '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ],
+    [ '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ],
+];
 
 $worksheet->fromArray( $criteria, NULL, 'A1' )
     ->fromArray( $database, NULL, 'A4' );
@@ -928,21 +928,21 @@ in which you specify a condition for the column.
 ##### Examples
 
 ``` php
-$database = array(
-    array( 'Tree',  'Height', 'Age', 'Yield', 'Profit' ),
-    array( 'Apple',  18,       20,    14,      105.00  ),
-    array( 'Pear',   12,       12,    10,       96.00  ),
-    array( 'Cherry', 13,       14,     9,      105.00  ),
-    array( 'Apple',  14,       15,    10,       75.00  ),
-    array( 'Pear',    9,        8,     8,       76.80  ),
-    array( 'Apple',   8,        9,     6,       45.00  ),
-);
+$database = [
+    [ 'Tree',  'Height', 'Age', 'Yield', 'Profit' ],
+    [ 'Apple',  18,       20,    14,      105.00  ],
+    [ 'Pear',   12,       12,    10,       96.00  ],
+    [ 'Cherry', 13,       14,     9,      105.00  ],
+    [ 'Apple',  14,       15,    10,       75.00  ],
+    [ 'Pear',    9,        8,     8,       76.80  ],
+    [ 'Apple',   8,        9,     6,       45.00  ],
+];
 
-$criteria = array(
-    array( 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ),
-    array( '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ),
-    array( '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ),
-);
+$criteria = [
+    [ 'Tree',      'Height', 'Age', 'Yield', 'Profit', 'Height' ],
+    [ '="=Apple"', '>10',    NULL,  NULL,    NULL,     '<16'    ],
+    [ '="=Pear"',  NULL,     NULL,  NULL,    NULL,     NULL     ],
+];
 
 $worksheet->fromArray( $criteria, NULL, 'A1' )
     ->fromArray( $database, NULL, 'A4' );
@@ -1055,8 +1055,8 @@ $saveFormat = \PhpOffice\PhpSpreadsheet\Calculation\Functions::getReturnDateType
 );
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATE'),
-    array(2008, 12, 31)
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATE'],
+    [2008, 12, 31]
 );
 // $retVal = 39813.0
 
@@ -1065,8 +1065,8 @@ $retVal = call_user_func_array(
 );
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATE'),
-    array(2008, 12, 31)
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATE'],
+    [2008, 12, 31]
 );
 // $retVal = 1230681600
 
@@ -1167,38 +1167,38 @@ $date1 = 1193317015; // PHP timestamp for 25-Oct-2007
 $date2 = 1449579415; // PHP timestamp for 8-Dec-2015
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEDIF'),
-    array($date1, $date2, 'd')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEDIF'],
+    [$date1, $date2, 'd']
 );
 // $retVal = 2966
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEDIF'),
-    array($date1, $date2, 'm')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEDIF'],
+    [$date1, $date2, 'm']
 );
 // $retVal = 97
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEDIF'),
-    array($date1, $date2, 'y')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEDIF'],
+    [$date1, $date2, 'y']
 );
 // $retVal = 8
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEDIF'),
-    array($date1, $date2, 'ym')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEDIF'],
+    [$date1, $date2, 'ym']
 );
 // $retVal = 1
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEDIF'),
-    array($date1, $date2, 'yd')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEDIF'],
+    [$date1, $date2, 'yd']
 );
 // $retVal = 44
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEDIF'),
-    array($date1, $date2, 'md')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEDIF'],
+    [$date1, $date2, 'md']
 );
 // $retVal = 13
 ```
@@ -1267,8 +1267,8 @@ $saveFormat = \PhpOffice\PhpSpreadsheet\Calculation\Functions::getReturnDateType
 );
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEVALUE'),
-    array('31-Dec-2008')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEVALUE'],
+    ['31-Dec-2008']
 );
 // $retVal = 39813.0
 
@@ -1277,8 +1277,8 @@ $retVal = call_user_func_array(
 );
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEVALUE'),
-    array('31-Dec-2008')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DATEVALUE'],
+    ['31-Dec-2008']
 );
 // $retVal = 1230681600
 
@@ -1342,8 +1342,8 @@ $retVal = $worksheet->getCell('B3')->getCalculatedValue();
 
 ``` php
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DAYOFMONTH'),
-    array('25-Dec-2008')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DAYOFMONTH'],
+    ['25-Dec-2008']
 );
 // $retVal = 25
 ```
@@ -1428,14 +1428,14 @@ $date1 = 37655.0; // Excel timestamp for 25-Oct-2007
 $date2 = 39233.0; // Excel timestamp for 8-Dec-2015
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DAYS360'),
-    array($date1, $date2)
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DAYS360'],
+    [$date1, $date2]
 );
 // $retVal = 1558
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DAYS360'),
-    array($date1, $date2, TRUE)
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'DAYS360'],
+    [$date1, $date2, TRUE]
 );
 // $retVal = 1557
 ```
@@ -1508,8 +1508,8 @@ $retVal = $worksheet->getCell('B3')->getCalculatedValue();
 );
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'EDATE'),
-    array('31-Oct-2008',25)
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'EDATE'],
+    ['31-Oct-2008', 25]
 );
 // $retVal = 40512.0 (30-Nov-2010)
 ```
@@ -1579,8 +1579,8 @@ $retVal = $worksheet->getCell('B3')->getCalculatedValue();
 );
 
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'EOMONTH'),
-    array('31-Oct-2008',13)
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'EOMONTH'],
+    ['31-Oct-2008', 13]
 );
 // $retVal = 40147.0 (30-Nov-2010)
 ```
@@ -1637,8 +1637,8 @@ $retVal = $worksheet->getCell('B4')->getCalculatedValue();
 
 ``` php
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'HOUROFDAY'),
-    array('09:30')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'HOUROFDAY'],
+    ['09:30']
 );
 // $retVal = 9
 ```
@@ -1695,8 +1695,8 @@ $retVal = $worksheet->getCell('B4')->getCalculatedValue();
 
 ``` php
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'MINUTE'),
-    array('09:30')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'MINUTE'],
+    ['09:30']
 );
 // $retVal = 30
 ```
@@ -1748,8 +1748,8 @@ $retVal = $worksheet->getCell('B3')->getCalculatedValue();
 
 ``` php
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'MONTHOFYEAR'),
-    array('14-July-2008')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'MONTHOFYEAR'],
+    ['14-July-2008']
 );
 // $retVal = 7
 ```
@@ -1893,8 +1893,8 @@ $retVal = $worksheet->getCell('B4')->getCalculatedValue();
 
 ``` php
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'SECOND'),
-    array('09:30:17')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'SECOND'],
+    ['09:30:17']
 );
 // $retVal = 17
 ```
@@ -1977,8 +1977,8 @@ $retVal = $worksheet->getCell('B4')->getCalculatedValue();
 
 ``` php
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'WEEKDAY'),
-    array('14-July-2008')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'WEEKDAY'],
+    ['14-July-2008']
 );
 // $retVal = 7
 ```
@@ -2037,8 +2037,8 @@ $retVal = $worksheet->getCell('B3')->getCalculatedValue();
 
 ``` php
 $retVal = call_user_func_array(
-    array('\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'YEAR'),
-    array('14-July-2001')
+    ['\PhpOffice\PhpSpreadsheet\Calculation\Functions', 'YEAR'],
+    ['14-July-2001']
 );
 // $retVal = 2001
 ```

--- a/docs/topics/reading-and-writing-to-file.md
+++ b/docs/topics/reading-and-writing-to-file.md
@@ -107,7 +107,7 @@ reader to only load the sheets with a given name:
 
 ``` php
 $reader = new \PhpOffice\PhpSpreadsheet\Reader\Xlsx();
-$reader->setLoadSheetsOnly( array("Sheet 1", "My special sheet") );
+$reader->setLoadSheetsOnly(["Sheet 1", "My special sheet"]);
 $spreadsheet = $reader->load("05featuredemo.xlsx");
 ```
 
@@ -225,7 +225,7 @@ reader to only load the sheets with a given name:
 
 ``` php
 $reader = new \PhpOffice\PhpSpreadsheet\Reader\Xls();
-$reader->setLoadSheetsOnly( array("Sheet 1", "My special sheet") );
+$reader->setLoadSheetsOnly(["Sheet 1", "My special sheet"]);
 $spreadsheet = $reader->load("05featuredemo.xls");
 ```
 

--- a/docs/topics/reading-files.md
+++ b/docs/topics/reading-files.md
@@ -198,7 +198,7 @@ of sheet names as an array parameter to the `setLoadSheetsOnly()` method.
 ``` php
 $inputFileType = 'Xls';
 $inputFileName = './sampleData/example1.xls';
-$sheetnames = array('Data Sheet #1','Data Sheet #3');
+$sheetnames = ['Data Sheet #1','Data Sheet #3'];
 
 /**  Create a new Reader of the type defined in $inputFileType  **/
 $reader = \PhpOffice\PhpSpreadsheet\IOFactory::createReader($inputFileType);
@@ -292,7 +292,7 @@ class MyReadFilter implements \PhpOffice\PhpSpreadsheet\Reader\IReadFilter
 {
     private $startRow = 0;
     private $endRow   = 0;
-    private $columns  = array();
+    private $columns  = [];
 
     /**  Get the list of rows and columns to read  */
     public function __construct($startRow, $endRow, $columns) {
@@ -395,10 +395,11 @@ the file into that worksheet.
 
 ``` php
 $inputFileType = 'Csv';
-$inputFileNames = array('./sampleData/example1.csv',
+$inputFileNames = [
+    './sampleData/example1.csv',
     './sampleData/example2.csv'
     './sampleData/example3.csv'
-);
+];
 
 /**  Create a new Reader of the type defined in $inputFileType  **/
 $reader = \PhpOffice\PhpSpreadsheet\IOFactory::createReader($inputFileType);

--- a/docs/topics/recipes.md
+++ b/docs/topics/recipes.md
@@ -549,29 +549,29 @@ sets a cell's style to font bold, alignment right, top border thin and a
 gradient fill:
 
 ``` php
-$styleArray = array(
-    'font' => array(
+$styleArray = [
+    'font' => [
         'bold' => true,
-    ),
-    'alignment' => array(
+    ],
+    'alignment' => [
         'horizontal' => \PhpOffice\PhpSpreadsheet\Style\Alignment::HORIZONTAL_RIGHT,
-    ),
-    'borders' => array(
-        'top' => array(
+    ],
+    'borders' => [
+        'top' => [
             'borderStyle' => \PhpOffice\PhpSpreadsheet\Style\Border::BORDER_THIN,
-        ),
-    ),
-    'fill' => array(
+        ],
+    ],
+    'fill' => [
         'fillType' => \PhpOffice\PhpSpreadsheet\Style\Fill::FILL_GRADIENT_LINEAR,
         'rotation' => 90,
-        'startColor' => array(
+        'startColor' => [
             'argb' => 'FFA0A0A0',
-        ),
-        'endColor' => array(
+        ],
+        'endColor' => [
             'argb' => 'FFFFFFFF',
-        ),
-    ),
-);
+        ],
+    ],
+];
 
 $spreadsheet->getActiveSheet()->getStyle('A3')->applyFromArray($styleArray);
 ```
@@ -690,14 +690,14 @@ selection. Here is how to apply a thick red border outline around cells
 B2:G8.
 
 ``` php
-$styleArray = array(
-    'borders' => array(
-        'outline' => array(
+$styleArray = [
+    'borders' => [
+        'outline' => [
             'borderStyle' => \PhpOffice\PhpSpreadsheet\Style\Border::BORDER_THICK,
-            'color' => array('argb' => 'FFFF0000'),
-        ),
-    ),
-);
+            'color' => ['argb' => 'FFFF0000'],
+        ],
+    ],
+];
 
 $worksheet->getStyle('B2:G8')->applyFromArray($styleArray);
 ```

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -127,9 +127,9 @@ abstract class Coordinate
      *
      * @param string $pRange e.g. 'B4:D9' or 'B4:D9,H2:O11' or 'B4'
      *
-     * @return array Array containg one or more arrays containing one or two coordinate strings
-     *                                e.g. array('B4','D9') or array(array('B4','D9'),array('H2','O11'))
-     *                                        or array('B4')
+     * @return array Array containing one or more arrays containing one or two coordinate strings
+     *                                e.g. ['B4','D9'] or [['B4','D9'], ['H2','O11']]
+     *                                        or ['B4']
      */
     public static function splitRange($pRange)
     {
@@ -179,7 +179,7 @@ abstract class Coordinate
      *
      * @param string $pRange Cell range (e.g. A1:A1)
      *
-     * @return array Range coordinates array(Start Cell, End Cell)
+     * @return array Range coordinates [Start Cell, End Cell]
      *                    where Start Cell and End Cell are arrays (Column Number, Row Number)
      */
     public static function rangeBoundaries($pRange)
@@ -230,8 +230,8 @@ abstract class Coordinate
      *
      * @param string $pRange Cell range (e.g. A1:A1)
      *
-     * @return array Range coordinates array(Start Cell, End Cell)
-     *                    where Start Cell and End Cell are arrays (Column ID, Row Number)
+     * @return array Range coordinates [Start Cell, End Cell]
+     *                    where Start Cell and End Cell are arrays [Column ID, Row Number]
      */
     public static function getRangeBoundaries($pRange)
     {

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -7522,7 +7522,7 @@ class Xls extends BaseReader
 
     /**
      * read BIFF8 constant value array from array data
-     * returns e.g. array('value' => '{1,2;3,4}', 'size' => 40}
+     * returns e.g. ['value' => '{1,2;3,4}', 'size' => 40]
      * section 2.5.8.
      *
      * @param string $arrayData
@@ -7562,7 +7562,7 @@ class Xls extends BaseReader
     /**
      * read BIFF8 constant value which may be 'Empty Value', 'Number', 'String Value', 'Boolean Value', 'Error Value'
      * section 2.5.7
-     * returns e.g. array('value' => '5', 'size' => 9).
+     * returns e.g. ['value' => '5', 'size' => 9].
      *
      * @param string $valueData
      *

--- a/src/PhpSpreadsheet/Reader/Xls/Color.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Color.php
@@ -13,7 +13,7 @@ class Color
      * @param array $palette Color palette
      * @param int $version
      *
-     * @return array RGB color value, example: array('rgb' => 'FF0000')
+     * @return array RGB color value, example: ['rgb' => 'FF0000']
      */
     public static function map($color, $palette, $version)
     {

--- a/src/PhpSpreadsheet/Shared/Escher/DggContainer.php
+++ b/src/PhpSpreadsheet/Shared/Escher/DggContainer.php
@@ -164,7 +164,7 @@ class DggContainer
     }
 
     /**
-     * Set identifier clusters. array(<drawingId> => <max shape id>, ...).
+     * Set identifier clusters. [<drawingId> => <max shape id>, ...].
      *
      * @param array $pValue
      */

--- a/src/PhpSpreadsheet/Style/Alignment.php
+++ b/src/PhpSpreadsheet/Style/Alignment.php
@@ -126,12 +126,12 @@ class Alignment extends Supervisor
      * Apply styles from array.
      * <code>
      * $spreadsheet->getActiveSheet()->getStyle('B2')->getAlignment()->applyFromArray(
-     *        array(
-     *            'horizontal' => \PhpOffice\PhpSpreadsheet\Style\Alignment::HORIZONTAL_CENTER,
-     *            'vertical'   => \PhpOffice\PhpSpreadsheet\Style\Alignment::VERTICAL_CENTER,
-     *            'textRotation'   => 0,
-     *            'wrapText'            => TRUE
-     *        )
+     *        [
+     *            'horizontal'   => \PhpOffice\PhpSpreadsheet\Style\Alignment::HORIZONTAL_CENTER,
+     *            'vertical'     => \PhpOffice\PhpSpreadsheet\Style\Alignment::VERTICAL_CENTER,
+     *            'textRotation' => 0,
+     *            'wrapText'     => TRUE
+     *        ]
      * );
      * </code>.
      *

--- a/src/PhpSpreadsheet/Style/Border.php
+++ b/src/PhpSpreadsheet/Style/Border.php
@@ -114,12 +114,12 @@ class Border extends Supervisor
      *
      * <code>
      * $spreadsheet->getActiveSheet()->getStyle('B2')->getBorders()->getTop()->applyFromArray(
-     *        array(
+     *        [
      *            'borderStyle' => Border::BORDER_DASHDOT,
-     *            'color' => array(
+     *            'color' => [
      *                'rgb' => '808080'
-     *            )
-     *        )
+     *            ]
+     *        ]
      * );
      * </code>
      *

--- a/src/PhpSpreadsheet/Style/Borders.php
+++ b/src/PhpSpreadsheet/Style/Borders.php
@@ -162,32 +162,32 @@ class Borders extends Supervisor
      * Apply styles from array.
      * <code>
      * $spreadsheet->getActiveSheet()->getStyle('B2')->getBorders()->applyFromArray(
-     *         array(
-     *             'bottom'     => array(
+     *         [
+     *             'bottom' => [
      *                 'borderStyle' => Border::BORDER_DASHDOT,
-     *                 'color' => array(
+     *                 'color' => [
      *                     'rgb' => '808080'
-     *                 )
-     *             ),
-     *             'top'     => array(
+     *                 ]
+     *             ],
+     *             'top' => [
      *                 'borderStyle' => Border::BORDER_DASHDOT,
-     *                 'color' => array(
+     *                 'color' => [
      *                     'rgb' => '808080'
-     *                 )
-     *             )
-     *         )
+     *                 ]
+     *             ]
+     *         ]
      * );
      * </code>
      * <code>
      * $spreadsheet->getActiveSheet()->getStyle('B2')->getBorders()->applyFromArray(
-     *         array(
-     *             'allBorders' => array(
+     *         [
+     *             'allBorders' => [
      *                 'borderStyle' => Border::BORDER_DASHDOT,
-     *                 'color' => array(
+     *                 'color' => [
      *                     'rgb' => '808080'
-     *                 )
-     *             )
-     *         )
+     *                 ]
+     *             ]
+     *         ]
      * );
      * </code>.
      *

--- a/src/PhpSpreadsheet/Style/Color.php
+++ b/src/PhpSpreadsheet/Style/Color.php
@@ -87,7 +87,7 @@ class Color extends Supervisor
     /**
      * Apply styles from array.
      * <code>
-     * $spreadsheet->getActiveSheet()->getStyle('B2')->getFont()->getColor()->applyFromArray( array('rgb' => '808080') );
+     * $spreadsheet->getActiveSheet()->getStyle('B2')->getFont()->getColor()->applyFromArray(['rgb' => '808080']);
      * </code>.
      *
      * @param array $pStyles Array containing style information

--- a/src/PhpSpreadsheet/Style/Fill.php
+++ b/src/PhpSpreadsheet/Style/Fill.php
@@ -123,16 +123,16 @@ class Fill extends Supervisor
      * Apply styles from array.
      * <code>
      * $spreadsheet->getActiveSheet()->getStyle('B2')->getFill()->applyFromArray(
-     *        array(
-     *            'fillType'       => Fill::FILL_GRADIENT_LINEAR,
-     *            'rotation'   => 0,
-     *            'startColor' => array(
-     *                'rgb' => '000000'
-     *            ),
-     *            'endColor'   => array(
-     *                'argb' => 'FFFFFFFF'
-     *            )
-     *        )
+     *     [
+     *         'fillType' => Fill::FILL_GRADIENT_LINEAR,
+     *         'rotation' => 0,
+     *         'startColor' => [
+     *             'rgb' => '000000'
+     *         ],
+     *         'endColor' => [
+     *             'argb' => 'FFFFFFFF'
+     *         ]
+     *     ]
      * );
      * </code>.
      *

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -143,18 +143,18 @@ class Font extends Supervisor
      * Apply styles from array.
      * <code>
      * $spreadsheet->getActiveSheet()->getStyle('B2')->getFont()->applyFromArray(
-     *        array(
-     *            'name'      => 'Arial',
-     *            'bold'      => TRUE,
-     *            'italic'    => FALSE,
-     *            'underline' => \PhpOffice\PhpSpreadsheet\Style\Font::UNDERLINE_DOUBLE,
-     *            'strikethrough'    => FALSE,
-     *            'color'     => array(
-     *                'rgb' => '808080'
-     *            )
-     *        )
+     *     [
+     *         'name' => 'Arial',
+     *         'bold' => TRUE,
+     *         'italic' => FALSE,
+     *         'underline' => \PhpOffice\PhpSpreadsheet\Style\Font::UNDERLINE_DOUBLE,
+     *         'strikethrough' => FALSE,
+     *         'color' => [
+     *             'rgb' => '808080'
+     *         ]
+     *     ]
      * );
-     * </code>.
+     * </code>
      *
      * @param array $pStyles Array containing style information
      *

--- a/src/PhpSpreadsheet/Style/NumberFormat.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat.php
@@ -125,9 +125,9 @@ class NumberFormat extends Supervisor
      * Apply styles from array.
      * <code>
      * $spreadsheet->getActiveSheet()->getStyle('B2')->getNumberFormat()->applyFromArray(
-     *        array(
-     *            'formatCode' => NumberFormat::FORMAT_CURRENCY_EUR_SIMPLE
-     *        )
+     *     [
+     *         'formatCode' => NumberFormat::FORMAT_CURRENCY_EUR_SIMPLE
+     *     ]
      * );
      * </code>.
      *

--- a/src/PhpSpreadsheet/Style/Protection.php
+++ b/src/PhpSpreadsheet/Style/Protection.php
@@ -74,12 +74,12 @@ class Protection extends Supervisor
      * Apply styles from array.
      * <code>
      * $spreadsheet->getActiveSheet()->getStyle('B2')->getLocked()->applyFromArray(
-     *        array(
-     *            'locked' => TRUE,
-     *            'hidden' => FALSE
-     *        )
+     *     [
+     *         'locked' => TRUE,
+     *         'hidden' => FALSE
+     *     ]
      * );
-     * </code>.
+     * </code>
      *
      * @param array $pStyles Array containing style information
      *

--- a/src/PhpSpreadsheet/Style/Style.php
+++ b/src/PhpSpreadsheet/Style/Style.php
@@ -151,33 +151,33 @@ class Style extends Supervisor
      *
      * <code>
      * $spreadsheet->getActiveSheet()->getStyle('B2')->applyFromArray(
-     *         array(
-     *             'font'    => array(
-     *                 'name'      => 'Arial',
-     *                 'bold'      => true,
-     *                 'italic'    => false,
-     *                 'underline' => Font::UNDERLINE_DOUBLE,
-     *                 'strikethrough'    => false,
-     *                 'color'     => array(
+     *     [
+     *         'font' => [
+     *             'name' => 'Arial',
+     *             'bold' => true,
+     *             'italic' => false,
+     *             'underline' => Font::UNDERLINE_DOUBLE,
+     *             'strikethrough' => false,
+     *             'color' => [
+     *                 'rgb' => '808080'
+     *             ]
+     *         ],
+     *         'borders' => [
+     *             'bottom' => [
+     *                 'borderStyle' => Border::BORDER_DASHDOT,
+     *                 'color' => [
      *                     'rgb' => '808080'
-     *                 )
-     *             ),
-     *             'borders' => array(
-     *                 'bottom'     => array(
-     *                     'borderStyle' => Border::BORDER_DASHDOT,
-     *                     'color' => array(
-     *                         'rgb' => '808080'
-     *                     )
-     *                 ),
-     *                 'top'     => array(
-     *                     'borderStyle' => Border::BORDER_DASHDOT,
-     *                     'color' => array(
-     *                         'rgb' => '808080'
-     *                     )
-     *                 )
-     *             ),
-     *             'quotePrefix'    => true
-     *         )
+     *                 ]
+     *             ],
+     *             'top' => [
+     *                 'borderStyle' => Border::BORDER_DASHDOT,
+     *                 'color' => [
+     *                     'rgb' => '808080'
+     *                 ]
+     *             ]
+     *         ],
+     *         'quotePrefix'    => true
+     *     ]
      * );
      * </code>
      *

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2712,7 +2712,7 @@ class Worksheet implements IComparable
      * Extract worksheet title from range.
      *
      * Example: extractSheetTitle("testSheet!A1") ==> 'A1'
-     * Example: extractSheetTitle("'testSheet 1'!A1", true) ==> array('testSheet 1', 'A1');
+     * Example: extractSheetTitle("'testSheet 1'!A1", true) ==> ['testSheet 1', 'A1'];
      *
      * @param string $pRange Range to extract title from
      * @param bool $returnRange Return range? (see example)

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -552,8 +552,8 @@ class Worksheet extends BIFFwriter
             $lastCell = $explodes[1];
         }
 
-        $firstCellCoordinates = Coordinate::coordinateFromString($firstCell); // e.g. array(0, 1)
-        $lastCellCoordinates = Coordinate::coordinateFromString($lastCell); // e.g. array(1, 6)
+        $firstCellCoordinates = Coordinate::coordinateFromString($firstCell); // e.g. [0, 1]
+        $lastCellCoordinates = Coordinate::coordinateFromString($lastCell); // e.g. [1, 6]
 
         return pack('vvvv', $firstCellCoordinates[1] - 1, $lastCellCoordinates[1] - 1, Coordinate::columnIndexFromString($firstCellCoordinates[0]) - 1, Coordinate::columnIndexFromString($lastCellCoordinates[0]) - 1);
     }


### PR DESCRIPTION
This is a doc fix, which applies array short syntax over PHPDoc and 'docs'

### Why this change is needed?

Since this library requires PHP >= 5.6 and uses array shortsyntax in its source code, its documentation should use it too.