### PR TITLE
Fix add a maximum column width parameter for Worksheet and check it for autoSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Define a max column width for worksheet to avoid format issues - [#455](https://github.com/PHPOffice/PhpSpreadsheet/pull/455)
 - Avoid potentially unsupported PSR-16 cache keys - [#354](https://github.com/PHPOffice/PhpSpreadsheet/issues/354)
 - Check for MIME type to know if CSV reader can read a file - [#167](https://github.com/PHPOffice/PhpSpreadsheet/issues/167)
 - Use proper € symbol for currency format - [#379](https://github.com/PHPOffice/PhpSpreadsheet/pull/379)

--- a/src/PhpSpreadsheet/Worksheet/ColumnDimension.php
+++ b/src/PhpSpreadsheet/Worksheet/ColumnDimension.php
@@ -28,6 +28,15 @@ class ColumnDimension extends Dimension
     private $autoSize = false;
 
     /**
+     * Maximum column width.
+     *
+     * Define the maximum width of a column
+     *
+     * @var int
+     */
+    const MAX_WIDTH = 255;
+
+    /**
      * Create a new ColumnDimension.
      *
      * @param string $pIndex Character column index

--- a/src/PhpSpreadsheet/Worksheet/ColumnDimension.php
+++ b/src/PhpSpreadsheet/Worksheet/ColumnDimension.php
@@ -32,7 +32,6 @@ class ColumnDimension extends Dimension
      *
      * Define the maximum width of a column
      *
-     * @var int
      */
     const MAX_WIDTH = 255;
 

--- a/src/PhpSpreadsheet/Worksheet/ColumnDimension.php
+++ b/src/PhpSpreadsheet/Worksheet/ColumnDimension.php
@@ -27,12 +27,6 @@ class ColumnDimension extends Dimension
      */
     private $autoSize = false;
 
-    /**
-     * Maximum column width.
-     *
-     * Define the maximum width of a column
-     *
-     */
     const MAX_WIDTH = 255;
 
     /**

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -768,6 +768,9 @@ class Worksheet implements IComparable
                 if ($width == -1) {
                     $width = $this->getDefaultColumnDimension()->getWidth();
                 }
+                if ($width > ColumnDimension::MAX_WIDTH) {
+                    $width = ColumnDimension::MAX_WIDTH;
+                }
                 $this->getColumnDimension($columnIndex)->setWidth($width);
             }
         }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
If the autoSize() calculate a width for a column superior to 255 (maximum Excel width column) the column size is set at minimum width instead of maximum