### PR TITLE
fix iconv E_NOTICE error when import chinese xls

### DIFF
--- a/src/PhpSpreadsheet/Shared/StringHelper.php
+++ b/src/PhpSpreadsheet/Shared/StringHelper.php
@@ -453,7 +453,7 @@ class StringHelper
     public static function convertEncoding($value, $to, $from)
     {
         if (self::getIsIconvEnabled()) {
-            $result = iconv($from, $to . '//IGNORE//TRANSLIT', $value);
+            $result = @iconv($from, $to . '//IGNORE//TRANSLIT', $value);
             if (false !== $result) {
                 return $result;
             }


### PR DESCRIPTION

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

I import a Chinese excel(xls), iconv report E_NOTICE error, and the same content excel(xlsx) is normal
when i use Error Control Operators, it's ok, and the imported data is ok too