### PR TITLE
Filter | One implementation that covers them all

### DIFF
--- a/src/PhpSpreadsheet/Reader/Filter.php
+++ b/src/PhpSpreadsheet/Reader/Filter.php
@@ -36,12 +36,18 @@ class Filter implements IReadFilter {
         return $this;
     }
 
+    public function setCallback(\Closure $callback) : self {
+        $this->callback = $callback;
+        return $this;
+    }
+
     public function readCell($column, $row, $worksheetName = '') {
         $start_row = $this->start_row ? $row >= $this->start_row : TRUE;
         $end_row = $this->end_row ? $row <= $this->end_row : TRUE;
         $columns = $this->columns ? in_array($column, $this->columns) : TRUE;
         $worksheet_name = $this->worksheet_name ? $this->worksheet_name ===  $worksheetName : TRUE;
+        $callback = $this->callback ? ${$this->callback}($column, $row, $worksheetName) : TRUE;
 
-        return $start_row && $end_row && $columns && $worksheet_name;
+        return $start_row && $end_row && $columns && $worksheet_name && $callback;
     }
 }

--- a/src/PhpSpreadsheet/Reader/Filter.php
+++ b/src/PhpSpreadsheet/Reader/Filter.php
@@ -48,7 +48,8 @@ class Filter implements IReadFilter {
         $end_row = $this->end_row ? $row <= $this->end_row : TRUE;
         $columns = $this->columns ? in_array($column, $this->columns) : TRUE;
         $worksheet_name = $this->worksheet_name ? $this->worksheet_name ===  $worksheetName : TRUE;
-        $callback = $this->callback ? ${$this->callback}($column, $row, $worksheetName) : TRUE;
+        $callback = $this->callback;
+        $callback = $callback ? $callback($column, $row, $worksheetName) : TRUE;
 
         return $start_row && $end_row && $columns && $worksheet_name && $callback;
     }

--- a/src/PhpSpreadsheet/Reader/Filter.php
+++ b/src/PhpSpreadsheet/Reader/Filter.php
@@ -8,11 +8,7 @@ class Filter implements IReadFilter {
     private $start_row;
     private $end_row;
     private $columns;
-    private $worksheet_name
-
-    public function __construct() {
-        $this->reset();
-    }
+    private $worksheet_name;
 
     public function reset() : self {
         $this->start_row = NULL;

--- a/src/PhpSpreadsheet/Reader/Filter.php
+++ b/src/PhpSpreadsheet/Reader/Filter.php
@@ -7,12 +7,14 @@ class Filter implements IReadFilter {
     private $end_row;
     private $columns;
     private $worksheet_name;
+    private $callback;
 
     public function reset() : self {
         $this->start_row = NULL;
         $this->end_row = NULL;
         $this->columns = NULL;
         $this->worksheet_name = NULL;
+        $this->callback = NULL;
         return $this;
     }
 

--- a/src/PhpSpreadsheet/Reader/Filter.php
+++ b/src/PhpSpreadsheet/Reader/Filter.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Reader;
+
+use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
+
+class Filter implements IReadFilter {
+    private $start_row;
+    private $end_row;
+    private $columns;
+    private $worksheet_name
+
+    public function __construct() {
+        $this->reset();
+    }
+
+    public function reset() : self {
+        $this->start_row = NULL;
+        $this->end_row = NULL;
+        $this->columns = NULL;
+        $this->worksheet_name = NULL;
+        return $this;
+    }
+
+    public function setStartRow(int $start_row) : self {
+        $this->start_row = $start_row;
+        return $this;
+    }
+
+    public function setEndRow(int $end_row) : self {
+        $this->end_row = $end_row;
+        return $this;
+    }
+
+    public function setColumns(array $columns) : self {
+        $this->columns = $columns;
+        return $this;
+    }
+
+    public function setWorksheetName(string $worksheet_name) : self {
+        $this->worksheet_name = $worksheet_name;
+        return $this;
+    }
+
+    public function readCell($column, $row, $worksheetName = '') {
+        $start_row = $this->start_row ? $row >= $this->start_row : TRUE;
+        $end_row = $this->end_row ? $row <= $this->end_row : TRUE;
+        $columns = $this->columns ? in_array($column, $this->columns) : TRUE;
+        $worksheet_name = $this->worksheet_name ? $this->worksheet_name ===  $worksheetName : TRUE;
+
+        return $start_row && $end_row && $columns && $worksheet_name;
+    }
+}

--- a/src/PhpSpreadsheet/Reader/Filter.php
+++ b/src/PhpSpreadsheet/Reader/Filter.php
@@ -2,8 +2,6 @@
 
 namespace PhpOffice\PhpSpreadsheet\Reader;
 
-use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
-
 class Filter implements IReadFilter {
     private $start_row;
     private $end_row;


### PR DESCRIPTION
This single filter should get any situation covered. Just use the set*() methods for what is needed to be filtered and, for reuse in the same instance, just call reset().

This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
