### PR TITLE
Fix format on conditional formatting

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1916,7 +1916,13 @@ class Xlsx extends BaseReader
      */
     private static function readStyle(Style $docStyle, $style)
     {
-        $docStyle->getNumberFormat()->setFormatCode($style->numFmt);
+        if (isset($style->numFmt)) {
+            if (isset($style->numFmt['formatCode'])) {
+                $docStyle->getNumberFormat()->setFormatCode((string) $style->numFmt['formatCode']);
+            } else {
+                $docStyle->getNumberFormat()->setFormatCode($style->numFmt);
+            }
+        }
 
         // font
         if (isset($style->font)) {


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature


## Why this change is needed?

If you read a xlsx file with specific format (eg: percent) on conditional formatting, the format is ereasing.