### PR TITLE
Calculation formula correction

### DIFF
--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -271,9 +271,9 @@ class Cell
                     return $this->calculatedValue; // Fallback for calculations referencing external files.
                 }
 
-                throw new \PhpOffice\PhpSpreadsheet\Calculation\Exception(
-                    $this->getWorksheet()->getTitle() . '!' . $this->getCoordinate() . ' -> ' . $ex->getMessage()
-                );
+                //throw new \PhpOffice\PhpSpreadsheet\Calculation\Exception(
+                //    $this->getWorksheet()->getTitle() . '!' . $this->getCoordinate() . ' -> ' . $ex->getMessage()
+                //);
             }
 
             if ($result === '#Not Yet Implemented') {


### PR DESCRIPTION
When the formula cell returns an error value, throwing an exception causes the read to terminate, hoping to return a null value instead of the exception hint.

This is:

```
- [ ] a bugfix
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected

### Why this change is needed?
