### PR TITLE
Prevent problems with locales setting

### DIFF
--- a/src/PhpSpreadsheet/Writer/Ods/Content.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Content.php
@@ -314,7 +314,7 @@ class Content extends WriterPart
             }
 
             if ($size = $font->getSize()) {
-                $writer->writeAttribute('fo:font-size', sprintf('%.1fpt', $size));
+                $writer->writeAttribute('fo:font-size', sprintf('%.1Fpt', $size));
             }
 
             if ($font->getUnderline() && $font->getUnderline() != Font::UNDERLINE_NONE) {


### PR DESCRIPTION
Prevent invalid value if locale decimal separator is comma

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
