### PR TITLE
Add output encoding option to CSV writer

### DIFF
--- a/src/PhpSpreadsheet/Writer/Csv.php
+++ b/src/PhpSpreadsheet/Writer/Csv.php
@@ -106,7 +106,6 @@ class Csv extends BaseWriter
         return $this->outputEncoding;
     }
 
-
     /**
      * Save PhpSpreadsheet to file.
      *
@@ -361,7 +360,7 @@ class Csv extends BaseWriter
             } else {
                 $writeDelimiter = true;
             }
-            
+
             // Convert encoding if necessary
             if ($this->outputEncoding !== 'UTF-8') {
                 $element = StringHelper::convertEncoding($element, $this->outputEncoding, 'UTF-8');

--- a/src/PhpSpreadsheet/Writer/Csv.php
+++ b/src/PhpSpreadsheet/Writer/Csv.php
@@ -3,10 +3,18 @@
 namespace PhpOffice\PhpSpreadsheet\Writer;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class Csv extends BaseWriter
 {
+    /**
+     * Output encoding.
+     *
+     * @var string
+     */
+    private $outputEncoding = 'UTF-8';
+
     /**
      * PhpSpreadsheet object.
      *
@@ -73,6 +81,31 @@ class Csv extends BaseWriter
     {
         $this->spreadsheet = $spreadsheet;
     }
+
+    /**
+     * Set output encoding.
+     *
+     * @param string $pValue Output encoding, eg: 'UTF-8'
+     *
+     * @return Csv
+     */
+    public function setOutputEncoding($pValue)
+    {
+        $this->outputEncoding = $pValue;
+
+        return $this;
+    }
+
+    /**
+     * Get output encoding.
+     *
+     * @return string
+     */
+    public function getOutputEncoding()
+    {
+        return $this->outputEncoding;
+    }
+
 
     /**
      * Save PhpSpreadsheet to file.
@@ -327,6 +360,11 @@ class Csv extends BaseWriter
                 $line .= $this->delimiter;
             } else {
                 $writeDelimiter = true;
+            }
+            
+            // Convert encoding if necessary
+            if ($this->outputEncoding !== 'UTF-8') {
+                $element = StringHelper::convertEncoding($element, $this->outputEncoding, 'UTF-8');
             }
 
             // Add enclosed string


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

There is an option to set encoding on Reader. Let's add it to the writer as well.
