### PR TITLE
Fix branch pruning resolution of non boolean conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- ...
+- Fix branch pruning handling of non boolean conditions
 
 ## [1.9.0] - 2019-08-17
 

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -3804,13 +3804,19 @@ class Calculation
             if ($this->branchPruningEnabled && isset($tokenData['onlyIf'])) {
                 $onlyIfStoreKey = $tokenData['onlyIf'];
                 $storeValue = $branchStore[$onlyIfStoreKey] ?? null;
+                $storeValueAsBool = ($storeValue === null) ?
+                    true : (bool) Functions::flattenSingleValue($storeValue);
                 if (is_array($storeValue)) {
                     $wrappedItem = end($storeValue);
                     $storeValue = end($wrappedItem);
                 }
 
-                if (isset($storeValue) && (($storeValue !== true)
-                    || ($storeValue === 'Pruned branch'))
+                if (isset($storeValue)
+                    && (
+                        !$storeValueAsBool
+                        || Functions::isError($storeValue)
+                        || ($storeValue === 'Pruned branch')
+                    )
                 ) {
                     // If branching value is not true, we don't need to compute
                     if (!isset($fakedForBranchPruning['onlyIf-' . $onlyIfStoreKey])) {
@@ -3833,12 +3839,17 @@ class Calculation
             if ($this->branchPruningEnabled && isset($tokenData['onlyIfNot'])) {
                 $onlyIfNotStoreKey = $tokenData['onlyIfNot'];
                 $storeValue = $branchStore[$onlyIfNotStoreKey] ?? null;
+                $storeValueAsBool = ($storeValue === null) ?
+                    true : (bool) Functions::flattenSingleValue($storeValue);
                 if (is_array($storeValue)) {
                     $wrappedItem = end($storeValue);
                     $storeValue = end($wrappedItem);
                 }
-                if (isset($storeValue) && ($storeValue
-                    || ($storeValue === 'Pruned branch'))
+                if (isset($storeValue)
+                    && (
+                        $storeValueAsBool
+                        || Functions::isError($storeValue)
+                        || ($storeValue === 'Pruned branch'))
                 ) {
                     // If branching value is true, we don't need to compute
                     if (!isset($fakedForBranchPruning['onlyIfNot-' . $onlyIfNotStoreKey])) {

--- a/tests/data/Calculation/Calculation.php
+++ b/tests/data/Calculation/Calculation.php
@@ -55,7 +55,14 @@ function calculationTestDataGenerator()
     $formula3 = '=IF(A4="take A", A3, B3)';
     $set8 = [4, $dataArray5, $formula3, 'E5', ['A3'], ['B3']];
 
-    return [$set0, $set1, $set2, $set3, $set4, $set5, $set6, $set7, $set8];
+    $dataArray6 = [
+        ['=IF(22,"a","b")']
+    ];
+    $set9 = ['a', $dataArray6, '=A1', 'A2'];
+
+    return [
+        $set0, $set1, $set2, $set3, $set4, $set5, $set6, $set7, $set8, $set9
+    ];
 }
 
 return calculationTestDataGenerator();


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

Branch pruning was not properly handling non boolean conditions.