### PR TITLE
Issue 629 - Use gt operator instead of max for highest row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Fix column names if read filter calls in XLSX reader skip columns - [#777](https://github.com/PHPOffice/PhpSpreadsheet/pull/777)
 - Fix LOOKUP function which was breaking on edge cases - [#796](https://github.com/PHPOffice/PhpSpreadsheet/issues/796)
 - Fix VLOOKUP with exact matches
+- Improved performance when loading large spreadsheets - [#824](https://github.com/PHPOffice/PhpSpreadsheet/pull/824)
 
 ## [1.5.2] - 2018-11-25
 

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1268,7 +1268,9 @@ class Worksheet implements IComparable
         if (Coordinate::columnIndexFromString($this->cachedHighestColumn) < Coordinate::columnIndexFromString($aCoordinates[0])) {
             $this->cachedHighestColumn = $aCoordinates[0];
         }
-        $this->cachedHighestRow = max($this->cachedHighestRow, $aCoordinates[1]);
+        if ($aCoordinates[1] > $this->cachedHighestRow) {
+            $this->cachedHighestRow = $aCoordinates[1];
+        }
 
         // Cell needs appropriate xfIndex from dimensions records
         //    but don't create dimension records if they don't already exist


### PR DESCRIPTION
Using an operator is significantly faster than calling the max function.
As this method is called more than once per cell the difference adds up.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

When reading a large spreadsheet the `Worksheet::createNewCell` method is called more times than the number of cells in the spreadsheet.  When reading a ~100k cell spreadsheet I saw a 25% reduction in run time by replacing the call to `max` with a `>` comparison.

- [baseline](https://blackfire.io/profiles/914a6eb7-434e-4a98-99fb-077fe9dee6f8/graph)
- [this PR](https://blackfire.io/profiles/3cfddffd-0d1d-4291-8c4b-8480200461af/graph)
- [comparison](https://blackfire.io/profiles/compare/2adb1c26-a362-4840-a4bc-a9ae6e201633/graph)

