### PR TITLE
PHPOffice/PhpSpreadsheet#492 Allow CSV escape character to be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Subtotal 9 in a group that has other subtotals 9 exclude the totals of the other subtotals in the range - [#332](https://github.com/PHPOffice/PhpSpreadsheet/issues/332)
 - `Helper\Html` support UTF-8 HTML input - [#444](https://github.com/PHPOffice/PhpSpreadsheet/issues/444)
+- Allow escape character to be set in CSV reader – [#492](https://github.com/PHPOffice/PhpSpreadsheet/issues/492)
 
 ## [1.2.1] - 2018-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support to read Xlsm templates with form elements, macros, printer settings, protected elements and back compatibility drawing, and save result without losing important elements of document - [#435](https://github.com/PHPOffice/PhpSpreadsheet/issues/435)
 - Expose sheet title maximum length as `Worksheet::SHEET_TITLE_MAXIMUM_LENGTH` - [#482](https://github.com/PHPOffice/PhpSpreadsheet/issues/482)
+- Allow escape character to be set in CSV reader – [#492](https://github.com/PHPOffice/PhpSpreadsheet/issues/492)
 
 ### Fixed
 
 - Subtotal 9 in a group that has other subtotals 9 exclude the totals of the other subtotals in the range - [#332](https://github.com/PHPOffice/PhpSpreadsheet/issues/332)
 - `Helper\Html` support UTF-8 HTML input - [#444](https://github.com/PHPOffice/PhpSpreadsheet/issues/444)
-- Allow escape character to be set in CSV reader – [#492](https://github.com/PHPOffice/PhpSpreadsheet/issues/492)
 
 ## [1.2.1] - 2018-04-10
 

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -55,7 +55,7 @@ class Csv extends BaseReader
      *
      * @var string
      */
-    private $escapeCharacter;
+    private $escapeCharacter = '\\';
 
     /**
      * Create a new CSV Reader instance.

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -51,6 +51,13 @@ class Csv extends BaseReader
     private $contiguousRow = -1;
 
     /**
+     * The character that can escape the enclosure.
+     *
+     * @var string
+     */
+    private $escapeCharacter;
+
+    /**
      * Create a new CSV Reader instance.
      */
     public function __construct()
@@ -254,7 +261,7 @@ class Csv extends BaseReader
         $worksheetInfo[0]['totalColumns'] = 0;
 
         // Loop through each line of the file in turn
-        while (($rowData = fgetcsv($fileHandle, 0, $this->delimiter, $this->enclosure)) !== false) {
+        while (($rowData = fgetcsv($fileHandle, 0, $this->delimiter, $this->enclosure, $this->escapeCharacter)) !== false) {
             ++$worksheetInfo[0]['totalRows'];
             $worksheetInfo[0]['lastColumnIndex'] = max($worksheetInfo[0]['lastColumnIndex'], count($rowData) - 1);
         }
@@ -326,7 +333,7 @@ class Csv extends BaseReader
         }
 
         // Loop through each line of the file in turn
-        while (($rowData = fgetcsv($fileHandle, 0, $this->delimiter, $this->enclosure)) !== false) {
+        while (($rowData = fgetcsv($fileHandle, 0, $this->delimiter, $this->enclosure, $this->escapeCharacter)) !== false) {
             $columnLetter = 'A';
             foreach ($rowData as $rowDatum) {
                 if ($rowDatum != '' && $this->readFilter->readCell($columnLetter, $currentRow)) {
@@ -456,6 +463,30 @@ class Csv extends BaseReader
     public function getContiguous()
     {
         return $this->contiguous;
+    }
+
+    /**
+     * Set escape backslashes.
+     *
+     * @param string $escapeCharacter
+     *
+     * @return $this
+     */
+    public function setEscapeCharacter($escapeCharacter)
+    {
+        $this->escapeCharacter = $escapeCharacter;
+
+        return $this;
+    }
+
+    /**
+     * Get escape backslashes.
+     *
+     * @return string
+     */
+    public function getEscapeCharacter()
+    {
+        return $this->escapeCharacter;
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Reader/CsvTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/CsvTest.php
@@ -89,4 +89,20 @@ class CsvTest extends TestCase
             [true, '../samples/Reader/sampleData/example2.csv'],
         ];
     }
+
+    /** @test */
+    public function testEscapeCharacters()
+    {
+        $reader = (new Csv)->setEscapeCharacter('"');
+        $worksheet = $reader->load(__DIR__ . '/../../data/Reader/CSV/backslash.csv')
+            ->getActiveSheet();
+
+        $expected = [
+            ['field 1', 'field 2\\'],
+            ['field 3\\', 'field 4'],
+        ];
+
+        $this->assertSame('"', $reader->getEscapeCharacter());
+        $this->assertSame($expected, $worksheet->toArray());
+    }
 }

--- a/tests/PhpSpreadsheetTests/Reader/CsvTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/CsvTest.php
@@ -90,10 +90,9 @@ class CsvTest extends TestCase
         ];
     }
 
-    /** @test */
     public function testEscapeCharacters()
     {
-        $reader = (new Csv)->setEscapeCharacter('"');
+        $reader = (new Csv())->setEscapeCharacter('"');
         $worksheet = $reader->load(__DIR__ . '/../../data/Reader/CSV/backslash.csv')
             ->getActiveSheet();
 

--- a/tests/data/Reader/CSV/backslash.csv
+++ b/tests/data/Reader/CSV/backslash.csv
@@ -1,0 +1,2 @@
+"field 1","field 2\"
+"field 3\","field 4"


### PR DESCRIPTION
 From issue #492.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

### Why this change is needed?
Allows the escape character of the CSV reader to be set, enabling the parsing of files that include the default escape character.