### PR TITLE
Modify XLSX RW to keep decimal for floats with a zero decimal part

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -727,15 +727,6 @@ class Xlsx extends BaseReader
 
                                         // read empty cells or the cells are not empty
                                         if ($this->readEmptyCells || ($value !== null && $value !== '')) {
-                                            // Check for numeric values
-                                            if (is_numeric($value) && $cellDataType != 's') {
-                                                if ($value == (int) $value) {
-                                                    $value = (int) $value;
-                                                } elseif ($value == (float) $value) {
-                                                    $value = (float) $value;
-                                                }
-                                            }
-
                                             // Rich text?
                                             if ($value instanceof RichText && $this->readDataOnly) {
                                                 $value = $value->getPlainText();

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1135,6 +1135,13 @@ class Worksheet extends WriterPart
 
                     break;
                 case 'n':            // Numeric
+                    //force a decimal to be written if the type is float
+                    if (is_float($cellValue)) {
+                        $cellValue = (string) $cellValue;
+                        if (strpos($cellValue, '.') === false) {
+                            $cellValue = $cellValue . '.0';
+                        }
+                    }
                     // force point as decimal separator in case current locale uses comma
                     $objWriter->writeElement('v', str_replace(',', '.', $cellValue));
 

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/FloatsRetainedTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/FloatsRetainedTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Reader\Xlsx as Reader;
+use PhpOffice\PhpSpreadsheet\Settings;
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as Writer;
+use PHPUnit\Framework\TestCase;
+
+class FloatsRetainedTest extends TestCase
+{
+    /**
+     * @dataProvider providerIntyFloatsRetainedByWriter
+     *
+     * @param float|int $value
+     */
+    public function testIntyFloatsRetainedByWriter($value)
+    {
+        $outputFilename = tempnam(File::sysGetTempDir(), 'phpspreadsheet-test');
+        Settings::setLibXmlLoaderOptions(null);
+        $sheet = new Spreadsheet();
+        $sheet->getActiveSheet()->getCell('A1')->setValue($value);
+
+        $writer = new Writer($sheet);
+        $writer->save($outputFilename);
+
+        $reader = new Reader();
+        $sheet = $reader->load($outputFilename);
+
+        $this->assertSame($value, $sheet->getActiveSheet()->getCell('A1')->getValue());
+    }
+
+    public function providerIntyFloatsRetainedByWriter()
+    {
+        return [
+            [-1.0],
+            [-1],
+            [0.0],
+            [0],
+            [1.0],
+            [1],
+            [1e-3],
+            [1.3e-10],
+            [1e10],
+            [3.00000000000000000001],
+            [99999999999999999],
+            [99999999999999999.0],
+            [999999999999999999999999999999999999999999],
+            [999999999999999999999999999999999999999999.0],
+        ];
+    }
+}


### PR DESCRIPTION
This is:
- [x] a bugfix

### Why this change is needed?
```
Prior to 1.10, all numeric values where read as floats. In 1.10
numeric values are read using 0 + x, which relies on PHP type
juggling rules. As a result, float(0.0) is written as string('0'),
then read back as int(0). This fix causes the writer to retain the
the decimal for float values such that a reader can differentiate
floats from ints.
```



Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

