### PR TITLE
Fix #561: OFFSET should allow omitted height and width.

### DIFF
--- a/src/PhpSpreadsheet/Calculation/LookupRef.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef.php
@@ -355,6 +355,8 @@ class LookupRef
             return 0;
         }
 
+        $args = func_get_args();
+        $pCell = array_pop($args);
         if (!is_object($pCell)) {
             return Functions::REF();
         }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Commit [8dddf56] inadvertently removed the ability to omit the width and height arguments to the OFFSET function.

What is the expected behavior?
Optional width and height as in =OFFSET(range, 0, 2) should be supported as documented.

What is the current behavior?
#REF! is returned because the function is validating that the new $pCell argument is present. It is present, but it has been passed in the $height position.

Before commit [8dddf56] the $pCell was popped off the end of the argument list, this behaviour should be retained.