### PR TITLE
Fix the problem that the value of PHP_INT_MAX constant is too large i…

### DIFF
--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -13,6 +13,13 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 class Cell
 {
     /**
+     * The maximum integer value that the Excel cell can display without losing longitude.
+     *
+     * @var int
+     */
+    const INT_MAX = 999999999999999;
+
+    /**
      * Value binder to use.
      *
      * @var IValueBinder

--- a/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
@@ -65,7 +65,7 @@ class DefaultValueBinder implements IValueBinder
             $tValue = ltrim($pValue, '+-');
             if (is_string($pValue) && $tValue[0] === '0' && strlen($tValue) > 1 && $tValue[1] !== '.') {
                 return DataType::TYPE_STRING;
-            } elseif ((strpos($pValue, '.') === false) && ($pValue > PHP_INT_MAX)) {
+            } elseif ((strpos($pValue, '.') === false) && ($pValue > Cell::INT_MAX)) {
                 return DataType::TYPE_STRING;
             }
 


### PR DESCRIPTION
This is:
- [x] a bugfix
- [ ] a new feature

Checklist:
- [x] Changes are covered by unit tests
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
English version：
These words were translated from Chinese through Google Translate. If you find that you can't understand it, please read the Chinese version.
Discovery process: The table exported in the local environment can be displayed normally. The data of the table exported on the server is lost due to the accuracy, and it is displayed as `2.01908E+ 17`. The last few bits are all 0.
Cause Analysis:
1, `\PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder::dataTypeForValue()` This method uses the PHP_INT_MAX constant when judging the data type. The setting greater than PHP_INT_MAX is `DataType::TYPE_STRING`, which is less than PHP_INT_MAX set to `DataType: :TYPE_NUMERIC`, even if the format of the cell is set in advance.
2, the local environment is a 32-bit version of PHP, the size of PHP_INT_MAX is 2147483647; 3, the server environment is 64-bit PHP, the size of PHP_INT_MAX is 9223372036854775807;
4, after testing Excel cells in the numerical mode can display up to 999999999999999 without losing accuracy;
5, a given value, such as `201908011422379702` which is greater than 32-bit PHP PHP_INT_MAX, less than 64-bit PHP PHP_INT_MAX, so in 64-bit PHP it is judged as `DataType:: TYPE_NUMERIC`, however this value exceeds Excel can not lose the range of precision display, so the accuracy is lost;
6, the modified code has been tested, can be compatible with 32-bit PHP and 64-bit PHP;
7, check other locations to find other locations using the PHP_INT_MAX constant, will not affect the data export function;


中文版：
发现过程：在本地环境中导出的表格可以正常显示，服务器上导出的表格部分数据因精度丢失，显示为`2.01908E+ 17`的样子，最后几位全是0。
原因分析：
1、`\PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder::dataTypeForValue()`这个方法在判断数据类型的时候使用了PHP_INT_MAX这个常量，大于PHP_INT_MAX的设置为`DataType::TYPE_STRING`，小于PHP_INT_MAX设置为`DataType::TYPE_NUMERIC`，即便事先设置了单元格的格式也是如此。
2、本地环境是32位版本PHP，PHP_INT_MAX的大小为2147483647；3、服务器环境是64位PHP，PHP_INT_MAX的大小为9223372036854775807；
4、经过测试Excel单元格在数值模式下最大能够显示999999999999999而不丢失精度；
5、一个给定的值，比如`201908011422379702`它大于32位PHP中的PHP_INT_MAX，小于64位PHP中的PHP_INT_MAX，所以在64位PHP中它被判断为`DataType::TYPE_NUMERIC`，然而这个数值超过了Excel能够不丢失精度显示的范围，所以造成了精度丢失；
6、修改后的代码经过测试，可以兼容32位PHP和64位PHP；
7、检查其他位置发现其他使用了PHP_INT_MAX常量的位置，不会影响数据导出功能；