### PR TITLE
Fix the date format range.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
- ## [Unreleased]
- 
- ### Fixed
+## [Unreleased]
 
+### Fixed
+
+- Allow iterators to go out of bounds with prev - [#587](https://github.com/PHPOffice/PhpSpreadsheet/issues/587)
+- Fix warning when reading xlsx without styles - [#631](https://github.com/PHPOffice/PhpSpreadsheet/pull/631)
 - Fix the date format range, it should be in [1900/1/1, 9999/12/31], but the code before is not checked! - [#675](https://github.com/PHPOffice/PhpSpreadsheet/pull/675) [issue#669](https://github.com/PHPOffice/PhpSpreadsheet/issues/669)
+
 ## [1.4.0] - 2018-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Allow iterators to go out of bounds with prev - [#587](https://github.com/PHPOffice/PhpSpreadsheet/issues/587)
 - Fix warning when reading xlsx without styles - [#631](https://github.com/PHPOffice/PhpSpreadsheet/pull/631)
+- Fix the date format range, it should be in [1900/1/1, 9999/12/31], but the code before is not checked! - [#675](https://github.com/PHPOffice/PhpSpreadsheet/pull/675) [issue#669](https://github.com/PHPOffice/PhpSpreadsheet/issues/669)
 
 ## [1.4.0] - 2018-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Allow iterators to go out of bounds with prev - [#587](https://github.com/PHPOffice/PhpSpreadsheet/issues/587)
 - Fix warning when reading xlsx without styles - [#631](https://github.com/PHPOffice/PhpSpreadsheet/pull/631)
+
 - Fix the date format range, it should be in [1900/1/1, 9999/12/31], but the code before is not checked! - [#675](https://github.com/PHPOffice/PhpSpreadsheet/pull/675) [issue#669](https://github.com/PHPOffice/PhpSpreadsheet/issues/669)
 
 ## [1.4.0] - 2018-08-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Allow iterators to go out of bounds with prev - [#587](https://github.com/PHPOffice/PhpSpreadsheet/issues/587)
 - Fix warning when reading xlsx without styles - [#631](https://github.com/PHPOffice/PhpSpreadsheet/pull/631)
-- Fix the date format range, it should be in [1900/1/1, 9999/12/31], but the code before is not checked! - [#675](https://github.com/PHPOffice/PhpSpreadsheet/pull/675) [issue#669](https://github.com/PHPOffice/PhpSpreadsheet/issues/669)
 
 ## [1.4.0] - 2018-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Allow iterators to go out of bounds with prev - [#587](https://github.com/PHPOffice/PhpSpreadsheet/issues/587)
 - Fix warning when reading xlsx without styles - [#631](https://github.com/PHPOffice/PhpSpreadsheet/pull/631)
 
-- Fix the date format range, it should be in [1900/1/1, 9999/12/31], but the code before is not checked! - [#675](https://github.com/PHPOffice/PhpSpreadsheet/pull/675) [issue#669](https://github.com/PHPOffice/PhpSpreadsheet/issues/669)
-
 ## [1.4.0] - 2018-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+ ## [Unreleased]
+ 
+ ### Fixed
+
+- Fix the date format range, it should be in [1900/1/1, 9999/12/31], but the code before is not checked! - [#675](https://github.com/PHPOffice/PhpSpreadsheet/pull/675) [issue#669](https://github.com/PHPOffice/PhpSpreadsheet/issues/669)
 ## [1.4.0] - 2018-08-06
 
 ### Added

--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -270,7 +270,7 @@ class Date
     }
 
     /**
-     * formattedPHPToExcel.
+     * formattedPHPToExcel. Date range should in [1900/1/1, 9999/12/31]
      *
      * @param int $year
      * @param int $month
@@ -279,10 +279,15 @@ class Date
      * @param int $minutes
      * @param int $seconds
      *
-     * @return float Excel date/time value
+     * @return float|false Excel date/time value
      */
     public static function formattedPHPToExcel($year, $month, $day, $hours = 0, $minutes = 0, $seconds = 0)
     {
+        // date range check, should in range [1900/1/1, 9999/12/31],
+        // the number is in range [0, 2958465]
+        if ($year < 1900 || $year > 9999) {
+            return false;
+        }
         if (self::$excelCalendar == self::CALENDAR_WINDOWS_1900) {
             //
             //    Fudge factor for the erroneous fact that the year 1900 is treated as a Leap Year in MS Excel

--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -270,7 +270,7 @@ class Date
     }
 
     /**
-     * formattedPHPToExcel. Date range should in [1900/1/1, 9999/12/31]
+     * formattedPHPToExcel. Date range should in [1900/1/1, 9999/12/31].
      *
      * @param int $year
      * @param int $month
@@ -279,7 +279,7 @@ class Date
      * @param int $minutes
      * @param int $seconds
      *
-     * @return float|false Excel date/time value
+     * @return false|float Excel date/time value
      */
     public static function formattedPHPToExcel($year, $month, $day, $hours = 0, $minutes = 0, $seconds = 0)
     {

--- a/tests/data/Shared/Date/DateTimeToExcel.php
+++ b/tests/data/Shared/Date/DateTimeToExcel.php
@@ -4,6 +4,18 @@
 return [
     // Excel 1900 base calendar date
     [
+        false,
+        new DateTime('1899-12-30'),
+    ],
+    [
+        2958465.0,
+        new DateTime('9999-12-31'),
+    ],
+    [
+        36526.416666666664,
+        new DateTime('10000-01-01'), // DateTime will convert 10000 to 2000
+    ],
+    [
         1.0,
         new DateTime('1900-01-01'),
     ],

--- a/tests/data/Shared/Date/FormattedPHPToExcel1900.php
+++ b/tests/data/Shared/Date/FormattedPHPToExcel1900.php
@@ -3,6 +3,40 @@
 // Year   Month  Day  Hours  Minutes  Seconds  Result            Comments
 
 return [
+    // 31-Dec-1899, the wrong date
+    [
+        false,
+        1899,
+        12,
+        31,
+    ],
+    // the default value for 0 in excel
+    [
+        0.0,
+        1900,
+        1,
+        0,
+    ],
+    // 1-Jan-1900 the real minimum date
+    [
+        1.0,
+        1900,
+        1,
+        1,
+    ],
+    // 31-Dec-9999 the real maximum date
+    [
+        2958465.0,
+        9999,
+        12,
+        31,
+    ],
+    [
+        false,
+        10000,
+        1,
+        1,
+    ],
     // PHP 32-bit Earliest Date 14-Dec-1901
     [
         714,


### PR DESCRIPTION
This is:

- [x] a bugfix

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Fix the date format range in PhpOffice\PhpSpreadsheet\Shared::formattedPHPToExcel(), it should be in [1900/1/1, 9999/12/31], but the code before is not checked!
Now when a date is not in range give, the method will return false instead of break with wrong messages!