### PR TITLE
Bugfix/remove column out of range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Fixed
 
 - Call garbage collector after removing a column to prevent stale cached values
+- Trying to remove a column that doesn't exist deletes the latest column
 
 ## [1.9.0] - 2019-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- ...
+- Call garbage collector after removing a column to prevent stale cached values
 
 ## [1.9.0] - 2019-08-17
 

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2154,6 +2154,7 @@ class Worksheet implements IComparable
                 $this->getCellCollection()->removeColumn($highestColumn);
                 $highestColumn = Coordinate::stringFromColumnIndex(Coordinate::columnIndexFromString($highestColumn) - 1);
             }
+            $this->garbageCollect();
         } else {
             throw new Exception('Column references should not be numeric.');
         }

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2160,8 +2160,10 @@ class Worksheet implements IComparable
         $pColumn = Coordinate::stringFromColumnIndex($pColumnIndex + $pNumCols);
         $objReferenceHelper = ReferenceHelper::getInstance();
         $objReferenceHelper->insertNewBefore($pColumn . '1', -$pNumCols, 0, $this);
-        
-        for ($c = 0; $c < $pNumCols; ++$c) {
+
+        $maxPossibleColumnsToBeRemoved = $highestColumnIndex - $pColumnIndex + 1;
+
+        for ($c = 0, $n = min($maxPossibleColumnsToBeRemoved, $pNumCols); $c < $n; ++$c) {
             $this->getCellCollection()->removeColumn($highestColumn);
             $highestColumn = Coordinate::stringFromColumnIndex(Coordinate::columnIndexFromString($highestColumn) - 1);
         }

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2145,19 +2145,28 @@ class Worksheet implements IComparable
      */
     public function removeColumn($pColumn, $pNumCols = 1)
     {
-        if (!is_numeric($pColumn)) {
-            $highestColumn = $this->getHighestDataColumn();
-            $pColumn = Coordinate::stringFromColumnIndex(Coordinate::columnIndexFromString($pColumn) + $pNumCols);
-            $objReferenceHelper = ReferenceHelper::getInstance();
-            $objReferenceHelper->insertNewBefore($pColumn . '1', -$pNumCols, 0, $this);
-            for ($c = 0; $c < $pNumCols; ++$c) {
-                $this->getCellCollection()->removeColumn($highestColumn);
-                $highestColumn = Coordinate::stringFromColumnIndex(Coordinate::columnIndexFromString($highestColumn) - 1);
-            }
-            $this->garbageCollect();
-        } else {
+        if (is_numeric($pColumn)) {
             throw new Exception('Column references should not be numeric.');
         }
+
+        $highestColumn = $this->getHighestDataColumn();
+        $highestColumnIndex = Coordinate::columnIndexFromString($highestColumn);
+        $pColumnIndex = Coordinate::columnIndexFromString($pColumn);
+
+        if ($pColumnIndex > $highestColumnIndex) {
+            return $this;
+        }
+
+        $pColumn = Coordinate::stringFromColumnIndex($pColumnIndex + $pNumCols);
+        $objReferenceHelper = ReferenceHelper::getInstance();
+        $objReferenceHelper->insertNewBefore($pColumn . '1', -$pNumCols, 0, $this);
+        
+        for ($c = 0; $c < $pNumCols; ++$c) {
+            $this->getCellCollection()->removeColumn($highestColumn);
+            $highestColumn = Coordinate::stringFromColumnIndex(Coordinate::columnIndexFromString($highestColumn) - 1);
+        }
+
+        $this->garbageCollect();
 
         return $this;
     }

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -181,4 +181,65 @@ class WorksheetTest extends TestCase
             $worksheet->getCell('C1')->getValue()
         );
     }
