### PR TITLE
Mark minified JS as binary in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /tests export-ignore
 README.md export-ignore
+*.min.js binary


### PR DESCRIPTION
This makes it easier to read the output of git grep :-)
