### PR TITLE
Fix return type hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Fix handling for escaped enclosures and new lines in CSV Separator Inference
 - Fix MATCH an error was appearing when comparing strings against 0 (always true)
+- Fix return type hint
 
 ## [1.6.0] - 2019-01-02
 

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -715,7 +715,7 @@ class Spreadsheet
      *
      * @param string $pName Sheet name
      *
-     * @return Worksheet
+     * @return null|Worksheet
      */
     public function getSheetByName($pName)
     {


### PR DESCRIPTION
Fix return type hint

This is:

```
- [x ] a bugfix
- [ ] a new feature
```

Checklist:

- [x ] Changes are covered by unit tests
- [ x] Code style is respected
- [x ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x ] CHANGELOG.md contains a short summary of the change
- [ x] Documentation is updated as necessary

### Why this change is needed?
IDEs and Static analysis indicates that checks for a null return type always return false.