### PR TITLE
Fix to allow iconv to fail silently, allowing mb_convert_encoding to process the value

### DIFF
--- a/src/PhpSpreadsheet/Shared/StringHelper.php
+++ b/src/PhpSpreadsheet/Shared/StringHelper.php
@@ -453,7 +453,7 @@ class StringHelper
     public static function convertEncoding($value, $to, $from)
     {
         if (self::getIsIconvEnabled()) {
-            $result = iconv($from, $to . '//IGNORE//TRANSLIT', $value);
+            $result = @iconv($from, $to . '//IGNORE//TRANSLIT', $value);
             if (false !== $result) {
                 return $result;
             }


### PR DESCRIPTION
Fix to allow iconv to fail silently, allowing mb_convert_encoding to process the value.

iconv could fail on some systems with an uncaught error, for example:
```
Notice: iconv(): Wrong charset, conversion from `ISO-8859-1' to `UTF-8//IGNORE//TRANSLIT' is not  
   allowed
```

There is two solutions to fix this bug.
The first one is removing the `//IGNORE//TRANSLIT` suffix to `UTF-8`, but this could be a nice feature to keep for some compatible systems.
Otherwise, we should allow iconv to fail silently so the process could still rely on `mb_*`.

Having neither prevents me to use PhpSpreadsheet to load my CSV file (ISO-8859-1)

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
