### PR TITLE
Detect if cell is text format

### DIFF
--- a/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
@@ -31,9 +31,18 @@ class DefaultValueBinder implements IValueBinder
                 $value = (string) $value;
             }
         }
+        
+        $formatCode = $cell->getStyle()->getNumberFormat()->getFormatCode();
+
+        // Detect if cell is text format
+        if($formatCode === '@') {
+            $dataType = DataType::TYPE_STRING;
+        } else {
+            $dataType = static::dataTypeForValue($value);
+        }
 
         // Set value explicit
-        $cell->setValueExplicit($value, static::dataTypeForValue($value));
+        $cell->setValueExplicit($value, $dataType);
 
         // Done!
         return true;


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Text format cells do not need to be converted. Automatic recognition of the type will cause some cells set to text type to be distorted, which is not common sense.
