### PR TITLE
Fix 1055

### DIFF
--- a/src/PhpSpreadsheet/Calculation/LookupRef.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef.php
@@ -794,8 +794,10 @@ class LookupRef
             $lookupLower = StringHelper::strToLower($lookup_value);
             $rowDataLower = StringHelper::strToLower($rowData);
 
-            if (($bothNumeric && $rowData > $lookup_value) ||
-                ($bothNotNumeric && $rowDataLower > $lookupLower)) {
+            if ($not_exact_match && (
+                ($bothNumeric && $rowData > $lookup_value) ||
+                ($bothNotNumeric && $rowDataLower > $lookupLower)
+                )) {
                 break;
             }
 

--- a/tests/data/Calculation/LookupRef/HLOOKUP.php
+++ b/tests/data/Calculation/LookupRef/HLOOKUP.php
@@ -284,5 +284,15 @@ return [
         ],
         2,
         false
-    ]
+    ],
+    [
+        2,
+        'B',
+        [
+            ['Selection column', 'C', 'B', 'A'],
+            ['Value to retrieve', 3, 2, 1]
+        ],
+        2,
+        false
+    ],
 ];


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

To fix the issue 1055, which make PhpSpreadsheet Hlookup function work only if the list is ordered if range_lookup is false, which isn't the behaviour in Excel and Calc documentation