### PR TITLE
Ods reader fix for property reader when none set

### DIFF
--- a/src/PhpSpreadsheet/Reader/Ods/Properties.php
+++ b/src/PhpSpreadsheet/Reader/Ods/Properties.php
@@ -26,7 +26,7 @@ class Properties
             }
             $this->setCoreProperties($docProps, $officePropertiesDC);
 
-            $officePropertyMeta = [];
+            $officePropertyMeta = (object) [];
             if (isset($namespacesMeta['dc'])) {
                 $officePropertyMeta = $officePropertyData->children($namespacesMeta['meta']);
             }

--- a/src/PhpSpreadsheet/Reader/Ods/Properties.php
+++ b/src/PhpSpreadsheet/Reader/Ods/Properties.php
@@ -20,7 +20,7 @@ class Properties
         $officeProperty = $xml->children($namespacesMeta['office']);
         foreach ($officeProperty as $officePropertyData) {
             /** @var \SimpleXMLElement $officePropertyData */
-            $officePropertiesDC = [];
+            $officePropertiesDC = (object) [];
             if (isset($namespacesMeta['dc'])) {
                 $officePropertiesDC = $officePropertyData->children($namespacesMeta['dc']);
             }


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

ODS files without spreadsheet properties were triggering a fatal error [Issue #1047](https://github.com/PHPOffice/PhpSpreadsheet/issues/1047)