### PR TITLE
add encode HTML option in HTML writer

### DIFF
--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -1274,7 +1274,7 @@ class Html extends BaseWriter
 
                         // Convert UTF8 data to PCDATA
                         $cellText = $element->getText();
-                        $cellData .= ($this->encodeHtml)?htmlspecialchars($cellText):$cellText;
+                        $cellData .= ($this->encodeHtml) ? htmlspecialchars($cellText) : $cellText;
 
                         if ($element instanceof Run) {
                             if ($element->getFont()->getSuperscript()) {
@@ -1300,7 +1300,7 @@ class Html extends BaseWriter
                             [$this, 'formatColor']
                         );
                     }
-                    $cellData = ($this->encodeHtml)?htmlspecialchars($cellData):$cellData;
+                    $cellData = ($this->encodeHtml) ? htmlspecialchars($cellData) : $cellData;
                     if ($pSheet->getParent()->getCellXfByIndex($cell->getXfIndex())->getFont()->getSuperscript()) {
                         $cellData = '<sup>' . $cellData . '</sup>';
                     } elseif ($pSheet->getParent()->getCellXfByIndex($cell->getXfIndex())->getFont()->getSubscript()) {
@@ -1522,7 +1522,7 @@ class Html extends BaseWriter
     }
 
     /**
-     * Set encode HTML text inside cell
+     * Set encode HTML text inside cell.
      *
      * @param bool $pValue
      *

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -126,6 +126,13 @@ class Html extends BaseWriter
     private $generateSheetNavigationBlock = true;
 
     /**
+     * Encode text displayed inside the cell.
+     *
+     * @var bool
+     */
+    private $encodeHtml = true;
+
+    /**
      * Create a new HTML.
      *
      * @param Spreadsheet $spreadsheet
@@ -1267,7 +1274,7 @@ class Html extends BaseWriter
 
                         // Convert UTF8 data to PCDATA
                         $cellText = $element->getText();
-                        $cellData .= htmlspecialchars($cellText);
+                        $cellData .= ($this->encodeHtml)?htmlspecialchars($cellText):$cellText;
 
                         if ($element instanceof Run) {
                             if ($element->getFont()->getSuperscript()) {
@@ -1293,7 +1300,7 @@ class Html extends BaseWriter
                             [$this, 'formatColor']
                         );
                     }
-                    $cellData = htmlspecialchars($cellData);
+                    $cellData = ($this->encodeHtml)?htmlspecialchars($cellData):$cellData;
                     if ($pSheet->getParent()->getCellXfByIndex($cell->getXfIndex())->getFont()->getSuperscript()) {
                         $cellData = '<sup>' . $cellData . '</sup>';
                     } elseif ($pSheet->getParent()->getCellXfByIndex($cell->getXfIndex())->getFont()->getSubscript()) {
@@ -1510,6 +1517,20 @@ class Html extends BaseWriter
     public function setUseInlineCss($pValue)
     {
         $this->useInlineCss = $pValue;
+
+        return $this;
+    }
+
+    /**
+     * Set encode HTML text inside cell
+     *
+     * @param bool $pValue
+     *
+     * @return HTML
+     */
+    public function setEncodeHtml($pValue)
+    {
+        $this->encodeHtml = $pValue;
 
         return $this;
     }


### PR DESCRIPTION
Added the feature to bypass the htmlspecialchars function when render as HTML.
This is useful if you want to put some html inputs instead of plain value to use the generated html as an excel form so it can be edited in browser or to attach some javascript event listeners (for example a right click for a context menu) The escaping of the text inside the input then became the responsibility of the input.