### PR TITLE
Fix Xlsx Writer's handling of decimal commas

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1137,13 +1137,13 @@ class Worksheet extends WriterPart
                 case 'n':            // Numeric
                     //force a decimal to be written if the type is float
                     if (is_float($cellValue)) {
-                        $cellValue = (string) $cellValue;
+                        // force point as decimal separator in case current locale uses comma
+                        $cellValue = str_replace(',', '.', (string) $cellValue);
                         if (strpos($cellValue, '.') === false) {
                             $cellValue = $cellValue . '.0';
                         }
                     }
-                    // force point as decimal separator in case current locale uses comma
-                    $objWriter->writeElement('v', str_replace(',', '.', $cellValue));
+                    $objWriter->writeElement('v', $cellValue);
 
                     break;
                 case 'b':            // Boolean


### PR DESCRIPTION
Perform the comma -> period substitution in Xlsx Writer writeCell()
before checking if the decimal value has a period in it. The previous
behavior led to decimals of the form "1,1" to become "1.1.0".

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
See #1281 