### PR TITLE
Update Xlsx.php

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -210,12 +210,12 @@ class Xlsx extends BaseWriter
             $zip = new ZipArchive();
 
             if (file_exists($pFilename)) {
-				//	Added by muhammad.begawala@gmail.com
-				//	'@' will stop displaying "Resource Unavailable" error because of file is open some where.
-				//	'unlink($pFilename) !== true' will check if file is deleted successfully.
-				//  Throwing exception so that we can handle error easily instead of displaying to users.
+                //Added by muhammad.begawala@gmail.com
+                //'@' will stop displaying "Resource Unavailable" error because of file is open some where.
+                //'unlink($pFilename) !== true' will check if file is deleted successfully.
+                //Throwing exception so that we can handle error easily instead of displaying to users.
                 if( @unlink($pFilename) !== true )
-					throw new WriterException('Could not delete file: ' . $pFilename . ' Please close all applications that are using it.');
+                    throw new WriterException('Could not delete file: ' . $pFilename . ' Please close all applications that are using it.');
             }
             // Try opening the ZIP file
             if ($zip->open($pFilename, ZipArchive::OVERWRITE) !== true) {
@@ -400,7 +400,7 @@ class Xlsx extends BaseWriter
             Calculation::getInstance($this->spreadSheet)->getDebugLog()->setWriteDebugLog($saveDebugLog);
 
             // Close file
-            if ( @$zip->close() === false ) { //	updated by muhammad.begawala@gmail.com
+            if (@$zip->close() === false) { // updated by muhammad.begawala@gmail.com
                 throw new WriterException("Could not close zip file $pFilename.");
             }
 
@@ -411,8 +411,8 @@ class Xlsx extends BaseWriter
                 }
                 @unlink($pFilename);
             }
-			return true;
-			//	Return True to make sure that file is created successfully with no ExceptionsAdded by muhammad.begawala@gmail.com
+            return true;
+            // Return True to make sure that file is created successfully with no ExceptionsAdded by muhammad.begawala@gmail.com
         } else {
             throw new WriterException('PhpSpreadsheet object unassigned.');
         }

--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -210,7 +210,12 @@ class Xlsx extends BaseWriter
             $zip = new ZipArchive();
 
             if (file_exists($pFilename)) {
-                unlink($pFilename);
+				//	Added by muhammad.begawala@gmail.com
+				//	'@' will stop displaying "Resource Unavailable" error because of file is open some where.
+				//	'unlink($pFilename) !== true' will check if file is deleted successfully.
+				//  Throwing exception so that we can handle error easily instead of displaying to users.
+                if( @unlink($pFilename) !== true )
+					throw new WriterException('Could not delete file: ' . $pFilename . ' Please close all applications that are using it.');
             }
             // Try opening the ZIP file
             if ($zip->open($pFilename, ZipArchive::OVERWRITE) !== true) {
@@ -395,7 +400,7 @@ class Xlsx extends BaseWriter
             Calculation::getInstance($this->spreadSheet)->getDebugLog()->setWriteDebugLog($saveDebugLog);
 
             // Close file
-            if ($zip->close() === false) {
+            if ( @$zip->close() === false ) { //	updated by muhammad.begawala@gmail.com
                 throw new WriterException("Could not close zip file $pFilename.");
             }
 
@@ -406,6 +411,8 @@ class Xlsx extends BaseWriter
                 }
                 @unlink($pFilename);
             }
+			return true;
+			//	Return True to make sure that file is created successfully with no ExceptionsAdded by muhammad.begawala@gmail.com
         } else {
             throw new WriterException('PhpSpreadsheet object unassigned.');
         }


### PR DESCRIPTION
**1) Handling "Resource Unavailable" error by unlink() as Exception using try catch so that It doesn't show error _when file is being used by some applications_ when we tries to delete it using unlink.**

Major Changes:

> if (file_exists($pFilename)) {
				//	Added by muhammad.begawala@gmail.com
				//	'@' will stop displaying "Resource Unavailable" error because of file is open some where.
				//	'unlink($pFilename) !== true' will check if file is deleted successfully.
				//  Throwing exception so that we can handle error easily instead of displaying to users.
                if( @unlink($pFilename) !== true )
					throw new WriterException('Could not delete file: ' . $pFilename . ' Please close all applications that are using it.');
            }

**2) $writer->save('hello world.xlsx') will return TRUE if file is successfully created else throw Exception.**

Usage:

> try {
	if( $writer->save('hello world.xlsx') === true )
		echo 'File Created';
}
catch (WriterException $e) {
    echo "Unable to save file. Please close any other applications(s) that are using it: [",  $e->getMessage(), "]\n";
}

This is:
- [x] a bugfix
- [x] a new feature

Checklist:
- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
1) Handling "Resource Unavailable" error by unlink() as Exception using try catch so that It doesn't show error when file is being used by some applications when we tries to delete it using unlink.
2) $writer->save('hello world.xlsx') will return TRUE if file is successfully created else throw Exception.