### PR TITLE
fixbug:the setCellValue second parameter can't accept int

### DIFF
--- a/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
@@ -55,7 +55,7 @@ class DefaultValueBinder implements IValueBinder
             return DataType::TYPE_STRING;
         } elseif ($pValue instanceof RichText) {
             return DataType::TYPE_INLINE;
-        } elseif ($pValue[0] === '=' && strlen($pValue) > 1) {
+        } elseif (strpos($pValue, "=") === 0 && strlen($pValue) > 1) {
             return DataType::TYPE_FORMULA;
         } elseif (is_bool($pValue)) {
             return DataType::TYPE_BOOL;


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Spreadsheet.setCellValue method cannot accept int parameter. I got fatal error:"Trying to access array offset on value of type int at /vendor/phpoffice/phpspreadsheet/src/PhpSpreadsheet/Cell/DefaultValueBinder.php:58"