### PR TITLE
Dde call safe handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Added
 
 - Added support for inline styles in Html reader (borders, alignment, width, height)
+- QuotedText cells no longer treated as formulae if the content begins with a `=`
+- Clean handling for DDE in formulae
 
 ## [1.6.0] - 2019-01-02
 

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -2892,7 +2892,7 @@ class Calculation
         $cellValue = null;
 
         //  Quote-Prefixed cell values cannot be formulae, but are treated as strings
-        if ($pCell->getStyle()->getQuotePrefix() === true) {
+        if ($pCell !== null && $pCell->getStyle()->getQuotePrefix() === true) {
             return self::wrapResult((string) $formula);
         }
 

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -2703,7 +2703,7 @@ class Calculation
      * @param Cell $pCell Cell to calculate
      * @param bool $resetLog Flag indicating whether the debug log should be reset or not
      *
-     * @throws Exception
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
      *
      * @return mixed
      */
@@ -2807,7 +2807,7 @@ class Calculation
      * @param string $cellID Address of the cell to calculate
      * @param Cell $pCell Cell to calculate
      *
-     * @throws Exception
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
      *
      * @return mixed
      */
@@ -2890,6 +2890,15 @@ class Calculation
     public function _calculateFormulaValue($formula, $cellID = null, Cell $pCell = null)
     {
         $cellValue = null;
+
+        //  Quote-Prefixed cell values cannot be formulae, but are treated as strings
+        if ($pCell->getStyle()->getQuotePrefix() === true) {
+            return self::wrapResult((string) $formula);
+        }
+
+        if (preg_match('/^=\s*cmd\s*\|/miu', $formula) !== 0) {
+            return self::wrapResult($formula);
+        }
 
         //    Basic validation that this is indeed a formula
         //    We simply return the cell value if not

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -140,4 +140,27 @@ class CalculationTest extends TestCase
         $cell->setValue('=OFFSET(D3, -1, -2)');
         self::assertEquals(5, $cell->getCalculatedValue(), 'missing arguments should be filled with null');
     }
+
+    public function testCellSetAsQuotedText()
+    {
+        $spreadsheet = new Spreadsheet();
+        $workSheet = $spreadsheet->getActiveSheet();
+        $cell = $workSheet->getCell('A1');
+
+        $cell->setValue("=cmd|'/C calc'!A0");
+        $cell->getStyle()->setQuotePrefix(true);
+
+        self::assertEquals("=cmd|'/C calc'!A0", $cell->getCalculatedValue());
+    }
+
+    public function testCellWithDdeExpresion()
+    {
+        $spreadsheet = new Spreadsheet();
+        $workSheet = $spreadsheet->getActiveSheet();
+        $cell = $workSheet->getCell('A1');
+
+        $cell->setValue("=cmd|'/C calc'!A0");
+
+        self::assertEquals("=cmd|'/C calc'!A0", $cell->getCalculatedValue());
+    }
 }


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Correct handling for cells styles as Quoted Prefix, so that they aren't treated as formulae if they contain a string beginning with `=`
Prevent calculation engine from trying to parse DDE expressions as formulae, and simply return the expression as a string
