### PR TITLE
Fix ODS Reader when no DC namespace are defined

### DIFF
--- a/src/PhpSpreadsheet/Reader/Ods/Properties.php
+++ b/src/PhpSpreadsheet/Reader/Ods/Properties.php
@@ -20,11 +20,10 @@ class Properties
         $officeProperty = $xml->children($namespacesMeta['office']);
         foreach ($officeProperty as $officePropertyData) {
             /** @var \SimpleXMLElement $officePropertyData */
-            $officePropertiesDC = (object) [];
             if (isset($namespacesMeta['dc'])) {
                 $officePropertiesDC = $officePropertyData->children($namespacesMeta['dc']);
+                $this->setCoreProperties($docProps, $officePropertiesDC);
             }
-            $this->setCoreProperties($docProps, $officePropertiesDC);
 
             $officePropertyMeta = (object) [];
             if (isset($namespacesMeta['dc'])) {


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
ODS files without spreadsheet properties were triggering a fatal error Issue #1176.
