### PR TITLE
Fix #868 with incorrect cache clearance on row deletion

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2115,6 +2115,9 @@ class Worksheet implements IComparable
     public function removeRow($pRow, $pNumRows = 1)
     {
         if ($pRow >= 1) {
+            for ($r = 0; $r < $pNumRows; ++$r) {
+                $this->getCellCollection()->removeRow($pRow + $r);
+            }
             $highestRow = $this->getHighestDataRow();
             $objReferenceHelper = ReferenceHelper::getInstance();
             $objReferenceHelper->insertNewBefore('A' . ($pRow + $pNumRows), 0, -$pNumRows, $this);

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -158,7 +158,8 @@ class WorksheetTest extends TestCase
     }
 
     /**
-     * Fix https://github.com/PHPOffice/PhpSpreadsheet/issues/868
+     * Fix https://github.com/PHPOffice/PhpSpreadsheet/issues/868 when cells are not removed correctly
+     * on row deletion.
      */
     public function testRemoveCellsCorrectlyWhenRemovingRow()
     {

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -156,4 +156,23 @@ class WorksheetTest extends TestCase
         self::assertSame($expectTitle, $arRange[0]);
         self::assertSame($expectCell2, $arRange[1]);
     }
+
+    /**
+     * Fix https://github.com/PHPOffice/PhpSpreadsheet/issues/868
+     */
+    public function testRemoveCellsCorrectlyWhenRemovingRow()
+    {
+        $workbook = new Spreadsheet();
+        $worksheet = $workbook->getActiveSheet();
+        $worksheet->getCell('A2')->setValue('A2');
+        $worksheet->getCell('C1')->setValue('C1');
+        $worksheet->removeRow(1);
+        $this->assertEquals(
+            'A2',
+            $worksheet->getCell('A1')->getValue()
+        );
+        $this->assertNull(
+            $worksheet->getCell('C1')->getValue()
+        );
+    }
 }


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Fix the https://github.com/PHPOffice/PhpSpreadsheet/issues/868 when row deletion leads to invalid cell cache.