### PR TITLE
Improvements to Charts reading and writing for Xlsx files

### DIFF
--- a/src/PhpSpreadsheet/Chart/Axis.php
+++ b/src/PhpSpreadsheet/Chart/Axis.php
@@ -192,7 +192,7 @@ class Axis extends Properties
      * @param string $position
      * @param int $delete
      */
-    public function setAxisOptionsProperties($axis_labels, $horizontal_crosses_value = null, $horizontal_crosses = null, $axis_orientation = null, $major_tmt = null, $minor_tmt = null, $minimum = null, $maximum = null, $major_unit = null, $minor_unit = null, $position = null, $delete = 0)
+    public function setAxisOptionsProperties($axis_labels, $horizontal_crosses_value = null, $horizontal_crosses = null, $axis_orientation = null, $major_tmt = null, $minor_tmt = null, $minimum = null, $maximum = null, $major_unit = null, $minor_unit = null, $position = null, $delete = null)
     {
         $this->axisOptions['axis_labels'] = (string) $axis_labels;
         ($horizontal_crosses_value !== null) ? $this->axisOptions['horizontal_crosses_value'] = (string) $horizontal_crosses_value : null;
@@ -206,7 +206,7 @@ class Axis extends Properties
         ($major_unit !== null) ? $this->axisOptions['major_unit'] = (string) $major_unit : null;
         ($minor_unit !== null) ? $this->axisOptions['minor_unit'] = (string) $minor_unit : null;
         ($position !== null) ? $this->axisOptions['position'] = (string) $position : null;
-        ($delete !== null) ? $this->axisOptions['delete'] = (string) $delete : null;
+        ($delete !== null) ? $this->axisOptions['delete'] = (int) $delete : null;
     }
 
     /**

--- a/src/PhpSpreadsheet/Chart/Axis.php
+++ b/src/PhpSpreadsheet/Chart/Axis.php
@@ -36,6 +36,7 @@ class Axis extends Properties
         'axis_labels' => self::AXIS_LABELS_NEXT_TO,
         'horizontal_crosses' => self::HORIZONTAL_CROSSES_AUTOZERO,
         'horizontal_crosses_value' => null,
+        'position' => 'b',
     ];
 
     /**
@@ -165,6 +166,16 @@ class Axis extends Properties
     }
 
     /**
+     * Set Axis Number Source Linked.
+     *
+     * @param mixed $source_linked
+     */
+    public function setAxisNumberSourceLinked($source_linked)
+    {
+        $this->axisNumber['source_linked'] = $source_linked;
+    }
+
+    /**
      * Set Axis Options Properties.
      *
      * @param string $axis_labels
@@ -177,8 +188,10 @@ class Axis extends Properties
      * @param string $maximum
      * @param string $major_unit
      * @param string $minor_unit
+     * @param string $position
+     * @param integer $delete
      */
