### PR TITLE
Update Calculation.php

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -528,7 +528,7 @@ class Calculation
         'COUNTIFS' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Functions::class, 'DUMMY'],
-            'argumentCount' => '2',
+            'argumentCount' => '2+',
         ],
         'COUPDAYBS' => [
             'category' => Category::CATEGORY_FINANCIAL,


### PR DESCRIPTION
Added for more compatibility with Excel COUNTIF functions that can have more than 2 arguments

This is:

```
- [ ] a bugfix
- [V ] a new feature
```

### Why this change is needed?

Because COUNTIFS in Excel have more than 2 arguments, so if I need use more than 2 arguments now I can't.