### PR TITLE
fix for `maximum number of columns per sheet was exceeded` in LibreOffice.

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx/ColumnAndRowAttributes.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/ColumnAndRowAttributes.php
@@ -136,7 +136,7 @@ class ColumnAndRowAttributes extends BaseParserClass
             for ($columnAddress = $startColumn; $columnAddress !== $endColumn; ++$columnAddress) {
                 $columnAttributes[$columnAddress] = $this->readColumnRangeAttributes($column, $readDataOnly);
 
-                /**
+                /*
                  * LibreOffice saves xlsx files with 1025 columns mapping,
                  * while MS Office saves it with 16384 columns mapping.
                  */

--- a/src/PhpSpreadsheet/Reader/Xlsx/ColumnAndRowAttributes.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/ColumnAndRowAttributes.php
@@ -136,7 +136,11 @@ class ColumnAndRowAttributes extends BaseParserClass
             for ($columnAddress = $startColumn; $columnAddress !== $endColumn; ++$columnAddress) {
                 $columnAttributes[$columnAddress] = $this->readColumnRangeAttributes($column, $readDataOnly);
 
-                if ((int) ($column['max']) == 16384) {
+                /**
+                 * LibreOffice saves xlsx files with 1025 columns mapping,
+                 * while MS Office saves it with 16384 columns mapping.
+                 */
+                if (in_array((int) $column['max'], [1025, 16384])) {
                     break;
                 }
             }


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

### Why this change is needed?

XLSX files saved in LibreOffice are not correctly loaded by the reader.  
LibreOffice saves files with metadata for 1025 columns and reader consider only 16384 columns from MS Office. It leads to mapping all of trailing empty columns in Libre's file. Next, when we've saved the file by writer and trying to open it in Libre the warning `The data could not be loaded completely because the maximum number of columns per sheet was exceeded.` occurs. It's because Libre handle only 1024 columns.  
This fix added handling for trailing metadata columns from LibreOffice files.