### PR TITLE
Issue #750 - Changed page addition to allow margins to be inherited f…

### DIFF
--- a/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
@@ -73,9 +73,9 @@ class Mpdf extends Pdf
         $pdf->AddPageByArray([
             'orientation' => $orientation,
             'margin-left' => $this->spreadsheet->getActiveSheet()->getPageMargins()->getLeft(),
-            'margin-right' => $this->spreadsheet->getActiveSheet()->getPageMargins()->getLeft(),
-            'margin-top' => $this->spreadsheet->getActiveSheet()->getPageMargins()->getLeft(),
-            'margin-bottom' => $this->spreadsheet->getActiveSheet()->getPageMargins()->getLeft(),
+            'margin-right' => $this->spreadsheet->getActiveSheet()->getPageMargins()->getRight(),
+            'margin-top' => $this->spreadsheet->getActiveSheet()->getPageMargins()->getTop(),
+            'margin-bottom' => $this->spreadsheet->getActiveSheet()->getPageMargins()->getBottom(),
         ]);
 
         //  Document info

--- a/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
@@ -70,7 +70,13 @@ class Mpdf extends Pdf
         $ortmp = $orientation;
         $pdf->_setPageSize(strtoupper($paperSize), $ortmp);
         $pdf->DefOrientation = $orientation;
-        $pdf->AddPage($orientation);
+        $pdf->AddPageByArray([
+            'orientation' => $orientation,
+            'margin-left' => $this->spreadsheet->getActiveSheet()->getPageMargins()->getLeft(),
+            'margin-right' => $this->spreadsheet->getActiveSheet()->getPageMargins()->getLeft(),
+            'margin-top' => $this->spreadsheet->getActiveSheet()->getPageMargins()->getLeft(),
+            'margin-bottom' => $this->spreadsheet->getActiveSheet()->getPageMargins()->getLeft(),
+        ]);
 
         //  Document info
         $pdf->SetTitle($this->spreadsheet->getProperties()->getTitle());


### PR DESCRIPTION
…rom active sheet

This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Currently there is no way to update the margins of the pdf that gets printed using mPDF. This change rectifies that in that it inherits the margins of the active sheet.