### PR TITLE
Fix column names if read filter calls in XLSX reader skip columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Support overriding `DefaultValueBinder::dataTypeForValue()` without overriding `DefaultValueBinder::bindValue()` - [#735](https://github.com/PHPOffice/PhpSpreadsheet/pull/735)
 - Mpdf export can exceed pcre.backtrack_limit - [#637](https://github.com/PHPOffice/PhpSpreadsheet/issues/637)
 - Fix index overflow on data values array - [#748](https://github.com/PHPOffice/PhpSpreadsheet/pull/748)
+- Fix column names if read filter calls in XLSX reader skip columns - [#777](https://github.com/PHPOffice/PhpSpreadsheet/pull/777)
 
 ## [1.5.0] - 2018-10-21
 

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -909,6 +909,8 @@ class Xlsx extends BaseReader
                                             $coordinates = Coordinate::coordinateFromString($r);
 
                                             if (!$this->getReadFilter()->readCell($coordinates[0], (int) $coordinates[1], $docSheet->getTitle())) {
+                                                $rowIndex += 1;
+
                                                 continue;
                                             }
                                         }

--- a/tests/PhpSpreadsheetTests/Reader/OddColumnReadFilter.php
+++ b/tests/PhpSpreadsheetTests/Reader/OddColumnReadFilter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader;
+
+use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
+
+/**
+ * Show only cells from odd columns
+ */
+class OddColumnReadFilter implements IReadFilter
+{
+    public function readCell($column, $row, $worksheetName = '')
+    {
+        return ((\ord(\substr($column, -1, 1)) % 2) === 1);
+    }
+}

--- a/tests/PhpSpreadsheetTests/Reader/XlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XlsxTest.php
@@ -16,4 +16,20 @@ class XlsxTest extends TestCase
         $reader = new Xlsx();
         $reader->load($filename);
     }
+    
+    /**
+     * Test load Xlsx file and use a read filter
+     */
+    public function testLoadWithReadFilter()
+    {
+        $filename = './data/Reader/XLSX/without_cell_reference.xlsx';
+        $reader = new Xlsx();
+        $reader->setReadFilter(new OddColumnReadFilter());
+        $data = $reader->load($filename)->getActiveSheet()->toArray();
+        $ref = [1.0, null, 3.0, null, 5.0, null, 7.0, null, 9.0, null];
+        
+        for ($i=0; $i<10; $i++) {
+            $this->assertEquals($ref, \array_slice($data[$i], 0, 10, true));
+        }
+    }
 }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made
- [x] CHANGELOG.md contains a short summary of the change

### Why this change is needed?
See bug #777 