### PR TITLE
Fix #519 Prevent infinite loop when getting references from invalid range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Helper\Html` support UTF-8 HTML input - [#444](https://github.com/PHPOffice/PhpSpreadsheet/issues/444)
 - Xlsx loaded an extra empty comment for each real comment - [#375](https://github.com/PHPOffice/PhpSpreadsheet/issues/375)
 - Xlsx reader do not read rows and columns filtered out in readFilter at all - [#370](https://github.com/PHPOffice/PhpSpreadsheet/issues/370)
+- `Coordinate::ExtractAllCellReferencesInRange()` returns empty array instead of looping when passed an invalid range – [#519](https://github.com/PHPOffice/PhpSpreadsheet/issues/519)
 
 ## [1.2.1] - 2018-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Helper\Html` support UTF-8 HTML input - [#444](https://github.com/PHPOffice/PhpSpreadsheet/issues/444)
 - Xlsx loaded an extra empty comment for each real comment - [#375](https://github.com/PHPOffice/PhpSpreadsheet/issues/375)
 - Xlsx reader do not read rows and columns filtered out in readFilter at all - [#370](https://github.com/PHPOffice/PhpSpreadsheet/issues/370)
-- `Coordinate::ExtractAllCellReferencesInRange()` returns empty array instead of looping when passed an invalid range – [#519](https://github.com/PHPOffice/PhpSpreadsheet/issues/519)
+- `Coordinate::ExtractAllCellReferencesInRange()` throws an exception for an invalid range – [#519](https://github.com/PHPOffice/PhpSpreadsheet/issues/519)
 
 ## [1.2.1] - 2018-04-10
 

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -327,7 +327,7 @@ abstract class Coordinate
     }
 
     /**
-     * Extract all cell references in range.
+     * Extract all cell references in range, which may be comprised of multiple cell ranges.
      *
      * @param string $pRange Range (e.g. A1 or A1:C10 or A1:E10 A20:E25)
      *
@@ -335,53 +335,12 @@ abstract class Coordinate
      */
     public static function extractAllCellReferencesInRange($pRange)
     {
-        // Returnvalue
         $returnValue = [];
 
         // Explode spaces
-        $cellBlocks = explode(' ', str_replace('$', '', strtoupper($pRange)));
+        $cellBlocks = self::getCellBlocksFromRangeString($pRange);
         foreach ($cellBlocks as $cellBlock) {
-            // Single cell?
-            if (!self::coordinateIsRange($cellBlock)) {
-                $returnValue[] = $cellBlock;
-
-                continue;
-            }
-
-            // Range...
-            $ranges = self::splitRange($cellBlock);
-            foreach ($ranges as $range) {
-                // Single cell?
-                if (!isset($range[1])) {
-                    $returnValue[] = $range[0];
-
-                    continue;
-                }
-
-                // Range...
-                list($rangeStart, $rangeEnd) = $range;
-                sscanf($rangeStart, '%[A-Z]%d', $startCol, $startRow);
-                sscanf($rangeEnd, '%[A-Z]%d', $endCol, $endRow);
-                ++$endCol;
-
-                // Current data
-                $currentCol = $startCol;
-                $currentRow = $startRow;
-
-                if ($startCol >= $endCol || $currentRow > $endRow) {
-                    throw new Exception('Invalid range: "' . $pRange . '"');
-                }
-
-                // Loop cells
-                while ($currentCol < $endCol) {
-                    while ($currentRow <= $endRow) {
-                        $returnValue[] = $currentCol . $currentRow;
-                        ++$currentRow;
-                    }
-                    ++$currentCol;
-                    $currentRow = $startRow;
-                }
-            }
+            $returnValue = array_merge($returnValue, static::getReferencesForCellBlock($cellBlock));
         }
 
         //    Sort the result by column and row
@@ -394,6 +353,74 @@ abstract class Coordinate
 
         // Return value
         return array_values($sortKeys);
+    }
+
+    /**
+     * Get all cell references for an individual cell block.
+     *
+     * @param string $cellBlock A cell range e.g. A4:B5
+     *
+     * @throws Exception
+     *
+     * @return array All individual cells in that range
+     */
+    protected static function getReferencesForCellBlock($cellBlock)
+    {
+        $returnValue = [];
+
+        // Single cell?
+        if (!self::coordinateIsRange($cellBlock)) {
+            return (array) $cellBlock;
+        }
+
+        // Range...
+        $ranges = self::splitRange($cellBlock);
+        foreach ($ranges as $range) {
+            // Single cell?
+            if (!isset($range[1])) {
+                $returnValue[] = $range[0];
+
+                continue;
+            }
+
+            // Range...
+            list($rangeStart, $rangeEnd) = $range;
+            list($startCol, $startRow) = static::extractColumnAndRow($rangeStart);
+            list($endCol, $endRow) = static::extractColumnAndRow($rangeEnd);
+            ++$endCol;
+
+            // Current data
+            $currentCol = $startCol;
+            $currentRow = $startRow;
+
+            if ($startCol >= $endCol || $currentRow > $endRow) {
+                throw new Exception('Invalid range: "' . $cellBlock . '"');
+            }
+
+            // Loop cells
+            while ($currentCol < $endCol) {
+                while ($currentRow <= $endRow) {
+                    $returnValue[] = $currentCol . $currentRow;
+                    ++$currentRow;
+                }
+                ++$currentCol;
+                $currentRow = $startRow;
+            }
+        }
+
+        return $returnValue;
+    }
+
+    /**
+     * Extract the column and row from a cell reference in the format [$column, $row].
+     *
+     * @param string $cell
+     *
+     * @return array
+     */
+    protected static function extractColumnAndRow($cell)
+    {
+        return sscanf($cell, '%[A-Z]%d');
     }
 
     /**
@@ -480,5 +507,17 @@ abstract class Coordinate
         }
 
         return $mergedCoordCollection;
+    }
+
+    /**
+     * Get the individual cell blocks from a range string, splitting by space and removing any $ characters.
+     *
+     * @param string $pRange
+     *
+     * @return string[]
+     */
+    protected static function getCellBlocksFromRangeString($pRange)
+    {
+        return explode(' ', str_replace('$', '', strtoupper($pRange)));
     }
 }

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -368,6 +368,10 @@ abstract class Coordinate
                 $currentCol = $startCol;
                 $currentRow = $startRow;
 
+                if ($startCol >= $endCol || $currentRow > $endRow) {
+                    throw new Exception('Invalid range: "'. $pRange . '"');
+                }
+
                 // Loop cells
                 while ($currentCol < $endCol) {
                     while ($currentRow <= $endRow) {

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -393,9 +393,7 @@ abstract class Coordinate
             $currentCol = $startCol;
             $currentRow = $startRow;
 
-            if ($startCol >= $endCol || $currentRow > $endRow) {
-                throw new Exception('Invalid range: "' . $cellBlock . '"');
-            }
+            static::validateRange($cellBlock, $startCol, $endCol, $currentRow, $endRow);
 
             // Loop cells
             while ($currentCol < $endCol) {
@@ -519,5 +517,24 @@ abstract class Coordinate
     protected static function getCellBlocksFromRangeString($pRange)
     {
         return explode(' ', str_replace('$', '', strtoupper($pRange)));
+    }
+
+    /**
+     * Check that the given range is valid, i.e. that the start column and row are not greater than the end column and
+     * row.
+     *
+     * @param string $cellBlock The original range, for displaying a meaningful error message
+     * @param string $startCol
+     * @param string $endCol
+     * @param int $currentRow
+     * @param int $endRow
+     *
+     * @throws Exception
+     */
+    protected static function validateRange($cellBlock, $startCol, $endCol, $currentRow, $endRow)
+    {
+        if ($startCol >= $endCol || $currentRow > $endRow) {
+            throw new Exception('Invalid range: "' . $cellBlock . '"');
+        }
     }
 }

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -369,7 +369,7 @@ abstract class Coordinate
                 $currentRow = $startRow;
 
                 if ($startCol >= $endCol || $currentRow > $endRow) {
-                    throw new Exception('Invalid range: "'. $pRange . '"');
+                    throw new Exception('Invalid range: "' . $pRange . '"');
                 }
 
                 // Loop cells

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -369,7 +369,7 @@ abstract class Coordinate
                 $currentRow = $startRow;
 
                 // Loop cells
-                while ($currentCol != $endCol) {
+                while ($currentCol < $endCol) {
                     while ($currentRow <= $endRow) {
                         $returnValue[] = $currentCol . $currentRow;
                         ++$currentRow;

--- a/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
@@ -62,7 +62,7 @@ class CoordinateTest extends TestCase
      * @dataProvider providerColumnIndex
      *
      * @param mixed $expectedResult
-     * @param int   $columnIndex
+     * @param int $columnIndex
      */
     public function testStringFromColumnIndex($expectedResult, $columnIndex)
     {
@@ -70,8 +70,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($expectedResult, $string);
 
         $columnIndexBack = Coordinate::columnIndexFromString($string);
-        self::assertEquals($columnIndexBack, $columnIndex,
-            'should be able to get the original input with opposite method');
+        self::assertEquals($columnIndexBack, $columnIndex, 'should be able to get the original input with opposite method');
     }
 
     public function providerColumnIndex()

--- a/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
@@ -211,7 +211,7 @@ class CoordinateTest extends TestCase
     {
         $result = Coordinate::splitRange(...$args);
         foreach ($result as $key => $split) {
-            if (! is_array($expectedResult[$key])) {
+            if (!is_array($expectedResult[$key])) {
                 self::assertEquals($expectedResult[$key], $split[0]);
             } else {
                 self::assertEquals($expectedResult[$key], $split);

--- a/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
@@ -315,6 +315,13 @@ class CoordinateTest extends TestCase
         return require 'data/CellExtractAllCellReferencesInRange.php';
     }
 
+    public function testExtractAllCellReferencesInRangeInvalidRange()
+    {
+        $result = Coordinate::extractAllCellReferencesInRange('Z1:A1');
+
+        self::assertSame([], $result);
+    }
+
     /**
      * @dataProvider providerMergeRangesInCollection
      *

--- a/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
@@ -62,7 +62,7 @@ class CoordinateTest extends TestCase
      * @dataProvider providerColumnIndex
      *
      * @param mixed $expectedResult
-     * @param int $columnIndex
+     * @param int   $columnIndex
      */
     public function testStringFromColumnIndex($expectedResult, $columnIndex)
     {
@@ -70,7 +70,8 @@ class CoordinateTest extends TestCase
         self::assertEquals($expectedResult, $string);
 
         $columnIndexBack = Coordinate::columnIndexFromString($string);
-        self::assertEquals($columnIndexBack, $columnIndex, 'should be able to get the original input with opposite method');
+        self::assertEquals($columnIndexBack, $columnIndex,
+            'should be able to get the original input with opposite method');
     }
 
     public function providerColumnIndex()
@@ -210,7 +211,7 @@ class CoordinateTest extends TestCase
     {
         $result = Coordinate::splitRange(...$args);
         foreach ($result as $key => $split) {
-            if (!is_array($expectedResult[$key])) {
+            if (! is_array($expectedResult[$key])) {
                 self::assertEquals($expectedResult[$key], $split[0]);
             } else {
                 self::assertEquals($expectedResult[$key], $split);
@@ -315,11 +316,27 @@ class CoordinateTest extends TestCase
         return require 'data/CellExtractAllCellReferencesInRange.php';
     }
 
-    public function testExtractAllCellReferencesInRangeInvalidRange()
+    /**
+     * @dataProvider providerInvalidRange
+     *
+     * @param string $range
+     */
+    public function testExtractAllCellReferencesInRangeInvalidRange($range)
     {
-        $result = Coordinate::extractAllCellReferencesInRange('Z1:A1');
+        try {
+            Coordinate::extractAllCellReferencesInRange($range);
+        } catch (Exception $e) {
+            self::assertSame('Invalid range: "' . $range . '"', $e->getMessage());
 
-        self::assertSame([], $result);
+            return;
+        }
+
+        self::fail('Exception not thrown for invalid range "' . $range . '".');
+    }
+
+    public function providerInvalidRange()
+    {
+        return [['Z1:A1'], ['A4:A1'], ['B1:A1'], ['AA1:Z1']];
     }
 
     /**


### PR DESCRIPTION
Fixes #519 

Didn't realise it was such an easy fix..! Currently it returns an empty array of references when passed an invalid range, not sure if an exception would be more suitable.