### PR TITLE
allow return in save function param

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -172,13 +172,14 @@ class Xlsx extends BaseWriter
      */
     public function save($pFilename)
     {
+		$return = null;
         if ($this->spreadSheet !== null) {
             // garbage collect
             $this->spreadSheet->garbageCollect();
 
             // If $pFilename is php://output or php://stdout, make it a temporary file...
             $originalFilename = $pFilename;
-            if (strtolower($pFilename) == 'php://output' || strtolower($pFilename) == 'php://stdout') {
+            if (strtolower($pFilename) == 'php://output' || strtolower($pFilename) == 'php://stdout' || strtolower($pFilename) == 'return') {
                 $pFilename = @tempnam(File::sysGetTempDir(), 'phpxltmp');
                 if ($pFilename == '') {
                     $pFilename = $originalFilename;
@@ -377,7 +378,9 @@ class Xlsx extends BaseWriter
 
             // If a temporary file was used, copy it to the correct file stream
             if ($originalFilename != $pFilename) {
-                if (copy($pFilename, $originalFilename) === false) {
+                if($originalFilename == 'return') {
+                    $return = file_get_contents($pFilename);
+                } elseif (copy($pFilename, $originalFilename) === false) {
                     throw new WriterException("Could not copy temporary zip file $pFilename to $originalFilename.");
                 }
                 @unlink($pFilename);
@@ -385,6 +388,7 @@ class Xlsx extends BaseWriter
         } else {
             throw new WriterException('PhpSpreadsheet object unassigned.');
         }
+		return $return;
     }
 
     /**


### PR DESCRIPTION
set first param to return to get the content instead of put in a file

This is:

- [ ] a bugfix
- [ X] a new feature

Checklist:

    Changes are covered by unit tests
    [ X] Code style is respected
    [ X] Commit message explains why the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
    CHANGELOG.md contains a short summary of the change
    Documentation is updated as necessary

Why this change is needed?

insted of make :

$Excel->save($tempfile);
$content = file_get_content($tempfile);
unset($tempfile);

We have just :

$content = $Excel->save('return');

Very usefull when we want to add many Excel Files to a unique zip.