### PR TITLE
fix getCalculatedValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Best effort to support invalid colspan values in HTML reader - [878](https://github.com/PHPOffice/PhpSpreadsheet/pull/878)
 - Fixes incorrect rows deletion [#868](https://github.com/PHPOffice/PhpSpreadsheet/issues/868)
 - MATCH function fix (value search by type, stop search when match_type=-1 and unordered element encountered) - [Issue #1116](https://github.com/PHPOffice/PhpSpreadsheet/issues/1116)
+- Fix getCalculatedValue error with more than two INDIRECT
 
 ## [1.8.2] - 2019-07-08
 

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -4140,6 +4140,9 @@ class Calculation
 
                 // if the token is a function, pop arguments off the stack, hand them to the function, and push the result back on
             } elseif (preg_match('/^' . self::CALCULATION_REGEXP_FUNCTION . '$/i', $token, $matches)) {
+                if ($pCellParent) {
+                    $pCell->attach($pCellParent);
+                }
                 if (($cellID == 'AC99') || (isset($pCell) && $pCell->getCoordinate() == 'AC99')) {
                     if (defined('RESOLVING')) {
                         define('RESOLVING2', true);
@@ -4215,6 +4218,7 @@ class Calculation
                         }
                         unset($arg);
                     }
+
                     $result = call_user_func_array($functionCall, $args);
 
                     if ($functionName != 'MKMATRIX') {

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -164,6 +164,22 @@ class CalculationTest extends TestCase
         self::assertEquals("=cmd|'/C calc'!A0", $cell->getCalculatedValue());
     }
 
+    public function testCellWithFormulaTwoIndirect()
+    {
+        $spreadsheet = new Spreadsheet();
+        $workSheet = $spreadsheet->getActiveSheet();
+        $cell1 = $workSheet->getCell('A1');
+        $cell1->setValue('2');
+        $cell2 = $workSheet->getCell('B1');
+        $cell2->setValue('3');
+        $cell2 = $workSheet->getCell('C1');
+        $cell2->setValue('4');
+        $cell3 = $workSheet->getCell('D1');
+        $cell3->setValue('=SUM(INDIRECT("A"&ROW()),INDIRECT("B"&ROW()),INDIRECT("C"&ROW()))');
+
+        self::assertEquals('9', $cell3->getCalculatedValue());
+    }
+
     public function testBranchPruningFormulaParsingSimpleCase()
     {
         $calculation = Calculation::getInstance();


### PR DESCRIPTION
This is:

```
- [o] a bugfix
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- Documentation is updated as necessary

### Why this change is needed?
Because when the formula got two or more INDIRECT in one line, the file will NOT be generated. It is a very dangerous for output a file. So we need to fix it.