### PR TITLE
Fix wrong calculation of highest column

### DIFF
--- a/src/PhpSpreadsheet/Collection/Cells.php
+++ b/src/PhpSpreadsheet/Collection/Cells.php
@@ -259,7 +259,7 @@ class Cells
             $columnList[] = Coordinate::columnIndexFromString($c);
         }
 
-        return Coordinate::stringFromColumnIndex(max($columnList) + 1);
+        return Coordinate::stringFromColumnIndex(max($columnList));
     }
 
     /**

--- a/src/PhpSpreadsheet/Collection/Cells.php
+++ b/src/PhpSpreadsheet/Collection/Cells.php
@@ -259,7 +259,7 @@ class Cells
             $columnList[] = Coordinate::columnIndexFromString($c);
         }
 
-        return Coordinate::stringFromColumnIndex(max($columnList));
+        return Coordinate::stringFromColumnIndex(max($columnList) + 1);
     }
 
     /**

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2525,6 +2525,10 @@ class Xlsx extends BaseReader
         if (isset($xmlSheet->cols) && !$this->readDataOnly) {
             foreach ($xmlSheet->cols->col as $col) {
                 for ($i = (int) ($col['min']); $i <= (int) ($col['max']); ++$i) {
+                    if ((int) ($col['max']) == 16384) {
+                        break;
+                    }
+                    
                     if ($col['style'] && !$this->readDataOnly) {
                         $columnsAttributes[Coordinate::stringFromColumnIndex($i)]['xfIndex'] = (int) $col['style'];
                     }
@@ -2538,10 +2542,6 @@ class Xlsx extends BaseReader
                         $columnsAttributes[Coordinate::stringFromColumnIndex($i)]['outlineLevel'] = (int) $col['outlineLevel'];
                     }
                     $columnsAttributes[Coordinate::stringFromColumnIndex($i)]['width'] = (float) $col['width'];
-
-                    if ((int) ($col['max']) == 16384) {
-                        break;
-                    }
                 }
             }
         }

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2538,7 +2538,7 @@ class Xlsx extends BaseReader
                         $columnsAttributes[Coordinate::stringFromColumnIndex($i)]['outlineLevel'] = (int) $col['outlineLevel'];
                     }
                     $columnsAttributes[Coordinate::stringFromColumnIndex($i)]['width'] = (float) $col['width'];
-                    
+
                     if ((int) ($col['max']) == 16384) {
                         break;
                     }

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2525,10 +2525,6 @@ class Xlsx extends BaseReader
         if (isset($xmlSheet->cols) && !$this->readDataOnly) {
             foreach ($xmlSheet->cols->col as $col) {
                 for ($i = (int) ($col['min']); $i <= (int) ($col['max']); ++$i) {
-                    if ((int) ($col['max']) == 16384) {
-                        break;
-                    }
-                    
                     if ($col['style'] && !$this->readDataOnly) {
                         $columnsAttributes[Coordinate::stringFromColumnIndex($i)]['xfIndex'] = (int) $col['style'];
                     }
@@ -2542,6 +2538,10 @@ class Xlsx extends BaseReader
                         $columnsAttributes[Coordinate::stringFromColumnIndex($i)]['outlineLevel'] = (int) $col['outlineLevel'];
                     }
                     $columnsAttributes[Coordinate::stringFromColumnIndex($i)]['width'] = (float) $col['width'];
+                    
+                    if ((int) ($col['max']) == 16384) {
+                        break;
+                    }
                 }
             }
         }

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2525,10 +2525,6 @@ class Xlsx extends BaseReader
         if (isset($xmlSheet->cols) && !$this->readDataOnly) {
             foreach ($xmlSheet->cols->col as $col) {
                 for ($i = (int) ($col['min']); $i <= (int) ($col['max']); ++$i) {
-                    if ((int) ($col['max']) == 16384) {
-                        break;
-                    }
-                    
                     if ($col['style'] && !$this->readDataOnly) {
                         $columnsAttributes[Coordinate::stringFromColumnIndex($i)]['xfIndex'] = (int) $col['style'];
                     }
@@ -2542,6 +2538,10 @@ class Xlsx extends BaseReader
                         $columnsAttributes[Coordinate::stringFromColumnIndex($i)]['outlineLevel'] = (int) $col['outlineLevel'];
                     }
                     $columnsAttributes[Coordinate::stringFromColumnIndex($i)]['width'] = (float) $col['width'];
+
+                    if ((int) ($col['max']) == 16384) {
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
issue #700

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

As described in issue #700, calculation of highest column is wrong.
Returned value is +1 higher than the actual column count.
The wrong value is caused by two parts:

\PhpOffice\PhpSpreadsheet\Collection\Cells::getHighestColumn()
   - Calculated value is +1 before return.

\PhpOffice\PhpSpreadsheet\Reader\Xlsx::readColumnsAndRowsAttributes()
   - A wrong default value is cached when loading file.

This commit fixes both parts and is tested on a production website.

On the production website, the produced XLSX files contain many blank pages when printed, which is due to the wrong +1 column count as described in issue #700. This commit fixes the printing issue with correct count value returned.