### PR TITLE
careful treatment of string PHPExcel in migrator

### DIFF
--- a/src/PhpSpreadsheet/Helper/Migrator.php
+++ b/src/PhpSpreadsheet/Helper/Migrator.php
@@ -204,7 +204,6 @@ class Migrator
             'PHPExcel_Settings' => \PhpOffice\PhpSpreadsheet\Settings::class,
             'PHPExcel_Style' => \PhpOffice\PhpSpreadsheet\Style\Style::class,
             'PHPExcel_Worksheet' => \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet::class,
-            'PHPExcel' => \PhpOffice\PhpSpreadsheet\Spreadsheet::class,
         ];
 
         $methods = [
@@ -271,6 +270,11 @@ class Migrator
                 }
                 $original = file_get_contents($file);
                 $converted = str_replace($from, $to, $original);
+
+                // The string "PHPExcel" gets special treatment because of how common it might be.
+                // This regex requires a word boundary around the string, and it can't be
+                // preceded by $ or -> (goal is to filter out cases where a variable is named $PHPExcel or similar)
+                $converted = preg_replace('/(?<!\$|->)\bPHPExcel\b/', \PhpOffice\PhpSpreadsheet\Spreadsheet::class, $original);
 
                 if ($original !== $converted) {
                     echo $file . " converted\n";


### PR DESCRIPTION
Fixes #598

This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

This PR resolves #598 by using a stricter regex when replacing the plain string 'PHPExcel' in the migration tool.