### PR TITLE
Fix chart data references on sheet title update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - SUMIFS containing multiple conditions - [#704](https://github.com/PHPOffice/PhpSpreadsheet/issues/704)
 - Csv reader avoid notice when the file is empty - [#743](https://github.com/PHPOffice/PhpSpreadsheet/pull/743)
 - Fix print area parser for XLSX reader - [#734](https://github.com/PHPOffice/PhpSpreadsheet/pull/734)
+- Fix chart data references on sheet title update - [#745](https://github.com/PHPOffice/PhpSpreadsheet/pull/745)
 
 ## [1.5.0] - 2018-10-21
 

--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -4,8 +4,6 @@ namespace PhpOffice\PhpSpreadsheet;
 
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
-use PhpOffice\PhpSpreadsheet\Chart\DataSeries;
-use PhpOffice\PhpSpreadsheet\Chart\DataSeriesValues;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class ReferenceHelper
@@ -818,39 +816,6 @@ class ReferenceHelper
                         $formula = str_replace("'" . $oldName . "'!", "'" . $newName . "'!", $formula);
                         $formula = str_replace($oldName . '!', $newName . '!', $formula);
                         $cell->setValueExplicit($formula, DataType::TYPE_FORMULA);
-                    }
-                }
-            }
-
-            foreach ($sheet->getChartCollection() as $chart) {
-                /** @var DataSeries $plotGroup */
-                foreach ($chart->getPlotArea()->getPlotGroup() as $plotGroup) {
-                    /** @var DataSeriesValues $plotCategory */
-                    foreach ($plotGroup->getPlotCategories() as $plotCategory) {
-                        $dataSource = $plotCategory->getDataSource();
-                        if (strpos($dataSource, $oldName) !== false) {
-                            $dataSource = str_replace("'" . $oldName . "'!", "'" . $newName . "'!", $dataSource);
-                            $dataSource = str_replace($oldName . '!', $newName . '!', $dataSource);
-                            $plotCategory->setDataSource($dataSource);
-                        }
-                    }
-                    /** @var DataSeriesValues $plotLabel */
-                    foreach ($plotGroup->getPlotLabels() as $plotLabel) {
-                        $dataSource = $plotLabel->getDataSource();
-                        if (strpos($dataSource, $oldName) !== false) {
-                            $dataSource = str_replace("'" . $oldName . "'!", "'" . $newName . "'!", $dataSource);
-                            $dataSource = str_replace($oldName . '!', $newName . '!', $dataSource);
-                            $plotLabel->setDataSource($dataSource);
-                        }
-                    }
-                    /** @var DataSeriesValues $plotValue */
-                    foreach ($plotGroup->getPlotValues() as $plotValue) {
-                        $dataSource = $plotValue->getDataSource();
-                        if (strpos($dataSource, $oldName) !== false) {
-                            $dataSource = str_replace("'" . $oldName . "'!", "'" . $newName . "'!", $dataSource);
-                            $dataSource = str_replace($oldName . '!', $newName . '!', $dataSource);
-                            $plotValue->setDataSource($dataSource);
-                        }
                     }
                 }
             }

--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -4,6 +4,8 @@ namespace PhpOffice\PhpSpreadsheet;
 
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Chart\DataSeries;
+use PhpOffice\PhpSpreadsheet\Chart\DataSeriesValues;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class ReferenceHelper
@@ -816,6 +818,39 @@ class ReferenceHelper
                         $formula = str_replace("'" . $oldName . "'!", "'" . $newName . "'!", $formula);
                         $formula = str_replace($oldName . '!', $newName . '!', $formula);
                         $cell->setValueExplicit($formula, DataType::TYPE_FORMULA);
+                    }
+                }
+            }
+
+            foreach ($sheet->getChartCollection() as $chart) {
+                /** @var DataSeries $plotGroup */
+                foreach ($chart->getPlotArea()->getPlotGroup() as $plotGroup) {
+                    /** @var DataSeriesValues $plotCategory */
+                    foreach ($plotGroup->getPlotCategories() as $plotCategory) {
+                        $dataSource = $plotCategory->getDataSource();
+                        if (strpos($dataSource, $oldName) !== false) {
+                            $dataSource = str_replace("'" . $oldName . "'!", "'" . $newName . "'!", $dataSource);
+                            $dataSource = str_replace($oldName . '!', $newName . '!', $dataSource);
+                            $plotCategory->setDataSource($dataSource);
+                        }
+                    }
+                    /** @var DataSeriesValues $plotLabel */
+                    foreach ($plotGroup->getPlotLabels() as $plotLabel) {
+                        $dataSource = $plotLabel->getDataSource();
+                        if (strpos($dataSource, $oldName) !== false) {
+                            $dataSource = str_replace("'" . $oldName . "'!", "'" . $newName . "'!", $dataSource);
+                            $dataSource = str_replace($oldName . '!', $newName . '!', $dataSource);
+                            $plotLabel->setDataSource($dataSource);
+                        }
+                    }
+                    /** @var DataSeriesValues $plotValue */
+                    foreach ($plotGroup->getPlotValues() as $plotValue) {
+                        $dataSource = $plotValue->getDataSource();
+                        if (strpos($dataSource, $oldName) !== false) {
+                            $dataSource = str_replace("'" . $oldName . "'!", "'" . $newName . "'!", $dataSource);
+                            $dataSource = str_replace($oldName . '!', $newName . '!', $dataSource);
+                            $plotValue->setDataSource($dataSource);
+                        }
                     }
                 }
             }

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -885,6 +885,39 @@ class Worksheet implements IComparable
         $this->title = $pValue;
         $this->dirty = true;
 
