### PR TITLE
Named ranges sheet name (XLSX Reader fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Fix column names if read filter calls in XLSX reader skip columns - [#777](https://github.com/PHPOffice/PhpSpreadsheet/pull/777)
 - Fix LOOKUP function which was breaking on edge cases - [#796](https://github.com/PHPOffice/PhpSpreadsheet/issues/796)
 - Fix VLOOKUP with exact matches
+- Fix named range resolution
 
 ## [1.5.2] - 2018-11-25
 

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1888,6 +1888,7 @@ class Xlsx extends BaseReader
                                                     $range = Worksheet::extractSheetTitle((string) $definedName, true);
                                                     $range[0] = str_replace("''", "'", $range[0]);
                                                     $range[0] = str_replace("'", '', $range[0]);
+                                                    $range[0] = preg_replace('/^\[\d\]/', '', $range[0]);
                                                     if ($worksheet = $docSheet->getParent()->getSheetByName($range[0])) {
                                                         $extractedRange = str_replace('$', '', $range[1]);
                                                         $scope = $docSheet->getParent()->getSheet($mapSheetId[(int) $definedName['localSheetId']]);


### PR DESCRIPTION
 In some files I have observed that names ranges are attached to strangely named sheets. For example if a sheet is named "Hello" the range can be associate with "[1]Hello", since the brackets are forbidden in Excel sheet names I am certain that this has no side effects.

I haven't been able to complete the current unit test as I don't know how to reproduce it in an Excel file, I have just observed it with files I have received.

I have read in some pull request comments, concerns about the speed of regular expressions, since this is happening only on file load, I think it's an ok thing.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

It was causing a bug with some xslx files.