### PR TITLE
Fix "A non-numeric value encountered" bug

### DIFF
--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -217,7 +217,7 @@ class Cell
 
                 break;
             case DataType::TYPE_NUMERIC:
-                if ($pValue === null) {
+                if ($pValue === null || $pValue === "") {
                     $pValue = 0;
                 }
                 $this->value = 0 + $pValue;

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -217,7 +217,7 @@ class Cell
 
                 break;
             case DataType::TYPE_NUMERIC:
-                $this->value = 0 + $pValue;
+                $this->value = (int)$pValue;
 
                 break;
             case DataType::TYPE_FORMULA:

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -217,7 +217,7 @@ class Cell
 
                 break;
             case DataType::TYPE_NUMERIC:
-                if ($pValue === null || $pValue === "") {
+                if ($pValue === null || $pValue === '') {
                     $pValue = 0;
                 }
                 $this->value = 0 + $pValue;

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -217,7 +217,10 @@ class Cell
 
                 break;
             case DataType::TYPE_NUMERIC:
-                $this->value = (int)$pValue;
+                if ($pValue === null) {
+                    $pValue = 0;
+                }
+                $this->value = 0 + $pValue;
 
                 break;
             case DataType::TYPE_FORMULA:


### PR DESCRIPTION
This is:

```
- [X ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
In some XLSX documents I have an error: 
``` 
A non-numeric value encountered in [***/vendor/phpoffice/phpspreadsheet/src/PhpSpreadsheet/Cell/Cell.php, line 220]
```