-    public function setAxisOptionsProperties($axis_labels, $horizontal_crosses_value = null, $horizontal_crosses = null, $axis_orientation = null, $major_tmt = null, $minor_tmt = null, $minimum = null, $maximum = null, $major_unit = null, $minor_unit = null)
+    public function setAxisOptionsProperties($axis_labels, $horizontal_crosses_value = null, $horizontal_crosses = null, $axis_orientation = null, $major_tmt = null, $minor_tmt = null, $minimum = null, $maximum = null, $major_unit = null, $minor_unit = null, $position = null, $delete = 0)
     {
         $this->axisOptions['axis_labels'] = (string) $axis_labels;
         ($horizontal_crosses_value !== null) ? $this->axisOptions['horizontal_crosses_value'] = (string) $horizontal_crosses_value : null;
@@ -191,6 +204,8 @@ class Axis extends Properties
         ($maximum !== null) ? $this->axisOptions['maximum'] = (string) $maximum : null;
         ($major_unit !== null) ? $this->axisOptions['major_unit'] = (string) $major_unit : null;
         ($minor_unit !== null) ? $this->axisOptions['minor_unit'] = (string) $minor_unit : null;
+        ($position !== null) ? $this->axisOptions['position'] = (string) $position : null;
+        ($delete !== null) ? $this->axisOptions['delete'] = (string) $delete : null;
     }
 
     /**

--- a/src/PhpSpreadsheet/Chart/Axis.php
+++ b/src/PhpSpreadsheet/Chart/Axis.php
@@ -37,6 +37,7 @@ class Axis extends Properties
         'horizontal_crosses' => self::HORIZONTAL_CROSSES_AUTOZERO,
         'horizontal_crosses_value' => null,
         'position' => 'b',
+        'delete' => 0,
     ];
 
     /**
@@ -189,7 +190,7 @@ class Axis extends Properties
      * @param string $major_unit
      * @param string $minor_unit
      * @param string $position
-     * @param integer $delete
+     * @param int $delete
      */
     public function setAxisOptionsProperties($axis_labels, $horizontal_crosses_value = null, $horizontal_crosses = null, $axis_orientation = null, $major_tmt = null, $minor_tmt = null, $minimum = null, $maximum = null, $major_unit = null, $minor_unit = null, $position = null, $delete = 0)
     {

--- a/src/PhpSpreadsheet/Chart/Chart.php
+++ b/src/PhpSpreadsheet/Chart/Chart.php
@@ -43,7 +43,7 @@ class Chart
     private $xAxisLabel;
 
     /**
-     * Secondary X-Axis Label
+     * Secondary X-Axis Label.
      *
      * @var Title
      */
@@ -57,7 +57,7 @@ class Chart
     private $yAxisLabel;
 
     /**
-     * Secondary Y-Axis Label
+     * Secondary Y-Axis Label.
      *
      * @var Title
      */

--- a/src/PhpSpreadsheet/Chart/Chart.php
+++ b/src/PhpSpreadsheet/Chart/Chart.php
@@ -43,11 +43,25 @@ class Chart
     private $xAxisLabel;
 
     /**
+     * Secondary X-Axis Label
+     *
+     * @var Title
+     */
+    private $secondaryXAxisLabel;
+
+    /**
      * Y-Axis Label.
      *
      * @var Title
      */
     private $yAxisLabel;
+
+    /**
+     * Secondary Y-Axis Label
+     *
+     * @var Title
+     */
+    private $secondaryYAxisLabel;
 
     /**
      * Chart Plot Area.
@@ -78,11 +92,25 @@ class Chart
     private $yAxis;
 
     /**
+     * Secondary Chart Asix Y as.
+     *
+     * @var Title
+     */
+    private $secondaryYAxis;
+
+    /**
      * Chart Asix X as.
      *
      * @var Axis
      */
     private $xAxis;
+
+    /**
+     * Secondary Chart Asix X as.
+     *
+     * @var Title
+     */
+    private $secondaryXAxis;
 
     /**
      * Chart Major Gridlines as.
@@ -155,8 +183,12 @@ class Chart
      * @param null|Axis $yAxis
      * @param null|GridLines $majorGridlines
      * @param null|GridLines $minorGridlines
+     * @param null|Title $secondaryXAxisLabel
+     * @param null|Title $secondaryYAxisLabel
+     * @param null|Axis $secondaryXAxis
+     * @param null|Axis $secondaryYAxis
      */
-    public function __construct($name, Title $title = null, Legend $legend = null, PlotArea $plotArea = null, $plotVisibleOnly = true, $displayBlanksAs = '0', Title $xAxisLabel = null, Title $yAxisLabel = null, Axis $xAxis = null, Axis $yAxis = null, GridLines $majorGridlines = null, GridLines $minorGridlines = null)
+    public function __construct($name, Title $title = null, Legend $legend = null, PlotArea $plotArea = null, $plotVisibleOnly = true, $displayBlanksAs = '0', Title $xAxisLabel = null, Title $yAxisLabel = null, Axis $xAxis = null, Axis $yAxis = null, GridLines $majorGridlines = null, GridLines $minorGridlines = null, Title $secondaryXAxisLabel = null, Title $secondaryYAxisLabel = null, Axis $secondaryXAxis = null, Axis $secondaryYAxis = null)
     {
         $this->name = $name;
         $this->title = $title;
@@ -170,6 +202,10 @@ class Chart
         $this->yAxis = $yAxis;
         $this->majorGridlines = $majorGridlines;
         $this->minorGridlines = $minorGridlines;
+        $this->secondaryXAxisLabel = $secondaryXAxisLabel;
+        $this->secondaryYAxisLabel = $secondaryYAxisLabel;
+        $this->secondaryXAxis = $secondaryXAxis;
+        $this->secondaryYAxis = $secondaryYAxis;
     }
 
     /**
@@ -303,6 +339,54 @@ class Chart
     }
 
     /**
+     * Get Secondary X-Axis Label.
+     *
+     * @return Title
+     */
+    public function getSecondaryXAxisLabel()
+    {
+        return $this->secondaryXAxisLabel;
+    }
+
+    /**
+     * Set Secondary X-Axis Label.
+     *
+     * @param Title $label
+     *
+     * @return Chart
+     */
+    public function setSecondaryXAxisLabel(Title $label)
+    {
+        $this->secondaryXAxisLabel = $label;
+
+        return $this;
+    }
+
+    /**
+     * Get Secondary Y-Axis Label.
+     *
+     * @return Title
+     */
+    public function getSecondaryYAxisLabel()
+    {
+        return $this->secondaryYAxisLabel;
+    }
+
+    /**
+     * Set Secondary Y-Axis Label.
+     *
+     * @param Title $label
+     *
+     * @return Chart
+     */
+    public function setSecondaryYAxisLabel(Title $label)
+    {
+        $this->secondaryYAxisLabel = $label;
+
+        return $this;
+    }
+
+    /**
      * Get Plot Area.
      *
      * @return PlotArea
@@ -367,11 +451,11 @@ class Chart
      */
     public function getChartAxisY()
     {
-        if ($this->yAxis !== null) {
-            return $this->yAxis;
+        if ($this->yAxis === null) {
+            $this->yAxis = new Axis();
         }
 
-        return new Axis();
+        return $this->yAxis;
     }
 
     /**
@@ -381,11 +465,55 @@ class Chart
      */
     public function getChartAxisX()
     {
-        if ($this->xAxis !== null) {
-            return $this->xAxis;
+        if ($this->xAxis === null) {
+            $this->xAxis = new Axis();
         }
 
-        return new Axis();
+        return $this->xAxis;
+    }
+
+    /**
+     * Get Secondary yAxis.
+     *
+     * @return Axis
+     */
+    public function getChartSecondaryAxisY()
+    {
+        return $this->secondaryYAxis;
+    }
+
+    /**
+     * Set Secondary yAxis.
+     *
+     * @return Chart
+     */
+    public function setChartSecondaryAxisY(Axis $axis)
+    {
+        $this->secondaryYAxis = $axis;
+
+        return $this;
+    }
+
+    /**
+     * Get Secondary xAxis.
+     *
+     * @return Axis
+     */
+    public function getChartSecondaryAxisX()
+    {
+        return $this->secondaryXAxis;
+    }
+
+    /**
+     * Set Secondary xAxis.
+     *
+     * @return Chart
+     */
+    public function setChartSecondaryAxisX(Axis $axis)
+    {
+        $this->secondaryXAxis = $axis;
+
+        return $this;
     }
 
     /**
@@ -395,11 +523,11 @@ class Chart
      */
     public function getMajorGridlines()
     {
-        if ($this->majorGridlines !== null) {
-            return $this->majorGridlines;
+        if ($this->majorGridlines === null) {
+            $this->majorGridlines = new GridLines();
         }
 
-        return new GridLines();
+        return $this->majorGridlines;
     }
 
     /**
@@ -409,11 +537,11 @@ class Chart
      */
     public function getMinorGridlines()
     {
-        if ($this->minorGridlines !== null) {
-            return $this->minorGridlines;
+        if ($this->minorGridlines === null) {
+            $this->minorGridlines = new GridLines();
         }
 
-        return new GridLines();
+        return $this->minorGridlines;
     }
 
     /**

--- a/src/PhpSpreadsheet/Chart/Chart.php
+++ b/src/PhpSpreadsheet/Chart/Chart.php
@@ -94,7 +94,7 @@ class Chart
     /**
      * Secondary Chart Asix Y as.
      *
-     * @var Title
+     * @var Axis
      */
     private $secondaryYAxis;
 
@@ -108,7 +108,7 @@ class Chart
     /**
      * Secondary Chart Asix X as.
      *
-     * @var Title
+     * @var Axis
      */
     private $secondaryXAxis;
 

--- a/src/PhpSpreadsheet/Reader/Xlsx/Chart.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Chart.php
@@ -63,8 +63,8 @@ class Chart
         $namespacesChartMeta = $chartElements->getNamespaces(true);
         $chartElementsC = $chartElements->children($namespacesChartMeta['c']);
 
+        $plotArea = $dispBlanksAs = $plotVisOnly = null;
         $XaxisLabel = $YaxisLabel = $legend = $title = null;
-        $dispBlanksAs = $plotVisOnly = null;
         $Xaxis = $secondaryXaxis = $Yaxis = $secondaryYaxis = null;
         $minorGridLines = $majorGridLines = null;
 
@@ -120,7 +120,7 @@ class Chart
                                                     $Xaxis = $axis;
                                                 }
 
-                                                if (!isset($majorGridlines) && isset($chartDetail->majorGridlines)) {
+                                                if (!isset($majorGridLines) && isset($chartDetail->majorGridlines)) {
                                                     $majorGridLines = self::chartGridlines($chartDetail->majorGridlines->children($namespacesChartMeta['c']), $namespacesChartMeta);
                                                 }
 
@@ -346,8 +346,7 @@ class Chart
 
                                 break;
                             case 'ln':
-                                $line_width = $compound_type = $cap_type = $dash_type = $join_type =
-                                $head_arrow_type = $head_arrow_size = $end_arrow_type = $end_arrow_size = null;
+                                $dash_type = $join_type = $head_arrow_type = $head_arrow_size = $end_arrow_type = $end_arrow_size = null;
 
                                 $line_width = self::getAttribute($spPrItem, 'w', 'integer') / 12700;
                                 $cap_type = self::getAttribute($spPrItem, 'cap', 'string');
@@ -424,12 +423,6 @@ class Chart
     private static function chartGridlines(SimpleXMLElement $linesDetails, array $namespacesChartMeta)
     {
         $gridLines = new GridLines();
-
-        $major_unit = $minor_unit =
-        $horizontal_crosses_value = $horizontal_crosses =
-        $axis_orientation = $axis_labels =
-        $major_tmt = $minor_tmt =
-        $minimum = $maximum = $position = null;
 
         foreach ($linesDetails as $linesDetailKey => $linesDetail) {
             switch ($linesDetailKey) {

--- a/src/PhpSpreadsheet/Reader/Xlsx/Chart.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Chart.php
@@ -3,14 +3,14 @@
 namespace PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
+use PhpOffice\PhpSpreadsheet\Chart\Axis;
 use PhpOffice\PhpSpreadsheet\Chart\DataSeries;
 use PhpOffice\PhpSpreadsheet\Chart\DataSeriesValues;
+use PhpOffice\PhpSpreadsheet\Chart\GridLines;
 use PhpOffice\PhpSpreadsheet\Chart\Layout;
 use PhpOffice\PhpSpreadsheet\Chart\Legend;
 use PhpOffice\PhpSpreadsheet\Chart\PlotArea;
 use PhpOffice\PhpSpreadsheet\Chart\Title;
-use PhpOffice\PhpSpreadsheet\Chart\Axis;
-use PhpOffice\PhpSpreadsheet\Chart\GridLines;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Style\Color;
 use PhpOffice\PhpSpreadsheet\Style\Font;
@@ -103,7 +103,7 @@ class Chart
                                             if (isset($chartDetail->title)) {
                                                 $XaxisLabel = self::chartTitle($chartDetail->title->children($namespacesChartMeta['c']), $namespacesChartMeta);
                                             }
-                                            /** @todo Read Yaxis and mark it as date axis */
+                                            // @todo Read Yaxis and mark it as date axis
 
                                             break;
                                         case 'valAx':
@@ -329,11 +329,11 @@ class Chart
                                 $fillOptions = $spPrItem->children($namespacesChartMeta['a']);
                                 foreach ($fillOptions as $optionKey => $optionItem) {
                                     switch ($optionKey) {
-                                        case "srgbClr":
+                                        case 'srgbClr':
                                             $fillColor = self::getAttribute($optionItem, 'val', 'string');
 
                                             break;
-                                        case "alpha":
+                                        case 'alpha':
                                             $fillAlpha = self::getAttribute($optionItem, 'val', 'integer');
 
                                             break;
@@ -370,12 +370,12 @@ class Chart
                                             break;
                                         case 'headEnd':
                                             $head_arrow_type = self::getAttribute($lnItem, 'type', 'string');
-                                            /** @todo read $head_arrow_size */
+                                            // @todo read $head_arrow_size
 
                                             break;
                                         case 'tailEnd':
                                             $end_arrow_type = self::getAttribute($lnItem, 'type', 'string');
-                                            /** @todo read $end_arrow_size */
+                                            // @todo read $end_arrow_size
 
                                             break;
                                         case 'noFill':
@@ -462,16 +462,16 @@ class Chart
                                             break;
                                         case 'headEnd':
                                             $head_arrow_type = self::getAttribute($lnItem, 'type', 'string');
-                                            /** @todo read $head_arrow_size */
+                                            // @todo read $head_arrow_size
 
                                             break;
                                         case 'tailEnd':
                                             $end_arrow_type = self::getAttribute($lnItem, 'type', 'string');
-                                            /** @todo read $end_arrow_size */
+                                            // @todo read $end_arrow_size
 
                                             break;
                                         case 'noFill':
-                                            $gridLines->setLineColorProperties("000000", 100); // emulate no fill property
+                                            $gridLines->setLineColorProperties('000000', 100); // emulate no fill property
 
                                             break;
                                         case 'solidFill':
@@ -611,7 +611,7 @@ class Chart
                                 break;
                             case 'spPr':
                                 $spPr = $seriesDetail->children($namespacesChartMeta['a']);
-                                foreach($spPr as $spPrKey => $spPrDetail) {
+                                foreach ($spPr as $spPrKey => $spPrDetail) {
                                     switch ($spPrKey) {
                                         case 'solidFill':
                                             if (isset($spPrDetail->srgbClr)) {
@@ -622,7 +622,7 @@ class Chart
                                         case 'ln':
                                             $seriesLineWidth[$seriesIndex] = self::getAttribute($spPrDetail, 'w', 'integer');
 
-                                            if (isset($spPrDetail->solidFill) && isset($spPrDetail->solidFill->srgbClr)) {
+                                            if (isset($spPrDetail->solidFill, $spPrDetail->solidFill->srgbClr)) {
                                                 $seriesColor[$seriesIndex] = self::getAttribute($spPrDetail->solidFill->srgbClr, 'val', 'string');
                                             }
 
@@ -636,7 +636,7 @@ class Chart
             }
         }
 
-        foreach($seriesValues as $seriesIndex => $seriesItem) {
+        foreach ($seriesValues as $seriesIndex => $seriesItem) {
             if (isset($seriesColor[$seriesIndex])) {
                 $seriesItem->setFillColor($seriesColor[$seriesIndex]);
             }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
@@ -211,7 +211,7 @@ class Chart extends WriterPart
      * @param Axis $xAxis
      * @param Axis $yAxis
      * @param null|GridLines $majorGridlines
-     * @param null|GridLines $minorGridlines.
+     * @param null|GridLines $minorGridlines
      * @param Title $xAxisLabelSecondary
      * @param Title $yAxisLabelSecondary
      * @param Axis $xAxisSecondary
@@ -360,12 +360,16 @@ class Chart extends WriterPart
         if ($yAxisSecondary || $xAxisSecondary) {
             if (($chartType !== DataSeries::TYPE_PIECHART) && ($chartType !== DataSeries::TYPE_PIECHART_3D) && ($chartType !== DataSeries::TYPE_DONUTCHART)) {
                 if ($chartType === DataSeries::TYPE_BUBBLECHART) {
-                    $this->writeValueAxis($objWriter, $yAxisLabelSecondary, $chartType, $id1s, $id2s, $catIsMultiLevelSeries, $xAxisSecondary, $majorGridlines, $minorGridlines);
-                } else {
+                    if ($xAxisSecondary) {
+                        $this->writeValueAxis($objWriter, $yAxisLabelSecondary, $chartType, $id1s, $id2s, $catIsMultiLevelSeries, $xAxisSecondary, $majorGridlines, $minorGridlines);
+                    }
+                } elseif ($yAxisSecondary) {
                     $this->writeCategoryAxis($objWriter, $xAxisLabelSecondary, $id1s, $id2s, $catIsMultiLevelSeries, $yAxisSecondary);
                 }
 
-                $this->writeValueAxis($objWriter, $yAxisLabelSecondary, $chartType, $id1s, $id2s, $valIsMultiLevelSeries, $xAxisSecondary, $majorGridlines, $minorGridlines);
+                if ($xAxisSecondary) {
+                    $this->writeValueAxis($objWriter, $yAxisLabelSecondary, $chartType, $id1s, $id2s, $valIsMultiLevelSeries, $xAxisSecondary, $majorGridlines, $minorGridlines);
+                }
             }
         }
 
@@ -1200,7 +1204,7 @@ class Chart extends WriterPart
                 if ($groupType == DataSeries::TYPE_STOCKCHART) {
                     $objWriter->startElement('a:noFill');
                     $objWriter->endElement();
-                } else if ($plotSeriesValues->getFillColor()) { // Write line fill color
+                } elseif ($plotSeriesValues->getFillColor()) { // Write line fill color
                     $objWriter->startElement('a:solidFill');
                     $objWriter->startElement('a:srgbClr');
                     $objWriter->writeAttribute('val', $plotSeriesValues->getFillColor());

--- a/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
@@ -78,7 +78,7 @@ class Chart extends WriterPart
         $objWriter->writeAttribute('val', 0);
         $objWriter->endElement();
 
-        $this->writePlotArea($objWriter, $pChart->getWorksheet(), $pChart->getPlotArea(), $pChart->getXAxisLabel(), $pChart->getYAxisLabel(), $pChart->getChartAxisX(), $pChart->getChartAxisY(), $pChart->getMajorGridlines(), $pChart->getMinorGridlines());
+        $this->writePlotArea($objWriter, $pChart->getWorksheet(), $pChart->getPlotArea(), $pChart->getXAxisLabel(), $pChart->getYAxisLabel(), $pChart->getChartAxisX(), $pChart->getChartAxisY(), $pChart->getMajorGridlines(), $pChart->getMinorGridlines(), $pChart->getSecondaryXAxisLabel(), $pChart->getSecondaryYAxisLabel(), $pChart->getChartSecondaryAxisX(), $pChart->getChartSecondaryAxisY());
 
         $this->writeLegend($objWriter, $pChart->getLegend());
 
@@ -211,11 +211,15 @@ class Chart extends WriterPart
      * @param Axis $xAxis
      * @param Axis $yAxis
      * @param null|GridLines $majorGridlines
-     * @param null|GridLines $minorGridlines
+     * @param null|GridLines $minorGridlines.
+     * @param Title $xAxisLabelSecondary
+     * @param Title $yAxisLabelSecondary
+     * @param Axis $xAxisSecondary
+     * @param Axis $yAxisSecondary
      *
      * @throws WriterException
      */
-    private function writePlotArea(XMLWriter $objWriter, \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $pSheet, PlotArea $plotArea, Title $xAxisLabel = null, Title $yAxisLabel = null, Axis $xAxis = null, Axis $yAxis = null, GridLines $majorGridlines = null, GridLines $minorGridlines = null)
+    private function writePlotArea(XMLWriter $objWriter, \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $pSheet, PlotArea $plotArea, Title $xAxisLabel = null, Title $yAxisLabel = null, Axis $xAxis = null, Axis $yAxis = null, GridLines $majorGridlines = null, GridLines $minorGridlines = null, Title $xAxisLabelSecondary = null, Title $yAxisLabelSecondary = null, Axis $xAxisSecondary = null, Axis $yAxisSecondary = null)
     {
         if ($plotArea === null) {
             return;
@@ -232,7 +236,7 @@ class Chart extends WriterPart
         $chartTypes = self::getChartType($plotArea);
         $catIsMultiLevelSeries = $valIsMultiLevelSeries = false;
         $plotGroupingType = '';
-        foreach ($chartTypes as $chartType) {
+        foreach ($chartTypes as $index => $chartType) {
             $objWriter->startElement('c:' . $chartType);
 
             $groupCount = $plotArea->getPlotGroupCount();
@@ -303,13 +307,31 @@ class Chart extends WriterPart
             $id1 = '75091328';
             $id2 = '75089408';
 
+            // axId for secondary axis
+            $id1s = '76091328';
+            $id2s = '76089408';
+
             if (($chartType !== DataSeries::TYPE_PIECHART) && ($chartType !== DataSeries::TYPE_PIECHART_3D) && ($chartType !== DataSeries::TYPE_DONUTCHART)) {
-                $objWriter->startElement('c:axId');
-                $objWriter->writeAttribute('val', $id1);
-                $objWriter->endElement();
-                $objWriter->startElement('c:axId');
-                $objWriter->writeAttribute('val', $id2);
-                $objWriter->endElement();
+                if ($index == 0) {
+                    $objWriter->startElement('c:axId');
+                    $objWriter->writeAttribute('val', $id1);
+                    $objWriter->endElement();
+                    $objWriter->startElement('c:axId');
+                    $objWriter->writeAttribute('val', $id2);
+                    $objWriter->endElement();
+                } else {
+                    if ($xAxisSecondary) {
+                        $objWriter->startElement('c:axId');
+                        $objWriter->writeAttribute('val', $id1s);
+                        $objWriter->endElement();
+                    }
+
+                    if ($yAxisSecondary) {
+                        $objWriter->startElement('c:axId');
+                        $objWriter->writeAttribute('val', $id2s);
+                        $objWriter->endElement();
+                    }
+                }
             } else {
                 $objWriter->startElement('c:firstSliceAng');
                 $objWriter->writeAttribute('val', 0);
@@ -333,6 +355,18 @@ class Chart extends WriterPart
             }
 
             $this->writeValueAxis($objWriter, $yAxisLabel, $chartType, $id1, $id2, $valIsMultiLevelSeries, $xAxis, $majorGridlines, $minorGridlines);
+        }
+
+        if ($yAxisSecondary || $xAxisSecondary) {
+            if (($chartType !== DataSeries::TYPE_PIECHART) && ($chartType !== DataSeries::TYPE_PIECHART_3D) && ($chartType !== DataSeries::TYPE_DONUTCHART)) {
+                if ($chartType === DataSeries::TYPE_BUBBLECHART) {
+                    $this->writeValueAxis($objWriter, $yAxisLabelSecondary, $chartType, $id1s, $id2s, $catIsMultiLevelSeries, $xAxisSecondary, $majorGridlines, $minorGridlines);
+                } else {
+                    $this->writeCategoryAxis($objWriter, $xAxisLabelSecondary, $id1s, $id2s, $catIsMultiLevelSeries, $yAxisSecondary);
+                }
+
+                $this->writeValueAxis($objWriter, $yAxisLabelSecondary, $chartType, $id1s, $id2s, $valIsMultiLevelSeries, $xAxisSecondary, $majorGridlines, $minorGridlines);
+            }
         }
 
         $objWriter->endElement();
@@ -415,11 +449,11 @@ class Chart extends WriterPart
         $objWriter->endElement();
 
         $objWriter->startElement('c:delete');
-        $objWriter->writeAttribute('val', 0);
+        $objWriter->writeAttribute('val', $yAxis->getAxisOptionsProperty('delete'));
         $objWriter->endElement();
 
         $objWriter->startElement('c:axPos');
-        $objWriter->writeAttribute('val', 'b');
+        $objWriter->writeAttribute('val', $yAxis->getAxisOptionsProperty('position'));
         $objWriter->endElement();
 
         if ($xAxisLabel !== null) {
@@ -552,11 +586,11 @@ class Chart extends WriterPart
         $objWriter->endElement();
 
         $objWriter->startElement('c:delete');
-        $objWriter->writeAttribute('val', 0);
+        $objWriter->writeAttribute('val', $xAxis->getAxisOptionsProperty('delete'));
         $objWriter->endElement();
 
         $objWriter->startElement('c:axPos');
-        $objWriter->writeAttribute('val', 'l');
+        $objWriter->writeAttribute('val', $xAxis->getAxisOptionsProperty('position'));
         $objWriter->endElement();
 
         $objWriter->startElement('c:majorGridlines');
@@ -953,7 +987,7 @@ class Chart extends WriterPart
 
         if ($id1 > 0) {
             $objWriter->startElement('c:crossAx');
-            $objWriter->writeAttribute('val', $id2);
+            $objWriter->writeAttribute('val', $id1);
             $objWriter->endElement();
 
             if ($xAxis->getAxisOptionsProperty('horizontal_crosses_value') !== null) {
@@ -1166,8 +1200,35 @@ class Chart extends WriterPart
                 if ($groupType == DataSeries::TYPE_STOCKCHART) {
                     $objWriter->startElement('a:noFill');
                     $objWriter->endElement();
+                } else if ($plotSeriesValues->getFillColor()) { // Write line fill color
+                    $objWriter->startElement('a:solidFill');
+                    $objWriter->startElement('a:srgbClr');
+                    $objWriter->writeAttribute('val', $plotSeriesValues->getFillColor());
+                    $objWriter->endElement();
+                    $objWriter->endElement();
                 }
+
                 $objWriter->endElement();
+                $objWriter->endElement();
+            }
+
+            //    Write fill color for barcharts
+            if ($groupType == DataSeries::TYPE_BARCHART) {
+                $objWriter->startElement('c:spPr');
+
+                $objWriter->startElement('a:ln');
+                $objWriter->startElement('a:noFill');
+                $objWriter->endElement();
+                $objWriter->endElement();
+
+                if ($plotSeriesValues->getFillColor()) {
+                    $objWriter->startElement('a:solidFill');
+                    $objWriter->startElement('a:srgbClr');
+                    $objWriter->writeAttribute('val', $plotSeriesValues->getFillColor());
+                    $objWriter->endElement();
+                    $objWriter->endElement();
+                }
+
                 $objWriter->endElement();
             }
 
@@ -1195,6 +1256,12 @@ class Chart extends WriterPart
                 $objWriter->endElement();
             }
 
+            // Map DataSeriesValues types to plot series value types
+            $dataTypeValuesMap = [
+                DataSeriesValues::DATASERIES_TYPE_STRING => 'str',
+                DataSeriesValues::DATASERIES_TYPE_NUMBER => 'num',
+            ];
+
             //    Category Labels
             $plotSeriesCategory = $plotGroup->getPlotCategoryByIndex($plotSeriesRef);
             if ($plotSeriesCategory && ($plotSeriesCategory->getPointCount() > 0)) {
@@ -1217,7 +1284,7 @@ class Chart extends WriterPart
                     $objWriter->startElement('c:cat');
                 }
 
-                $this->writePlotSeriesValues($plotSeriesCategory, $objWriter, $groupType, 'str');
+                $this->writePlotSeriesValues($plotSeriesCategory, $objWriter, $groupType, $dataTypeValuesMap[$plotSeriesCategory->getDataType()]);
                 $objWriter->endElement();
             }
 
@@ -1231,7 +1298,7 @@ class Chart extends WriterPart
                     $objWriter->startElement('c:val');
                 }
 
-                $this->writePlotSeriesValues($plotSeriesValues, $objWriter, $groupType, 'num');
+                $this->writePlotSeriesValues($plotSeriesValues, $objWriter, $groupType, $dataTypeValuesMap[$plotSeriesValues->getDataType()]);
                 $objWriter->endElement();
             }
 

--- a/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
@@ -225,7 +225,7 @@ class Chart extends WriterPart
             return;
         }
 
-        $id1 = $id2 = 0;
+        $id1 = $id2 = $id1s = $id2s = 0;
         $this->seriesIndex = 0;
         $objWriter->startElement('c:plotArea');
 
@@ -307,7 +307,7 @@ class Chart extends WriterPart
             $id1 = '75091328';
             $id2 = '75089408';
 
-            // axId for secondary axis
+            //    Generate 2 unique numbers to use for axId values on secondary axis
             $id1s = '76091328';
             $id2s = '76089408';
 
@@ -1204,12 +1204,15 @@ class Chart extends WriterPart
                 if ($groupType == DataSeries::TYPE_STOCKCHART) {
                     $objWriter->startElement('a:noFill');
                     $objWriter->endElement();
-                } elseif ($plotSeriesValues->getFillColor()) { // Write line fill color
-                    $objWriter->startElement('a:solidFill');
-                    $objWriter->startElement('a:srgbClr');
-                    $objWriter->writeAttribute('val', $plotSeriesValues->getFillColor());
-                    $objWriter->endElement();
-                    $objWriter->endElement();
+                } else { // Write line fill color
+                    $fillColor = $plotSeriesValues->getFillColor();
+                    if (!empty($fillColor)) {
+                        $objWriter->startElement('a:solidFill');
+                        $objWriter->startElement('a:srgbClr');
+                        $objWriter->writeAttribute('val', is_array($fillColor) ? $fillColor[0] : $fillColor);
+                        $objWriter->endElement();
+                        $objWriter->endElement();
+                    }
                 }
 
                 $objWriter->endElement();
@@ -1225,10 +1228,11 @@ class Chart extends WriterPart
                 $objWriter->endElement();
                 $objWriter->endElement();
 
-                if ($plotSeriesValues->getFillColor()) {
+                $fillColor = $plotSeriesValues->getFillColor();
+                if (!empty($fillColor)) {
                     $objWriter->startElement('a:solidFill');
                     $objWriter->startElement('a:srgbClr');
-                    $objWriter->writeAttribute('val', $plotSeriesValues->getFillColor());
+                    $objWriter->writeAttribute('val', is_array($fillColor) ? $fillColor[0] : $fillColor);
                     $objWriter->endElement();
                     $objWriter->endElement();
                 }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -373,10 +373,10 @@ class Worksheet extends WriterPart
             $lastColumIndex = -1;
             foreach ($pSheet->getColumnDimensions() as $colDimension) {
                 $width = $colDimension->getWidth() ?: -1;
-                $hidden = $colDimension->getVisible() == false;
+                $hidden = $colDimension->getVisible() === false;
                 $bestFit = $colDimension->getAutoSize();
                 $customWidth = $colDimension->getWidth() != $pSheet->getDefaultColumnDimension()->getWidth();
-                $collapsed = $colDimension->getCollapsed() == true;
+                $collapsed = $colDimension->getCollapsed() === true;
                 $outlineLevel = $colDimension->getOutlineLevel();
                 $style = $colDimension->getXfIndex();
 

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -372,7 +372,7 @@ class Worksheet extends WriterPart
             $columnDimensions = [];
             $lastColumIndex = -1;
             foreach ($pSheet->getColumnDimensions() as $colDimension) {
-                $width = $colDimension->getWidth() ? : -1;
+                $width = $colDimension->getWidth() ?: -1;
                 $hidden = $colDimension->getVisible() == false;
                 $bestFit = $colDimension->getAutoSize();
                 $customWidth = $colDimension->getWidth() != $pSheet->getDefaultColumnDimension()->getWidth();
@@ -393,7 +393,7 @@ class Worksheet extends WriterPart
                         'customWidth' => $customWidth,
                         'outlineLevel' => $outlineLevel,
                     ];
-                    $lastColumIndex++;
+                    ++$lastColumIndex;
                 } else {
                     $columnDimensions[$lastColumIndex]['max'] = Coordinate::columnIndexFromString($colDimension->getColumnIndex());
                 }


### PR DESCRIPTION
I made some improvements to the Charts structure and their Axis.
I was working in a private project using this library and I noticed how some data from Xlsx charts wasn't being read or writing and I needed them for my project in which I had to read some Xlsx templates with charts, write new values and setup new ranges for Dataseries.

I had to make some changes to Reader/Xlsx/Chart to read data from the category and values axis, gridlines and secondary axis. Also, I made some improvements to the writing process (Writer/Xlsx/Chart) to write these new values.

I noticed, also, a bug opening saved files with the Xlsx writer using LibreOffice Calc, the process take a lot of time to open a simple workbook with only one sheet some data. The error was on to the process of writing the column dimensions and I ended up by grouping similar columns using the min and max values to avoid writing a lot of columns with the same characteristics where the difference was only the max and min value (in a similar way in which Microsoft Excel is doing it)

This is:

```
- [x] a bugfix
- [x] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Because is necessary to support more properties for Charts, and allows to read more data from Xlsx files with Charts, this is useful for working with template files.