### PR TITLE
Feature: branch pruning in calculation engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Refactored Matrix Functions to use external Matrix library
 - Possibility to specify custom colors of values for pie and donut charts - [#768](https://github.com/PHPOffice/PhpSpreadsheet/pull/768)
+- Branch pruning around IF function calls to avoid resolution of every branches
 
 ### Fixed
 

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -2256,7 +2256,6 @@ class Calculation
     {
         $this->clearCalculationCache();
         $this->clearBranchStore();
-        $this->branchStoreKeyCounter = 0;
     }
 
     /**
@@ -3443,7 +3442,6 @@ class Calculation
                 }
 
                 if (preg_match('/^' . self::CALCULATION_REGEXP_FUNCTION . '$/i', $d['value'], $matches)) {    //    Did this parenthesis just close a function?
-
                     if (!empty($pendingStoreKey) && $parenthesisDepthMap[$pendingStoreKey] == -1) {
                         // we are closing an IF(
                         if ($d['value'] != 'IF(') {
@@ -3519,9 +3517,7 @@ class Calculation
                 }
                 ++$index;
             } elseif ($opCharacter == ',') {            //    Is this the separator for function arguments?
-
-                if (
-                    !empty($pendingStoreKey) &&
+                if (!empty($pendingStoreKey) &&
                     $parenthesisDepthMap[$pendingStoreKey] == 0
                 ) {
                     // We must go to the IF next argument
@@ -3590,8 +3586,7 @@ class Calculation
                             }
                         }
 
-                        $stack->push('Function', $valToUpper, null,
-                            $currentCondition, $currentOnlyIf, $currentOnlyIfNot);
+                        $stack->push('Function', $valToUpper, null, $currentCondition, $currentOnlyIf, $currentOnlyIfNot);
                         // tests if the function is closed right after opening
                         $ax = preg_match('/^\s*(\s*\))/ui', substr($formula, $index + $length), $amatch);
                         if ($ax) {
@@ -3626,9 +3621,7 @@ class Calculation
                         }
                     }
 
-                    $outputItem = $stack->getStackItem('Cell Reference', $val,
-                        $val, $currentCondition, $currentOnlyIf,
-                        $currentOnlyIfNot);
+                    $outputItem = $stack->getStackItem('Cell Reference', $val, $val, $currentCondition, $currentOnlyIf, $currentOnlyIfNot);
 
                     $output[] = $outputItem;
                 } else {    // it's a variable, constant, string, number or boolean
@@ -3802,7 +3795,6 @@ class Calculation
                 if (isset($storeValue) && (($storeValue !== true)
                     || ($storeValue === 'Pruned branch'))
                 ) {
-
                     // If branching value is not true, we don't need to compute
                     if (!isset($fakedForBranchPruning['onlyIf-' . $onlyIfStoreKey])) {
                         $stack->push('Value', 'Pruned branch (only if ' . $onlyIfStoreKey . ') ' . $token);
@@ -3831,7 +3823,6 @@ class Calculation
                 if (isset($storeValue) && ($storeValue
                     || ($storeValue === 'Pruned branch'))
                 ) {
-
                     // If branching value is true, we don't need to compute
                     if (!isset($fakedForBranchPruning['onlyIfNot-' . $onlyIfNotStoreKey])) {
                         $stack->push('Value', 'Pruned branch (only if not ' . $onlyIfNotStoreKey . ') ' . $token);

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -67,6 +67,13 @@ class Calculation
     private $calculationCacheEnabled = true;
 
     /**
+     * Used to generate unique store keys
+     *
+     * @var int
+     */
+    private $storeKeyCounter = 0;
+
+    /**
      * List of operators that can be used within formulae
      * The true/false value indicates whether it is a binary operator or a unary operator.
      *
@@ -2710,6 +2717,7 @@ class Calculation
      */
     public function calculateCellValue(Cell $pCell = null, $resetLog = true)
     {
+        var_dump('calculateCellValue start: Working on ' . $pCell->getCoordinate());
         if ($pCell === null) {
             return null;
         }
@@ -2736,6 +2744,7 @@ class Calculation
             $cellAddress = array_pop($this->cellStack);
             $this->spreadsheet->getSheetByName($cellAddress['sheet'])->getCell($cellAddress['cell']);
         } catch (\Exception $e) {
+            throw $e; // @todo HCK remove
             $cellAddress = array_pop($this->cellStack);
             $this->spreadsheet->getSheetByName($cellAddress['sheet'])->getCell($cellAddress['cell']);
 
@@ -2773,6 +2782,8 @@ class Calculation
         } elseif ((is_float($result)) && ((is_nan($result)) || (is_infinite($result)))) {
             return Functions::NAN();
         }
+
+        var_dump('calculateCellValue end: Resolving ' . $pCell->getCoordinate() . ' at ' . $result);
 
         return $result;
     }
@@ -3308,9 +3319,37 @@ class Calculation
                                                     //        - is a negation or + is a positive operator rather than an operation
         $expectingOperand = false; //    We use this test in syntax-checking the expression to determine whether an operand
                                                     //        should be null in a function call
