### PR TITLE
Set default delimiter character in CSV reader

### DIFF
--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -20,7 +20,7 @@ class Csv extends BaseReader
      *
      * @var string
      */
-    private $delimiter;
+    private $delimiter = ',';
 
     /**
      * Enclosure.


### PR DESCRIPTION
The CSV reader doesn't have a default delimiter character set. This means when fgetcsv is being used to import CSV data, it's treating the delimiter as a null, which makes it separate fields wherever there is a space instead of where there is a comma. This sets a default.

Prior to this I was using `$reader->setDelimiter(',');` as a workaround before loading files.

This is:

```
- [x] a bugfix
- [ ] a new feature
```
