### PR TITLE
Fix #485 Missing required parameters

### DIFF
--- a/src/PhpSpreadsheet/Shared/Trend/PolynomialBestFit.php
+++ b/src/PhpSpreadsheet/Shared/Trend/PolynomialBestFit.php
@@ -164,7 +164,7 @@ class PolynomialBestFit extends BestFit
         $this->intersect = array_shift($coefficients);
         $this->slope = $coefficients;
 
-        $this->calculateGoodnessOfFit($x_sum, $y_sum, $xx_sum, $yy_sum, $xy_sum);
+        $this->calculateGoodnessOfFit($x_sum, $y_sum, $xx_sum, $yy_sum, $xy_sum, 0, 0, 0);
         foreach ($this->xValues as $xKey => $xValue) {
             $this->yBestFitValues[$xKey] = $this->getValueOfYForX($xValue);
         }

--- a/src/PhpSpreadsheet/Shared/Trend/PolynomialBestFit.php
+++ b/src/PhpSpreadsheet/Shared/Trend/PolynomialBestFit.php
@@ -164,7 +164,7 @@ class PolynomialBestFit extends BestFit
         $this->intersect = array_shift($coefficients);
         $this->slope = $coefficients;
 
-        $this->calculateGoodnessOfFit($x_sum, $y_sum, $xx_sum, $yy_sum, $xy_sum, 0, 0, 0);
+        $this->calculateGoodnessOfFit($x_sum, $y_sum, $xx_sum, $yy_sum, $xy_sum, null, null, null);
         foreach ($this->xValues as $xKey => $xValue) {
             $this->yBestFitValues[$xKey] = $this->getValueOfYForX($xValue);
         }

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -827,7 +827,7 @@ class Worksheet extends BIFFwriter
             $formula = substr($formula, 1);
         } else {
             // Error handling
-            $this->writeString($row, $col, 'Unrecognised character for formula');
+            $this->writeString($row, $col, 'Unrecognised character for formula', 0);
 
             return -1;
         }

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -827,7 +827,7 @@ class Worksheet extends BIFFwriter
             $formula = substr($formula, 1);
         } else {
             // Error handling
-            $this->writeString($row, $col, 'Unrecognised character for formula', 0);
+            $this->writeString($row, $col, 'Unrecognised character for formula', null);
 
             return -1;
         }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
This fixes issue #485.

I don't know if those are the proper values, but those are the ones PHP5 would have used till now.