### PR TITLE
Call static method with static keyword instead of self in DefaultValueBinder

### DIFF
--- a/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
@@ -31,7 +31,7 @@ class DefaultValueBinder implements IValueBinder
         }
 
         // Set value explicit
-        $cell->setValueExplicit($value, self::dataTypeForValue($value));
+        $cell->setValueExplicit($value, static::dataTypeForValue($value));
 
         // Done!
         return true;


### PR DESCRIPTION
When I extended `DefaultValueBinder` and used my custom value binder, I overriden static method `dataTypeForValue` to examine all cells as strings. But my method is not called, because in `DefaultValueBinder` it is called with `self` keyword. Since the class is designed to be extended (not final), I think the use of `self` keyword is bad design, and `static` keyword should be used. When used with `static`, my overriden method `dataTypeForValue` is called properly.

Maybe same problem exists in other classes in project, but I only discovered this one.