### PR TITLE
Allow XmlScanner to correctly restore libxml entity_loader setting

### DIFF
--- a/src/PhpSpreadsheet/Reader/BaseReader.php
+++ b/src/PhpSpreadsheet/Reader/BaseReader.php
@@ -58,21 +58,6 @@ abstract class BaseReader implements IReader
     public function __construct()
     {
         $this->readFilter = new DefaultReadFilter();
-
-        // A fatal error will bypass the destructor, so we register a shutdown here
-        register_shutdown_function([$this, '__destruct']);
-    }
-
-    private function shutdown()
-    {
-        if ($this->securityScanner !== null) {
-            $this->securityScanner = null;
-        }
-    }
-
-    public function __destruct()
-    {
-        $this->shutdown();
     }
 
     public function getReadDataOnly()
@@ -146,7 +131,7 @@ abstract class BaseReader implements IReader
         return $this;
     }
 
-    public function getSecuritySCanner()
+    public function getSecurityScanner()
     {
         if (property_exists($this, 'securityScanner')) {
             return $this->securityScanner;

--- a/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
@@ -9,6 +9,11 @@ use PHPUnit\Framework\TestCase;
 
 class XmlScannerTest extends TestCase
 {
+    protected function setUp()
+    {
+        libxml_disable_entity_loader(false);
+    }
+
     /**
      * @dataProvider providerValidXML
      *
@@ -74,7 +79,7 @@ class XmlScannerTest extends TestCase
     public function testGetSecurityScannerForXmlBasedReader()
     {
         $fileReader = new Xlsx();
-        $scanner = $fileReader->getSecuritySCanner();
+        $scanner = $fileReader->getSecurityScanner();
 
         //    Must return an object...
         $this->assertInternalType('object', $scanner);
@@ -85,7 +90,7 @@ class XmlScannerTest extends TestCase
     public function testGetSecurityScannerForNonXmlBasedReader()
     {
         $fileReader = new Xls();
-        $scanner = $fileReader->getSecuritySCanner();
+        $scanner = $fileReader->getSecurityScanner();
         //    Must return a null...
         $this->assertNull($scanner);
     }
@@ -99,7 +104,7 @@ class XmlScannerTest extends TestCase
     public function testSecurityScanWithCallback($filename, $expectedResult)
     {
         $fileReader = new Xlsx();
-        $scanner = $fileReader->getSecuritySCanner();
+        $scanner = $fileReader->getSecurityScanner();
         $scanner->setAdditionalCallback('strrev');
         $xml = $scanner->scanFile($filename);
 
@@ -114,5 +119,22 @@ class XmlScannerTest extends TestCase
         }
 
         return $tests;
+    }
+
+    public function testLibxmlDisableEntityLoaderIsRestoredWithoutShutdown()
+    {
+        $reader = new Xlsx();
+        unset($reader);
+
+        $reader = new \XMLReader();
+        $opened = $reader->open(__DIR__ . '/../../../data/Reader/Xml/SecurityScannerWithCallbackExample.xml');
+        $this->assertTrue($opened);
+    }
+
+    public function testEncodingAllowsMixedCase()
+    {
+        $scanner = new XmlScanner();
+        $output = $scanner->scan($input = '<?xml version="1.0" encoding="utf-8"?><foo>bar</foo>');
+        $this->assertSame($input, $output);
     }
 }


### PR DESCRIPTION
XmlScanner was not restoring libxml_disable_entity_loader since
destruct was not being called until script shutdown. This is because
the shutdown handler required an XmlScanner instance.

Also fix an unrelated bug where the UTF-8 encoding test was
case sensitive.

This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

Fix #1045 