### PR TITLE
Allow Html Reader to write into existing spreadsheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Improve performance of IF function calls via ranch pruning to avoid resolution of every branches [#844](https://github.com/PHPOffice/PhpSpreadsheet/pull/844)
 - MATCH function supports `*?~` Excel functionality, when match_type=0 [#1116](https://github.com/PHPOffice/PhpSpreadsheet/issues/1116)
 - Allow HTML Reader to accept HTML as a string [#1136](https://github.com/PHPOffice/PhpSpreadsheet/pull/1136)
+- Allow HTML Reader to accept HTML as a string into an existing spreadsheet [#1212](https://github.com/PHPOffice/PhpSpreadsheet/pull/1212)
 
 ### Fixed
 

--- a/docs/topics/reading-and-writing-to-file.md
+++ b/docs/topics/reading-and-writing-to-file.md
@@ -902,3 +902,27 @@ $spreadsheet = $reader->loadFromString($htmlString);
 $writer = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($spreadsheet, 'Xls');
 $writer->save('write.xls'); 
 ```
+
+Suppose you have multiple worksheets you'd like created from html. This can be 
+accomplished as follows.
+
+```php
+$firstHtmlString = '<table>
+                  <tr>
+                      <td>Hello World</td>
+                  </tr>
+              </table>';
+$secondHtmlString = '<table>
+                  <tr>
+                      <td>Hello World</td>
+                  </tr>
+              </table>';
+
+$reader = new \PhpOffice\PhpSpreadsheet\Reader\Html();
+$spreadsheet = $reader->loadFromString($firstHtmlString);
+$reader->setSheetIndex(1);
+$spreadhseet = $reader->loadFromString($secondHtmlString, $spreadsheet);
+
+$writer = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($spreadsheet, 'Xls');
+$writer->save('write.xls');
+```

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -606,8 +606,8 @@ class Html extends BaseReader
     /**
      * Spreadsheet from content.
      *
-     * @param string           $content
-     * @param Spreadsheet|null $spreadsheet
+     * @param string $content
+     * @param null|Spreadsheet $spreadsheet
      *
      * @return Spreadsheet
      */

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -606,13 +606,12 @@ class Html extends BaseReader
     /**
      * Spreadsheet from content.
      *
-     * @param string $content
-     *
-     * @throws Exception
+     * @param string           $content
+     * @param Spreadsheet|null $spreadsheet
      *
      * @return Spreadsheet
      */
-    public function loadFromString($content): Spreadsheet
+    public function loadFromString($content, ?Spreadsheet $spreadsheet = null): Spreadsheet
     {
         //    Create a new DOM object
         $dom = new DOMDocument();
@@ -622,7 +621,7 @@ class Html extends BaseReader
             throw new Exception('Failed to load content as a DOM Document');
         }
 
-        return $this->loadDocument($dom, new Spreadsheet());
+        return $this->loadDocument($dom, $spreadsheet ?? new Spreadsheet());
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Reader/HtmlTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/HtmlTest.php
@@ -329,6 +329,48 @@ class HtmlTest extends TestCase
         $this->assertContains("\n", $cellValue);
     }
 
+    public function testCanLoadFromStringIntoExistingSpreadsheet()
+    {
+        $html = '<table>
+                    <tr>
+                        <td>Hello World</td>
+                    </tr>
+                    <tr>
+                        <td>Hello<br />World</td>
+                    </tr>
+                    <tr>
+                        <td>Hello<br>World</td>
+                    </tr>
+                </table>';
+        $reader = new Html();
+        $spreadsheet = $reader->loadFromString($html);
+        $firstSheet = $spreadsheet->getSheet(0);
+
+        $cellStyle = $firstSheet->getStyle('A1');
+        self::assertFalse($cellStyle->getAlignment()->getWrapText());
+
+        $cellStyle = $firstSheet->getStyle('A2');
+        self::assertTrue($cellStyle->getAlignment()->getWrapText());
+        $cellValue = $firstSheet->getCell('A2')->getValue();
+        $this->assertContains("\n", $cellValue);
+
+        $cellStyle = $firstSheet->getStyle('A3');
+        self::assertTrue($cellStyle->getAlignment()->getWrapText());
+        $cellValue = $firstSheet->getCell('A3')->getValue();
+        $this->assertContains("\n", $cellValue);
+
+        $reader->setSheetIndex(1);
+        $html = '<table>
+                    <tr>
+                        <td>Goodbye World</td>
+                    </tr>
+                </table>';
+
+        self::assertEquals(1, $spreadsheet->getSheetCount());
+        $spreadsheet = $reader->loadFromString($html, $spreadsheet);
+        self::assertEquals(2, $spreadsheet->getSheetCount());
+    }
+
     /**
      * @param string $html
      *


### PR DESCRIPTION
Sometimes you may want to read html into multiple worksheets within one
spreadsheet. Allowing the passing of a spreadsheet in makes this possible.

This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
Its cumbersome to use the reader to create multiple worksheets within one spreadsheet from html content. This allows us to pass in a pre-existing spreadsheet object.