### PR TITLE
Fix Integer value having 15-18 digits casted into E+ float format unn…

### DIFF
--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -217,7 +217,7 @@ class Cell
 
                 break;
             case DataType::TYPE_NUMERIC:
-                $this->value = (float) $pValue;
+                $this->value = 0 + $pValue;
 
                 break;
             case DataType::TYPE_FORMULA:


### PR DESCRIPTION
…ecessary

small value casted integer correctory, value bigger than PHP_INT_MAX handled as string, but 14-16 digits numeric string is casted in float and turnd out as E+ format.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

**wrong**

```
"999999999"
"9999999999"
"99999999999"
"999999999999"
"9999999999999"
"99999999999999"
"1.0E+15"
"1.0E+16"
"1.0E+17"
"1.0E+18"
"9999999999999999999"
"99999999999999999999"
```

