### PR TITLE
Bugfix/invalid cached highest column after column removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- ...
+- Call garbage collector after removing a column to prevent stale cached values
 
 ## [1.9.0] - 2019-08-17
 

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2154,6 +2154,7 @@ class Worksheet implements IComparable
                 $this->getCellCollection()->removeColumn($highestColumn);
                 $highestColumn = Coordinate::stringFromColumnIndex(Coordinate::columnIndexFromString($highestColumn) - 1);
             }
+            $this->garbageCollect();
         } else {
             throw new Exception('Column references should not be numeric.');
         }

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -181,4 +181,65 @@ class WorksheetTest extends TestCase
             $worksheet->getCell('C1')->getValue()
         );
     }
+
+    public function removeColumnProvider(): array
+    {
+        return [
+            'Remove first column' => [
+                [
+                    ['A1', 'B1', 'C1'],
+                    ['A2', 'B2', 'C2'],
+                ],
+                'A',
+                [
+                    ['B1', 'C1'],
+                    ['B2', 'C2'],
+                ],
+                'B',
+            ],
+            'Remove middle column' => [
+                [
+                    ['A1', 'B1', 'C1'],
+                    ['A2', 'B2', 'C2'],
+                ],
+                'B',
+                [
+                    ['A1', 'C1'],
+                    ['A2', 'C2'],
+                ],
+                'B',
+            ],
+            'Remove last column' => [
+                [
+                    ['A1', 'B1', 'C1'],
+                    ['A2', 'B2', 'C2'],
+                ],
+                'C',
+                [
+                    ['A1', 'B1'],
+                    ['A2', 'B2'],
+                ],
+                'B',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider removeColumnProvider
+     */
+    public function testRemoveColumn(
+        array $initialData,
+        string $columnToBeRemoved,
+        array $expectedData,
+        string $expectedHighestColumn
+    ) {
+        $spreadsheet = new Spreadsheet();
+        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet->fromArray($initialData);
+
+        $worksheet->removeColumn($columnToBeRemoved);
+
+        self::assertSame($expectedHighestColumn, $worksheet->getHighestColumn());
+        self::assertSame($expectedData, $worksheet->toArray());
+    }
 }


### PR DESCRIPTION
Otherwise callers of getHighestColumn get stale values

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

It fixes issue #953