### PR TITLE
Fix in XLSX Reader -> Trying to access array offset on value of type null 

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -163,7 +163,7 @@ class Styles extends BaseParserClass
             self::readBorderStyle($docStyle->getBorders(), $style->border);
         }
 
-        if (isset($style->alignment)) {
+        if (isset($style->alignment->alignment)) {
             self::readAlignmentStyle($docStyle->getAlignment(), $style->alignment);
         }
 


### PR DESCRIPTION
Fix for error `Trying to access array offset on value of type null on PhpSpreadsheet\Reader\Xlsx\Styles.php(133)` when reading XLSX file.

PHP Version: 7.4

There is an error when reading specific XLSX files. Testfile is attached.
[test.xlsx](https://github.com/PHPOffice/PhpSpreadsheet/files/3782711/test.xlsx)

Testscript:

	$path = __DIR__ . "/test.xlsx";
	$reader = IOFactory::createReaderForFile($path);
	$reader->load($path);

The method `self::readAlignmentStyle` cannot be called with an empty `alignment` SimpleXml object, it requires the attribute `alignment` to be present.

I don't have time to write unit tests for this, sorry.
