### PR TITLE
Deleteing file using File::deleteFile() created in ..\Shared\File.php

### DIFF
--- a/src/PhpSpreadsheet/Shared/File.php
+++ b/src/PhpSpreadsheet/Shared/File.php
@@ -159,6 +159,7 @@ class File
                 return false;
             }
         }
+
         return true;
     }
 }

--- a/src/PhpSpreadsheet/Shared/File.php
+++ b/src/PhpSpreadsheet/Shared/File.php
@@ -141,22 +141,23 @@ class File
             throw new InvalidArgumentException('Could not open "' . $filename . '" for reading.');
         }
     }
-    
+
     /**
-     * Deletes given file if its exists and is NOT BEING USED BY SOME APPLICATIONS.
+     * Deletes given file if an existing its exists and is NOT BEING USED BY SOME APPLICATIONS.
      *
-     * @param string $filename
+     * @param string $file
      *
      * @returns false If file could not be deleted.
      */
     public static function deleteFile($file)
     {
         if (file_exists($file)) {
-            // '@' will stop displaying "Resource Unavailable" error because of file is open some where.
+            // '@before unlink' will stop displaying "Resource Unavailable" error because of file is open some where.
             // 'unlink($pFilename) !== true' will check if file is deleted successfully.
             // Return so that we can handle error easily instead of displaying to users.
-            if (@unlink($file) !== true)
+            if (@unlink($file) !== true) {
                 return false;
+            }
         }
         return true;
     }

--- a/src/PhpSpreadsheet/Shared/File.php
+++ b/src/PhpSpreadsheet/Shared/File.php
@@ -141,4 +141,23 @@ class File
             throw new InvalidArgumentException('Could not open "' . $filename . '" for reading.');
         }
     }
+    
+    /**
+     * Deletes given file if its exists and is NOT BEING USED BY SOME APPLICATIONS.
+     *
+     * @param string $filename
+     *
+     * @returns false If file could not be deleted.
+     */
+    public static function deleteFile($file)
+    {
+        if (file_exists($file)) {
+            // '@' will stop displaying "Resource Unavailable" error because of file is open some where.
+            // 'unlink($pFilename) !== true' will check if file is deleted successfully.
+            // Return so that we can handle error easily instead of displaying to users.
+            if (@unlink($file) !== true)
+                return false;
+        }
+        return true;
+    }
 }

--- a/src/PhpSpreadsheet/Shared/File.php
+++ b/src/PhpSpreadsheet/Shared/File.php
@@ -143,23 +143,21 @@ class File
     }
 
     /**
-     * Deletes given file if an existing its exists and is NOT BEING USED BY SOME APPLICATIONS.
+     * Deletes given file if its exists with proper permissions and is NOT BEING USED BY SOME APPLICATIONS.
      *
      * @param string $file
      *
-     * @returns false If file could not be deleted.
+     * @throws InvalidArgumentException
      */
-    public static function deleteFile($file)
+    public static function delete($file)
     {
         if (file_exists($file)) {
             // '@before unlink' will stop displaying "Resource Unavailable" error because of file is open some where.
-            // 'unlink($pFilename) !== true' will check if file is deleted successfully.
-            // Return so that we can handle error easily instead of displaying to users.
+            // 'unlink($file) !== true' will check if file is deleted successfully.
+            // throws Exception so that we can handle error easily instead of displaying to users.
             if (@unlink($file) !== true) {
-                return false;
+                throw new InvalidArgumentException('Could not delete file: ' . $file . ' Please check for file permissions and make sure  file is not being used by some applications.');
             }
         }
-
-        return true;
     }
 }

--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -407,7 +407,6 @@ class Xlsx extends BaseWriter
                 }
                 @unlink($pFilename);
             }
-
         } else {
             throw new WriterException('PhpSpreadsheet object unassigned.');
         }

--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -209,9 +209,10 @@ class Xlsx extends BaseWriter
 
             $zip = new ZipArchive();
 
-            if (file_exists($pFilename)) {
-                unlink($pFilename);
+            if (File::deleteFile($pFilename) !== true) {
+                throw new WriterException('Could not delete file: ' . $pFilename . ' Please close all applications that are using it.');
             }
+        
             // Try opening the ZIP file
             if ($zip->open($pFilename, ZipArchive::OVERWRITE) !== true) {
                 if ($zip->open($pFilename, ZipArchive::CREATE) !== true) {
@@ -394,8 +395,8 @@ class Xlsx extends BaseWriter
             Functions::setReturnDateType($saveDateReturnType);
             Calculation::getInstance($this->spreadSheet)->getDebugLog()->setWriteDebugLog($saveDebugLog);
 
-            // Close file
-            if ($zip->close() === false) {
+            // Close file, If can't close Throws an Exception
+            if ( @$zip->close() === false ) {
                 throw new WriterException("Could not close zip file $pFilename.");
             }
 
@@ -406,6 +407,7 @@ class Xlsx extends BaseWriter
                 }
                 @unlink($pFilename);
             }
+
         } else {
             throw new WriterException('PhpSpreadsheet object unassigned.');
         }

--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -395,7 +395,7 @@ class Xlsx extends BaseWriter
             Functions::setReturnDateType($saveDateReturnType);
             Calculation::getInstance($this->spreadSheet)->getDebugLog()->setWriteDebugLog($saveDebugLog);
 
-            // Close file, If can't close Throws an Exception
+            // Close file, If can't close throws an Exception
             if (@$zip->close() === false) {
                 throw new WriterException("Could not close zip file $pFilename.");
             }

--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -212,7 +212,7 @@ class Xlsx extends BaseWriter
             if (File::deleteFile($pFilename) !== true) {
                 throw new WriterException('Could not delete file: ' . $pFilename . ' Please close all applications that are using it.');
             }
-        
+
             // Try opening the ZIP file
             if ($zip->open($pFilename, ZipArchive::OVERWRITE) !== true) {
                 if ($zip->open($pFilename, ZipArchive::CREATE) !== true) {
@@ -396,7 +396,7 @@ class Xlsx extends BaseWriter
             Calculation::getInstance($this->spreadSheet)->getDebugLog()->setWriteDebugLog($saveDebugLog);
 
             // Close file, If can't close Throws an Exception
-            if ( @$zip->close() === false ) {
+            if (@$zip->close() === false) {
                 throw new WriterException("Could not close zip file $pFilename.");
             }
 


### PR DESCRIPTION
**Deleteing file using File::deleteFile() created in** `..\Shared\File.php`
As mentioned by @PowerKiKi I created function into ..\Shared\File so that It can be used any where we need.

**Deletes given file or returns False ITS BEING USED BY SOME APPLICATIONS in** `..\Writer\Xlsx.php`
As mentioned by @PowerKiKi I created function into here so that It can be used any where we need, It returns False If file is exists but is being used by some application instead of giving Error.

This is:

```
- [+] a bugfix
- [+] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
Handling "Resource Unavailable" error by unlink() as Exception using try catch so that It doesn't show Error when **file is being used by some applications** when we tries to delete it using `unlink()`.