### PR TITLE
Add cache entry for highest row and column

### DIFF
--- a/src/PhpSpreadsheet/Collection/Cells.php
+++ b/src/PhpSpreadsheet/Collection/Cells.php
@@ -10,6 +10,9 @@ use Psr\SimpleCache\CacheInterface;
 
 class Cells
 {
+
+    const CACHE_ID_HIGHEST_ROW_AND_COLUMN = 'highestRowAndColumn';
+
     /**
      * @var \Psr\SimpleCache\CacheInterface
      */
@@ -168,6 +171,10 @@ class Cells
      */
     public function getHighestRowAndColumn()
     {
+        if ($this->cache->has(self::CACHE_ID_HIGHEST_ROW_AND_COLUMN)) {
+            return $this->cache->get(self::CACHE_ID_HIGHEST_ROW_AND_COLUMN);
+        }
+
         // Lookup highest column and highest row
         $col = ['A' => '1A'];
         $row = [1];
@@ -182,10 +189,14 @@ class Cells
             $highestColumn = substr(max($col), 1);
         }
 
-        return [
+        $highestRowAndColumn = [
             'row' => $highestRow,
             'column' => $highestColumn,
         ];
+
+        $this->cache->set(self::CACHE_ID_HIGHEST_ROW_AND_COLUMN, $highestRowAndColumn);
+
+        return $highestRowAndColumn;
     }
 
     /**


### PR DESCRIPTION
this prevents to much calls to expensive sscanf and strlen

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

The calls to Cell::getHighestRowAndColumn() are extremely expensive and increase the runtime on spreadsheets for reading.
This does not directly belong to #468 but was inspired by finding when debugging this. The PR is just to start the discussion about the performance in this part.