### PR TITLE
Issue 629 - Remove duplicate strtoupper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Fix column names if read filter calls in XLSX reader skip columns - [#777](https://github.com/PHPOffice/PhpSpreadsheet/pull/777)
 - Fix LOOKUP function which was breaking on edge cases - [#796](https://github.com/PHPOffice/PhpSpreadsheet/issues/796)
 - Fix VLOOKUP with exact matches
+- Improved performance when loading large spreadsheets - [#825](https://github.com/PHPOffice/PhpSpreadsheet/pull/825)
 
 ## [1.5.2] - 2018-11-25
 

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1191,8 +1191,11 @@ class Worksheet implements IComparable
      */
     public function getCell($pCoordinate, $createIfNotExists = true)
     {
+        // Uppercase coordinate
+        $pCoordinateUpper = strtoupper($pCoordinate);
+
         // Check cell collection
-        if ($this->cellCollection->has(strtoupper($pCoordinate))) {
+        if ($this->cellCollection->has($pCoordinateUpper)) {
             return $this->cellCollection->get($pCoordinate);
         }
 
@@ -1214,9 +1217,6 @@ class Worksheet implements IComparable
             }
         }
 
-        // Uppercase coordinate
-        $pCoordinate = strtoupper($pCoordinate);
-
         if (Coordinate::coordinateIsRange($pCoordinate)) {
             throw new Exception('Cell coordinate can not be a range of cells.');
         } elseif (strpos($pCoordinate, '$') !== false) {
@@ -1224,7 +1224,7 @@ class Worksheet implements IComparable
         }
 
         // Create new cell object, if required
-        return $createIfNotExists ? $this->createNewCell($pCoordinate) : null;
+        return $createIfNotExists ? $this->createNewCell($pCoordinateUpper) : null;
     }
 
     /**


### PR DESCRIPTION
Removing the duplicate strtoupper call has a meaningful impact on
performance since this method is called at least once per cell.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

`Worksheet::getCells` currently calls `strtoupper` twice.  `strtoupper` is kind of expensive and this method is called at least once for every cell in the spreadsheet.  By removing the unnecessary second call the runtime decreases by 18% when importing a ~100K cell spreadsheet.

I _think_ the line could just be changed to `$pCoordinate = strtoupper($pCoordinate)` but I'm not familiar enough with the worksheet references and named ranges to be confident that won't break anything.

- [baseline benchmark](https://blackfire.io/profiles/914a6eb7-434e-4a98-99fb-077fe9dee6f8/graph)
- [this PR benchmark](https://blackfire.io/profiles/bc463091-06fc-43d9-8480-df90753603b7/graph)
- [comparison](https://blackfire.io/profiles/compare/5aa199cc-1bbd-4459-bf6d-402ae00a1d31/graph)  