### PR TITLE
Fix broken sample links on windows due to $baseDir having backslash

### DIFF
--- a/src/PhpSpreadsheet/Helper/Sample.php
+++ b/src/PhpSpreadsheet/Helper/Sample.php
@@ -82,7 +82,7 @@ class Sample
 
         $files = [];
         foreach ($regex as $file) {
-            $file = str_replace($baseDir . '/', '', $file[0]);
+            $file = str_replace(str_replace('\\','/',$baseDir) . '/', '', str_replace('\\','/',$file[0]));
             $info = pathinfo($file);
             $category = str_replace('_', ' ', $info['dirname']);
             $name = str_replace('_', ' ', preg_replace('/(|\.php)/', '', $info['filename']));


### PR DESCRIPTION
Fix broken sample links on windows due to $baseDir having backslash instead of forward slash

On windows when running the samples on a local php server, all links to samples all malformed, pointing to something like
href="/C:\Users\jalgaba\Documents\GitHub\PhpSpreadsheet\samples\Basic\01_Simple.php"
when expected links are something like
href="/Basic/01_Simple.php"