### PR TITLE
NamedRanges with ' in name wont get wiped

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1910,7 +1910,7 @@ class Xlsx extends BaseReader
                                     if (strpos((string) $definedName, '!') !== false) {
                                         // Extract sheet name
                                         $extractedSheetName = Worksheet::extractSheetTitle((string) $definedName, true);
-                                        $extractedSheetName = $extractedSheetName[0];
+                                        $extractedSheetName = trim($extractedSheetName[0],"'");
 
                                         // Locate sheet
                                         $locatedSheet = $excel->getSheetByName($extractedSheetName);


### PR DESCRIPTION
Example: 'attr_values'!$D$3:$D$49
earlier this would probably be flushed and getNamedRanges() would not show it because sheet "'attr_values'" does not exist. It should be "attr_values"

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Because without this change, multi sheet workbooks having named ranges cant be read correctly