### PR TITLE
corrects class cases for documented return types

### DIFF
--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -415,7 +415,7 @@ class Csv extends BaseReader
      *
      * @param string $delimiter Delimiter, eg: ','
      *
-     * @return CSV
+     * @return Csv
      */
     public function setDelimiter($delimiter)
     {
@@ -439,7 +439,7 @@ class Csv extends BaseReader
      *
      * @param string $enclosure Enclosure, defaults to "
      *
-     * @return CSV
+     * @return Csv
      */
     public function setEnclosure($enclosure)
     {
@@ -466,7 +466,7 @@ class Csv extends BaseReader
      *
      * @param int $pValue Sheet index
      *
-     * @return CSV
+     * @return Csv
      */
     public function setSheetIndex($pValue)
     {

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -669,7 +669,7 @@ class Html extends BaseReader
      *
      * @param int $pValue Sheet index
      *
-     * @return HTML
+     * @return Html
      */
     public function setSheetIndex($pValue)
     {

--- a/src/PhpSpreadsheet/Writer/Csv.php
+++ b/src/PhpSpreadsheet/Writer/Csv.php
@@ -147,7 +147,7 @@ class Csv extends BaseWriter
      *
      * @param string $pValue Delimiter, defaults to ','
      *
-     * @return CSV
+     * @return Csv
      */
     public function setDelimiter($pValue)
     {
@@ -171,7 +171,7 @@ class Csv extends BaseWriter
      *
      * @param string $pValue Enclosure, defaults to "
      *
-     * @return CSV
+     * @return Csv
      */
     public function setEnclosure($pValue)
     {
@@ -198,7 +198,7 @@ class Csv extends BaseWriter
      *
      * @param string $pValue Line ending, defaults to OS line ending (PHP_EOL)
      *
-     * @return CSV
+     * @return Csv
      */
     public function setLineEnding($pValue)
     {
@@ -222,7 +222,7 @@ class Csv extends BaseWriter
      *
      * @param bool $pValue Use UTF-8 byte-order mark? Defaults to false
      *
-     * @return CSV
+     * @return Csv
      */
     public function setUseBOM($pValue)
     {
@@ -246,7 +246,7 @@ class Csv extends BaseWriter
      *
      * @param bool $pValue Use separator line? Defaults to false
      *
-     * @return CSV
+     * @return Csv
      */
     public function setIncludeSeparatorLine($pValue)
     {
@@ -271,7 +271,7 @@ class Csv extends BaseWriter
      * @param bool $pValue Set the file to be written as a fully Excel compatible csv file
      *                                Note that this overrides other settings such as useBOM, enclosure and delimiter
      *
-     * @return CSV
+     * @return Csv
      */
     public function setExcelCompatibility($pValue)
     {
@@ -295,7 +295,7 @@ class Csv extends BaseWriter
      *
      * @param int $pValue Sheet index
      *
-     * @return CSV
+     * @return Csv
      */
     public function setSheetIndex($pValue)
     {

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -297,7 +297,7 @@ class Html extends BaseWriter
      *
      * @param int $pValue Sheet index
      *
-     * @return HTML
+     * @return Html
      */
     public function setSheetIndex($pValue)
     {
@@ -321,7 +321,7 @@ class Html extends BaseWriter
      *
      * @param bool $pValue Flag indicating whether the sheet navigation block should be generated or not
      *
-     * @return HTML
+     * @return Html
      */
     public function setGenerateSheetNavigationBlock($pValue)
     {
@@ -1438,7 +1438,7 @@ class Html extends BaseWriter
      *
      * @param string $pValue
      *
-     * @return HTML
+     * @return Html
      */
     public function setImagesRoot($pValue)
     {
@@ -1462,7 +1462,7 @@ class Html extends BaseWriter
      *
      * @param bool $pValue
      *
-     * @return HTML
+     * @return Html
      */
     public function setEmbedImages($pValue)
     {
@@ -1486,7 +1486,7 @@ class Html extends BaseWriter
      *
      * @param bool $pValue
      *
-     * @return HTML
+     * @return Html
      */
     public function setUseInlineCss($pValue)
     {
@@ -1510,7 +1510,7 @@ class Html extends BaseWriter
      *
      * @param bool $pValue
      *
-     * @return HTML
+     * @return Html
      */
     public function setUseEmbeddedCSS($pValue)
     {


### PR DESCRIPTION
This is:

```
- [x ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
corrected documented return types for setter methods in Csv/Html reader and writer classes
