### PR TITLE
Added delete() in Shared/File.php and used in Writer/Xlsx.php

### DIFF
--- a/src/PhpSpreadsheet/Shared/File.php
+++ b/src/PhpSpreadsheet/Shared/File.php
@@ -141,4 +141,23 @@ class File
             throw new InvalidArgumentException('Could not open "' . $filename . '" for reading.');
         }
     }
+
+    /**
+     * Deletes given file if its exists with proper permissions and is NOT BEING USED BY SOME APPLICATIONS.
+     *
+     * @param string $file
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function delete($file)
+    {
+        if (file_exists($file)) {
+            // '@before unlink' will stop displaying "Resource Unavailable" error because of file is open some where.
+            // 'unlink($file) !== true' will check if file is deleted successfully.
+            // throws Exception so that we can handle error easily instead of displaying to users.
+            if (@unlink($file) !== true) {
+                throw new InvalidArgumentException('Could not delete file: ' . $file . ' Please check for file permissions and make sure  file is not being used by some applications.');
+            }
+        }
+    }
 }

--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -209,9 +209,8 @@ class Xlsx extends BaseWriter
 
             $zip = new ZipArchive();
 
-            if (file_exists($pFilename)) {
-                unlink($pFilename);
-            }
+            File::delete($pFilename);
+
             // Try opening the ZIP file
             if ($zip->open($pFilename, ZipArchive::OVERWRITE) !== true) {
                 if ($zip->open($pFilename, ZipArchive::CREATE) !== true) {
@@ -394,8 +393,8 @@ class Xlsx extends BaseWriter
             Functions::setReturnDateType($saveDateReturnType);
             Calculation::getInstance($this->spreadSheet)->getDebugLog()->setWriteDebugLog($saveDebugLog);
 
-            // Close file
-            if ($zip->close() === false) {
+            // Close file, If can't close Throws an Exception
+            if (@$zip->close() === false) {
                 throw new WriterException("Could not close zip file $pFilename.");
             }
 


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [x] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)

### Why this change is needed?
1) Handling "Resource Unavailable" error by unlink() as Exception using try catch so that It doesn't show error when file is being used by some applications when we tries to delete it using unlink.
2) $writer->save('hello world.xlsx') will throw Exception if no proper permissions or file us being used by some applications.