### PR TITLE
Fixes #801 libxml_disable_entity_loader() is changed

### DIFF
--- a/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
+++ b/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
@@ -14,13 +14,6 @@ class XmlScanner
     private $libxmlDisableEntityLoader = false;
 
     /**
-     * Store the initial setting of libxmlDisableEntityLoader so that we can resore t later.
-     *
-     * @var bool
-     */
-    private $previousLibxmlDisableEntityLoaderValue;
-
-    /**
      * String used to identify risky xml elements.
      *
      * @var string
@@ -33,17 +26,6 @@ class XmlScanner
     {
         $this->pattern = $pattern;
         $this->libxmlDisableEntityLoader = $this->identifyLibxmlDisableEntityLoaderAvailability();
-
-        if ($this->libxmlDisableEntityLoader) {
-            $this->previousLibxmlDisableEntityLoaderValue = libxml_disable_entity_loader(true);
-        }
-    }
-
-    public function __destruct()
-    {
-        if ($this->libxmlDisableEntityLoader) {
-            libxml_disable_entity_loader($this->previousLibxmlDisableEntityLoaderValue);
-        }
     }
 
     public static function getInstance(Reader\IReader $reader)
@@ -95,6 +77,10 @@ class XmlScanner
      */
     public function scan($xml)
     {
+        if ($this->libxmlDisableEntityLoader) {
+            $previousLibxmlDisableEntityLoaderValue = libxml_disable_entity_loader(true);
+        }
+
         $pattern = '/encoding="(.*?)"/';
         $result = preg_match($pattern, $xml, $matches);
         $charset = $result ? $matches[1] : 'UTF-8';
@@ -105,12 +91,18 @@ class XmlScanner
 
         // Don't rely purely on libxml_disable_entity_loader()
         $pattern = '/\\0?' . implode('\\0?', str_split($this->pattern)) . '\\0?/';
-        if (preg_match($pattern, $xml)) {
-            throw new Reader\Exception('Detected use of ENTITY in XML, spreadsheet file load() aborted to prevent XXE/XEE attacks');
-        }
+        try {
+            if (preg_match($pattern, $xml)) {
+                throw new Reader\Exception('Detected use of ENTITY in XML, spreadsheet file load() aborted to prevent XXE/XEE attacks');
+            }
 
-        if ($this->callback !== null && is_callable($this->callback)) {
-            $xml = call_user_func($this->callback, $xml);
+            if ($this->callback !== null && is_callable($this->callback)) {
+                $xml = call_user_func($this->callback, $xml);
+            }
+        } finally {
+            if ($this->libxmlDisableEntityLoader) {
+                libxml_disable_entity_loader($previousLibxmlDisableEntityLoaderValue);
+            }
         }
 
         return $xml;

--- a/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Reader\Security;
 use PhpOffice\PhpSpreadsheet\Reader\Security\XmlScanner;
 use PhpOffice\PhpSpreadsheet\Reader\Xls;
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
+use PhpOffice\PhpSpreadsheet\Reader\Xml;
 use PHPUnit\Framework\TestCase;
 
 class XmlScannerTest extends TestCase
@@ -14,19 +15,26 @@ class XmlScannerTest extends TestCase
      *
      * @param mixed $filename
      * @param mixed $expectedResult
+     * @param $libxmlDisableEntityLoader
      */
-    public function testValidXML($filename, $expectedResult)
+    public function testValidXML($filename, $expectedResult, $libxmlDisableEntityLoader)
     {
+        libxml_disable_entity_loader($libxmlDisableEntityLoader);
+
         $reader = XmlScanner::getInstance(new \PhpOffice\PhpSpreadsheet\Reader\Xml());
         $result = $reader->scanFile($filename);
         self::assertEquals($expectedResult, $result);
+        self::assertEquals($libxmlDisableEntityLoader, libxml_disable_entity_loader());
     }
 
     public function providerValidXML()
     {
         $tests = [];
         foreach (glob(__DIR__ . '/../../../data/Reader/Xml/XEETestValid*.xml') as $file) {
-            $tests[basename($file)] = [realpath($file), file_get_contents($file)];
+            $filename = realpath($file);
+            $expectedResult = file_get_contents($file);
+            $tests[basename($file) . '_libxml_entity_loader_disabled'] = [$filename, $expectedResult, true];
+            $tests[basename($file) . '_libxml_entity_loader_enabled'] = [$filename, $expectedResult, false];
         }
 
         return $tests;
@@ -36,22 +44,28 @@ class XmlScannerTest extends TestCase
      * @dataProvider providerInvalidXML
      *
      * @param mixed $filename
+     * @param $libxmlDisableEntityLoader
      */
-    public function testInvalidXML($filename)
+    public function testInvalidXML($filename, $libxmlDisableEntityLoader)
     {
         $this->expectException(\PhpOffice\PhpSpreadsheet\Reader\Exception::class);
+
+        libxml_disable_entity_loader($libxmlDisableEntityLoader);
 
         $reader = XmlScanner::getInstance(new \PhpOffice\PhpSpreadsheet\Reader\Xml());
         $expectedResult = 'FAILURE: Should throw an Exception rather than return a value';
         $result = $reader->scanFile($filename);
         self::assertEquals($expectedResult, $result);
+        self::assertEquals($libxmlDisableEntityLoader, libxml_disable_entity_loader());
     }
 
     public function providerInvalidXML()
     {
         $tests = [];
         foreach (glob(__DIR__ . '/../../../data/Reader/Xml/XEETestInvalidUTF*.xml') as $file) {
-            $tests[basename($file)] = [realpath($file)];
+            $filename = realpath($file);
+            $tests[basename($file) . '_libxml_entity_loader_disabled'] = [$filename, true];
+            $tests[basename($file) . '_libxml_entity_loader_enabled'] = [$filename, false];
         }
 
         return $tests;
@@ -100,5 +114,27 @@ class XmlScannerTest extends TestCase
         }
 
         return $tests;
+    }
+
+    /**
+     * @dataProvider providerLibxmlSettings
+     *
+     * @param $libxmDisableLoader
+     */
+    public function testNewInstanceCreationDoesntChangeLibxmlSettings($libxmDisableLoader)
+    {
+        libxml_disable_entity_loader($libxmDisableLoader);
+
+        $reader = new Xml();
+
+        self::assertEquals($libxmDisableLoader, libxml_disable_entity_loader($libxmDisableLoader));
+    }
+
+    public function providerLibxmlSettings()
+    {
+        return [
+            [true],
+            [false]
+        ];
     }
 }


### PR DESCRIPTION
```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
#802 already provides fix for #801, but scenario like this:
``` php
$reader = new \PhpOffice\PhpSpreadsheet\Reader\Xlsx();

libxml_use_internal_errors(true);
libxml_clear_errors();

$document = new DOMDocument();
$document->load("test.xml");

echo libxml_get_last_error()->message. "\n";
```
will still fail. This PR will fix both issues.