### PR TITLE
Fix index overflow on data values array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - SUMIFS containing multiple conditions - [#704](https://github.com/PHPOffice/PhpSpreadsheet/issues/704)
 - Csv reader avoid notice when the file is empty - [#743](https://github.com/PHPOffice/PhpSpreadsheet/pull/743)
 - Fix print area parser for XLSX reader - [#734](https://github.com/PHPOffice/PhpSpreadsheet/pull/734)
+- Fix index overflow on data values array - [#748](https://github.com/PHPOffice/PhpSpreadsheet/pull/748)
 
 ## [1.5.0] - 2018-10-21
 

--- a/src/PhpSpreadsheet/Chart/DataSeriesValues.php
+++ b/src/PhpSpreadsheet/Chart/DataSeriesValues.php
@@ -271,7 +271,7 @@ class DataSeriesValues
     public function isMultiLevelSeries()
     {
         if (count($this->dataValues) > 0) {
-            return is_array($this->dataValues[0]);
+            return is_array(array_values($this->dataValues)[0]);
         }
 
         return null;


### PR DESCRIPTION
This is:

```
- [x] a bugfix
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

[isMultiLevelSeries](https://github.com/PHPOffice/PhpSpreadsheet/blob/fdc224af7cc1d0d386fd91770869d99af0eafab3/src/PhpSpreadsheet/Chart/DataSeriesValues.php#L274) function throw an error on discontinuous indices  : `Notice: Undefined offset: 0`.