### PR TITLE
Add ReferenceHelper::cellSort and ReferenceHelper::cellReverseSort tests

### DIFF
--- a/tests/PhpSpreadsheetTests/ReferenceHelperTest.php
+++ b/tests/PhpSpreadsheetTests/ReferenceHelperTest.php
@@ -53,4 +53,46 @@ class ReferenceHelperTest extends TestCase
             self::assertEquals($columnExpectedResult[$key], $value);
         }
     }
+
+    public function testCellSort()
+    {
+        $cellBase = $columnExpectedResult = [
+            'A1', 'B1', 'AZB1',
+            'BBB1', 'BB2', 'BAB2',
+            'BZA2', 'Z3', 'AZA3',
+            'BZB3', 'AB5', 'AZ6',
+            'ABZ7', 'BA9', 'BZ9',
+            'AAA9', 'AAZ9', 'BA10',
+            'BZZ10', 'ZA11', 'AAB11',
+            'BBZ29', 'BAA32', 'ZZ43',
+            'AZZ43', 'BAZ67', 'ZB78',
+            'ABA121', 'ABB289', 'BBA544',
+        ];
+        shuffle($cellBase);
+        usort($cellBase, [ReferenceHelper::class, 'cellSort']);
+        foreach ($cellBase as $key => $value) {
+            self::assertEquals($columnExpectedResult[$key], $value);
+        }
+    }
+
+    public function testCellReverseSort()
+    {
+        $cellBase = $columnExpectedResult = [
+            'BBA544', 'ABB289', 'ABA121',
+            'ZB78', 'BAZ67', 'AZZ43',
+            'ZZ43', 'BAA32', 'BBZ29',
+            'AAB11', 'ZA11', 'BZZ10',
+            'BA10', 'AAZ9', 'AAA9',
+            'BZ9', 'BA9', 'ABZ7',
+            'AZ6', 'AB5', 'BZB3',
+            'AZA3', 'Z3', 'BZA2',
+            'BAB2', 'BB2', 'BBB1',
+            'AZB1', 'B1', 'A1',
+        ];
+        shuffle($cellBase);
+        usort($cellBase, [ReferenceHelper::class, 'cellReverseSort']);
+        foreach ($cellBase as $key => $value) {
+            self::assertEquals($columnExpectedResult[$key], $value);
+        }
+    }
 }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [x] unit tests
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Improve unit test