### PR TITLE
fix xlsx Cell datavalidations bug

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx/DataValidations.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/DataValidations.php
@@ -19,7 +19,7 @@ class DataValidations
 
     public function load()
     {
-        foreach ($this->worksheetXml->dataValidation as $dataValidation) {
+        foreach ($this->worksheetXml->dataValidations->dataValidation as $dataValidation) {
             // Uppercase coordinate
             $range = strtoupper($dataValidation['sqref']);
             $rangeSet = explode(' ', $range);


### PR DESCRIPTION
This is:

```
- [ *] a bugfix
- [ ] a new feature
```

Checklist:

- [*] Changes are covered by unit tests
- [*] Code style is respected
- [*] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Cell datavalidations settings not readed from xlsx files. This fix this issue.