### PR TITLE
fix color from css in reading from html - add missing '{'

### DIFF
--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -634,7 +634,7 @@ class Html extends BaseReader
 
                     break;
                 case 'color':
-                    $sheet->getStyle($column . $row)->applyFromArray(['font' => ['color' => ['rgb' => "$style_color}"]]]);
+                    $sheet->getStyle($column . $row)->applyFromArray(['font' => ['color' => ['rgb' => "{$style_color}"]]]);
 
                     break;
             }

--- a/tests/PhpSpreadsheetTests/Reader/HtmlTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/HtmlTest.php
@@ -44,7 +44,8 @@ class HtmlTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public function testBackgroundColorInRanding(){
+    public function testBackgroundColorInRanding()
+    {
         $html = '<table>
                     <tr>
                         <td style="background-color: #000000;color: #FFFFFF">Blue background</td>

--- a/tests/PhpSpreadsheetTests/Reader/HtmlTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/HtmlTest.php
@@ -43,4 +43,21 @@ class HtmlTest extends TestCase
 
         self::assertSame($expected, $actual);
     }
+
+    public function testBackgroundColorInRanding(){
+        $html = '<table>
+                    <tr>
+                        <td style="background-color: #000000;color: #FFFFFF">Blue background</td>
+                    </tr>
+                </table>';
+        $filename = tempnam(sys_get_temp_dir(), 'html');
+        file_put_contents($filename, $html);
+        $reader = new Html();
+        $spreadsheet = $reader->load($filename);
+        $firstSheet = $spreadsheet->getSheet(0);
+        $style = $firstSheet->getCell('A1')->getStyle();
+
+        self::assertEquals('FFFFFF', $style->getFont()->getColor()->getRGB());
+        unlink($filename);
+    }
 }


### PR DESCRIPTION
This is:

```
- [ x ] a bugfix
- [ ] a new feature
```

Checklist:

- [ x ] Changes are covered by unit tests
- [ x ] Code style is respected
- [ x ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
in case we generate Spreadsheet from html file and the code in file have text color in css "color:#FF00FF" it will showing as black color because it will render like rgb content with } "FF00FF}"
So, we fix it by adding missing bracket "{"