### PR TITLE
Fix #783 Csv separator detection nesting limit error.

### DIFF
--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -255,7 +255,8 @@ class Csv extends BaseReader
 
         // Drop everything that is enclosed to avoid counting false positives in enclosures
         $enclosure = preg_quote($this->enclosure, '/');
-        $line = preg_replace('/(' . $enclosure . '.*' . $enclosure . ')/U', '', $line);
+        // Add 's' to the replace rule in order for '.' to also match newline.
+        $line = preg_replace('/(' . $enclosure . '.*' . $enclosure . ')/Us', '', $line);
 
         // See if we have any enclosures left in the line
         $matches = [];


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
In the original regex, the rule won't match expressions that contain the newline character. The result is that a new line is loaded until either the entire file is loaded or a maximum function nesting level is reached.
The 's' flag must be explicitly enabled for the '.*' symbol  to match expressions that contain the newline character.

This solution will pass the test proposed by @ikulis on #783, but it will fail a test that has a cell with more than 256 line breaks. To pass that, the function will have to be refactored so that the recursion is removed.