### PR TITLE
fix customer format read bug.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,11 @@
 {
-    "name": "mulgor/phpspreadsheet",
-    "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine,forked from https://github.com/PHPOffice/PhpSpreadsheet, and fix bug",
+    "name": "phpoffice/phpspreadsheet",
+    "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
     "keywords": ["PHP", "OpenXML", "Excel", "xlsx", "xls", "ods", "gnumeric", "spreadsheet"],
-    "homepage": "https://github.com/mulgor/Mulgor-PhpSpreadsheet",
+    "homepage": "https://github.com/PHPOffice/PhpSpreadsheet",
     "type": "library",
     "license": "MIT",
     "authors": [
-        {
-            "name": "Pony Hu",
-            "homepage": "https://github.com/mulgor"
-        },
         {
             "name": "Maarten Balliauw",
             "homepage": "https://blog.maartenballiauw.be"

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
-    "name": "phpoffice/phpspreadsheet",
-    "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
+    "name": "mulgor/phpspreadsheet",
+    "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine,forked from https://github.com/PHPOffice/PhpSpreadsheet, and fix bug",
     "keywords": ["PHP", "OpenXML", "Excel", "xlsx", "xls", "ods", "gnumeric", "spreadsheet"],
-    "homepage": "https://github.com/PHPOffice/PhpSpreadsheet",
+    "homepage": "https://github.com/mulgor/Mulgor-PhpSpreadsheet",
     "type": "library",
     "license": "MIT",
     "authors": [
+        {
+            "name": "Pony Hu",
+            "homepage": "https://github.com/mulgor"
+        },
         {
             "name": "Maarten Balliauw",
             "homepage": "https://blog.maartenballiauw.be"

--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -149,7 +149,16 @@ class Styles extends BaseParserClass
 
     private function readStyle(Style $docStyle, $style)
     {
-        $docStyle->getNumberFormat()->setFormatCode($style->numFmt);
+        $formatCode = $style->numFmt;
+        if($formatCode instanceof \SimpleXMLElement){
+            if(isset($formatCode['formatCode'])){
+                $formatCode = (String)$formatCode['formatCode'];
+            }
+            else{
+                $formatCode = '';
+            }
+        }
+        $docStyle->getNumberFormat()->setFormatCode($formatCode);
 
         if (isset($style->font)) {
             self::readFontStyle($docStyle->getFont(), $style->font);

--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -152,7 +152,7 @@ class Styles extends BaseParserClass
         $formatCode = $style->numFmt;
         if ($formatCode instanceof \SimpleXMLElement) {
             if (isset($formatCode['formatCode'])) {
-                $formatCode = (String)$formatCode['formatCode'];
+                $formatCode = (string) $formatCode['formatCode'];
             }
             else {
                 $formatCode = '';

--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -150,11 +150,11 @@ class Styles extends BaseParserClass
     private function readStyle(Style $docStyle, $style)
     {
         $formatCode = $style->numFmt;
-        if($formatCode instanceof \SimpleXMLElement){
-            if(isset($formatCode['formatCode'])){
+        if ($formatCode instanceof \SimpleXMLElement) {
+            if (isset($formatCode['formatCode'])) {
                 $formatCode = (String)$formatCode['formatCode'];
             }
-            else{
+            else {
                 $formatCode = '';
             }
         }

--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -153,8 +153,7 @@ class Styles extends BaseParserClass
         if ($formatCode instanceof \SimpleXMLElement) {
             if (isset($formatCode['formatCode'])) {
                 $formatCode = (string) $formatCode['formatCode'];
-            }
-            else {
+            } else {
                 $formatCode = '';
             }
         }

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -645,7 +645,25 @@ class Html extends BaseWriter
                     $filename = htmlspecialchars($filename);
 
                     $html .= PHP_EOL;
-                    if ((!$this->embedImages) || ($this->isPdf)) {
+                    if (strpos($filename,'zip://') === 0) {
+                        $imageDetails = getimagesize($filename);
+                        if ($fp = fopen($filename, 'rb', 0)) {
+                            $picture = '';
+                            while (!feof($fp)) {
+                                $picture .= fread($fp, 1024);
+                            }
+                            fclose($fp);
+                            // base64 encode the binary data
+                            $base64 = base64_encode($picture); 
+                            // if not pdf, break it into chunks according to RFC 2045 semantics
+                            if (!$this->isPdf) {
+                                $base64 = chunk_split(base64_encode($picture));
+                            }
+                            $imageData = 'data:' . $imageDetails['mime'] . ';base64,' . $base64;
+                        } else {
+                            $imageData = $filename;
+                        }
+                    } else if ((!$this->embedImages) || ($this->isPdf)) {
                         $imageData = $filename;
                     } else {
                         $imageDetails = getimagesize($filename);

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -654,7 +654,7 @@ class Html extends BaseWriter
                             }
                             fclose($fp);
                             // base64 encode the binary data
-                            $base64 = base64_encode($picture); 
+                            $base64 = base64_encode($picture);
                             // if not pdf, break it into chunks according to RFC 2045 semantics
                             if (!$this->isPdf) {
                                 $base64 = chunk_split(base64_encode($picture));

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -663,7 +663,7 @@ class Html extends BaseWriter
                         } else {
                             $imageData = $filename;
                         }
-                    } else if ((!$this->embedImages) || ($this->isPdf)) {
+                    } elseif ((!$this->embedImages) || ($this->isPdf)) {
                         $imageData = $filename;
                     } else {
                         $imageDetails = getimagesize($filename);

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -645,7 +645,7 @@ class Html extends BaseWriter
                     $filename = htmlspecialchars($filename);
 
                     $html .= PHP_EOL;
-                    if (strpos($filename,'zip://') === 0) {
+                    if (strpos($filename, 'zip://') === 0) {
                         $imageDetails = getimagesize($filename);
                         if ($fp = fopen($filename, 'rb', 0)) {
                             $picture = '';


### PR DESCRIPTION
This is:

```
- [ *] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
sometimes(eg: customer conditional format), $sytle->numFmt is type of SimpleXMLElement, and the 'formatCode' in this element's attribute, so this need process it. 