### PR TITLE
fix: allow iterators to go out of bounds with prev()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Upcoming
+
+### Fixed
+
+- Allow iterators to go out of bounds with prev - [#587](https://github.com/PHPOffice/PhpSpreadsheet/issues/587)
+
 ## [1.4.0] - 2018-08-06
 
 ### Added

--- a/src/PhpSpreadsheet/Worksheet/ColumnCellIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/ColumnCellIterator.php
@@ -153,10 +153,6 @@ class ColumnCellIterator extends CellIterator
      */
     public function prev()
     {
-        if ($this->currentRow <= $this->startRow) {
-            throw new PhpSpreadsheetException("Row is already at the beginning of range ({$this->startRow} - {$this->endRow})");
-        }
-
         do {
             --$this->currentRow;
         } while (($this->onlyExistingCells) &&

--- a/src/PhpSpreadsheet/Worksheet/ColumnIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/ColumnIterator.php
@@ -157,14 +157,9 @@ class ColumnIterator implements \Iterator
 
     /**
      * Set the iterator to its previous value.
-     *
-     * @throws PhpSpreadsheetException
      */
     public function prev()
     {
-        if ($this->currentColumnIndex <= $this->startColumnIndex) {
-            throw new PhpSpreadsheetException('Column is already at the beginning of range (' . Coordinate::stringFromColumnIndex($this->endColumnIndex) . ' - ' . Coordinate::stringFromColumnIndex($this->endColumnIndex) . ')');
-        }
         --$this->currentColumnIndex;
     }
 

--- a/src/PhpSpreadsheet/Worksheet/RowIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/RowIterator.php
@@ -152,15 +152,9 @@ class RowIterator implements \Iterator
 
     /**
      * Set the iterator to its previous value.
-     *
-     * @throws PhpSpreadsheetException
      */
     public function prev()
     {
-        if ($this->position <= $this->startRow) {
-            throw new PhpSpreadsheetException("Row is already at the beginning of range ({$this->startRow} - {$this->endRow})");
-        }
-
         --$this->position;
     }
 

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnCellIteratorTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnCellIteratorTest.php
@@ -78,8 +78,6 @@ class ColumnCellIteratorTest extends TestCase
 
     public function testPrevOutOfRange()
     {
-        $this->expectException(\PhpOffice\PhpSpreadsheet\Exception::class);
-
         $iterator = new ColumnCellIterator($this->mockWorksheet, 'A', 2, 4);
         $iterator->prev();
     }

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnIteratorTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnIteratorTest.php
@@ -77,8 +77,6 @@ class ColumnIteratorTest extends TestCase
 
     public function testPrevOutOfRange()
     {
-        $this->expectException(\PhpOffice\PhpSpreadsheet\Exception::class);
-
         $iterator = new ColumnIterator($this->mockWorksheet, 'B', 'D');
         $iterator->prev();
     }

--- a/tests/PhpSpreadsheetTests/Worksheet/RowIteratorTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/RowIteratorTest.php
@@ -75,8 +75,6 @@ class RowIteratorTest extends TestCase
 
     public function testPrevOutOfRange()
     {
-        $this->expectException(\PhpOffice\PhpSpreadsheet\Exception::class);
-
         $iterator = new RowIterator($this->mockWorksheet, 2, 4);
         $iterator->prev();
     }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

See #587.