### PR TITLE
Allow nullable theme for Xlsx Style Reader class

### DIFF
--- a/samples/Basic/16_Csv.php
+++ b/samples/Basic/16_Csv.php
@@ -6,6 +6,7 @@ require __DIR__ . '/../Header.php';
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 
 $helper->log('Write to CSV format');
+/** @var \PhpOffice\PhpSpreadsheet\Writer\Csv $writer */
 $writer = IOFactory::createWriter($spreadsheet, 'Csv')->setDelimiter(',')
     ->setEnclosure('"')
     ->setSheetIndex(0);
@@ -17,6 +18,7 @@ $helper->logWrite($writer, $filename, $callStartTime);
 
 $helper->log('Read from CSV format');
 
+/** @var \PhpOffice\PhpSpreadsheet\Reader\Csv $reader */
 $reader = IOFactory::createReader('Csv')->setDelimiter(',')
     ->setEnclosure('"')
     ->setSheetIndex(0);
@@ -30,6 +32,7 @@ $helper->write($spreadsheetFromCSV, __FILE__, ['Xlsx']);
 
 // Write CSV
 $filenameCSV = $helper->getFilename(__FILE__, 'csv');
+/** @var \PhpOffice\PhpSpreadsheet\Writer\Csv $writerCSV */
 $writerCSV = IOFactory::createWriter($spreadsheetFromCSV, 'Csv');
 $writerCSV->setExcelCompatibility(true);
 

--- a/samples/Basic/26_Utf8.php
+++ b/samples/Basic/26_Utf8.php
@@ -24,6 +24,7 @@ $worksheet->removeRow(1, 2);
 
 // Export to CSV (.csv)
 $helper->log('Write to CSV format');
+/** @var \PhpOffice\PhpSpreadsheet\Writer\Csv $writer */
 $writer = IOFactory::createWriter($spreadsheet, 'Csv');
 $filename = $helper->getFilename(__FILE__, 'csv');
 $callStartTime = microtime(true);

--- a/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
+++ b/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
@@ -8,13 +8,6 @@ use PhpOffice\PhpSpreadsheet\Settings;
 class XmlScanner
 {
     /**
-     * Identifies whether the thread-safe libxmlDisableEntityLoader() function is available.
-     *
-     * @var bool
-     */
-    private $libxmlDisableEntityLoader = false;
-
-    /**
      * String used to identify risky xml elements.
      *
      * @var string

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -32,7 +32,6 @@ use PhpOffice\PhpSpreadsheet\Style\Color;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Style\Protection;
 use PhpOffice\PhpSpreadsheet\Style\Style;
-use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column;
 use PhpOffice\PhpSpreadsheet\Worksheet\HeaderFooterDrawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use SimpleXMLElement;

--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -31,7 +31,7 @@ class Styles extends BaseParserClass
         $this->styleXml = $styleXml;
     }
 
-    public function setStyleBaseData(Theme $theme, $styles, $cellStyles)
+    public function setStyleBaseData(Theme $theme = null, $styles = [], $cellStyles = [])
     {
         self::$theme = $theme;
         $this->styles = $styles;


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Fix for new Xlsx Styles Reader class when file doesn't have a theme

Reference [Issue #1043](https://github.com/PHPOffice/PhpSpreadsheet/issues/1043)