### PR TITLE
[BC break/RFC] Fix default cell type treatment as numeric for XLSX

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheet\Reader;
 
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Cell\Hyperlink;
 use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Reader\Security\XmlScanner;
@@ -260,6 +261,13 @@ class Xlsx extends BaseReader
     private static function castToString($c)
     {
         return isset($c->v) ? (string) $c->v : null;
+    }
+
+    private static function castToNumeric($c)
+    {
+        $v = self::castToString($c);
+
+        return $v === null ? null : 0 + $v;
     }
 
     private function castToFormula($c, $r, &$cellDataType, &$value, &$calculatedValue, &$sharedFormulas, $castBaseType)
@@ -674,7 +682,7 @@ class Xlsx extends BaseReader
 
                                         // Read cell!
                                         switch ($cellDataType) {
-                                            case 's':
+                                            case DataType::TYPE_STRING:
                                                 if ((string) $c->v != '') {
                                                     $value = $sharedStrings[(int) ($c->v)];
 
@@ -686,7 +694,7 @@ class Xlsx extends BaseReader
                                                 }
 
                                                 break;
-                                            case 'b':
+                                            case DataType::TYPE_BOOL:
                                                 if (!isset($c->f)) {
                                                     $value = self::castToBoolean($c);
                                                 } else {
@@ -699,7 +707,7 @@ class Xlsx extends BaseReader
                                                 }
 
                                                 break;
-                                            case 'inlineStr':
+                                            case DataType::TYPE_INLINE:
                                                 if (isset($c->f)) {
                                                     $this->castToFormula($c, $r, $cellDataType, $value, $calculatedValue, $sharedFormulas, 'castToError');
                                                 } else {
@@ -707,7 +715,7 @@ class Xlsx extends BaseReader
                                                 }
 
                                                 break;
-                                            case 'e':
+                                            case DataType::TYPE_ERROR:
                                                 if (!isset($c->f)) {
                                                     $value = self::castToError($c);
                                                 } else {
@@ -716,12 +724,16 @@ class Xlsx extends BaseReader
                                                 }
 
                                                 break;
+
+
+                                            case DataType::TYPE_NUMERIC:
+                                                //numeric is the default cell type
                                             default:
                                                 if (!isset($c->f)) {
-                                                    $value = self::castToString($c);
+                                                    $value = self::castToNumeric($c);
                                                 } else {
                                                     // Formula
-                                                    $this->castToFormula($c, $r, $cellDataType, $value, $calculatedValue, $sharedFormulas, 'castToString');
+                                                    $this->castToFormula($c, $r, $cellDataType, $value, $calculatedValue, $sharedFormulas, 'castToNumeric');
                                                 }
 
                                                 break;

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/NumericCellTypeTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/NumericCellTypeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Cell\IValueBinder;
+use PhpOffice\PhpSpreadsheet\Reader\Xlsx as Reader;
+use PhpOffice\PhpSpreadsheet\Settings;
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as Writer;
+use PHPUnit\Framework\TestCase;
+
+class NumericCellTypeTest extends TestCase
+{
+    protected $oldBinder;
+
+    protected function setUp()
+    {
+        Settings::setLibXmlLoaderOptions(null);
+        $this->oldBinder = Cell::getValueBinder();
+
+        $binder = new class() implements IValueBinder {
+            public function bindValue(Cell $cell, $value)
+            {
+                if (is_float($value) || is_int($value)) {
+                    $type = DataType::TYPE_NUMERIC;
+                } elseif (is_string($value)) {
+                    $type = DataType::TYPE_STRING;
+                } else {
+                    return false;
+                }
+
+                $cell->setValueExplicit($value, $type);
+
+                return true;
+            }
+        };
+
+        Cell::setValueBinder($binder);
+    }
+
+    protected function tearDown()
+    {
+        Cell::setValueBinder($this->oldBinder);
+    }
+
+    /**
+     * @dataProvider providerCellShouldHaveNumericTypeAttribute
+     *
+     * @param float|int|string $value
+     */
+    public function testCellShouldHaveNumericTypeAttribute($value)
+    {
+        $outputFilename = tempnam(File::sysGetTempDir(), 'phpspreadsheet-test');
+
+        $sheet = new Spreadsheet();
+        $sheet->getActiveSheet()->getCell('A1')->setValue($value);
+
+        $writer = new Writer($sheet);
+        $writer->save($outputFilename);
+
+        $reader = new Reader();
+        $sheet = $reader->load($outputFilename);
+
+        $this->assertSame($value, $sheet->getActiveSheet()->getCell('A1')->getValue());
+    }
+
+    public function providerCellShouldHaveNumericTypeAttribute()
+    {
+        return [
+            ['1.0'],
+            [1.0],
+            ['-1.0'],
+            [-1.0],
+            ['0'],
+            [0],
+            ['0.0'],
+            [0.0],
+            ['1e1'],
+            [1e1],
+        ];
+    }
+}


### PR DESCRIPTION
SpreadsheetML defines cell type attribute t to indicate the cell type.
The attribute is optional and defaults to "n" for numeric. The XLSX
Reader incorrectly defaults the cell type to "stringy" for both
undefined t attribute and t="n".

This is:

```
- [X] a bugfix
- [] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

SpreadsheetML defines the default cell type as numeric, but the XLSX reader treats a missing cell type or cell type = numeric as a "stringy" value. This means that the reader is discarding the numeric type information from the XML. In most cases this is masked by the `DefaultBinder` which explicitly preg's for numeric strings and correct the reader's behavior. 

The bugs / inconsistencies are:

1. Strings that pass the numeric preg are incorrectly casted to numeric
2. The`IValueBinder` is always presented with string, even when the XML defines the type as numeric
3. A numeric cell that contains non-numeric information is not treated as an exception

This is probably a BC break as it seems like a fundamental issue with the Reader - I would expect there is lots of code relying on numeric strings being casted to a number despite the XML declaring them as strings.
