### PR TITLE
Fix issue with plain text and richtext being in the same cell

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2068,7 +2068,9 @@ class Xlsx extends BaseReader
         } else {
             if (is_object($is->r)) {
                 foreach ($is->r as $run) {
-                    if (isset($run->rPr)) {
+                    if (!isset($run->rPr)) {
+                        $objText = $value->createText(StringHelper::controlCharacterOOXML2PHP((string) $run->t));
+                    } else {
                         $objText = $value->createTextRun(StringHelper::controlCharacterOOXML2PHP((string) $run->t));
 
                         if (isset($run->rPr->rFont['val'])) {


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```
### Why this change is needed?

Fixes #442. Introduced in 0084776160abcc2bd1d5be3012c7b9cf5edd7dd1. I am not exactly sure why condition was removed, but returning it the way it was fixes the issue.
