### PR TITLE
Fix PHPDocs in Chart/DateSeries

### DIFF
--- a/src/PhpSpreadsheet/Chart/DataSeries.php
+++ b/src/PhpSpreadsheet/Chart/DataSeries.php
@@ -217,7 +217,7 @@ class DataSeries
     /**
      * Get Plot Order.
      *
-     * @return string
+     * @return int[]
      */
     public function getPlotOrder()
     {


### PR DESCRIPTION
Wrong return type make PHPStorm Inspect Code not happy

This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [ ] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
For futur migration on PHP +7.X and type checking 