### PR TITLE
Document calculation caching; and how to disable it and how to flush …

### DIFF
--- a/docs/topics/accessing-cells.md
+++ b/docs/topics/accessing-cells.md
@@ -78,6 +78,10 @@ So when we try to display the value and address a second time, we can display
 its value, but trying to display its address/coordinate will throw an
 exception because that link has been set to null.
 
+__Note:__ There are some internal methods that will fetch other cells from the
+collection, and this too will detach the link to the collection from any cell
+that you might have assigned to a variable.
+
 ## Excel DataTypes
 
 MS Excel supports 7 basic datatypes:

--- a/docs/topics/accessing-cells.md
+++ b/docs/topics/accessing-cells.md
@@ -86,6 +86,33 @@ Formats handled by the advanced value binder include:
 You can read more about value binders later in this section of the
 documentation.
 
+### Setting a formula in a Cell
+
+As stated above, if you store a string value with the first character an `=`
+in a cell. PHPSpreadsheet will treat that value as a formula, and then you
+can evaluate that formula by calling `getCalculatedValue()` against the cell.
+
+There may be times though, when you wish to store a value beginning with `=`
+as a string, and that you don't want PHPSpreadsheet to evaluate as though it
+was a formula.
+
+To do this, you need to "escape" the value by setting it as "quoted text".
+
+```
+// Set cell A4 with a formula
+$spreadsheet->getActiveSheet()->setCellValue(
+    'A4',
+    '=IF(A3, CONCATENATE(A1, " ", A2), CONCATENATE(A2, " ", A1))'
+);
+$spreadsheet->getActiveSheet()->getCell('A4')
+    ->->getStyle()->setQuotePrefix(true);
+```
+
+Then, even if you ask PHPSpreadsheet to return the calculated value for cell
+`A4`, it will return `=IF(A3, CONCATENATE(A1, " ", A2), CONCATENATE(A2, " ", A1))`
+as a string, and not try to evaluate the formula.
+
+
 ### Setting a date and/or time value in a cell
 
 Date or time values are held as timestamp in Excel (a simple floating

--- a/docs/topics/calculation-engine.md
+++ b/docs/topics/calculation-engine.md
@@ -43,6 +43,30 @@ inserted 2 new rows), changed to "SUM(E4:E11)". Also, the inserted cells
 duplicate style information of the previous cell, just like Excel's
 behaviour. Note that you can both insert rows and columns.
 
+## Calculation Cache
+
+Once the Calculation engine has evaluated the formula in a cell, the result
+will be cached, so if you call `getCalculatedValue()` a second time for the
+same cell, the result will be returned from the cache rather than evaluating
+the formula a second time. This helps boost performance, because evaluating
+a formula is an expensive operation in terms of performance and speed.
+
+However, there may be times when you don't want this, perhaps you've changed
+the underlying data and need to re-evaluate the same formula with that new
+data.
+
+```
+Calculation::getInstance($spreadsheet)->disableCalculationCache();
+```
+
+Will disable calculation caching, and flush the current calculation cache.
+
+If you want only to flush the cache, then you can call
+
+```
+Calculation::getInstance($spreadsheet)->clearCalculationCache();
+```
+
 ## Known limitations
 
 There are some known limitations to the PhpSpreadsheet calculation


### PR DESCRIPTION
…the cache

This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] documentation
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [X] Documentation is updated as necessary

### Why this change is needed?

Clarification of behaviour
