### PR TITLE
Fixed conditional formatting for BIFF file format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Allow iterators to go out of bounds with prev - [#587](https://github.com/PHPOffice/PhpSpreadsheet/issues/587)
 - Fix warning when reading xlsx without styles - [#631](https://github.com/PHPOffice/PhpSpreadsheet/pull/631)
+- Fixed conditional formatting for BIFF file format - [#841](https://github.com/PHPOffice/PHPExcel/issues/841)
 
 ## [1.4.0] - 2018-08-06
 


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

This is a fix for bug PHPOffice/PHPExcel#841 . The existing implementation disregarded the individual ranges of a conditional and was appling the conditional to the enclosing range (the minimum range which covers all individual ranges)