### PR TITLE
fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
-/tests/codeCoverage
-/analysis
-/vendor/
-/phpunit.xml
-/.php_cs.cache
+tests/codeCoverage
+analysis
+vendor/
+phpunit.xml.dist
+.php_cs.cache
 
 ## IDE support
 *.buildpath
 *.project
-/.settings
-/.idea
+.settings
+.idea


### PR DESCRIPTION
This is:

- [x] an update
- [ ] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
The old .gitignore file is not enough to keep up with times, like phpunit.xml now is phpunit.xml.dist;
And cannot use absolute path, but should use relative path instead.