+
+        // HCK: support for IF branch pruning
+        // currently pending storeKey (last item of the storeKeysStack
+        $pendingStoreKey = null;
+        // stores a list of storeKeys (string[])
+        $pendingStoreKeysStack = [];
+        $expectingConditionMap = []; // ['storeKey' => true, ...]
+        $expectingThenMap = []; // ['storeKey' => true, ...]
+        $expectingElseMap = []; // ['storeKey' => true, ...]
+        $parenthesisDepthMap = []; // ['storeKey' => 4, ...]
+
+
         //    The guts of the lexical parser
         //    Loop through the formula extracting each operator and operand in turn
         while (true) {
+            // HCK: we adapt the output item to the context (it will
+            // be used to limit its computation)
+            $currentCondition = null;
+            $currentOnlyIf = null;
+            $currentOnlyIfNot = null;
+            if ($expectingConditionMap[$pendingStoreKey] ?? false) {
+                $currentCondition = $pendingStoreKey;
+            }
+            if ($expectingThenMap[$pendingStoreKey] ?? false) {
+                $currentOnlyIf = $pendingStoreKey;
+            }
+            if ($expectingElseMap[$pendingStoreKey] ?? false) {
+                $currentOnlyIfNot = $pendingStoreKey;
+            }
+            $pendingStoreKey = end($pendingStoreKeysStack);
+
             $opCharacter = $formula[$index]; //    Get the first character of the value at the current index position
             if ((isset(self::$comparisonOperators[$opCharacter])) && (strlen($formula) > $index) && (isset(self::$comparisonOperators[$formula[$index + 1]]))) {
                 $opCharacter .= $formula[++$index];
@@ -3320,10 +3359,13 @@ class Calculation
             $isOperandOrFunction = preg_match($regexpMatchString, substr($formula, $index), $match);
 
             if ($opCharacter == '-' && !$expectingOperator) {                //    Is it a negation instead of a minus?
-                $stack->push('Unary Operator', '~'); //    Put a negation on the stack
+                //    Put a negation on the stack
+                // HCK we inject context information
+                $stack->push('Unary Operator', '~', null, $currentCondition, $currentOnlyIf, $currentOnlyIfNot);
                 ++$index; //        and drop the negation symbol
             } elseif ($opCharacter == '%' && $expectingOperator) {
-                $stack->push('Unary Operator', '%'); //    Put a percentage on the stack
+                //    Put a percentage on the stack
+                $stack->push('Unary Operator', '%', null, $currentCondition, $currentOnlyIf, $currentOnlyIfNot);
                 ++$index;
             } elseif ($opCharacter == '+' && !$expectingOperator) {            //    Positive (unary plus rather than binary operator plus) can be discarded?
                 ++$index; //    Drop the redundant plus symbol
@@ -3336,7 +3378,9 @@ class Calculation
                     @(self::$operatorAssociativity[$opCharacter] ? self::$operatorPrecedence[$opCharacter] < self::$operatorPrecedence[$o2['value']] : self::$operatorPrecedence[$opCharacter] <= self::$operatorPrecedence[$o2['value']])) {
                     $output[] = $stack->pop(); //    Swap operands and higher precedence operators from the stack to the output
                 }
-                $stack->push('Binary Operator', $opCharacter); //    Finally put our current operator onto the stack
+                //    Finally put our current operator onto the stack
+                // HCK we inject context information
+                $stack->push('Binary Operator', $opCharacter, null, $currentCondition, $currentOnlyIf, $currentOnlyIfNot);
                 ++$index;
                 $expectingOperator = false;
             } elseif ($opCharacter == ')' && $expectingOperator) {            //    Are we expecting to close a parenthesis?
@@ -3349,6 +3393,23 @@ class Calculation
                 }
                 $d = $stack->last(2);
                 if (preg_match('/^' . self::CALCULATION_REGEXP_FUNCTION . '$/i', $d['value'], $matches)) {    //    Did this parenthesis just close a function?
+                    
+                    // HCK
+                    if (isset($pendingStoreKey) && $parenthesisDepthMap[$pendingStoreKey] == 0) {
+                        // we are closing an IF(
+                        if ($d['value'] != 'IF(') {
+                            return $this->raiseFormulaError('Parser bug we should be in an "IF("');
+                        }
+                        if ($expectingConditionMap[$pendingStoreKey]) {
+                            return $this->raiseFormulaError('We should not be expecting a condition');
+                        }
+                        $expectingThenMap[$pendingStoreKey] = false;
+                        $expectingElseMap[$pendingStoreKey] = false;
+                        $parenthesisDepthMap[$pendingStoreKey] -= 1;
+                        array_pop($pendingStoreKeysStack);
+                        unset($pendingStoreKey);
+                    }
+
                     $functionName = $matches[1]; //    Get the function name
                     $d = $stack->pop();
                     $argumentCount = $d['value']; //    See how many arguments there were (argument count is the next value stored on the stack)
@@ -3406,9 +3467,31 @@ class Calculation
                     if ($argumentCountError) {
                         return $this->raiseFormulaError("Formula Error: Wrong number of arguments for $functionName() function: $argumentCount given, " . $expectedArgumentCountString . ' expected');
                     }
+                } else {
+                    // HCK we decrease the depth whether is it a function call or a
+                    // parenthesis
+                    if (isset($pendingStoreKey)) {
+                        $parenthesisDepthMap[$pendingStoreKey] -= 1;
+                    }
                 }
                 ++$index;
             } elseif ($opCharacter == ',') {            //    Is this the separator for function arguments?
+
+                if (
+                    isset($pendingStoreKey) &&
+                    $parenthesisDepthMap[$pendingStoreKey] == 0
+                ) {
+                    // HCK we must step to the IF next step
+                    if ($expectingConditionMap[$pendingStoreKey]) {
+                        $expectingConditionMap[$pendingStoreKey] = false;
+                        $expectingThenMap[$pendingStoreKey] = true;
+                    } elseif ($expectingThenMap[$pendingStoreKey]) {
+                        $expectingThenMap[$pendingStoreKey] = false;
+                        $expectingElseMap[$pendingStoreKey] = true;
+                    } elseif ($expectingElseMap[$pendingStoreKey]) {
+                        return $this->raiseFormulaError('Reaching fourth argument of an IF');
+                    }
+                }
                 while (($o2 = $stack->pop()) && $o2['value'] != '(') {        //    Pop off the stack back to the last (
                     if ($o2 === null) {
                         return $this->raiseFormulaError('Formula Error: Unexpected ,');
@@ -3432,6 +3515,9 @@ class Calculation
                 $expectingOperand = true;
                 ++$index;
             } elseif ($opCharacter == '(' && !$expectingOperator) {
+                if (isset($pendingStoreKey)) { // HCK we go deeper
+                    $parenthesisDepthMap[$pendingStoreKey] += 1;
+                }
                 $stack->push('Brace', '(');
                 ++$index;
             } elseif ($isOperandOrFunction && !$expectingOperator) {    // do we now have a function/variable/number?
@@ -3440,16 +3526,33 @@ class Calculation
                 $val = $match[1];
                 $length = strlen($val);
 
+
                 if (preg_match('/^' . self::CALCULATION_REGEXP_FUNCTION . '$/i', $val, $matches)) {
                     $val = preg_replace('/\s/u', '', $val);
                     if (isset(self::$phpSpreadsheetFunctions[strtoupper($matches[1])]) || isset(self::$controlFunctions[strtoupper($matches[1])])) {    // it's a function
-                        $stack->push('Function', strtoupper($val));
+                        $valToUpper = strtoupper($val);
+                        // HCK: here $matches[1] will contain values like IF, and $val IF(
+                        $injectStoreKey = null;
+                        if ($valToUpper == 'IF(') { // we handle a new if
+                            $pendingStoreKey = $this->getUnusedStoreKey();
+                            $pendingStoreKeysStack[] = $pendingStoreKey;
+                            $expectingConditionMap[$pendingStoreKey] = true;
+                            $parenthesisDepthMap[$pendingStoreKey] = 0;
+                        } else { // this is not a if but we good deeper
+                            $parenthesisDepthMap[$pendingStoreKey] += 1;
+                        }
+
+                        $stack->push('Function', $valToUpper);
+                        // tests if the function is closed right after opening
                         $ax = preg_match('/^\s*(\s*\))/ui', substr($formula, $index + $length), $amatch);
                         if ($ax) {
-                            $stack->push('Operand Count for Function ' . strtoupper($val) . ')', 0);
+                            $stack->push('Operand Count for Function ' . $valToUpper . ')', 0);
                             $expectingOperator = true;
+
+                            // HCK (this is a closed function we don't go deeper)
+                            $parenthesisDepthMap[$pendingStoreKey] -= 1;
                         } else {
-                            $stack->push('Operand Count for Function ' . strtoupper($val) . ')', 1);
+                            $stack->push('Operand Count for Function ' . $valToUpper . ')', 1);
                             $expectingOperator = false;
                         }
                         $stack->push('Brace', '(');
@@ -3477,7 +3580,12 @@ class Calculation
                         }
                     }
 
-                    $output[] = ['type' => 'Cell Reference', 'value' => $val, 'reference' => $val];
+                    // HCK patching on context
+                    $outputItem = $stack->getStackItem('Cell Reference', $val,
+                        $val, $currentCondition, $currentOnlyIf,
+                        $currentOnlyIfNot);
+
+                    $output[] = $outputItem;
                 } else {    // it's a variable, constant, string, number or boolean
                     //    If the last entry on the stack was a : operator, then we may have a row or column range reference
                     $testPrevOp = $stack->last(1);
@@ -3524,7 +3632,7 @@ class Calculation
                     } elseif (($localeConstant = array_search(trim(strtoupper($val)), self::$localeBoolean)) !== false) {
                         $val = self::$excelConstants[$localeConstant];
                     }
-                    $details = ['type' => 'Value', 'value' => $val, 'reference' => null];
+                    $details = $stack->getStackItem('Value', $val, null, $currentCondition, $currentOnlyIf, $currentOnlyIfNot);
                     if ($localeConstant) {
                         $details['localeValue'] = $localeConstant;
                     }
@@ -3580,6 +3688,7 @@ class Calculation
             }
         }
 
