### PR TITLE
Correct display of the European currency

### DIFF
--- a/src/PhpSpreadsheet/Style/NumberFormat.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat.php
@@ -47,7 +47,8 @@ class NumberFormat extends Supervisor
 
     const FORMAT_CURRENCY_USD_SIMPLE = '"$"#,##0.00_-';
     const FORMAT_CURRENCY_USD = '$#,##0_-';
-    const FORMAT_CURRENCY_EUR_SIMPLE = '[$EUR ]#,##0.00_-';
+    const FORMAT_CURRENCY_EUR_SIMPLE = '#,##0_-"€"';
+    const FORMAT_CURRENCY_EUR = '#,##0.00_-"€"';
 
     /**
      * Excel built-in number formats.


### PR DESCRIPTION
This is:

```
- [x] a fix style EUR

```

### Why this change is needed?

Correct display of the European currency
