### PR TITLE
skip non numeric value in SUMIF

### DIFF
--- a/src/PhpSpreadsheet/Calculation/MathTrig.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig.php
@@ -1222,9 +1222,11 @@ class MathTrig
             }
 
             $testCondition = '=' . $arg . $condition;
-            if (Calculation::getInstance()->_calculateFormulaValue($testCondition)) {
-                // Is it a value within our criteria
-                $returnValue += $sumArgs[$key];
+
+            if ( is_numeric( $sumArgs[ $key ] )  &&
+                Calculation::getInstance()->_calculateFormulaValue( $testCondition ) ) {
+                // Is it a value within our criteria and only numeric can be added to the result
+                $returnValue += $sumArgs[ $key ];
             }
         }
 


### PR DESCRIPTION
This is:

```
- [x ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
MS Excel skip non numeric values also. PhpSpreadsheet fail on string value with: Warning: A non-numeric value encountered

 PHP 7.1.18