### PR TITLE
fixes for continue inside switch statement

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -1127,7 +1127,7 @@ class Xls extends BaseReader
                             // TODO: Why is there no BSE Index? Is this a new Office Version? Password protected field?
                             // More likely : a uncompatible picture
                             if (!$BSEindex) {
-                                continue;
+                                continue 2;
                             }
 
                             $BSECollection = $escherWorkbook->getDggContainer()->getBstoreContainer()->getBSECollection();

--- a/src/PhpSpreadsheet/Shared/OLE.php
+++ b/src/PhpSpreadsheet/Shared/OLE.php
@@ -320,7 +320,7 @@ class OLE
 
                     break;
                 default:
-                    continue;
+                    break;
             }
             fseek($fh, 1, SEEK_CUR);
             $pps->Type = $type;


### PR DESCRIPTION
This a bugfix for php 7.3 (or even 7.2?) related errors where using continue inside a switch raises a php warning. Either use `continue 2` or `break`. Previously `continue` behaves like `break` but the intended usage is to continue the for loop instead, i guess.