### PR TITLE
Add notes for the Timezone functions in Date class

### DIFF
--- a/docs/topics/calculation-engine.md
+++ b/docs/topics/calculation-engine.md
@@ -263,7 +263,7 @@ return an Excel date timestamp.
 Takes year, month and day values (and optional hour, minute and second
 values) and returns an Excel date timestamp value.
 
-### Timezone Support for Excel date timestamp conversions
+### Timezone support for Excel date timestamp conversions
 
 The default timezone for the date functions in PhpSpreadsheet is UST (Universal Standard Time).
 If a different timezone needs to be used, these methods are available:

--- a/docs/topics/calculation-engine.md
+++ b/docs/topics/calculation-engine.md
@@ -263,6 +263,28 @@ return an Excel date timestamp.
 Takes year, month and day values (and optional hour, minute and second
 values) and returns an Excel date timestamp value.
 
+### Timezone Support for Excel date timestamp conversions
+
+The default timezone for the date functions in PhpSpreadsheet is UST (Universal Standard Time).
+If a different timezone needs to be used, these methods are available:
+
+#### \PhpOffice\PhpSpreadsheet\Shared\Date::getDefaultTimezone()
+
+Returns the current timezone value PhpSpeadsheet is using to handle dates and times.
+
+#### \PhpOffice\PhpSpreadsheet\Shared\Date::setDefaultTimezone($timeZone)
+
+Sets the timezone for Excel date timestamp conversions to $timeZone,
+which must be a valid PHP DateTimeZone value.
+The return value is a Boolean, where true is success,
+and false is failure (e.g. an invalid DateTimeZone value was passed.)
+
+#### \PhpOffice\PhpSpreadsheet\Shared\Date::excelToDateTimeObject($excelDate, $timeZone)
+#### \PhpOffice\PhpSpreadsheet\Shared\Date::excelToTimeStamp($excelDate, $timeZone)
+
+These functions support a timezone as an optional second parameter.
+This applies a specific timezone to that function call without affecting the default PhpSpreadsheet Timezone.
+
 ## Function Reference
 
 ### Database Functions


### PR DESCRIPTION
The \PhpOffice\PhpSpreadsheet\Shared\Date class has support for setting an alternate timezone which affects the conversion of Excel Date timestamps in PhpSpreadsheet. This amendment is an effort to document this support.

This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [X] Documentation is updated as necessary

### Why this change is needed?
The \PhpOffice\PhpSpreadsheet\Shared\Date class has functions that support using different timezones. This change provides documentation for how to update the default timezone as well as how to apply a different timezone via parameter for specific function calls.
I only discovered this capability by looking at the Date class source code.