### PR TITLE
CALCULATION_REGEXP_CELLREF is not sufficiently robust.

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -25,7 +25,7 @@ class Calculation
     //    Function (allow for the old @ symbol that could be used to prefix a function, but we'll ignore it)
     const CALCULATION_REGEXP_FUNCTION = '@?(?:_xlfn\.)?([A-Z][A-Z0-9\.]*)[\s]*\(';
     //    Cell reference (cell or range of cells, with or without a sheet reference)
-    const CALCULATION_REGEXP_CELLREF = '((([^\s,!&%^\/\*\+<>=-]*)|(\'[^\']*\')|(\"[^\"]*\"))!)?\$?([a-z]{1,3})\$?(\d{1,7})';
+    const   CALCULATION_REGEXP_CELLREF = '((([^\s,!&%^\/\*\+<>=-]*)|(\'[^\']*\')|(\"[^\"]*\"))!)?\$?\b([a-z]{1,3})\$?(\d{1,7})(?![\w.])';
     //    Named Range of cells
     const CALCULATION_REGEXP_NAMEDRANGE = '((([^\s,!&%^\/\*\+<>=-]*)|(\'[^\']*\')|(\"[^\"]*\"))!)?([_A-Z][_A-Z0-9\.]*)';
     //    Error

--- a/tests/PhpSpreadsheetTests/Calculation/DefinedNameConfusedForCellTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/DefinedNameConfusedForCellTest.php
@@ -6,6 +6,22 @@ use PHPUnit\Framework\TestCase;
 
 class DefinedNameConfusedForCellTest extends TestCase
 {
+    const FILENAM = 'calcerror';
+    const TYP = 'Xlsx';
+
+    private static function getfilename()
+    {
+        return self::FILENAM . '.' . strtolower(self::TYP);
+    }
+
+    public function tearDown()
+    {
+        $out = self::getfilename();
+        if (file_exists($out)) {
+            unlink($out);
+        }
+    }
+
     public function testDefinedName()
     {
         $obj = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
@@ -13,16 +29,9 @@ class DefinedNameConfusedForCellTest extends TestCase
         $sheet0->setCellValue('A1', 2);
         $obj->addNamedRange(new \PhpOffice\PhpSpreadsheet\NamedRange('A1A', $sheet0, 'A1'));
         $sheet0->setCellValue('B1', '=2*A1A');
-        $writer = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($obj, 'Xlsx');
-        $out = 'calcerror.xlsx';
-
-        try {
-            $writer->save($out);
-        } catch (\Exception $e) {
-            unlink($out);
-            $this->fail();
-        }
-        unlink($out);
-        $this->assertTrue(true);
+        $writer = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($obj, self::TYP);
+        $out = self::getfilename();
+        $writer->save($out);
+        self::assertTrue(true);
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/DefinedNameConfusedForCellTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/DefinedNameConfusedForCellTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Calculation;
+
+use PHPUnit\Framework\TestCase;
+
+class DefinedNameConfusedForCellTest extends TestCase
+{
+    public function testDefinedName()
+    {
+        $obj = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
+        $sheet0 = $obj->setActiveSheetIndex(0);
+        $sheet0->setCellValue('A1', 2);
+        $obj->addNamedRange(new \PhpOffice\PhpSpreadsheet\NamedRange('A1A', $sheet0, 'A1'));
+        $sheet0->setCellValue('B1', '=2*A1A');
+        $writer = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($obj, 'Xlsx');
+        $out = 'calcerror.xlsx';
+
+        try {
+            $writer->save($out);
+        } catch (Exception $e) {
+            @unlink($out);
+            $this->fail();
+        }
+        unlink($out);
+        $this->assertTrue(true);
+    }
+}

--- a/tests/PhpSpreadsheetTests/Calculation/DefinedNameConfusedForCellTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/DefinedNameConfusedForCellTest.php
@@ -18,8 +18,8 @@ class DefinedNameConfusedForCellTest extends TestCase
 
         try {
             $writer->save($out);
-        } catch (Exception $e) {
-            @unlink($out);
+        } catch (\Exception $e) {
+            unlink($out);
             $this->fail();
         }
         unlink($out);


### PR DESCRIPTION
It treats some perfectly legal defined names, e.g. A1A, as cell refs.
When the Xlsx Writer tries to save a worksheet which uses such a name
in a formula in a cell, it throws an exception.
The new DefinedNameConfusedForCellTest is a simple demonstration.
The Regexp has been changed to ensure the name starts on a Word boundary,
   and to make sure it is not followed by a word character or period.
This fixes the problem, and does not appear to cause any regression
   problems in the test suite.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
Bug fix, as described above. I am not sure how to go about adding a summary of the change to
CHANGELOG.md - that seems to be something that the project maintainer would do.
No documentation change is required.
