### PR TITLE
Conditional formatting - support for Conditional::CONDITION_CONTAINSB…

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -519,6 +519,9 @@ class Worksheet extends WriterPart
                             // Formula
                             $objWriter->writeElement('formula', $formula);
                         }
+                    } elseif ($conditional->getConditionType() == Conditional::CONDITION_CONTAINSBLANKS) {
+                        // formula copied from ms xlsx xml source file
+                        $objWriter->writeElement('formula', 'LEN(TRIM(' . $cellCoordinate . '))=0');
                     }
 
                     $objWriter->endElement();


### PR DESCRIPTION
…LANKS

Condition formating option was not supported. I unziped xlsx and found this formula to option blank field

This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
1. Works (for me). 
2. New feature.