+
         while (($op = $stack->pop()) !== null) {    // pop everything off the stack and push onto output
             if ((is_array($op) && $op['value'] == '(') || ($op === '(')) {
                 return $this->raiseFormulaError("Formula Error: Expecting ')'"); // if there are any opening braces on the stack, then braces were unbalanced
@@ -3617,6 +3726,9 @@ class Calculation
      */
     private function processTokenStack($tokens, $cellID = null, Cell $pCell = null)
     {
+
+        var_dump('begin process stack for ' . $cellID);
+
         if ($tokens == false) {
             return false;
         }
@@ -3627,9 +3739,37 @@ class Calculation
         $pCellParent = ($pCell !== null) ? $pCell->getParent() : null;
         $stack = new Stack();
 
+        //var_dump($tokens);die;
+
         //    Loop through each token in turn
         foreach ($tokens as $tokenData) {
+
             $token = $tokenData['value'];
+            // HCK skip useless keys
+            $storeKey = $tokenData['storeKey'] ?? null;
+
+            if (isset($tokenData['onlyIf'])) {
+                $onlyIfStoreKey = $tokenData['onlyIf'];
+                $this->getValueFromCache($onlyIfStoreKey, $storeValue);
+                if (isset($storeValue) && $storeValue) {
+                    // ... now ... how do we bypass this ? :/
+                    // continue;
+                }
+            }
+
+            if (isset($tokenData['onlyIfNot'])) {
+                $onlyIfNotStoreKey = $tokenData['onlyIfNot'];
+                $this->getValueFromCache($onlyIfNotStoreKey, $storeValue);
+                if (isset($storeValue) && !$storeValue) {
+                    // ... now ... how do we bypass this ? :/
+                    // continue;
+                }
+            }
+
+            var_dump('');
+            var_dump('processing ', $token);
+            var_dump('');
+
             // if the token is a binary operator, pop the top two values off the stack, do the operation, and push the result back on the stack
             if (isset(self::$binaryOperators[$token])) {
                 //    We must have two operands, error if we don't
@@ -3659,8 +3799,8 @@ class Calculation
                     case '<=':            //    Less than or Equal to
                     case '=':            //    Equality
                     case '<>':            //    Inequality
-                        $this->executeBinaryComparisonOperation($cellID, $operand1, $operand2, $token, $stack);
-
+                        $result = $this->executeBinaryComparisonOperation($cellID, $operand1, $operand2, $token, $stack);
+                        if (isset($storeKey)) { $this->saveValueToCache($storeKey, $result); }
                         break;
                     //    Binary Operators
                     case ':':            //    Range
@@ -3715,24 +3855,24 @@ class Calculation
 
                         break;
                     case '+':            //    Addition
-                        $this->executeNumericBinaryOperation($operand1, $operand2, $token, 'plusEquals', $stack);
-
+                        $result = $this->executeNumericBinaryOperation($operand1, $operand2, $token, 'plusEquals', $stack);
+                        if (isset($storeKey)) { $this->saveValueToCache($storeKey, $result); }
                         break;
                     case '-':            //    Subtraction
-                        $this->executeNumericBinaryOperation($operand1, $operand2, $token, 'minusEquals', $stack);
-
+                        $result = $this->executeNumericBinaryOperation($operand1, $operand2, $token, 'minusEquals', $stack);
+                        if (isset($storeKey)) { $this->saveValueToCache($storeKey, $result); }
                         break;
                     case '*':            //    Multiplication
-                        $this->executeNumericBinaryOperation($operand1, $operand2, $token, 'arrayTimesEquals', $stack);
-
+                        $result = $this->executeNumericBinaryOperation($operand1, $operand2, $token, 'arrayTimesEquals', $stack);
+                        if (isset($storeKey)) { $this->saveValueToCache($storeKey, $result); }
                         break;
                     case '/':            //    Division
-                        $this->executeNumericBinaryOperation($operand1, $operand2, $token, 'arrayRightDivide', $stack);
-
+                        $result = $this->executeNumericBinaryOperation($operand1, $operand2, $token, 'arrayRightDivide', $stack);
+                        if (isset($storeKey)) { $this->saveValueToCache($storeKey, $result); }
                         break;
                     case '^':            //    Exponential
-                        $this->executeNumericBinaryOperation($operand1, $operand2, $token, 'power', $stack);
-
+                        $result = $this->executeNumericBinaryOperation($operand1, $operand2, $token, 'power', $stack);
+                        if (isset($storeKey)) { $this->saveValueToCache($storeKey, $result); }
                         break;
                     case '&':            //    Concatenation
                         //    If either of the operands is a matrix, we need to treat them both as matrices
@@ -3764,6 +3904,7 @@ class Calculation
                         $this->debugLog->writeDebugLog('Evaluation Result is ', $this->showTypeDetails($result));
                         $stack->push('Value', $result);
 
+                        if (isset($storeKey)) { $this->saveValueToCache($storeKey, $result); }
                         break;
                     case '|':            //    Intersect
                         $rowIntersect = array_intersect_key($operand1, $operand2);
@@ -3808,6 +3949,7 @@ class Calculation
                     }
                     $this->debugLog->writeDebugLog('Evaluation Result is ', $this->showTypeDetails($result));
                     $stack->push('Value', $result);
+                    if (isset($storeKey)) { $this->saveValueToCache($storeKey, $result); }
                 } else {
                     $this->executeNumericBinaryOperation($multiplier, $arg, '*', 'arrayTimesEquals', $stack);
                 }
@@ -3881,6 +4023,7 @@ class Calculation
                     }
                 }
                 $stack->push('Value', $cellValue, $cellRef);
+                if (isset($storeKey)) { $this->saveValueToCache($storeKey, $cellValue); }
 
             // if the token is a function, pop arguments off the stack, hand them to the function, and push the result back on
             } elseif (preg_match('/^' . self::CALCULATION_REGEXP_FUNCTION . '$/i', $token, $matches)) {
@@ -3904,6 +4047,7 @@ class Calculation
                     $args = $argArrayVals = [];
                     for ($i = 0; $i < $argCount; ++$i) {
                         $arg = $stack->pop();
+                        var_dump($arg);
                         $a = $argCount - $i - 1;
                         if (($passByReference) &&
                             (isset(self::$phpSpreadsheetFunctions[$functionName]['passByReference'][$a])) &&
@@ -3926,6 +4070,8 @@ class Calculation
                             }
                         }
                     }
