### PR TITLE
Allow HTML Reader to load from string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - HLookup needs an ordered list even if range_lookup is set to false [Issue #1055](https://github.com/PHPOffice/PhpSpreadsheet/issues/1055) and [PR #1076](https://github.com/PHPOffice/PhpSpreadsheet/pull/1076)
 - Improve performance of IF function calls via ranch pruning to avoid resolution of every branches [#844](https://github.com/PHPOffice/PhpSpreadsheet/pull/844)
 - MATCH function supports `*?~` Excel functionality, when match_type=0 - [Issue #1116](https://github.com/PHPOffice/PhpSpreadsheet/issues/1116)
+- Allow HTML Reader to accept HTML as a string [Issue #1136](https://github.com/PHPOffice/PhpSpreadsheet/pull/1136)
 
 ### Fixed
 

--- a/docs/topics/reading-and-writing-to-file.md
+++ b/docs/topics/reading-and-writing-to-file.md
@@ -876,15 +876,15 @@ $writer->save('write.xls');
 
 Notice that it is ok to load an xlsx file and generate an xls file.
 
-## Generating Excel files from html content
+## Generating Excel files from HTML content
 
-If you are generating an excel file from pre-rendered HTML content you can do so
+If you are generating an Excel file from pre-rendered HTML content you can do so
 automatically using the HTML Reader. This is most useful when you are generating 
-excel files from web application content that would be downloaded/sent to a user.
+Excel files from web application content that would be downloaded/sent to a user.
 
 For example:
 
-``` php
+```php
 $htmlString = '<table>
                   <tr>
                       <td>Hello World</td>
@@ -896,10 +896,10 @@ $htmlString = '<table>
                       <td>Hello<br>World</td>
                   </tr>
               </table>';
+
 $reader = new \PhpOffice\PhpSpreadsheet\Reader\Html();
 $spreadsheet = $reader->loadFromString($htmlString);
 
-// Or stream this to the user's browser setting Content-Type/Disposition headers etc...
 $writer = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($spreadsheet, 'Xls');
 $writer->save('write.xls'); 
 ```

--- a/docs/topics/reading-and-writing-to-file.md
+++ b/docs/topics/reading-and-writing-to-file.md
@@ -875,3 +875,31 @@ $writer->save('write.xls');
 ```
 
 Notice that it is ok to load an xlsx file and generate an xls file.
+
+## Generating Excel files from html content
+
+If you are generating an excel file from pre-rendered HTML content you can do so
+automatically using the HTML Reader. This is most useful when you are generating 
+excel files from web application content that would be downloaded/sent to a user.
+
+For example:
+
+``` php
+$htmlString = '<table>
+                  <tr>
+                      <td>Hello World</td>
+                  </tr>
+                  <tr>
+                      <td>Hello<br />World</td>
+                  </tr>
+                  <tr>
+                      <td>Hello<br>World</td>
+                  </tr>
+              </table>';
+$reader = new \PhpOffice\PhpSpreadsheet\Reader\Html();
+$spreadsheet = $reader->loadFromString($htmlString);
+
+// Or stream this to the user's browser setting Content-Type/Disposition headers etc...
+$writer = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($spreadsheet, 'Xls');
+$writer->save('write.xls'); 
+```

--- a/tests/PhpSpreadsheetTests/Reader/HtmlTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/HtmlTest.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheetTests\Reader;
 
 use PhpOffice\PhpSpreadsheet\Reader\Html;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Style\Border;
 use PhpOffice\PhpSpreadsheet\Style\Font;
@@ -297,6 +298,68 @@ class HtmlTest extends TestCase
         $this->assertContains("\n", $cellValue);
 
         unlink($filename);
+    }
+
+    public function testCanLoadFromString()
+    {
+        $html = '<table>
+                    <tr>
+                        <td>Hello World</td>
+                    </tr>
+                    <tr>
+                        <td>Hello<br />World</td>
+                    </tr>
+                    <tr>
+                        <td>Hello<br>World</td>
+                    </tr>
+                </table>';
+        $spreadsheet = (new Html())->loadFromString($html);
+        $firstSheet = $spreadsheet->getSheet(0);
+
+        $cellStyle = $firstSheet->getStyle('A1');
+        self::assertFalse($cellStyle->getAlignment()->getWrapText());
+
+        $cellStyle = $firstSheet->getStyle('A2');
+        self::assertTrue($cellStyle->getAlignment()->getWrapText());
+        $cellValue = $firstSheet->getCell('A2')->getValue();
+        $this->assertContains("\n", $cellValue);
+
+        $cellStyle = $firstSheet->getStyle('A3');
+        self::assertTrue($cellStyle->getAlignment()->getWrapText());
+        $cellValue = $firstSheet->getCell('A3')->getValue();
+        $this->assertContains("\n", $cellValue);
+    }
+
+    public function testCanLoadFromDomDocument()
+    {
+        $html = '<table>
+                    <tr>
+                        <td>Hello World</td>
+                    </tr>
+                    <tr>
+                        <td>Hello<br />World</td>
+                    </tr>
+                    <tr>
+                        <td>Hello<br>World</td>
+                    </tr>
+		</table>';
+        $document = new \DOMDocument();
+        $document->loadHTML($html);
+        $spreadsheet = (new Html())->loadDocument($document, new Spreadsheet());
+        $firstSheet = $spreadsheet->getSheet(0);
+
+        $cellStyle = $firstSheet->getStyle('A1');
+        self::assertFalse($cellStyle->getAlignment()->getWrapText());
+
+        $cellStyle = $firstSheet->getStyle('A2');
+        self::assertTrue($cellStyle->getAlignment()->getWrapText());
+        $cellValue = $firstSheet->getCell('A2')->getValue();
+        $this->assertContains("\n", $cellValue);
+
+        $cellStyle = $firstSheet->getStyle('A3');
+        self::assertTrue($cellStyle->getAlignment()->getWrapText());
+        $cellValue = $firstSheet->getCell('A3')->getValue();
+        $this->assertContains("\n", $cellValue);
     }
 
     /**


### PR DESCRIPTION
We often want to export a table as an excel sheet. The system renders the html and it seems like a waste of time to write it to the file system to use the reader. This allows us to render the html and then just pass it to a reader

This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
Just allows Reader\Html to accept html content as a string instead of just a file.