### PR TITLE
Fix CSV delimiter detection on line breaks (fixes #716)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Sheet title can contain exclamation mark - [#325](https://github.com/PHPOffice/PhpSpreadsheet/issues/325)
 - Xls file cause the exception during open by Xls reader - [#402](https://github.com/PHPOffice/PhpSpreadsheet/issues/402)
 - Skip non numeric value in SUMIF - [#618](https://github.com/PHPOffice/PhpSpreadsheet/pull/618)
+- Correctly determine delimiter when CSV contains line breaks inside enclosures - [#716](https://github.com/PHPOffice/PhpSpreadsheet/issues/716)
 
 ## [1.4.1] - 2018-09-30
 

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -163,11 +163,7 @@ class Csv extends BaseReader
 
         // Count how many times each of the potential delimiters appears in each line
         $numberLines = 0;
-        while (($line = fgets($this->fileHandle)) !== false && (++$numberLines < 1000)) {
-            // Drop everything that is enclosed to avoid counting false positives in enclosures
-            $enclosure = preg_quote($this->enclosure, '/');
-            $line = preg_replace('/(' . $enclosure . '.*' . $enclosure . ')/U', '', $line);
-
+        while (($line = $this->getNextLine()) !== false && (++$numberLines < 1000)) {
             $countLine = [];
             for ($i = strlen($line) - 1; $i >= 0; --$i) {
                 $char = $line[$i];
@@ -202,11 +198,11 @@ class Csv extends BaseReader
             }
 
             $meanSquareDeviations[$delimiter] = array_reduce(
-                $series,
-                function ($sum, $value) use ($median) {
-                    return $sum + pow($value - $median, 2);
-                }
-            ) / count($series);
+                    $series,
+                    function ($sum, $value) use ($median) {
+                        return $sum + pow($value - $median, 2);
+                    }
+                ) / count($series);
         }
 
         // ... and pick the delimiter with the smallest mean square deviation (in case of ties, the order in potentialDelimiters is respected)
@@ -228,6 +224,42 @@ class Csv extends BaseReader
         }
 
         return $this->skipBOM();
+    }
+
+    /**
+     * Get the next full line from the file
+     *
+     * @param string $line
+     *
+     * @return bool|string
+     */
+    private function getNextLine($line = '')
+    {
+        // Get the next line in the file
+        $newLine = fgets($this->fileHandle);
+
+        // Return false if there is no next line
+        if ($newLine == false) {
+            return false;
+        }
+
+        // Add the new line to the line passed in
+        $line = $line . $newLine;
+
+        // Drop everything that is enclosed to avoid counting false positives in enclosures
+        $enclosure = preg_quote($this->enclosure, '/');
+        $line = preg_replace('/(' . $enclosure . '.*' . $enclosure . ')/U', '', $line);
+
+        // See if we have any enclosures left in the line
+        $matches = [];
+        preg_match('/(' . $enclosure . ')/', $line, $matches);
+
+        // if we still have an enclosure then we need to read the next line aswell
+        if (count($matches) > 0) {
+            $line = $this->getNextLine($line);
+        }
+
+        return $line;
     }
 
     /**
@@ -447,7 +479,7 @@ class Csv extends BaseReader
      */
     public function setContiguous($contiguous)
     {
-        $this->contiguous = (bool) $contiguous;
+        $this->contiguous = (bool)$contiguous;
         if (!$contiguous) {
             $this->contiguousRow = -1;
         }

--- a/tests/PhpSpreadsheetTests/Reader/CsvTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/CsvTest.php
@@ -44,6 +44,12 @@ class CsvTest extends TestCase
                 '25,5',
             ],
             [
+                __DIR__ . '/../../data/Reader/CSV/line_break_in_enclosure.csv',
+                ',',
+                'A3',
+                'Test',
+            ],
+            [
                 __DIR__ . '/../../data/Reader/HTML/csv_with_angle_bracket.csv',
                 ',',
                 'B1',

--- a/tests/data/Reader/CSV/line_break_in_enclosure.csv
+++ b/tests/data/Reader/CSV/line_break_in_enclosure.csv
@@ -1,0 +1,18 @@
+Name,Copy,URL
+Test,"This is a test
+with line breaks
+that breaks the
+delimiters",http://google.com
+Test,"This is a test
+with line breaks
+that breaks the
+delimiters",http://google.com
+Test,"This is a test
+with line breaks
+that breaks the
+delimiters",http://google.com
+Test,"This is a test
+with line breaks
+that breaks the
+delimiters",http://google.com
+Test,"This is a test",http://google.com


### PR DESCRIPTION
The CSV Reader can now correctly ignore line breaks inside
enclosures which allows it to determine the delimiter
correctly.

This is:

```
- [X] a bugfix
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [X] Documentation is updated as necessary

### Why this change is needed?
The CSV Reader was incorrectly infering the separator due to it treating new lines inside enclosures as brand new lines in the CSV when it should have been treating it as part of the same line on the CSV.