+
+                    var_dump($functionName, 'done if');
                     //    Reverse the order of the arguments
                     krsort($args);
 
@@ -3956,15 +4102,18 @@ class Calculation
                         $this->debugLog->writeDebugLog('Evaluation Result for ', self::localeFunc($functionName), '() function call is ', $this->showTypeDetails($result));
                     }
                     $stack->push('Value', self::wrapResult($result));
+                    if (isset($storeKey)) { $this->saveValueToCache($storeKey, $result); }
                 }
             } else {
                 // if the token is a number, boolean, string or an Excel error, push it onto the stack
                 if (isset(self::$excelConstants[strtoupper($token)])) {
                     $excelConstant = strtoupper($token);
                     $stack->push('Constant Value', self::$excelConstants[$excelConstant]);
+                    if (isset($storeKey)) { $this->saveValueToCache($storeKey, self::$excelConstants[$excelConstant]); }
                     $this->debugLog->writeDebugLog('Evaluating Constant ', $excelConstant, ' as ', $this->showTypeDetails(self::$excelConstants[$excelConstant]));
                 } elseif ((is_numeric($token)) || ($token === null) || (is_bool($token)) || ($token == '') || ($token[0] == '"') || ($token[0] == '#')) {
                     $stack->push('Value', $token);
+                    if (isset($storeKey)) { $this->saveValueToCache($storeKey, $token); }
                 // if the token is a named range, push the named range name onto the stack
                 } elseif (preg_match('/^' . self::CALCULATION_REGEXP_NAMEDRANGE . '$/i', $token, $matches)) {
                     $namedRange = $matches[6];
@@ -3974,6 +4123,7 @@ class Calculation
                     $pCell->attach($pCellParent);
                     $this->debugLog->writeDebugLog('Evaluation Result for named range ', $namedRange, ' is ', $this->showTypeDetails($cellValue));
                     $stack->push('Named Range', $cellValue, $namedRange);
+                    if (isset($storeKey)) { $this->saveValueToCache($storeKey, $cellValue); }
                 } else {
                     return $this->raiseFormulaError("undefined variable '$token'");
                 }
@@ -3985,6 +4135,8 @@ class Calculation
         }
         $output = $stack->pop();
         $output = $output['value'];
+
+        var_dump('case N end process stack for ' . $cellID);
 
         return $output;
     }
@@ -4035,7 +4187,7 @@ class Calculation
      * @param Stack $stack
      * @param bool $recursingArrays
      *
-     * @return bool
+     * @return mixed
      */
     private function executeBinaryComparisonOperation($cellID, $operand1, $operand2, $operation, Stack &$stack, $recursingArrays = false)
     {
@@ -4072,7 +4224,7 @@ class Calculation
             //    And push the result onto the stack
             $stack->push('Array', $result);
 
-            return true;
+            return $result;
         }
 
         //    Simple validate the two operands if they are string values
@@ -4188,7 +4340,7 @@ class Calculation
      * @param string $matrixFunction
      * @param mixed $stack
      *
-     * @return bool
+     * @return mixed|bool
      */
     private function executeNumericBinaryOperation($operand1, $operand2, $operation, $matrixFunction, &$stack)
     {
@@ -4266,7 +4418,7 @@ class Calculation
         //    And push the result onto the stack
         $stack->push('Value', $result);
 
-        return true;
+        return $result;
     }
 
     // trigger an error, but nicely, if need be
