### PR TITLE
Add vertical cell merge setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Implementation of IFNA() logical function
 - Support "showZeros" worksheet option to change how Excel shows and handles "null" values returned from a calculation
+- Ability to disable vertical cell merging
 
 ### Fixed
 

--- a/docs/topics/settings.md
+++ b/docs/topics/settings.md
@@ -43,3 +43,16 @@ More details of the features available once a locale has been set,
 including a list of the languages and locales currently supported, can
 be found in [Locale Settings for
 Formulae](./recipes.md#locale-settings-for-formulae).
+
+## Vertical cell merging
+
+By default, PhpSpreadsheet will merge vertical cells as expected. If you are
+utilizing cell auto-sizing and merge cells within your worksheet, disabling
+vertical cell merging can significantly speed up the time it takes to
+save the worksheet.
+
+To disable vertical cell merging, you can add the following:
+
+``` php
+\PhpOffice\PhpSpreadsheet\Settings::setMergeVerticalCells(false);
+```

--- a/src/PhpSpreadsheet/Settings.php
+++ b/src/PhpSpreadsheet/Settings.php
@@ -45,6 +45,14 @@ class Settings
     private static $cache;
 
     /**
+     * Determines if we should process vertical cell merges or not.
+     * Default value is true and will merge vertical cells.
+     *
+     * @var bool
+     */
+    private static $mergeVerticalCells = true;
+
+    /**
      * Set the locale code to use for formula translations and any special formatting.
      *
      * @param string $locale The locale code to use (e.g. "fr" or "pt_br" or "en_uk")
@@ -163,5 +171,25 @@ class Settings
         }
 
         return self::$cache;
+    }
+
+    /**
+     * Sets the vertical cell merge setting.
+     *
+     * @param bool $enable
+     */
+    public static function setMergeVerticalCells(bool $option)
+    {
+        self::$mergeVerticalCells = $option;
+    }
+
+    /**
+     * Gets the vertical cell merge setting.
+     *
+     * @return bool
+     */
+    public static function shouldMergeVerticalCells()
+    {
+        return self::$mergeVerticalCells;
     }
 }

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -24,6 +24,7 @@ use PhpOffice\PhpSpreadsheet\Style\Color;
 use PhpOffice\PhpSpreadsheet\Style\Conditional;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Style\Style;
+use PhpOffice\PhpSpreadsheet\Settings;
 
 class Worksheet implements IComparable
 {
@@ -739,8 +740,8 @@ class Worksheet implements IComparable
                     //By default merged cells should be ignored
                     $isMergedButProceed = false;
 
-                    //The only exception is if it's a merge range value cell of a 'vertical' randge (1 column wide)
-                    if ($isMerged && $cell->isMergeRangeValueCell()) {
+                    //The only exception is if it's a merge range value cell of a 'vertical' range (1 column wide)
+                    if (Settings::shouldMergeVerticalCells() && $isMerged && $cell->isMergeRangeValueCell()) {
                         $range = $cell->getMergeRange();
                         $rangeBoundaries = Coordinate::rangeDimension($range);
                         if ($rangeBoundaries[0] == 1) {

--- a/tests/PhpSpreadsheetTests/SettingsTest.php
+++ b/tests/PhpSpreadsheetTests/SettingsTest.php
@@ -37,4 +37,16 @@ class SettingsTest extends TestCase
         self::assertTrue((bool) ((LIBXML_DTDLOAD | LIBXML_DTDATTR | LIBXML_DTDVALID) & $result));
         self::assertFalse(libxml_disable_entity_loader());
     }
+
+    public function testMergeVerticalCellsSetting()
+    {
+        // Test initial (default) case.
+        $initialSetting = Settings::shouldMergeVerticalCells();
+        self::assertTrue($initialSetting);
+
+        // Test setting / getting new value.
+        Settings::setMergeVerticalCells(false);
+        $newSetting = Settings::shouldMergeVerticalCells();
+        self::assertFalse($newSetting);
+    }
 }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

We are upgrading from PhpExcel to this library. The migration was very smooth, but our XLS file generation went from 2 seconds to over 50 seconds. We hooked up Xhprof and found a function that was making over 900k function calls when generating our workbook. Turns out that function does a lot of checks but doesn't effect our output. To remedy our issue, I've added a global setting that disables that code path. The default value matches the existing behavior, so anyone that upgrades will not see any changes in functionality.