### PR TITLE
Change usage of boolean to check delimiter

### DIFF
--- a/src/PhpSpreadsheet/Writer/Csv.php
+++ b/src/PhpSpreadsheet/Writer/Csv.php
@@ -312,31 +312,27 @@ class Csv extends BaseWriter
      */
     private function writeLine($pFileHandle, array $pValues)
     {
-        // No leading delimiter
-        $writeDelimiter = false;
+        // For no leading delimiter
+		$_delimiter = "";
 
-        // Build the line
-        $line = '';
+		// Build the line
+		$line = '';
 
-        foreach ($pValues as $element) {
-            // Escape enclosures
-            $element = str_replace($this->enclosure, $this->enclosure . $this->enclosure, $element);
+		foreach ( $pValues as $element ) {
+			// Escape enclosures
+			$element = str_replace($this->enclosure, $this->enclosure . $this->enclosure, $element);
 
-            // Add delimiter
-            if ($writeDelimiter) {
-                $line .= $this->delimiter;
-            } else {
-                $writeDelimiter = true;
-            }
+			// Add delimiter & enclosed string
+			$line .= $_delimiter . $this->enclosure . $element . $this->enclosure;
 
-            // Add enclosed string
-            $line .= $this->enclosure . $element . $this->enclosure;
-        }
+			// set delimiter
+			$_delimiter = $this->delimiter;
+		}
 
-        // Add line ending
-        $line .= $this->lineEnding;
+		// Add line ending
+		$line .= $this->lineEnding;
 
-        // Write to file
-        fwrite($pFileHandle, $line);
+		// Write to file
+		fwrite($pFileHandle, $line);
     }
 }


### PR DESCRIPTION
Instead of checking whether the delimiter has already been set, made it part of the line

This is:

- [ ] performance & bugfix


Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