@@ -4469,5 +4621,11 @@ class Calculation
         }
 
         return $args;
+    }
+
+    private function getUnusedStoreKey() {
+        $storeKeyValue = 'storeKey-' . $this->storeKeyCounter;
+        $this->storeKeyCounter++;
+        return $storeKeyValue;
     }
 }

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -3369,24 +3369,25 @@ class Calculation
             $pendingStoreKey = end($pendingStoreKeysStack);
 
             if ($this->branchPruningEnabled) {
-                if ($expectingConditionMap[$pendingStoreKey] ?? false) { // this is a condition
+                // this is a condition ?
+                if (isset($expectingConditionMap[$pendingStoreKey]) && $expectingConditionMap[$pendingStoreKey]) {
                     $currentCondition = $pendingStoreKey;
                     $stackDepth = count($pendingStoreKeysStack);
                     if ($stackDepth > 1) { // nested if
                         $previousStoreKey = $pendingStoreKeysStack[$stackDepth - 2];
                     }
                 }
-                if ($expectingThenMap[$pendingStoreKey] ?? false) {
+                if (isset($expectingThenMap[$pendingStoreKey]) && $expectingThenMap[$pendingStoreKey]) {
                     $currentOnlyIf = $pendingStoreKey;
                 } elseif (isset($previousStoreKey)) {
-                    if ($expectingThenMap[$previousStoreKey] ?? false) {
+                    if (isset($expectingThenMap[$previousStoreKey]) && $expectingThenMap[$previousStoreKey]) {
                         $currentOnlyIf = $previousStoreKey;
                     }
                 }
-                if ($expectingElseMap[$pendingStoreKey] ?? false) {
+                if (isset($expectingElseMap[$pendingStoreKey]) && $expectingElseMap[$pendingStoreKey]) {
                     $currentOnlyIfNot = $pendingStoreKey;
                 } elseif (isset($previousStoreKey)) {
-                    if ($expectingElseMap[$previousStoreKey] ?? false) {
+                    if (isset($expectingElseMap[$previousStoreKey]) && $expectingElseMap[$previousStoreKey]) {
                         $currentOnlyIfNot = $previousStoreKey;
                     }
                 }
@@ -3551,8 +3552,11 @@ class Calculation
                     return $this->raiseFormulaError('Formula Error: Unexpected ,');
                 }
                 $d = $stack->pop();
-                $stack->push($d['type'], ++$d['value'], $d['reference'], $d['storeKey'] ?? null, $d['onlyIf'] ?? null, $d['onlyIfNot'] ?? null); // increment the argument count
-                $stack->push('Brace', '(', null, $d['storeKey'] ?? null, $d['onlyIf'] ?? null, $d['onlyIfNot'] ?? null); // put the ( back on, we'll need to pop back to it again
+                $itemStoreKey = isset($d['storeKey']) ? $d['storeKey'] : null;
+                $itemOnlyIf = isset($d['onlyIf']) ? $d['onlyIf'] : null;
+                $itemOnlyIfNot = isset($d['onlyIfNot']) ? $d['onlyIfNot'] : null;
+                $stack->push($d['type'], ++$d['value'], $d['reference'], $itemStoreKey, $itemOnlyIf, $itemOnlyIfNot); // increment the argument count
+                $stack->push('Brace', '(', null, $itemStoreKey, $itemOnlyIf, $itemOnlyIfNot); // put the ( back on, we'll need to pop back to it again
                 $expectingOperator = false;
                 $expectingOperand = true;
                 ++$index;
@@ -3786,10 +3790,10 @@ class Calculation
             $token = $tokenData['value'];
 
             // Branch pruning: skip useless resolutions
-            $storeKey = $tokenData['storeKey'] ?? null;
+            $storeKey = isset($tokenData['storeKey']) ? $tokenData['storeKey'] : null;
             if ($this->branchPruningEnabled && isset($tokenData['onlyIf'])) {
                 $onlyIfStoreKey = $tokenData['onlyIf'];
-                $storeValue = $branchStore[$onlyIfStoreKey] ?? null;
+                $storeValue = isset($branchStore[$onlyIfStoreKey]) ? $branchStore[$onlyIfStoreKey] : null;
                 if (is_array($storeValue)) {
                     $wrappedItem = end($storeValue);
                     $storeValue = end($wrappedItem);
@@ -3819,7 +3823,7 @@ class Calculation
 
             if ($this->branchPruningEnabled && isset($tokenData['onlyIfNot'])) {
                 $onlyIfNotStoreKey = $tokenData['onlyIfNot'];
-                $storeValue = $branchStore[$onlyIfNotStoreKey] ?? null;
+                $storeValue = isset($branchStore[$onlyIfNotStoreKey]) ? $branchStore[$onlyIfNotStoreKey] : null;
                 if (is_array($storeValue)) {
                     $wrappedItem = end($storeValue);
                     $storeValue = end($wrappedItem);
@@ -4747,7 +4751,7 @@ class Calculation
     private function getTokensAsString($tokens)
     {
         $tokensStr = array_map(function ($token) {
-            $value = $token['value'] ?? 'no value';
+            $value = isset($token['value']) ? $token['value'] : 'no value';
             while (is_array($value)) {
                 $value = array_pop($value);
             }

--- a/src/PhpSpreadsheet/Calculation/Token/Stack.php
+++ b/src/PhpSpreadsheet/Calculation/Token/Stack.php
@@ -132,4 +132,19 @@ class Stack
         $this->stack = [];
         $this->count = 0;
     }
+
+    public function __toString() {
+        $str = 'Stack: ';
+        foreach ($this->stack as $index => $item) {
+            if ($index > $this->count - 1) {
+                break;
+            }
+            $value = $item['value'] ?? 'no value';
+            while (is_array($value)) {
+                $value = array_pop($value);
+            }
+            $str .= $value . ' |> ' ;
+        }
+        return $str;
+    }
 }

--- a/src/PhpSpreadsheet/Calculation/Token/Stack.php
+++ b/src/PhpSpreadsheet/Calculation/Token/Stack.php
@@ -36,20 +36,62 @@ class Stack
      * @param mixed $type
      * @param mixed $value
      * @param mixed $reference
+     * @param string|null $storeKey will store the result under this alias
+     * @param string|null $onlyIf will only run computation if the matching
+     *      store key is true
+     * @param string|null $onlyIfNot will only run computation if the matching
+     *      store key is false
+     *
+     * 
      */
-    public function push($type, $value, $reference = null)
-    {
-        $this->stack[$this->count++] = [
-            'type' => $type,
-            'value' => $value,
-            'reference' => $reference,
-        ];
+    public function push(
+        $type,
+        $value,
+        $reference = null,
+        $storeKey = null,
+        $onlyIf = null,
+        $onlyIfNot = null
+    ) {
+        $stackItem = $this->getStackItem($type, $value, $reference, $storeKey,
+            $onlyIf, $onlyIfNot);
+
+        $this->stack[$this->count++] = $stackItem;
+
         if ($type == 'Function') {
             $localeFunction = Calculation::localeFunc($value);
             if ($localeFunction != $value) {
                 $this->stack[($this->count - 1)]['localeValue'] = $localeFunction;
             }
         }
+    }
+
+    public function getStackItem(
+        $type,
+        $value,
+        $reference = null,
+        $storeKey = null,
+        $onlyIf = null,
+        $onlyIfNot = null
+    ) {
+        $stackItem = [
+            'type' => $type,
+            'value' => $value,
+            'reference' => $reference,
+        ];
+
+        if (isset($storeKey)) {
+            $stackItem['storeKey'] = $storeKey;
+        }
+
+        if (isset($onlyIf)) {
+            $stackItem['onlyIf'] = $onlyIf;
+        }
+
+        if (isset($onlyIfNot)) {
+            $stackItem['onlyIfNot'] = $onlyIfNot;
+        }
+
+        return $stackItem;
     }
 
     /**

--- a/src/PhpSpreadsheet/Calculation/Token/Stack.php
+++ b/src/PhpSpreadsheet/Calculation/Token/Stack.php
@@ -50,8 +50,7 @@ class Stack
         $onlyIf = null,
         $onlyIfNot = null
     ) {
-        $stackItem = $this->getStackItem($type, $value, $reference, $storeKey,
-            $onlyIf, $onlyIfNot);
+        $stackItem = $this->getStackItem($type, $value, $reference, $storeKey, $onlyIf, $onlyIfNot);
 
         $this->stack[$this->count++] = $stackItem;
 

--- a/src/PhpSpreadsheet/Calculation/Token/Stack.php
+++ b/src/PhpSpreadsheet/Calculation/Token/Stack.php
@@ -138,7 +138,7 @@ class Stack
             if ($index > $this->count - 1) {
                 break;
             }
-            $value = $item['value'] ?? 'no value';
+            $value = isset($item['value']) ? $item['value'] : 'no value';
             while (is_array($value)) {
                 $value = array_pop($value);
             }

--- a/src/PhpSpreadsheet/Calculation/Token/Stack.php
+++ b/src/PhpSpreadsheet/Calculation/Token/Stack.php
@@ -36,13 +36,11 @@ class Stack
      * @param mixed $type
      * @param mixed $value
      * @param mixed $reference
-     * @param string|null $storeKey will store the result under this alias
-     * @param string|null $onlyIf will only run computation if the matching
+     * @param null|string $storeKey will store the result under this alias
+     * @param null|string $onlyIf will only run computation if the matching
      *      store key is true
-     * @param string|null $onlyIfNot will only run computation if the matching
+     * @param null|string $onlyIfNot will only run computation if the matching
      *      store key is false
-     *
-     * 
      */
     public function push(
         $type,
@@ -133,7 +131,8 @@ class Stack
         $this->count = 0;
     }
 
-    public function __toString() {
+    public function __toString()
+    {
         $str = 'Stack: ';
         foreach ($this->stack as $index => $item) {
             if ($index > $this->count - 1) {
@@ -143,8 +142,9 @@ class Stack
             while (is_array($value)) {
                 $value = array_pop($value);
             }
-            $str .= $value . ' |> ' ;
+            $str .= $value . ' |> ';
         }
+
         return $str;
     }
 }

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -267,6 +267,7 @@ class Cell
                     }
                 }
             } catch (Exception $ex) {
+                throw $ex; // @todo HCK remove
                 if (($ex->getMessage() === 'Unable to access External Workbook') && ($this->calculatedValue !== null)) {
                     return $this->calculatedValue; // Fallback for calculations referencing external files.
                 }

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -267,7 +267,6 @@ class Cell
                     }
                 }
             } catch (Exception $ex) {
-                throw $ex; // @todo HCK remove
                 if (($ex->getMessage() === 'Unable to access External Workbook') && ($this->calculatedValue !== null)) {
                     return $this->calculatedValue; // Fallback for calculations referencing external files.
                 }

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -140,4 +140,103 @@ class CalculationTest extends TestCase
         $cell->setValue('=OFFSET(D3, -1, -2)');
         self::assertEquals(5, $cell->getCalculatedValue(), 'missing arguments should be filled with null');
     }
+
+    public function testBranchPruningFormulaParsing()
+    {
+        $calculation = Calculation::getInstance();
+
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        $sheet->fromArray(
+            [
+                ['please +', 'please *', 'increment'],
+                [1, 1, 1], // sum is 3
+                [3, 3, 3], // product is 27
+            ]
+        );
+
+        $cell = $sheet->getCell('E5');
+
+        // Very simple formula
+        $formula = '=IF(A1="please +",B1)';
+        $tokens = $calculation->parseFormula($formula);
+
+        $foundEqualAssociatedToStoreKey = false;
+        $foundConditionalOnB1 = false;
+        foreach ($tokens as $token) {
+            $isBinaryOperator = $token['type'] == 'Binary Operator';
+            $isEqual = $token['value'] == '=';
+            $correctStoreKey = ($token['storeKey'] ?? '') == 'storeKey-0';
+            $correctOnlyIf = ($token['onlyIf'] ?? '') == 'storeKey-0';
+            $isB1Reference = ($token['reference'] ?? '') == 'B1';
+
+            $foundEqualAssociatedToStoreKey = $foundEqualAssociatedToStoreKey ||
+                ($isBinaryOperator && $isEqual && $correctStoreKey);
+
+            $foundConditionalOnB1 = $foundConditionalOnB1 ||
+                ($isB1Reference && $correctOnlyIf);
+        }
+        $this->assertTrue($foundEqualAssociatedToStoreKey);
+        $this->assertTrue($foundConditionalOnB1);
+
+        
+        $calculation->flushInstance(); // resets the ids
+
+        //
+        // Internal opeartio
+        $formula = '=IF(A1="please +",SUM(B1:B3))+IF(A2="please *",PRODUCT(C1:C3), C1)';
+        $tokens = $calculation->parseFormula($formula);
+
+        $plusGotTagged = false;
+        $productFunctionCorrectlyTagged = false;
+        foreach ($tokens as $token) {
+            $isBinaryOperator = $token['type'] == 'Binary Operator';
+            $isPlus = $token['value'] == '+';
+            $anyStoreKey = isset($token['storeKey']);
+            $anyOnlyIf = isset($token['onlyIf']);
+            $anyOnlyIfNot = isset($token['onlyIfNot']);
+            $plusGotTagged = $plusGotTagged ||
+                ($isBinaryOperator && $isPlus &&
+                    ($anyStoreKey || $anyOnlyIfNot || $anyOnlyIf));
+
+            $isFunction = $token['type'] == 'Function';
+            $isProductFunction = $token['value'] == 'PRODUCT(';
+            $correctOnlyIf = ($token['onlyIf'] ?? '') == 'storeKey-1';
+            $productFunctionCorrectlyTagged = $productFunctionCorrectlyTagged ||
+                ($isFunction && $isProductFunction && $correctOnlyIf);
+        }
+        $this->assertFalse($plusGotTagged,
+            'chaining IF( should not affect the external operators');
+        $this->assertTrue($productFunctionCorrectlyTagged,
+            'function nested inside if should be tagged to be processed only if parent branching requires it');
+
+        $calculation->flushInstance(); // resets the ids
+
+        $formula = '=IF(A1="please +",SUM(B1:B3),1+IF(NOT(A2="please *"),C2-C1,PRODUCT(C1:C3)))';
+        $tokens = $calculation->parseFormula($formula);
+
+        $plusCorrectlyTagged = false;
+        $productFunctionCorrectlyTagged = false;
+        $notFunctionCorrectlyTagged = false;
+        foreach($tokens as $token) {
+            $value = $token['value'];
+            $isPlus = $value == '+';
+            $isProductFunction = $value == 'PRODUCT(';
+            $isNotFunction = $value == 'NOT(';
+            $isOnlyIfNotDepth1 = $token['onlyIfNot'] == 'storeKey-1';
+            $isStoreKeyDepth1 = $token['storeKey'] == 'storeKey-1';
+            $isOnlyIfNotDepth0 = $token['onlyIfNot'] == 'storeKey-0';
+
+            $plusCorrectlyTagged = $plusCorrectlyTagged ||
+                ($isPlus && $isOnlyIfNotDepth0);
+            $notFunctionCorrectlyTagged = $notFunctionCorrectlyTagged ||
+                ($isNotFunction && $isOnlyIfNotDepth0 && $isStoreKeyDepth1);
+            $productFunctionCorrectlyTagged = $productFunctionCorrectlyTagged ||
+                ($isProductFunction && $isOnlyIfNotDepth1 && !$isStoreKeyDepth1 && !$isOnlyIfNotDepth0);
+        }
+        $this->assertTrue($plusCorrectlyTagged);
+        $this->assertTrue($productFunctionCorrectlyTagged);
+        $this->assertTrue($notFunctionCorrectlyTagged);
+    }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -154,9 +154,9 @@ class CalculationTest extends TestCase
         foreach ($tokens as $token) {
             $isBinaryOperator = $token['type'] == 'Binary Operator';
             $isEqual = $token['value'] == '=';
-            $correctStoreKey = ($token['storeKey'] ?? '') == 'storeKey-0';
-            $correctOnlyIf = ($token['onlyIf'] ?? '') == 'storeKey-0';
-            $isB1Reference = ($token['reference'] ?? '') == 'B1';
+            $correctStoreKey = (isset($token['storeKey']) ? $token['storeKey'] : '') == 'storeKey-0';
+            $correctOnlyIf = (isset($token['onlyIf']) ? $token['onlyIf'] : '') == 'storeKey-0';
+            $isB1Reference = (isset($token['reference']) ? $token['reference'] : '') == 'B1';
 
             $foundEqualAssociatedToStoreKey = $foundEqualAssociatedToStoreKey ||
                 ($isBinaryOperator && $isEqual && $correctStoreKey);
@@ -188,7 +188,7 @@ class CalculationTest extends TestCase
 
             $isFunction = $token['type'] == 'Function';
             $isProductFunction = $token['value'] == 'PRODUCT(';
-            $correctOnlyIf = ($token['onlyIf'] ?? '') == 'storeKey-1';
+            $correctOnlyIf = (isset($token['onlyIf']) ? $token['onlyIf'] : '') == 'storeKey-1';
             $productFunctionCorrectlyTagged = $productFunctionCorrectlyTagged ||
                 ($isFunction && $isProductFunction && $correctOnlyIf);
         }
@@ -212,9 +212,9 @@ class CalculationTest extends TestCase
             $isProductFunction = $value == 'PRODUCT(';
             $isNotFunction = $value == 'NOT(';
             $isIfOperand = $token['type'] == 'Operand Count for Function IF()';
-            $isOnlyIfNotDepth1 = $token['onlyIfNot'] == 'storeKey-1';
-            $isStoreKeyDepth1 = $token['storeKey'] == 'storeKey-1';
-            $isOnlyIfNotDepth0 = $token['onlyIfNot'] == 'storeKey-0';
+            $isOnlyIfNotDepth1 = (array_key_exists('onlyIfNot', $token) ? $token['onlyIfNot'] : null) == 'storeKey-1';
+            $isStoreKeyDepth1 = (array_key_exists('storeKey', $token) ? $token['storeKey'] : null) == 'storeKey-1';
+            $isOnlyIfNotDepth0 = (array_key_exists('onlyIfNot', $token) ? $token['onlyIfNot'] : null) == 'storeKey-0';
 
             $plusCorrectlyTagged = $plusCorrectlyTagged ||
                 ($isPlus && $isOnlyIfNotDepth0);
@@ -243,7 +243,7 @@ class CalculationTest extends TestCase
         $properlyTaggedPlus = false;
         foreach ($tokens as $token) {
             $isPlus = $token['value'] === '+';
-            $hasOnlyIf = !empty($token['onlyIf'] ?? null);
+            $hasOnlyIf = !empty($token['onlyIf']);
 
             $properlyTaggedPlus = $properlyTaggedPlus ||
                 ($isPlus && $hasOnlyIf);
@@ -267,7 +267,7 @@ class CalculationTest extends TestCase
     public function testFullExecution(
         $expectedResult,
         $dataArray,
-        string $formula,
+        $formula,
         $cellCoordinates,
         $shouldBeSetInCacheCells = [],
         $shouldNotBeSetInCacheCells = [])

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -206,7 +206,7 @@ class CalculationTest extends TestCase
         $productFunctionCorrectlyTagged = false;
         $notFunctionCorrectlyTagged = false;
         $findOneOperandCountTagged = false;
-        foreach($tokens as $token) {
+        foreach ($tokens as $token) {
             $value = $token['value'];
             $isPlus = $value == '+';
             $isProductFunction = $value == 'PRODUCT(';
@@ -228,7 +228,6 @@ class CalculationTest extends TestCase
         $this->assertTrue($plusCorrectlyTagged);
         $this->assertTrue($productFunctionCorrectlyTagged);
         $this->assertTrue($notFunctionCorrectlyTagged);
-
 
         $calculation->flushInstance(); // resets the ids
 
@@ -261,10 +260,11 @@ class CalculationTest extends TestCase
      *  be set in cache
      * @param string[] $shouldNotBeSetInCacheCells coordinates of cells that must
      *  not be set in cache because of pruning
+     *
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @dataProvider dataProviderBranchPruningFullExecution
      */
-    public function testBranchPruningFullExecution(
+    public function testFullExecution(
         $expectedResult,
         $dataArray,
         string $formula,
@@ -304,8 +304,8 @@ class CalculationTest extends TestCase
         $this->assertEquals($expectedResult, $calculated);
     }
 
-    public function dataProviderBranchPruningFullExecution() {
+    public function dataProviderBranchPruningFullExecution()
+    {
         return require 'data/Calculation/Calculation.php';
     }
-
 }

--- a/tests/data/Calculation/Calculation.php
+++ b/tests/data/Calculation/Calculation.php
@@ -1,0 +1,60 @@
+<?php
+
+return (function() {
+    $dataArray1 = [
+        ['please +', 'please *', 'increment'],
+        [1, 1, 1], // sum is 3
+        [3, 3, 3], // product is 27
+    ];
+    $set0 = [3, $dataArray1, '=IF(A1="please +", SUM(A2:C2), 2)', 'E5'];
+
+    $set1 = [3, $dataArray1, '=IF(TRUE(), SUM(A2:C2), 2)', 'E5'];
+
+    $formula1 = '=IF(A1="please +",SUM(A2:C2),7 + IF(B1="please *", 4, 2))';
+    $set2 = [3, $dataArray1, $formula1, 'E5'];
+
+    $originalDataArray = $dataArray1;
+
+    $dataArray1[0][0] = 'not please + something else';
+    $set3 = [11, $dataArray1, $formula1, 'E5'];
+
+    $dataArray2 = [
+        ['flag1', 'flag2', 'flag3', 'flag1'],
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+    ];
+    $set4 = [3, $dataArray2, '=IF($A$1=$B$1,A2,IF($A$1=$C$1,B2,IF($A$1=$D$1,C2,C3)))', 'E5'];
+
+    $dataArray2[0][0] = 'flag3';
+    $set5 = [2, $dataArray2, '=IF(A1=B1,A2,IF(A1=C1,B2,IF(A1=D1,C2,C3)))', 'E5'];
+
+    $dataArray3 = [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+    ];
+    $set6 = [0, $dataArray3, '=IF(A1+B1>3,C1,0)', 'E5'];
+
+    $dataArray4 = [
+        ['noflag',    0, 0],
+        [127000,    0, 0],
+        [ 10000,  0.03, 0],
+        [ 20000,  0.06, 0],
+        [ 40000,  0.09, 0],
+        [ 70000,  0.12, 0],
+        [ 90000,  0.03, 0]
+    ];
+    $formula2 = '=IF(A1="flag",IF(A2<10, 0) + IF(A3<10000, 0))';
+    $set7 = [false, $dataArray4, $formula2, 'E5'];
+
+    $dataArray5 = [
+        [1, 2],
+        [3, 4],
+        ['=A1+A2', '=SUM(B1:B2)'],
+        [ 'take A', 0]
+    ];
+    $formula3 = '=IF(A4="take A", A3, B3)';
+    $set8 = [4, $dataArray5, $formula3, 'E5', ['A3'], ['B3']];
+
+    return [$set0, $set1, $set2, $set3, $set4, $set5, $set6, $set7, $set8];
+})();

--- a/tests/data/Calculation/Calculation.php
+++ b/tests/data/Calculation/Calculation.php
@@ -1,6 +1,7 @@
 <?php
 
-function calculationTestDataGenerator() {
+function calculationTestDataGenerator()
+{
     $dataArray1 = [
         ['please +', 'please *', 'increment'],
         [1, 1, 1], // sum is 3

--- a/tests/data/Calculation/Calculation.php
+++ b/tests/data/Calculation/Calculation.php
@@ -1,6 +1,6 @@
 <?php
 
-return (function() {
+function calculationTestDataGenerator() {
     $dataArray1 = [
         ['please +', 'please *', 'increment'],
         [1, 1, 1], // sum is 3
@@ -57,4 +57,6 @@ return (function() {
     $set8 = [4, $dataArray5, $formula3, 'E5', ['A3'], ['B3']];
 
     return [$set0, $set1, $set2, $set3, $set4, $set5, $set6, $set7, $set8];
-})();
+};
+
+return calculationTestDataGenerator();


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Calculation engine was resolving every function by first resolving its arguments including IFs, this was causing significant over evaluation when IFs were used as it meant for every case to be evaluated.

I have tested against 5 files made by 4 different people to ensure that this was not introducing regression, I have observed none. It generates speed improvement from 0% to 80% on those files.