### PR TITLE
Issue 629 - Use a generator for Cells::getAllCacheKeys to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Fix column names if read filter calls in XLSX reader skip columns - [#777](https://github.com/PHPOffice/PhpSpreadsheet/pull/777)
 - Fix LOOKUP function which was breaking on edge cases - [#796](https://github.com/PHPOffice/PhpSpreadsheet/issues/796)
 - Fix VLOOKUP with exact matches
+- Improved memory usage and performance when loading large spreadsheets - [#822](https://github.com/PHPOffice/PhpSpreadsheet/pull/822)
 
 ## [1.5.2] - 2018-11-25
 

--- a/src/PhpSpreadsheet/Collection/Cells.php
+++ b/src/PhpSpreadsheet/Collection/Cells.php
@@ -495,15 +495,12 @@ class Cells
     /**
      * Returns all known cache keys.
      *
-     * @return string[]
+     * @return \Generator|string[]
      */
     private function getAllCacheKeys()
     {
-        $keys = [];
         foreach ($this->getCoordinates() as $coordinate) {
-            $keys[] = $this->cachePrefix . $coordinate;
+            yield $this->cachePrefix . $coordinate;
         }
-
-        return $keys;
     }
 }


### PR DESCRIPTION
Using a generator reduces memory usage and improves performance
when loading large spreadsheets.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

PHPSpreadsheet currently uses a lot of memory when loading large spreadsheets (see #648, #629).  All of the coordinates in the spreadsheet are copied into a new array when the method `Cells::getAllCacheKeys` is called.  Since the coordinates are concatenated with a new string this results in new strings being created in memory.

This result of this method is only ever passed to `Psr\SimpleCache\Cacheinterface::getMultiple` and `Psr\SimpleCache\Cacheinterface::setMultiple`.  Since both of these methods accept an `iterable` we can use a generator instead.  Using a generator means we don't need to build the entire array in memory and instead can return one value at a time as needed.

I benchmarked this with a ~100K row spreadsheet and saw a 16% improvement in run time and 20% improvement in memory usage.  You can view a comparison [here](https://blackfire.io/profiles/compare/914a6eb7-434e-4a98-99fb-077fe9dee6f8...8babce2f-42b1-4d3c-b855-c71aaf07161c/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=PhpOffice%5CPhpSpreadsheet%5CWorksheet%5CWorksheet%3A%3AgetCell&callname=main()).

You can also view the individual profiles here:

- [baseline profile](https://blackfire.io/profiles/914a6eb7-434e-4a98-99fb-077fe9dee6f8/graph)
- [with generator](https://blackfire.io/profiles/8babce2f-42b1-4d3c-b855-c71aaf07161c/graph)

This is the benchmark script I used:

```php
<?php

require __DIR__ . '/vendor/autoload.php';

$reader = new \PhpOffice\PhpSpreadsheet\Reader\Xlsx();

$spreadsheet = $reader->load(__DIR__ . '/my_export_100k.xlsx');
```

I also attached the [xlsx](https://github.com/PHPOffice/PhpSpreadsheet/files/2691239/my_export_100k.xlsx) if you would like to run the benchmark yourself.
