### PR TITLE
Implement borders for HTML reader

### DIFF
--- a/src/PhpSpreadsheet/Helper/Html.php
+++ b/src/PhpSpreadsheet/Helper/Html.php
@@ -684,7 +684,14 @@ class Html
         $this->stringData = '';
     }
 
-    protected function rgbToColour($rgb)
+    /**
+     * Convert CSS RGB color string to HEX color.
+     *
+     * @param string $rgb a string containing integer RGB values
+     *
+     * @return string
+     */
+    protected static function rgbToColour($rgb)
     {
         preg_match_all('/\d+/', $rgb, $values);
         foreach ($values[0] as &$value) {
@@ -694,9 +701,34 @@ class Html
         return implode($values[0]);
     }
 
-    protected function colourNameLookup($rgb)
+    /**
+     * Get the corresponding HEX color from a human-readable CSS color name.
+     *
+     * @param string $rgb a human-readable CSS color name
+     *
+     * @return null|string
+     */
+    protected static function colourNameLookup($rgb)
     {
         return self::$colourMap[$rgb];
+    }
+
+    /**
+     * Extract HEX color from its CSS representation.
+     *
+     * @param string $color CSS representation of a color
+     *
+     * @return null|string
+     */
+    public static function extractColor($color)
+    {
+        if (preg_match('/rgb\s*\(/', $color)) {
+            return self::rgbToColour($color);
+        } elseif (strpos(trim($color), '#') === 0) {
+            return ltrim($color, '#');
+        }
+
+        return self::colourNameLookup($color);
     }
 
     protected function startFontTag($tag)
@@ -706,13 +738,7 @@ class Html
             $attributeValue = $attribute->value;
 
             if ($attributeName == 'color') {
-                if (preg_match('/rgb\s*\(/', $attributeValue)) {
-                    $this->$attributeName = $this->rgbToColour($attributeValue);
-                } elseif (strpos(trim($attributeValue), '#') === 0) {
-                    $this->$attributeName = ltrim($attributeValue, '#');
-                } else {
-                    $this->$attributeName = $this->colourNameLookup($attributeValue);
-                }
+                $this->color = self::extractColor($attributeValue);
             } else {
                 $this->$attributeName = $attributeValue;
             }

--- a/tests/PhpSpreadsheetTests/Reader/HtmlTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/HtmlTest.php
@@ -48,7 +48,7 @@ class HtmlTest extends TestCase
     {
         $html = '<table>
                     <tr>
-                        <td style="background-color: #000000;color: #FFFFFF">Blue background</td>
+                        <td style="background-color: #000000;color: #FFFFFF;border: 2px dashed blueviolet">Blue background</td>
                     </tr>
                 </table>';
         $filename = tempnam(sys_get_temp_dir(), 'html');
@@ -57,8 +57,11 @@ class HtmlTest extends TestCase
         $spreadsheet = $reader->load($filename);
         $firstSheet = $spreadsheet->getSheet(0);
         $style = $firstSheet->getCell('A1')->getStyle();
+        $borderTop = $style->getBorders()->getTop();
 
         self::assertEquals('FFFFFF', $style->getFont()->getColor()->getRGB());
+        self::assertEquals(\PhpOffice\PhpSpreadsheet\Style\Border::BORDER_MEDIUMDASHDOT, $borderTop->getBorderStyle());
+        self::assertEquals('8a2be2', $borderTop->getColor()->getRGB());
         unlink($filename);
     }
 }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
`border` shorthand property from inline styles on `td` and `th` tags can now be used to set `allBorders` on separate cells:
* Border style depends on the `border-width` and `border-style` parts of  `border` using conversion logic similar to HTML Writer.
* Border color depends on the `border-color` of the `border` and allows to use RGB, HEX or named colors. Earlier all the other supported inline styles worked only with HEX-formatted colors, now they support RGB and named colors as well. In order to
achieve this visibility of several functions of the HTML Helper used for color format conversion has been changed from `protected` to `public static`. The only place of their previous usage has been refactored correspondingly. PHPDoc annotations have been added to these functions since they have become exposed to public.