### PR TITLE
Allow to get current iterator position

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/RowCellIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/RowCellIterator.php
@@ -171,6 +171,16 @@ class RowCellIterator extends CellIterator
     }
 
     /**
+     * Return the current iterator position.
+     *
+     * @return int
+     */
+    public function getCurrentColumnIndex()
+    {
+        return $this->currentColumnIndex;
+    }
+
+    /**
      * Validate start/end values for "IterateOnlyExistingCells" mode, and adjust if necessary.
      *
      * @throws PhpSpreadsheetException


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
make cell access more comfortable.

without `getCurrentColumnIndex`
```php
$columnIndex = Coordinate::columnIndexFromString($cell->getColumn());
// later
$cellValue = $worksheet->getCellByColumnAndRow($columnIndex , $rowIndex)->getValue();
```
with `getCurrentColumnIndex`
```php
$columnIndex = $cell->getCurrentColumnIndex();
// later
$cellValue = $worksheet->getCellByColumnAndRow($columnIndex , $rowIndex)->getValue();
```