### PR TITLE
Cache readFilter access and skip inner loops for empty/default read filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Support overriding `DefaultValueBinder::dataTypeForValue()` without overriding `DefaultValueBinder::bindValue()` - [#735](https://github.com/PHPOffice/PhpSpreadsheet/pull/735)
 - Mpdf export can exceed pcre.backtrack_limit - [#637](https://github.com/PHPOffice/PhpSpreadsheet/issues/637)
 - Fix index overflow on data values array - [#748](https://github.com/PHPOffice/PhpSpreadsheet/pull/748)
+- Improve XLSX parsing speed if no readFilter is applied - [#772](https://github.com/PHPOffice/PhpSpreadsheet/issues/772)
 
 ## [1.5.0] - 2018-10-21
 

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2562,13 +2562,15 @@ class Xlsx extends BaseReader
             }
         }
 
+        $readFilter = (\get_class($this->getReadFilter()) !== DefaultReadFilter::class ? $this->getReadFilter() : null);
+
         // set columns/rows attributes
         $columnsAttributesSet = [];
         $rowsAttributesSet = [];
         foreach ($columnsAttributes as $coordColumn => $columnAttributes) {
-            foreach ($rowsAttributes as $coordRow => $rowAttributes) {
-                if ($this->getReadFilter() !== null) {
-                    if (!$this->getReadFilter()->readCell($coordColumn, $coordRow, $docSheet->getTitle())) {
+            if ($readFilter !== null) {
+                foreach ($rowsAttributes as $coordRow => $rowAttributes) {
+                    if (!$readFilter->readCell($coordColumn, $coordRow, $docSheet->getTitle())) {
                         continue 2;
                     }
                 }
@@ -2581,9 +2583,9 @@ class Xlsx extends BaseReader
         }
 
         foreach ($rowsAttributes as $coordRow => $rowAttributes) {
-            foreach ($columnsAttributes as $coordColumn => $columnAttributes) {
-                if ($this->getReadFilter() !== null) {
-                    if (!$this->getReadFilter()->readCell($coordColumn, $coordRow, $docSheet->getTitle())) {
+            if ($readFilter !== null) {
+                foreach ($columnsAttributes as $coordColumn => $columnAttributes) {
+                    if (!$readFilter->readCell($coordColumn, $coordRow, $docSheet->getTitle())) {
                         continue 2;
                     }
                 }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
```

Checklist:

- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change

### Why this change is needed?
Loading large XSLX files and using styles has a severe performance penalty (2 seconds vs. 30 seconds for ~6k rows). The performance penalty is mitigated when using no custom read filter

Fixed #772 