### PR TITLE
support "showZeros" setting in Excel advanced worksheet options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Added
 
 - Implementation of IFNA() logical function
+- Support "showZeros" worksheet option to change how Excel shows and handles "null" values returned from a calculation
 
 ### Fixed
 

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -2813,7 +2813,7 @@ class Calculation
         }
         self::$returnArrayAsType = $returnArrayAsType;
 
-        if ($result === null && $pCell->getWorksheet()->getSheetView()->isShowZeros()) {
+        if ($result === null && $pCell->getWorksheet()->getSheetView()->getShowZeros()) {
             return 0;
         } elseif ((is_float($result)) && ((is_nan($result)) || (is_infinite($result)))) {
             return Functions::NAN();

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -2813,7 +2813,7 @@ class Calculation
         }
         self::$returnArrayAsType = $returnArrayAsType;
 
-        if ($result === null) {
+        if ($result === null && $pCell->getWorksheet()->getSheetView()->isShowZeros()) {
             return 0;
         } elseif ((is_float($result)) && ((is_nan($result)) || (is_infinite($result)))) {
             return Functions::NAN();

--- a/src/PhpSpreadsheet/Reader/Xlsx/SheetViews.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/SheetViews.php
@@ -24,6 +24,7 @@ class SheetViews extends BaseParserClass
         $this->gridLines();
         $this->headers();
         $this->direction();
+        $this->showZeros();
 
         if (isset($this->sheetViewXml->pane)) {
             $this->pane();
@@ -88,6 +89,15 @@ class SheetViews extends BaseParserClass
         if (isset($this->sheetViewXml['rightToLeft'])) {
             $this->worksheet->setRightToLeft(
                 self::boolean((string) $this->sheetViewXml['rightToLeft'])
+            );
+        }
+    }
+
+    private function showZeros()
+    {
+        if (isset($this->sheetViewXml['showZeros'])) {
+            $this->worksheet->getSheetView()->setShowZeros(
+                self::boolean((string) $this->sheetViewXml['showZeros'])
             );
         }
     }

--- a/src/PhpSpreadsheet/Worksheet/SheetView.php
+++ b/src/PhpSpreadsheet/Worksheet/SheetView.php
@@ -36,6 +36,16 @@ class SheetView
     private $zoomScaleNormal = 100;
 
     /**
+     * ShowZeros.
+     *
+     * If true, "null" values from a calculation will be shown as "0". This is the default Excel behaviour and can be changed
+     * with the advanced worksheet option "Show a zero in cells that have zero value"
+     *
+     * @var bool
+     */
+    private $showZeros = true;
+
+    /**
      * View.
      *
      * Valid values range from 10 to 400.
@@ -113,6 +123,24 @@ class SheetView
         }
 
         return $this;
+    }
+
+    /**
+     * Set ShowZeroes setting.
+     *
+     * @param bool $pValue
+     */
+    public function setShowZeros($pValue)
+    {
+        $this->showZeros = $pValue;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isShowZeros()
+    {
+        return $this->showZeros;
     }
 
     /**

--- a/src/PhpSpreadsheet/Worksheet/SheetView.php
+++ b/src/PhpSpreadsheet/Worksheet/SheetView.php
@@ -138,7 +138,7 @@ class SheetView
     /**
      * @return bool
      */
-    public function isShowZeros()
+    public function getShowZeros()
     {
         return $this->showZeros;
     }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -221,6 +221,11 @@ class Worksheet extends WriterPart
             $objWriter->writeAttribute('zoomScaleNormal', $pSheet->getSheetView()->getZoomScaleNormal());
         }
 
+        // Show zeros (Excel also writes this attribute only if set to false)
+        if ($pSheet->getSheetView()->isShowZeros() === false) {
+            $objWriter->writeAttribute('showZeros', 0);
+        }
+
         // View Layout Type
         if ($pSheet->getSheetView()->getView() !== SheetView::SHEETVIEW_NORMAL) {
             $objWriter->writeAttribute('view', $pSheet->getSheetView()->getView());

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -222,7 +222,7 @@ class Worksheet extends WriterPart
         }
 
         // Show zeros (Excel also writes this attribute only if set to false)
-        if ($pSheet->getSheetView()->isShowZeros() === false) {
+        if ($pSheet->getSheetView()->getShowZeros() === false) {
             $objWriter->writeAttribute('showZeros', 0);
         }
 


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [x] a new feature
```
Fixes #1196 

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

If you reference a cell with "=A2" and A2 contains nothing, the result of this calculation is a 0 (number) and not NULL (empty cell) as you would expect.

The default Excel behaviour is to show 0 when a calculation or reference returns null.

This behaviour can be changed with the view setting "Show a zero in cells that have zero value" (see: https://support.office.com/en-us/article/display-or-hide-zero-values-3ec7a433-46b8-4516-8085-a00e9e476b03). 

If this option is set to false (0), then Excel shows an empty cell in these cases.

This pull requests changes the following:

- The normal behaviour is not changed at all
- If you set "showZeros" to false (through WorkheetView->setShowZeros(false)) - OR by working with an Excel file containing this option - then this will happen:
  - if the result of "getCalculatedValue" is null, then null is returned
  - the "showZeros" setting is also saved to the generated XLSX.

It might be debatable if the current behaviour of getCalculatedValue (always convert NULL to 0) is correct.
