### PR TITLE
Use case-insensitive comparison for encoding

### DIFF
--- a/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
+++ b/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
@@ -96,12 +96,12 @@ class XmlScanner
         $result = preg_match($pattern, $xml, $matches);
         $charset = strtoupper($result ? $matches[1] : 'UTF-8');
 
-        if ($charset !== 'UTF-8') {
+        if (strcasecmp($charset, 'UTF-8')) {
             $xml = mb_convert_encoding($xml, 'UTF-8', $charset);
 
             $result = preg_match($pattern, $xml, $matches);
             $charset = $result ? $matches[1] : 'UTF-8';
-            if ($charset !== 'UTF-8') {
+            if (strcasecmp($charset, 'UTF-8')) {
                 throw new Reader\Exception('Suspicious Double-encoded XML, spreadsheet file load() aborted to prevent XXE/XEE attacks');
             }
         }


### PR DESCRIPTION
The recent change incorrectly assumes the encoding to be uppercase (`UTF-8`), but [IANA](https://www.iana.org/assignments/character-sets/character-sets.xhtml) says _no distinction is made
between use of upper and lower case letters_.

This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

The recent change to address CVE-2019-12331 breaks parsing of spreadsheets with lowercase XML, such as the following:

```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
...
```