### PR TITLE
Extended the docblock of Style::applyFromArray with example for alignment styling

### DIFF
--- a/src/PhpSpreadsheet/Style/Style.php
+++ b/src/PhpSpreadsheet/Style/Style.php
@@ -176,6 +176,11 @@ class Style extends Supervisor
      *                 ]
      *             ]
      *         ],
+     *         'alignment' => [
+     *             'horizontal' => Alignment::HORIZONTAL_CENTER,
+     *             'vertical' => Alignment::VERTICAL_CENTER,
+     *             'wrapText' => true,
+     *         ],
      *         'quotePrefix'    => true
      *     ]
      * );


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [x] a new feature


Checklist:

- [n/a] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [n/a] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

The doc block of `PhpOffice\PhpSpreadsheet\Style\Style::applyFromArray` shows how to assign some attributes but not all. Until now the usage of `alignment` is not shown. This commit extends the doc block with an example.