### PR TITLE
fix undefind index in sheet list if one of sheets is chartsheet

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -192,7 +192,12 @@ class Xlsx extends BaseReader
 
                 $worksheets = [];
                 foreach ($relsWorkbook->Relationship as $ele) {
-                    if ($ele['Type'] == 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet') {
+                    if (
+                        in_array($ele['Type'], [
+                            'http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet',
+                            'http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet',
+                        ])
+                    ) {
                         $worksheets[(string) $ele['Id']] = $ele['Target'];
                     }
                 }
@@ -466,6 +471,7 @@ class Xlsx extends BaseReader
                     foreach ($relsWorkbook->Relationship as $ele) {
                         switch ($ele['Type']) {
                             case 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet':
+                            case 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet':
                                 $worksheets[(string) $ele['Id']] = $ele['Target'];
 
                                 break;


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
if file has chartsheet Xlsx can't be loaded and listWorksheetInfo doesn't work. Chartsheet will set zero totals of rows and columns.