### PR TITLE
Enable twoCellAnchor for images - auto move and resize function

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/BaseDrawing.php
+++ b/src/PhpSpreadsheet/Worksheet/BaseDrawing.php
@@ -79,6 +79,13 @@ class BaseDrawing implements IComparable
     protected $height;
 
     /**
+     * Move and resize type.
+     *
+     * @var string
+     */
+    protected $resizeType = "oneCellAnchor";
+
+    /**
      * Proportional resize.
      *
      * @var bool
@@ -431,7 +438,31 @@ class BaseDrawing implements IComparable
 
         return $this;
     }
+    
+    /**
+     * Get ResizeType.
+     *
+     * @return string
+     */
+    public function getResizeType()
+    {
+        return $this->resizeType;
+    }
 
+    /**
+     * Set ResizeType.
+     *
+     * @param string $pValue
+     *
+     * @return BaseDrawing
+     */
+    public function setResizeType($pValue)
+    {
+        $this->resizeType = $pValue;
+
+        return $this;
+    }
+    
     /**
      * Get Rotation.
      *

--- a/src/PhpSpreadsheet/Writer/Xlsx/Drawing.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Drawing.php
@@ -162,8 +162,8 @@ class Drawing extends WriterPart
     public function writeDrawing(XMLWriter $objWriter, BaseDrawing $pDrawing, $pRelationId = -1, $hlinkClickId = null)
     {
         if ($pRelationId >= 0) {
-            // xdr:oneCellAnchor
-            $objWriter->startElement('xdr:oneCellAnchor');
+            // xdr oneCell or twoCell Anchor
+            $objWriter->startElement('xdr:'.$pDrawing->getResizeType());
             // Image location
             $aCoordinates = Coordinate::coordinateFromString($pDrawing->getCoordinates());
             $aCoordinates[0] = Coordinate::columnIndexFromString($aCoordinates[0]);
@@ -175,7 +175,17 @@ class Drawing extends WriterPart
             $objWriter->writeElement('xdr:row', $aCoordinates[1] - 1);
             $objWriter->writeElement('xdr:rowOff', \PhpOffice\PhpSpreadsheet\Shared\Drawing::pixelsToEMU($pDrawing->getOffsetY()));
             $objWriter->endElement();
-
+            
+            // xdr:to for twoCellAnchor
+            if($pDrawing->getResizeType()==='twoCellAnchor'){
+                $objWriter->startElement('xdr:to');
+                $objWriter->writeElement('xdr:col', $aCoordinates[0]);
+                $objWriter->writeElement('xdr:colOff', \PhpOffice\PhpSpreadsheet\Shared\Drawing::pixelsToEMU($pDrawing->getOffsetX()));
+                $objWriter->writeElement('xdr:row', $aCoordinates[1]);
+                $objWriter->writeElement('xdr:rowOff', \PhpOffice\PhpSpreadsheet\Shared\Drawing::pixelsToEMU($pDrawing->getOffsetY()));
+                $objWriter->endElement();
+            }
+            
             // xdr:ext
             $objWriter->startElement('xdr:ext');
             $objWriter->writeAttribute('cx', \PhpOffice\PhpSpreadsheet\Shared\Drawing::pixelsToEMU($pDrawing->getWidth()));


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
This allows users to change from a oneCellAnchor to a twoCellAnchor - which enables stretching to the full size of the cell and turns on move and resize by default in excel.