### PR TITLE
Use configured decimal- and thousandsseparator

### DIFF
--- a/src/PhpSpreadsheet/Calculation/TextData.php
+++ b/src/PhpSpreadsheet/Calculation/TextData.php
@@ -273,7 +273,11 @@ class TextData
             $decimals = 0;
         }
         if (!$no_commas) {
-            $valueResult = number_format($valueResult, $decimals);
+            $valueResult = number_format($valueResult,
+                                         $decimals, 
+                                         StringHelper::getDecimalSeparator(), 
+                                         StringHelper::getThousandsSeparator()
+                                        );
         }
 
         return (string) $valueResult;

--- a/src/PhpSpreadsheet/Calculation/TextData.php
+++ b/src/PhpSpreadsheet/Calculation/TextData.php
@@ -273,7 +273,10 @@ class TextData
             $decimals = 0;
         }
         if (!$no_commas) {
-            $valueResult = number_format($valueResult, $decimals);
+            $valueResult = number_format($valueResult, 
+                                         $decimals, 
+                                         StringHelper::getDecimalSeparator(), 
+                                         StringHelper::getThousandsSeparator());
         }
 
         return (string) $valueResult;

--- a/src/PhpSpreadsheet/Calculation/TextData.php
+++ b/src/PhpSpreadsheet/Calculation/TextData.php
@@ -273,10 +273,7 @@ class TextData
             $decimals = 0;
         }
         if (!$no_commas) {
-            $valueResult = number_format($valueResult, 
-                                         $decimals, 
-                                         StringHelper::getDecimalSeparator(), 
-                                         StringHelper::getThousandsSeparator());
+            $valueResult = number_format($valueResult, $decimals);
         }
 
         return (string) $valueResult;


### PR DESCRIPTION
This is:

```
- [x ] a bugfix
- [ ] a new feature
```

Checklist:

- [x ] Changes are covered by unit tests
- [x ] Code style is respected
- [x ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Because the formula function FIXED should return a correct result.