### PR TITLE
func getSheetByName update to throw exception instead return null

### DIFF
--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -712,10 +712,9 @@ class Spreadsheet
 
     /**
      * Get sheet by name.
-     *
      * @param string $pName Sheet name
-     *
-     * @return null|Worksheet
+     * @return Worksheet
+     * @throws \Exception
      */
     public function getSheetByName($pName)
     {
@@ -725,8 +724,7 @@ class Spreadsheet
                 return $this->workSheetCollection[$i];
             }
         }
-
-        return null;
+        throw new \Exception('Sheet name does not exist');
     }
 
     /**


### PR DESCRIPTION
This is:

```
- [] a bugfix
- [*] a new feature
```

Checklist:

- [*] Changes are covered by unit tests
- [*] Code style is respected
- [*] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
First the function getsheetByIndex throw a exception when don t find the index
Second not everytime we treat null return, i work with it on prestashop and i use that library for parse xls and csv files automaticaly so when a error come like our supplier write the name of page not good then is more better to have a exception than a null for treat, is more clean.
Thank you to take in consideration. 
 