### PR TITLE
Fix chained border operations on cell ranges operating on last cell only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Cell formats with escaped spaces were causing incorrect date formatting - [#557](https://github.com/PHPOffice/PhpSpreadsheet/issues/557)
 - Could not open CSV file containing HTML fragment - [#564](https://github.com/PHPOffice/PhpSpreadsheet/issues/564)
 - Exclude the vendor folder in migration - [#481](https://github.com/PHPOffice/PhpSpreadsheet/issues/481)
+- Chained operations on cell ranges involving borders operated on last cell only [#428](https://github.com/PHPOffice/PhpSpreadsheet/issues/428)
 
 ## [1.3.1] - 2018-06-12
 

--- a/src/PhpSpreadsheet/Style/Style.php
+++ b/src/PhpSpreadsheet/Style/Style.php
@@ -333,6 +333,9 @@ class Style extends Supervisor
                     }
                 }
 
+                // restore initial cell selection range
+                $this->getActiveSheet()->getStyle($pRange);
+
                 return $this;
             }
 

--- a/tests/PhpSpreadsheetTests/Style/BorderRangeTest.php
+++ b/tests/PhpSpreadsheetTests/Style/BorderRangeTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Style;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Border;
+use PhpOffice\PhpSpreadsheet\Style\Color;
+use PHPUnit\Framework\TestCase;
+
+class BorderRangeTest extends TestCase
+{
+    public function testBorderRangeInAction()
+    {
+        // testcase for the initial bug problem: setting border+color fails
+        // set red borders aroundlA1:B3 square. Verify that the borders set are actually correct
+
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        $argb = 'FFFF0000';
+        $color = new Color($argb);
+
+        $sheet->getStyle('A1:C1')->getBorders()->getTop()->setBorderStyle(Border::BORDER_THIN)->setColor($color);
+        $sheet->getStyle('A1:A3')->getBorders()->getLeft()->setBorderStyle(Border::BORDER_THIN)->setColor($color);
+        $sheet->getStyle('C1:C3')->getBorders()->getRight()->setBorderStyle(Border::BORDER_THIN)->setColor($color);
+        $sheet->getStyle('A3:C3')->getBorders()->getBottom()->setBorderStyle(Border::BORDER_THIN)->setColor($color);
+
+        // upper row
+        $expectations = [
+            // cell => Left/Right/Top/Bottom
+            'A1' => 'LT',
+            'B1' => 'T',
+            'C1' => 'RT',
+            'A2' => 'L',
+            'B2' => '',
+            'C2' => 'R',
+            'A3' => 'LB',
+            'B3' => 'B',
+            'C3' => 'RB',
+        ];
+        $sides = [
+            'L' => 'Left',
+            'R' => 'Right',
+            'T' => 'Top',
+            'B' => 'Bottom',
+        ];
+
+        foreach ($expectations as $cell => $borders) {
+            $bs = $sheet->getStyle($cell)->getBorders();
+            foreach ($sides as $sidekey => $side) {
+                $assertion = "setBorderStyle on a range of cells, $cell $side";
+                $func = "get$side";
+                $b = $bs->$func(); // boo
+
+                if (strpos($borders, $sidekey) === false) {
+                    self::assertSame(Border::BORDER_NONE, $b->getBorderStyle(), $assertion);
+                } else {
+                    self::assertSame(Border::BORDER_THIN, $b->getBorderStyle(), $assertion);
+                    self::assertSame($argb, $b->getColor()->getARGB(), $assertion);
+                }
+            }
+        }
+    }
+
+    public function testBorderRangeDirectly()
+    {
+        // testcase for the underlying problem directly
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $style = $sheet->getStyle('A1:C1')->getBorders()->getTop()->setBorderStyle(Border::BORDER_THIN);
+        self::assertSame('A1:C1', $style->getSelectedCells(), 'getSelectedCells should not change after a style operation on a border range');
+    }
+}


### PR DESCRIPTION
This is:
- [x] a bugfix

Checklist:
- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

Fix issue where chained operations on cell ranges involving borders seemed to operate on last cell only (issue #428).
