### PR TITLE
Fixes #787 libxml_disable_entity_loader() is changed

### DIFF
--- a/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
+++ b/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
@@ -14,11 +14,11 @@ class XmlScanner
     private $libxmlDisableEntityLoader = false;
 
     /**
-     * Store the initial setting of libxmlDisableEntityLoader so that we can resore t later.
+     * Stores the initial setting of libxmlDisableEntityLoader so that we can restore it later.
      *
      * @var bool
      */
-    private $previousLibxmlDisableEntityLoaderValue;
+    static private $previousLibxmlDisableEntityLoaderValue;
 
     /**
      * String used to identify risky xml elements.
@@ -34,16 +34,17 @@ class XmlScanner
         $this->pattern = $pattern;
         $this->libxmlDisableEntityLoader = $this->identifyLibxmlDisableEntityLoaderAvailability();
 
-        if ($this->libxmlDisableEntityLoader) {
-            $this->previousLibxmlDisableEntityLoaderValue = libxml_disable_entity_loader(true);
+        if ($this->libxmlDisableEntityLoader && self::$previousLibxmlDisableEntityLoaderValue === null) {
+            self::$previousLibxmlDisableEntityLoaderValue = libxml_disable_entity_loader(true);
         }
     }
 
     public function __destruct()
     {
         if ($this->libxmlDisableEntityLoader) {
-            libxml_disable_entity_loader($this->previousLibxmlDisableEntityLoaderValue);
+            libxml_disable_entity_loader(self::$previousLibxmlDisableEntityLoaderValue);
         }
+        self::$previousLibxmlDisableEntityLoaderValue = null;
     }
 
     public static function getInstance(Reader\IReader $reader)


### PR DESCRIPTION
This would be one way to fix https://github.com/PHPOffice/PhpSpreadsheet/issues/787

Somehow when I try to load a PDF the `XmlScanner::getInstance()` is called many times:
A new `getInstance()` is called before the `__destruct()` of the previous one, causing the `previousLibxmlDisableEntityLoaderValue` to contain `false` even when the original value was `true`.

My solution was to share `$previousLibxmlDisableEntityLoaderValue` accross all instances, and be sure to not overwrite the original value.