### PR TITLE
scrutinizer do not analyze test code

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,6 +9,10 @@ coding_style:
             around_operators:
                 concatenation: true
 
+filter:
+    excluded_paths:
+        - "tests/"
+
 build:
     nodes:
         analysis:


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [x] a CI adjustment
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests (**does not apply**)
- [x] Code style is respected (**does not apply**)
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change (**does not apply**)
- [x] Documentation is updated as necessary (**does not apply**)

### Why this change is needed?

The scrutinizer score is low, but it is lower because it is inspecting code under `tests` too.

[Here is an example of a relevant project](https://github.com/laravel-zero/laravel-zero/blob/stable/.scrutinizer.yml) doing the way I suggest you.

I think the `tests` directory should be ignored by scrutinizer. Do you agree? 