### PR TITLE
BUGFIX for issue #1161

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Handle Error in Formula Processing Better for Xls [#1267](https://github.com/PHPOffice/PhpSpreadsheet/pull/1267)
 - Handle ConditionalStyle NumberFormat When Reading Xlsx File [#1296](https://github.com/PHPOffice/PhpSpreadsheet/pull/1296)
 - Fix Xlsx Writer's handling of decimal commas [#1282](https://github.com/PHPOffice/PhpSpreadsheet/pull/1282)
-- Fix for issue by removing test code mistakenly left in
+- Fix for issue by removing test code mistakenly left in [#1328](https://github.com/PHPOffice/PhpSpreadsheet/pull/1328)
 
 ## [1.10.1] - 2019-12-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Handle Error in Formula Processing Better for Xls [#1267](https://github.com/PHPOffice/PhpSpreadsheet/pull/1267)
 - Handle ConditionalStyle NumberFormat When Reading Xlsx File [#1296](https://github.com/PHPOffice/PhpSpreadsheet/pull/1296)
 - Fix Xlsx Writer's handling of decimal commas [#1282](https://github.com/PHPOffice/PhpSpreadsheet/pull/1282)
+- Fix for issue by removing test code mistakenly left in
 
 ## [1.10.1] - 2019-12-02
 

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -4159,13 +4159,6 @@ class Calculation
                 if ($pCellParent) {
                     $pCell->attach($pCellParent);
                 }
-                if (($cellID == 'AC99') || (isset($pCell) && $pCell->getCoordinate() == 'AC99')) {
-                    if (defined('RESOLVING')) {
-                        define('RESOLVING2', true);
-                    } else {
-                        define('RESOLVING', true);
-                    }
-                }
 
                 $functionName = $matches[1];
                 $argCount = $stack->pop();


### PR DESCRIPTION
This is: 

```
- [x] a bugfix (#1161)
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests — No. Removed code that was never covered in tests and shouldn't have been there in the first place. Nothing to test.
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary — no not necessary

### Why this change is needed?
As noted in [#1161](https://github.com/PHPOffice/PhpSpreadsheet/issues/1161) there was some test code left in the calculation.php file. This would only show up on larger files, so it hasn't been prevalent, but it should be removed. There are no references to the constants being set. Even if they were, it's bad practice to set constants in code. Here it's in a loop and also in a simple if/else block.