### PR TITLE
Fix duplicate object method notation

### DIFF
--- a/docs/topics/accessing-cells.md
+++ b/docs/topics/accessing-cells.md
@@ -160,7 +160,7 @@ $spreadsheet->getActiveSheet()->setCellValue(
     '=IF(A3, CONCATENATE(A1, " ", A2), CONCATENATE(A2, " ", A1))'
 );
 $spreadsheet->getActiveSheet()->getCell('A4')
-    ->->getStyle()->setQuotePrefix(true);
+    ->getStyle()->setQuotePrefix(true);
 ```
 
 Then, even if you ask PHPSpreadsheet to return the calculated value for cell


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] a documentation update
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Documentation type error