### PR TITLE
fix font color issue in css {inlineStyle}

### DIFF
--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -649,7 +649,7 @@ class Html extends BaseReader
 
                     break;
                 case 'color':
-                    $sheet->getStyle($column . $row)->applyFromArray(['font' => ['color' => ['rgb' => "$style_color}"]]]);
+                    $sheet->getStyle($column . $row)->applyFromArray(['font' => ['color' => ['rgb' => "{$style_color}"]]]);
 
                     break;
             }


### PR DESCRIPTION
This is:

```
- [X ] a bugfix

### Why this change is needed?
to fix font color in css not applied because missing one practice "**{**"