### PR TITLE
Do not export .github folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 /tests export-ignore
 README.md export-ignore
 *.min.js binary
+/.github export-ignore


### PR DESCRIPTION
Just came across this. I do not think this is necessary. Keeps the built artifacts smaller and tidy.