### PR TITLE
Fix: Deal with VML-Comments containing an excel-new-line

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1421,8 +1421,10 @@ class Xlsx extends BaseReader
                                 foreach ($vmlComments as $relName => $relPath) {
                                     // Load VML comments file
                                     $relPath = File::realpath(dirname("$dir/$fileWorksheet") . '/' . $relPath);
+                                    $secureXml = $this->securityScan($this->getFromZipArchive($zip, $relPath));
+                                    $cleanedXml = str_replace('<br>', '<br/>', $secureXml);
                                     $vmlCommentsFile = simplexml_load_string(
-                                        $this->securityScanner->scan($this->getFromZipArchive($zip, $relPath)),
+                                        $cleanedXml,
                                         'SimpleXMLElement',
                                         Settings::getLibXmlLoaderOptions()
                                     );


### PR DESCRIPTION
Excel writes a new lineas "<br>"-tag without closing tag. That causes simplexml_load_string() to fail.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Fix: Deal with VML-Comments containing an excel-new-line  …
Excel writes a new lineas "<br>"-tag without closing tag. That causes simplexml_load_string() to fail.