### PR TITLE
fix customer conditional format parse bug.

### DIFF
--- a/src/PhpSpreadsheet/Style/NumberFormat.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat.php
@@ -180,6 +180,11 @@ class NumberFormat extends Supervisor
      */
     public function setFormatCode($pValue)
     {
+        // in Xlsx.php row:570 get customer conditional format,styleXml->dxfs->dxf is SimpleXMLElement array,so this need process it. -- by PonyHu@Mulgor
+        if($pValue instanceof \SimpleXMLElement){
+            $attributes = $pValue->attributes();
+            $pValue = (String)$attributes['formatCode'];
+        }
         if ($pValue == '') {
             $pValue = self::FORMAT_GENERAL;
         }


### PR DESCRIPTION
This is:

```
- [* ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
in Xlsx.php row:570 parse and set customer conditional format, styleXml->dxfs->dxf is SimpleXMLElement array, so this need process it.