### PR TITLE
If height is not set for a row, set default row height as 'ht' attrib…

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -990,6 +990,9 @@ class Worksheet extends WriterPart
                 if ($rowDimension->getRowHeight() >= 0) {
                     $objWriter->writeAttribute('customHeight', '1');
                     $objWriter->writeAttribute('ht', StringHelper::formatNumber($rowDimension->getRowHeight()));
+                } else {
+                    $objWriter->writeAttribute('customHeight', '1');
+                    $objWriter->writeAttribute('ht', StringHelper::formatNumber($pSheet->getDefaultRowDimension()->getRowHeight()));
                 }
 
                 // Row visibility


### PR DESCRIPTION
…ute.

This is:

```
- [x] a bugfix
- [] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

For lines with values in cells, 'ht' attribute for each row is required.
If this is not present, the default row height height will not be applied.
I am checking the latest version of Excel 365.
