### PR TITLE
fix topLeftCell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- HTML writer creates a generator meta tag - [#312](https://github.com/PHPOffice/PhpSpreadsheet/issues/312) 
+- HTML writer creates a generator meta tag - [#312](https://github.com/PHPOffice/PhpSpreadsheet/issues/312)
 - Support invalid zoom value in XLSX format - [#350](https://github.com/PHPOffice/PhpSpreadsheet/pull/350)
 - Support for `_xlfn.` prefixed functions and `ISFORMULA`, `MODE.SNGL`, `STDEV.S`, `STDEV.P` - [#390](https://github.com/PHPOffice/PhpSpreadsheet/pull/390)
 
 ### Fixed
 
-- Avoid potentially unsupported PSR-16 cache keys - [#354](https://github.com/PHPOffice/PhpSpreadsheet/issues/354) 
-- Check for MIME type to know if CSV reader can read a file - [#167](https://github.com/PHPOffice/PhpSpreadsheet/issues/167) 
-- Use proper € symbol for currency format - [#379](https://github.com/PHPOffice/PhpSpreadsheet/pull/379) 
-- Read printing area correctly when skipping some sheets - [#371](https://github.com/PHPOffice/PhpSpreadsheet/issues/371) 
+- Select correct cell when calling freezePane - [#389](https://github.com/PHPOffice/PhpSpreadsheet/issues/389)
+- Avoid potentially unsupported PSR-16 cache keys - [#354](https://github.com/PHPOffice/PhpSpreadsheet/issues/354)
+- Check for MIME type to know if CSV reader can read a file - [#167](https://github.com/PHPOffice/PhpSpreadsheet/issues/167)
+- Use proper € symbol for currency format - [#379](https://github.com/PHPOffice/PhpSpreadsheet/pull/379)
+- Read printing area correctly when skipping some sheets - [#371](https://github.com/PHPOffice/PhpSpreadsheet/issues/371)
 
 ## [1.1.0] - 2018-01-28
 

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1971,7 +1971,7 @@ class Worksheet implements IComparable
      *
      *     - A2 will freeze the rows above cell A2 (i.e row 1)
      *     - B1 will freeze the columns to the left of cell B1 (i.e column A)
-     *     - B2 will freeze the rows above and to the left of cell A2 (i.e row 1 and column A)
+     *     - B2 will freeze the rows above and to the left of cell B2 (i.e row 1 and column A)
      *
      * @param null|string $cell Position of the split
      * @param null|string $topLeftCell default position of the right bottom pane
@@ -1988,7 +1988,7 @@ class Worksheet implements IComparable
 
         if ($cell !== null && $topLeftCell === null) {
             $coordinate = Coordinate::coordinateFromString($cell);
-            $topLeftCell = $coordinate[0] . ($coordinate[1] + 1);
+            $topLeftCell = $coordinate[0] . $coordinate[1];
         }
 
         $this->freezePane = $cell;

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -127,7 +127,7 @@ class WorksheetTest extends TestCase
     public function testFreezePaneSelectedCell()
     {
         $worksheet = new Worksheet();
-        $worksheet->freezePane("B2");
-        self::assertSame("B2", $worksheet->getTopLeftCell());
+        $worksheet->freezePane('B2');
+        self::assertSame('B2', $worksheet->getTopLeftCell());
     }
 }

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -123,4 +123,11 @@ class WorksheetTest extends TestCase
         $sheet->setCodeName('Test Code Name', false);
         self::assertSame('Test Code Name', $sheet->getCodeName());
     }
+
+    public function testFreezePaneSelectedCell()
+    {
+        $worksheet = new Worksheet();
+        $worksheet->freezePane("B2");
+        self::assertSame("B2", $worksheet->getTopLeftCell());
+    }
 }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

Fixes a bug when calling `->freezePane("B2")` without a second argument.

The selected cell will be `B3` but should be `B2`

fixes #389