### PR TITLE
Ignore escaped enclosures within an enclosure when inferring csv separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Added support for inline styles in Html reader (borders, alignment, width, height)
 - QuotedText cells no longer treated as formulae if the content begins with a `=`
 - Clean handling for DDE in formulae
+- Fix handling for escaped enclosures and new lines in CSV Separator Inference
 
 ## [1.6.0] - 2019-01-02
 

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -254,8 +254,9 @@ class Csv extends BaseReader
         $line = $line . $newLine;
 
         // Drop everything that is enclosed to avoid counting false positives in enclosures
-        $enclosure = preg_quote($this->enclosure, '/');
-        $line = preg_replace('/(' . $enclosure . '.*' . $enclosure . ')/U', '', $line);
+        $enclosure = '(?<!' . preg_quote($this->escapeCharacter, '/') . ')'
+            . preg_quote($this->enclosure, '/');
+        $line = preg_replace('/(' . $enclosure . '.*' . $enclosure . ')/Us', '', $line);
 
         // See if we have any enclosures left in the line
         // if we still have an enclosure then we need to read the next line as well

--- a/tests/PhpSpreadsheetTests/Reader/CsvTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/CsvTest.php
@@ -50,6 +50,12 @@ class CsvTest extends TestCase
                 'Test',
             ],
             [
+                __DIR__ . '/../../data/Reader/CSV/line_break_in_enclosure_with_escaped_quotes.csv',
+                ',',
+                'A3',
+                'Test',
+            ],
+            [
                 __DIR__ . '/../../data/Reader/HTML/csv_with_angle_bracket.csv',
                 ',',
                 'B1',

--- a/tests/data/Reader/CSV/line_break_in_enclosure_with_escaped_quotes.csv
+++ b/tests/data/Reader/CSV/line_break_in_enclosure_with_escaped_quotes.csv
@@ -1,0 +1,21 @@
+Name,Copy,URL
+Test,"This is a \"test csv file\"
+with both \"line breaks\"
+and \"escaped
+quotes\" that breaks
+the delimiters",http://google.com
+Test,"This is a \"test csv file\"
+with both \"line breaks\"
+and \"escaped
+quotes\" that breaks
+the delimiters",http://google.com
+Test,"This is a \"test csv file\"
+with both \"line breaks\"
+and \"escaped
+quotes\" that breaks
+the delimiters",http://google.com
+Test,"This is a \"test csv file\"
+with both \"line breaks\"
+and \"escaped
+quotes\" that breaks
+the delimiters",http://google.com


### PR DESCRIPTION

This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

The inference logic for csv separator could return false values (or even break) when enclosed values contained escaped enclosures