### PR TITLE
Fix 337 : Reader\Csv::inferSeparator() generates a notice when the file is empty

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
     syntaxCheck="true"
     disallowTestOutput="true">
     <php>
+        <ini name="error_reporting" value="-1"/>
         <ini name="memory_limit" value="2048M"/>
     </php>
     <testsuite name="PhpSpreadsheet Unit Test Suite">

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -181,6 +181,13 @@ class Csv extends BaseReader
             }
         }
 
+        // If number of lines is 0, nothing to infer : fall back to the default
+        if ($numberLines === 0) {
+            $this->delimiter = reset($potentialDelimiters);
+
+            return $this->skipBOM();
+        }
+
         // Calculate the mean square deviations for each delimiter (ignoring delimiters that haven't been found consistently)
         $meanSquareDeviations = [];
         $middleIdx = floor(($numberLines - 1) / 2);

--- a/tests/PhpSpreadsheetTests/Reader/CsvTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/CsvTest.php
@@ -67,6 +67,18 @@ class CsvTest extends TestCase
                 'D8',
                 -58.373161,
             ],
+            [
+                'data/Reader/CSV/empty.csv',
+                ',',
+                'A1',
+                null,
+            ],
+            [
+                'data/Reader/CSV/no_delimiter.csv',
+                ',',
+                'A1',
+                'SingleLine',
+            ],
         ];
     }
 

--- a/tests/data/Reader/CSV/no_delimiter.csv
+++ b/tests/data/Reader/CSV/no_delimiter.csv
@@ -1,0 +1,1 @@
+SingleLine


### PR DESCRIPTION
This is:

```
- [ x ] a bugfix
- [ ] a new feature
```

Checklist:

- [ x ] Changes are covered by unit tests
- [ x ] Code style is respected
- [ x ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [    ] CHANGELOG.md contains a short summary of the change
- [    ] Documentation is updated as necessary

### Why this change is needed?
When loading an empty file with `Reader\Csv`, a notice is emitted because the `inferSeparator()` function tries to access an undefined array index. This can lead to an exception depending on your configuration.
Note that to detect the error in the first place, I changed the config to make phpunit fail on notices.