+        foreach ($this->getChartCollection() as $chart) {
+            /** @var DataSeries $plotGroup */
+            foreach ($chart->getPlotArea()->getPlotGroup() as $plotGroup) {
+                /** @var DataSeriesValues $plotCategory */
+                foreach ($plotGroup->getPlotCategories() as $plotCategory) {
+                    $dataSource = $plotCategory->getDataSource();
+                    if (strpos($dataSource, $oldTitle) !== false) {
+                        $dataSource = str_replace("'" . $oldTitle . "'!", "'" . $pValue . "'!", $dataSource);
+                        $dataSource = str_replace($oldTitle . '!', $pValue . '!', $dataSource);
+                        $plotCategory->setDataSource($dataSource);
+                    }
+                }
+                /** @var DataSeriesValues $plotLabel */
+                foreach ($plotGroup->getPlotLabels() as $plotLabel) {
+                    $dataSource = $plotLabel->getDataSource();
+                    if (strpos($dataSource, $oldTitle) !== false) {
+                        $dataSource = str_replace("'" . $oldTitle . "'!", "'" . $pValue . "'!", $dataSource);
+                        $dataSource = str_replace($oldTitle . '!', $pValue . '!', $dataSource);
+                        $plotLabel->setDataSource($dataSource);
+                    }
+                }
+                /** @var DataSeriesValues $plotValue */
+                foreach ($plotGroup->getPlotValues() as $plotValue) {
+                    $dataSource = $plotValue->getDataSource();
+                    if (strpos($dataSource, $oldTitle) !== false) {
+                        $dataSource = str_replace("'" . $oldTitle . "'!", "'" . $pValue . "'!", $dataSource);
+                        $dataSource = str_replace($oldTitle . '!', $pValue . '!', $dataSource);
+                        $plotValue->setDataSource($dataSource);
+                    }
+                }
+            }
+        }
+
         if ($this->parent && $this->parent->getCalculationEngine()) {
             // New title
             $newTitle = $this->getTitle();


### PR DESCRIPTION
Chart with sheet reference was not updated on sheet title renaming.

Fix #744

This is:

```
- [x] a bugfix
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

Chart with sheet reference was not updated on sheet title renaming.