### PR TITLE
Properly set selected cells for frozen panes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Helper\Html` support UTF-8 HTML input - [#444](https://github.com/PHPOffice/PhpSpreadsheet/issues/444)
 - Xlsx loaded an extra empty comment for each real comment - [#375](https://github.com/PHPOffice/PhpSpreadsheet/issues/375)
 - Xlsx reader do not read rows and columns filtered out in readFilter at all - [#370](https://github.com/PHPOffice/PhpSpreadsheet/issues/370)
+- Corruption errors for saved Xlsx docs with frozen panes [#532](https://github.com/PHPOffice/PhpSpreadsheet/issues/532)
 
 ## [1.2.1] - 2018-04-10
 

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -246,6 +246,7 @@ class Worksheet extends WriterPart
         }
 
         $activeCell = $pSheet->getActiveCell();
+        $sqref = $pSheet->getSelectedCells();
 
         // Pane
         $pane = '';
@@ -257,6 +258,7 @@ class Worksheet extends WriterPart
 
             $topLeftCell = $pSheet->getTopLeftCell();
             $activeCell = $topLeftCell;
+            $sqref = $topLeftCell;
 
             // pane
             $pane = 'topRight';
@@ -292,7 +294,7 @@ class Worksheet extends WriterPart
             $objWriter->writeAttribute('pane', $pane);
         }
         $objWriter->writeAttribute('activeCell', $activeCell);
-        $objWriter->writeAttribute('sqref', $pSheet->getSelectedCells());
+        $objWriter->writeAttribute('sqref', $sqref);
         $objWriter->endElement();
 
         $objWriter->endElement();

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/WorksheetTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Settings;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+class WorksheetTest extends TestCase
+{
+    public function testFrozenPaneSelection()
+    {
+        // Create a dummy workbook with two worksheets
+        $workbook = new Spreadsheet();
+        $worksheet = $workbook->getActiveSheet();
+        $worksheet->freezePane('A7', 'A24');
+        $worksheet->setSelectedCells('F5');
+
+        Settings::setLibXmlLoaderOptions(null); // reset to default options
+
+        $resultFilename = tempnam(sys_get_temp_dir(), 'xlsx');
+        $writer = new \PhpOffice\PhpSpreadsheet\Writer\Xlsx($workbook);
+        $writer->save($resultFilename);
+
+        try {
+            $this->assertFileExists($resultFilename);
+
+            $resultZip = new ZipArchive();
+            $resultZip->open($resultFilename);
+            $worksheetXmlStr = $resultZip->getFromName('xl/worksheets/sheet1.xml');
+            $worksheetXml = simplexml_load_string($worksheetXmlStr);
+            $this->assertInstanceOf('SimpleXMLElement', $worksheetXml);
+            $sheetViewEl = $worksheetXml->sheetViews->sheetView;
+
+            $paneEl = $sheetViewEl->pane;
+            $this->assertEquals('6', (string) $paneEl['ySplit']);
+            $this->assertEquals('A24', (string) $paneEl['topLeftCell']);
+            $this->assertEquals('bottomLeft', (string) $paneEl['activePane']);
+            $this->assertEquals('frozen', (string) $paneEl['state']);
+
+            $selectionEl = $sheetViewEl->selection;
+            $this->assertEquals('bottomLeft', (string) $selectionEl['pane']);
+            $this->assertEquals('A24', (string) $selectionEl['activeCell']);
+            $this->assertEquals('A24', (string) $selectionEl['sqref']);
+        } finally {
+            unlink($resultFilename);
+        }
+    }
+}


### PR DESCRIPTION
Fix for issue PHPOffice/PhpSpreadsheet#532.  Properly set the selected
cells for worksheets with frozen panes when writing Xlsx documents.
Beforehand, the saved Xlsx documents were generating corruption warnings
when opened in Excel.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
One gets corruption warnings from Excel when opening a saved Xlsx document
with a worksheet containing a frozen pane.

Note: This is a resubmission of a previous pull request, which had unwanted changes
due to merges.