### PR TITLE
Save the PHP 7.0.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "phpoffice/phpspreadsheet",
+    "name": "thaldos/phpspreadsheet",
     "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
     "keywords": ["PHP", "OpenXML", "Excel", "xlsx", "xls", "ods", "gnumeric", "spreadsheet"],
     "homepage": "https://github.com/PHPOffice/PhpSpreadsheet",

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -2458,6 +2458,8 @@ class Calculation
         $language = $locale = strtolower($locale);
         if (strpos($locale, '_') !== false) {
             [$language] = explode('_', $locale);
+            $exploded = explode('_', $locale);
+            $language = reset($exploded);
         }
         if (count(self::$validLocaleLanguages) == 1) {
             self::loadLocales();


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
```

Checklist:

- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

In PHP 7.0.x the Calculation.php file throws the error :
Parse error: syntax error, unexpected '=' in phpspreadsheet/src/PhpSpreadsheet/Calculation/Calculation.php on line 2460

You can see on this snippet : http://sandbox.onlinephpfunctions.com/code/12d20ff992200b59c2a62341ba74eec5a2b951d2

With my modifications, it works gracefully on PHP 7.0.x