### PR TITLE
Added condition to nullify cells when merging cells.

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1679,11 +1679,12 @@ class Worksheet implements IComparable
      *
      * @param string $pRange Cell range (e.g. A1:E1)
      *
-     * @throws Exception
+     * @param bool   $withAutofilter Fill merged cells for autofilter
      *
      * @return Worksheet
+     * @throws Exception
      */
-    public function mergeCells($pRange)
+    public function mergeCells($pRange, $withAutofilter = false)
     {
         // Uppercase coordinate
         $pRange = strtoupper($pRange);
@@ -1702,11 +1703,14 @@ class Worksheet implements IComparable
                 $this->getCell($upperLeft)->setValueExplicit(null, DataType::TYPE_NULL);
             }
 
-            // Blank out the rest of the cells in the range (if they exist)
-            $count = count($aReferences);
-            for ($i = 1; $i < $count; ++$i) {
-                if ($this->cellExists($aReferences[$i])) {
-                    $this->getCell($aReferences[$i])->setValueExplicit(null, DataType::TYPE_NULL);
+            // If we want to use autofilter on merged cells - we need their values
+            if (!$withAutofilter) {
+                // Blank out the rest of the cells in the range (if they exist)
+                $count = count($aReferences);
+                for ($i = 1; $i < $count; ++$i) {
+                    if ($this->cellExists($aReferences[$i])) {
+                        $this->getCell($aReferences[$i])->setValueExplicit(null, DataType::TYPE_NULL);
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
This is:

- [x] a bugfix


Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

When we merge cells, we nullify their values as it does Excel for windows.
But this breaks autofilter work on merged cells.
This PR adds parameter to Worksheet->mergeCells($pRange, $withAutoFilter = false) method.
When $withAutoFilter is true -> method wont nullify cells, so autofilter will work on merged cells.

I've made changes backwards - compatible, but i dunno how removed cell nullifying will affect on other parts of library. We have tested that PR on our excel sheets, and we are satisfied by that fix, using this in production.

Sorry, but i'm not ready to work on this PR after submitting.

No filters, merged cells:
![no_filters](https://user-images.githubusercontent.com/2886885/60585622-cd82c500-9d98-11e9-9729-e13ede81a86d.png)

Applying filters:
![filters](https://user-images.githubusercontent.com/2886885/60585674-ec815700-9d98-11e9-9426-d75dea4e1cc2.PNG)

Filters applied - BROKEN, before this PR:
(2 rows, but 10 needed as in next screenshot, 2 rows because of collapse, there will be 1 row if not using collapse)
![Annotation 2019-07-03 135803](https://user-images.githubusercontent.com/2886885/60586416-b349e680-9d9a-11e9-9855-ec65b44a674a.png)


Filters applied - WORKING, after this PR:
![filters_applied](https://user-images.githubusercontent.com/2886885/60585733-0e7ad980-9d99-11e9-870f-c4f9b8e69e75.PNG)

