### PR TITLE
Handle Error in Formula Processing Better for Xls

### DIFF
--- a/tests/PhpSpreadsheetTests/Writer/Xls/FormulaErrTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/FormulaErrTest.php
@@ -2,23 +2,18 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Writer\Xls\Workbook;
 
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\NamedRange;
+use PhpOffice\PhpSpreadsheet\Shared\File;
 use PHPUnit\Framework\TestCase;
 
 class FormulaErrTest extends TestCase
 {
-    const FILENAM = 'formulaerr';
-    const TYP = 'Xls';
-
-    private static function getfilename()
-    {
-        return self::FILENAM . '.' . strtolower(self::TYP);
-    }
-
     public function tearDown()
     {
-        $out = self::getfilename();
-        if (file_exists($out)) {
-            unlink($out);
+        $filename = tempnam(File::sysGetTempDir(), 'phpspreadsheet-test');
+        if (file_exists($filename)) {
+            unlink($filename);
         }
     }
 
@@ -27,18 +22,24 @@ class FormulaErrTest extends TestCase
         $obj = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
         $sheet0 = $obj->setActiveSheetIndex(0);
         $sheet0->setCellValue('A1', 2);
-        $obj->addNamedRange(new \PhpOffice\PhpSpreadsheet\NamedRange('DEFNAM', $sheet0, 'A1'));
+        $obj->addNamedRange(new NamedRange('DEFNAM', $sheet0, 'A1'));
         $sheet0->setCellValue('B1', '=2*DEFNAM');
-        $outtype = self::TYP;
-        $writer = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($obj, $outtype);
-        $out = self::getfilename();
-        $writer->save($out);
-        $reader = \PhpOffice\PhpSpreadsheet\IOFactory::createReader($outtype);
-        $robj = $reader->load($out);
+        $sheet0->setCellValue('C1', '=DEFNAM=2');
+        $sheet0->setCellValue('D1', '=CONCAT("X",DEFNAM)');
+        $writer = IOFactory::createWriter($obj, 'Xls');
+        $filename = tempnam(File::sysGetTempDir(), 'phpspreadsheet-test');
+        $writer->save($filename);
+        $reader = IOFactory::createReader('Xls');
+        $robj = $reader->load($filename);
         $sheet0 = $robj->setActiveSheetIndex(0);
         $a1 = $sheet0->getCell('A1')->getCalculatedValue();
         self::assertEquals(2, $a1);
         $b1 = $sheet0->getCell('B1')->getCalculatedValue();
         self::assertEquals(4, $b1);
+        $c1 = $sheet0->getCell('C1')->getCalculatedValue();
+        $tru = true;
+        self::assertEquals($tru, $c1);
+        $d1 = $sheet0->getCell('D1')->getCalculatedValue();
+        self::assertEquals('X2', $d1);
     }
 }

--- a/tests/PhpSpreadsheetTests/Writer/Xls/FormulaErrTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/FormulaErrTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xls\Workbook;
+
+use PHPUnit\Framework\TestCase;
+
+class FormulaErrTest extends TestCase
+{
+    const FILENAM = 'formulaerr';
+    const TYP = 'Xls';
+
+    private static function getfilename()
+    {
+        return self::FILENAM . '.' . strtolower(self::TYP);
+    }
+
+    public function tearDown()
+    {
+        $out = self::getfilename();
+        if (file_exists($out)) {
+            unlink($out);
+        }
+    }
+
+    public function testFormulaError()
+    {
+        $obj = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
+        $sheet0 = $obj->setActiveSheetIndex(0);
+        $sheet0->setCellValue('A1', 2);
+        $obj->addNamedRange(new \PhpOffice\PhpSpreadsheet\NamedRange('DEFNAM', $sheet0, 'A1'));
+        $sheet0->setCellValue('B1', '=2*DEFNAM');
+        $outtype = self::TYP;
+        $writer = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($obj, $outtype);
+        $out = self::getfilename();
+        $writer->save($out);
+        $reader = \PhpOffice\PhpSpreadsheet\IOFactory::createReader($outtype);
+        $robj = $reader->load($out);
+        $sheet0 = $robj->setActiveSheetIndex(0);
+        $a1 = $sheet0->getCell('A1')->getCalculatedValue();
+        self::assertEquals(2, $a1);
+        $b1 = $sheet0->getCell('B1')->getCalculatedValue();
+        self::assertEquals(4, $b1);
+    }
+}


### PR DESCRIPTION
When there is an error writing a formula to an Xls file,
which seems to happen when a defined name is part of a formula,
the cell is currently left blank. A better result would be to
write the calculated value of the formula.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
Bug fix, as described in the commit message.

No documentation change required.
I have not changed CHANGELOG.md, as that seems more like something the
   project maintainer should do.
