### PR TITLE
When <br> appears in a table cell, set the cell to wrap.

### DIFF
--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -376,7 +376,7 @@ class Html extends BaseReader
                         if ($this->tableLevel > 0) {
                             //    If we're inside a table, replace with a \n and set the cell to wrap
                             $cellContent .= "\n";
-			    $sheet->getStyle($column . $row)->getAlignment()->setWrapText(true);
+                            $sheet->getStyle($column . $row)->getAlignment()->setWrapText(true);
                         } else {
                             //    Otherwise flush our existing content and move the row cursor on
                             $this->flushCell($sheet, $column, $row, $cellContent);

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -374,8 +374,9 @@ class Html extends BaseReader
                         // no break
                     case 'br':
                         if ($this->tableLevel > 0) {
-                            //    If we're inside a table, replace with a \n
+                            //    If we're inside a table, replace with a \n and set the cell to wrap
                             $cellContent .= "\n";
+			    $sheet->getStyle($column . $row)->getAlignment()->setWrapText(true);
                         } else {
                             //    Otherwise flush our existing content and move the row cursor on
                             $this->flushCell($sheet, $column, $row, $cellContent);


### PR DESCRIPTION
This is:

- [X] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Fixes #1071 

If the cell is not set to wrap, it appears as a single line when first displayed in Excel, although editing the cell will cause Excel to wrap it.