+
+    public function removeColumnProvider(): array
+    {
+        return [
+            'Remove first column' => [
+                [
+                    ['A1', 'B1', 'C1'],
+                    ['A2', 'B2', 'C2'],
+                ],
+                'A',
+                [
+                    ['B1', 'C1'],
+                    ['B2', 'C2'],
+                ],
+                'B',
+            ],
+            'Remove middle column' => [
+                [
+                    ['A1', 'B1', 'C1'],
+                    ['A2', 'B2', 'C2'],
+                ],
+                'B',
+                [
+                    ['A1', 'C1'],
+                    ['A2', 'C2'],
+                ],
+                'B',
+            ],
+            'Remove last column' => [
+                [
+                    ['A1', 'B1', 'C1'],
+                    ['A2', 'B2', 'C2'],
+                ],
+                'C',
+                [
+                    ['A1', 'B1'],
+                    ['A2', 'B2'],
+                ],
+                'B',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider removeColumnProvider
+     */
+    public function testRemoveColumn(
+        array $initialData,
+        string $columnToBeRemoved,
+        array $expectedData,
+        string $expectedHighestColumn
+    ) {
+        $spreadsheet = new Spreadsheet();
+        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet->fromArray($initialData);
+
+        $worksheet->removeColumn($columnToBeRemoved);
+
+        self::assertSame($expectedHighestColumn, $worksheet->getHighestColumn());
+        self::assertSame($expectedData, $worksheet->toArray());
+    }
 }

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -191,6 +191,7 @@ class WorksheetTest extends TestCase
                     ['A2', 'B2', 'C2'],
                 ],
                 'A',
+                1,
                 [
                     ['B1', 'C1'],
                     ['B2', 'C2'],
@@ -203,6 +204,7 @@ class WorksheetTest extends TestCase
                     ['A2', 'B2', 'C2'],
                 ],
                 'B',
+                1,
                 [
                     ['A1', 'C1'],
                     ['A2', 'C2'],
@@ -215,6 +217,7 @@ class WorksheetTest extends TestCase
                     ['A2', 'B2', 'C2'],
                 ],
                 'C',
+                1,
                 [
                     ['A1', 'B1'],
                     ['A2', 'B2'],
@@ -227,11 +230,26 @@ class WorksheetTest extends TestCase
                     ['A2', 'B2', 'C2'],
                 ],
                 'D',
+                1,
                 [
                     ['A1', 'B1', 'C1'],
                     ['A2', 'B2', 'C2'],
                 ],
                 'C',
+            ],
+            'Remove multiple columns' => [
+                [
+                    ['A1', 'B1', 'C1'],
+                    ['A2', 'B2', 'C2'],
+                ],
+                'B',
+                5,
+                [
+                    ['A1'],
+                    ['A2'],
+                ],
+                'A',
+            ],
         ];
     }
 
@@ -241,6 +259,7 @@ class WorksheetTest extends TestCase
     public function testRemoveColumn(
         array $initialData,
         string $columnToBeRemoved,
+        int $columnsToBeRemoved,
         array $expectedData,
         string $expectedHighestColumn
     ) {
@@ -248,7 +267,7 @@ class WorksheetTest extends TestCase
         $worksheet = $spreadsheet->getActiveSheet();
         $worksheet->fromArray($initialData);
 
-        $worksheet->removeColumn($columnToBeRemoved);
+        $worksheet->removeColumn($columnToBeRemoved, $columnsToBeRemoved);
 
         self::assertSame($expectedHighestColumn, $worksheet->getHighestColumn());
         self::assertSame($expectedData, $worksheet->toArray());

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -221,6 +221,17 @@ class WorksheetTest extends TestCase
                 ],
                 'B',
             ],
+            'Remove a column out of range' => [
+                [
+                    ['A1', 'B1', 'C1'],
+                    ['A2', 'B2', 'C2'],
+                ],
+                'D',
+                [
+                    ['A1', 'B1', 'C1'],
+                    ['A2', 'B2', 'C2'],
+                ],
+                'C',
         ];
     }
 


### PR DESCRIPTION
Fix remove a column out of range removes the last column
```
Given:
+---+---+
| A | B |
+---+---+
When: Attempting to remove 'D'
Then: The worksheet should not be altered
```
The current behaviour is:
```
Given:
+---+---+
| A | B |
+---+---+
When: Attempting to remove 'D'
Then:
+---+
| A |
+---+
```

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

It fixes issue #953