### PR TITLE
[XLSX] Fix sheet title extract function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.5.1] - 
+
+### Fixed
+
+- Fix sheet title extract function in XLSX Worksheet - [#742](https://github.com/PHPOffice/PhpSpreadsheet/pull/742)
+
 ## [1.5.0] - 2018-10-21
 
 ### Added

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2734,7 +2734,14 @@ class Worksheet implements IComparable
         }
 
         if ($returnRange) {
-            return [substr($pRange, 0, $sep), substr($pRange, $sep + 1)];
+            $sheet = substr($pRange, 0, $sep);
+            if (($pos = strpos($sheet, "'")) !== false) {
+                $sheet = substr_replace($sheet, '', $pos, 1);
+            }
+            if (($pos = strrpos($sheet, "'")) !== false) {
+                $sheet = substr_replace($sheet, '', $pos, 1);
+            }
+            return [$sheet, substr($pRange, $sep + 1)];
         }
 
         return substr($pRange, $sep + 1);

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -136,6 +136,7 @@ class WorksheetTest extends TestCase
         return [
             ['B2', '', '', 'B2'],
             ['testTitle!B2', 'testTitle', 'B2', 'B2'],
+            ["'testTitle'!B2", 'testTitle', 'B2', 'B2'],
             ['test!Title!B2', 'test!Title', 'B2', 'B2'],
         ];
     }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

XLSX extractSheetTitle returned the quote character in sheet name

Fix #739