### PR TITLE
Fix Error in Ods.php Reader for some files

### DIFF
--- a/src/PhpSpreadsheet/Reader/Ods.php
+++ b/src/PhpSpreadsheet/Reader/Ods.php
@@ -377,6 +377,10 @@ class Ods extends BaseReader
                                     }
                                 }
 
+                                if (!method_exists($cellData, 'hasAttributeNS')) {
+                                    continue;
+                                }
+                                
                                 // Initialize variables
                                 $formatting = $hyperlink = null;
                                 $hasCalculatedValue = false;

--- a/src/PhpSpreadsheet/Reader/Ods.php
+++ b/src/PhpSpreadsheet/Reader/Ods.php
@@ -380,7 +380,7 @@ class Ods extends BaseReader
                                 if (!method_exists($cellData, 'hasAttributeNS')) {
                                     continue;
                                 }
-                                
+
                                 // Initialize variables
                                 $formatting = $hyperlink = null;
                                 $hasCalculatedValue = false;


### PR DESCRIPTION
#804 Catch Uncaught Error Call to undefined method DOMText::hasAttributeNS() in Ods.php Reader

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Some ODS files have a childNode of type DOMText, instead of DOMElement only. This tiny fix allows to read these files.