### PR TITLE
Find title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased] - 
 
+### Fixed 
+- Fix getSheetByName function in XLSX Worksheet - [#739](https://github.com/PHPOffice/PhpSpreadsheet/issues/739)
+
 ### Added
 
 - Added support for inline styles in Html reader (borders, alignment, width, height)

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -721,7 +721,8 @@ class Spreadsheet
     {
         $worksheetCount = count($this->workSheetCollection);
         for ($i = 0; $i < $worksheetCount; ++$i) {
-            if ($this->workSheetCollection[$i]->getTitle() === $pName) {
+              if(($this->workSheetCollection[$i]->getTitle() === $pName)
+                 || $this->workSheetCollection[$i]->getTitle() === trim($pName, "'")){
                 return $this->workSheetCollection[$i];
             }
         }

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -721,8 +721,8 @@ class Spreadsheet
     {
         $worksheetCount = count($this->workSheetCollection);
         for ($i = 0; $i < $worksheetCount; ++$i) {
-              if(($this->workSheetCollection[$i]->getTitle() === $pName)
-                 || $this->workSheetCollection[$i]->getTitle() === trim($pName, "'")){
+            if (($this->workSheetCollection[$i]->getTitle() === $pName)
+                 || $this->workSheetCollection[$i]->getTitle() === trim($pName, "'")) {
                 return $this->workSheetCollection[$i];
             }
         }

--- a/tests/PhpSpreadsheetTests/SpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/SpreadsheetTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PHPUnit\Framework\TestCase;
+
+class SpreadsheetTest extends TestCase
+{
+    /** @var Spreadsheet */
+    private $object;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->object = new Spreadsheet();
+        $sheet        = $this->object->getActiveSheet();
+
+        $sheet->setTitle('someSheet1');
+        $sheet = new Worksheet();
+        $sheet->setTitle("someSheet2");
+        $this->object->addSheet($sheet);
+        $sheet = new Worksheet();
+        $sheet->setTitle("someSheet 3");
+        $this->object->addSheet($sheet);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForSheetNames()
+    {
+        $array = [
+            [0, "someSheet1"],
+            [0, "'someSheet1'"],
+            [1, "someSheet2"],
+            [1, "'someSheet2'"],
+            [2, "someSheet 3"],
+            [2, "'someSheet 3'"],
+        ];
+
+        return $array;
+    }
+
+    /**
+     * @param $index
+     * @param $sheetname
+     *
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     * @dataProvider dataProviderForSheetNames
+     */
+    public function testGetSheetByName($index, $sheetname)
+    {
+        // Worksheet Setup
+        // create new sheet with column width
+
+        $sheet = $this->object->getActiveSheet();
+        $sheet->setTitle('someSheet1');
+
+        $this->assertEquals($this->object->getSheet($index), $this->object->getSheetByName($sheetname));
+    }
+}

--- a/tests/PhpSpreadsheetTests/SpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/SpreadsheetTest.php
@@ -52,12 +52,6 @@ class SpreadsheetTest extends TestCase
      */
     public function testGetSheetByName($index, $sheetname)
     {
-        // Worksheet Setup
-        // create new sheet with column width
-
-        $sheet = $this->object->getActiveSheet();
-        $sheet->setTitle('someSheet1');
-
         $this->assertEquals($this->object->getSheet($index), $this->object->getSheetByName($sheetname));
     }
 }

--- a/tests/PhpSpreadsheetTests/SpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/SpreadsheetTest.php
@@ -15,14 +15,14 @@ class SpreadsheetTest extends TestCase
     {
         parent::setUp();
         $this->object = new Spreadsheet();
-        $sheet        = $this->object->getActiveSheet();
+        $sheet = $this->object->getActiveSheet();
 
         $sheet->setTitle('someSheet1');
         $sheet = new Worksheet();
-        $sheet->setTitle("someSheet2");
+        $sheet->setTitle('someSheet2');
         $this->object->addSheet($sheet);
         $sheet = new Worksheet();
-        $sheet->setTitle("someSheet 3");
+        $sheet->setTitle('someSheet 3');
         $this->object->addSheet($sheet);
     }
 
@@ -32,11 +32,11 @@ class SpreadsheetTest extends TestCase
     public function dataProviderForSheetNames()
     {
         $array = [
-            [0, "someSheet1"],
+            [0, 'someSheet1'],
             [0, "'someSheet1'"],
-            [1, "someSheet2"],
+            [1, 'someSheet2'],
             [1, "'someSheet2'"],
-            [2, "someSheet 3"],
+            [2, 'someSheet 3'],
             [2, "'someSheet 3'"],
         ];
 

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -138,9 +138,9 @@ class WorksheetTest extends TestCase
             ['testTitle!B2', 'testTitle', 'B2', 'B2'],
             ['test!Title!B2', 'test!Title', 'B2', 'B2'],
             ['test!Title!B2', 'test!Title', 'B2', 'B2'],
-            ["'testSheet 1'!A3", "testSheet 1", '', 'A3'],
-            ["'testSheet1'!A1", "testSheet1", '', 'A1'],
-            ["'testSheet1!A1'", "testSheet1", '', 'A1'],
+            ["'testSheet 1'!A3", "'testSheet 1'", 'A3', 'A3'],
+            ["'testSheet1'!A2", "'testSheet1'", 'A2', 'A2'],
+            ["'testSheet 2'!A1", "'testSheet 2'", 'A1', 'A1'],
         ];
     }
 

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -137,6 +137,10 @@ class WorksheetTest extends TestCase
             ['B2', '', '', 'B2'],
             ['testTitle!B2', 'testTitle', 'B2', 'B2'],
             ['test!Title!B2', 'test!Title', 'B2', 'B2'],
+            ['test!Title!B2', 'test!Title', 'B2', 'B2'],
+            ["'testSheet 1'!A3", "testSheet 1", '', 'A3'],
+            ["'testSheet1'!A1", "testSheet1", '', 'A1'],
+            ["'testSheet1!A1'", "testSheet1", '', 'A1'],
         ];
     }
 


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
extractTitle returns the Sheetname with quotes. - see Issue [#739](https://github.com/PHPOffice/PhpSpreadsheet/issues/739)
getSheetByName was adaptet to remove any leading quotes to find the sheet