### PR TITLE
Fix: make newer Excel versions properly recalculate formulas on docum…

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/Workbook.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Workbook.php
@@ -176,10 +176,10 @@ class Workbook extends WriterPart
         $objWriter->writeAttribute('calcCompleted', ($recalcRequired) ? 1 : 0);
         $objWriter->writeAttribute('fullCalcOnLoad', ($recalcRequired) ? 0 : 1);
         $objWriter->writeAttribute('forceFullCalc', ($recalcRequired) ? 0 : 1);
-        
+
         $objWriter->endElement();
     }
-    
+
     /**
      * Write sheets.
      *

--- a/src/PhpSpreadsheet/Writer/Xlsx/Workbook.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Workbook.php
@@ -179,7 +179,7 @@ class Workbook extends WriterPart
         
         $objWriter->endElement();
     }
-
+    
     /**
      * Write sheets.
      *

--- a/src/PhpSpreadsheet/Writer/Xlsx/Workbook.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Workbook.php
@@ -175,7 +175,8 @@ class Workbook extends WriterPart
         //    fullCalcOnLoad isn't needed if we've recalculating for the save
         $objWriter->writeAttribute('calcCompleted', ($recalcRequired) ? 1 : 0);
         $objWriter->writeAttribute('fullCalcOnLoad', ($recalcRequired) ? 0 : 1);
-
+        $objWriter->writeAttribute('forceFullCalc', ($recalcRequired) ? 0 : 1);
+        
         $objWriter->endElement();
     }
 


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] Code style is respected
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Fixes #456 (make newer Excel versions properly recalculate formulas when opening document).