### PR TITLE
Update NumberFormat.php

### DIFF
--- a/src/PhpSpreadsheet/Style/NumberFormat.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat.php
@@ -49,6 +49,8 @@ class NumberFormat extends Supervisor
     const FORMAT_CURRENCY_USD = '$#,##0_-';
     const FORMAT_CURRENCY_EUR_SIMPLE = '#,##0.00_-"€"';
     const FORMAT_CURRENCY_EUR = '#,##0_-"€"';
+    const FORMAT_CURRENCY_GBP_SIMPLE = '"£"#,##0.00_-';
+    const FORMAT_CURRENCY_GBP = '"£"#,##0_-';
 
     /**
      * Excel built-in number formats.


### PR DESCRIPTION
Adding GBP number format

This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

GBP is missing, would be nice to have in the UK

