### PR TITLE
Bugfix for Issue 1271

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -2210,7 +2210,7 @@ class Calculation
     private static $controlFunctions = [
         'MKMATRIX' => [
             'argumentCount' => '*',
-            'functionCall' => 'self::mkMatrix',
+            'functionCall' => [__CLASS__, 'mkMatrix'],
         ],
     ];
 

--- a/src/PhpSpreadsheet/Calculation/Functions.php
+++ b/src/PhpSpreadsheet/Calculation/Functions.php
@@ -646,7 +646,7 @@ class Functions
     public static function flattenSingleValue($value = '')
     {
         while (is_array($value)) {
-            $value = array_pop($value);
+            $value = array_shift($value); // was array_pop
         }
 
         return $value;

--- a/src/PhpSpreadsheet/Calculation/Functions.php
+++ b/src/PhpSpreadsheet/Calculation/Functions.php
@@ -646,7 +646,7 @@ class Functions
     public static function flattenSingleValue($value = '')
     {
         while (is_array($value)) {
-            $value = array_shift($value); // was array_pop
+            $value = array_shift($value);
         }
 
         return $value;

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -266,7 +266,7 @@ class Cell
                 //    We don't yet handle array returns
                 if (is_array($result)) {
                     while (is_array($result)) {
-                        $result = array_pop($result);
+                        $result = array_shift($result); // was array_pop
                     }
                 }
             } catch (Exception $ex) {

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -266,7 +266,7 @@ class Cell
                 //    We don't yet handle array returns
                 if (is_array($result)) {
                     while (is_array($result)) {
-                        $result = array_shift($result); // was array_pop
+                        $result = array_shift($result);
                     }
                 }
             } catch (Exception $ex) {

--- a/tests/PhpSpreadsheetTests/Calculation/FormulaAsStringTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/FormulaAsStringTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Calculation;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+class FormulaAsStringTest extends TestCase
+{
+    /**
+     * @dataProvider providerFunctionsAsString
+     *
+     * @param mixed $expectedResult
+     * @param string $formula
+     */
+    public function testFunctionsAsString($expectedResult, $formula)
+    {
+        $spreadsheet = new Spreadsheet();
+        $workSheet = $spreadsheet->getActiveSheet();
+        $workSheet->setCellValue('A1', 10);
+        $workSheet->setCellValue('A2', 20);
+        $workSheet->setCellValue('A3', 30);
+        $workSheet->setCellValue('A4', 40);
+        $spreadsheet->addNamedRange(new \PhpOffice\PhpSpreadsheet\NamedRange('namedCell', $workSheet, 'A4'));
+        $workSheet->setCellValue('B1', 'uPPER');
+        $workSheet->setCellValue('B2', '=TRUE()');
+        $workSheet->setCellValue('B3', '=FALSE()');
+
+        $ws2 = $spreadsheet->createSheet();
+        $ws2->setCellValue('A1', 100);
+        $ws2->setCellValue('A2', 200);
+        $ws2->setTitle('Sheet2');
+        $spreadsheet->addNamedRange(new \PhpOffice\PhpSpreadsheet\NamedRange('A2B', $ws2, 'A2'));
+
+        $spreadsheet->setActiveSheetIndex(0);
+        $cell2 = $workSheet->getCell('D1');
+        $cell2->setValue($formula);
+        $result = $cell2->getCalculatedValue();
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerFunctionsAsString()
+    {
+        return require 'data/Calculation/FunctionsAsString.php';
+    }
+}

--- a/tests/data/Calculation/FunctionsAsString.php
+++ b/tests/data/Calculation/FunctionsAsString.php
@@ -1,0 +1,24 @@
+<?php
+
+    return [
+        // Note that these are meant to test the parser, not a comprehensive
+        // test of all Excel functions, which tests are handled elsewhere.
+        [6, '=SUM(1,2,3)'],
+        [60, '=SUM(A1:A3)'],
+        [70, '=SUM(A1,A2,A4)'],
+        [41, '=SUM(1,namedCell)'],
+        [50, '=A1+namedCell'],
+        [3, '=MATCH(6,{4,5,6,2},0)'],
+        ['#N/A', '=MATCH(8,{4,5,6,2},0)'],
+        [7, '=HLOOKUP(5,{1,5,10;2,6,11;3,7,12;4,8,13},3,FALSE)'],
+        ['Hello, World.', '=CONCATENATE("Hello, ", "World.")'],
+        ['{NON-EMPTY SET}', '=UPPER("{non-EMPTY set}")'], // braces not used for matrix
+        ['upper', '=LOWER(B1)'],
+        [false, '=and(B2,B3)'],
+        [0, '=acos(1)'],
+        [0.785398, '=round(atan({1,2,3}),6)'], // {1,2,3} will be flattened to 1
+        [2, '=minverse({-2.5,1.5;2,-1})'], // 2 is the flattened result of {2,3;4,5}
+        [4, '=MDETERM(MMULT({1,2;3,4},{5,6;7,8}))'], // multiple matrices
+        [110, '=SUM(A1,Sheet2!$A$1)'], // different sheet absolute address
+        [220, '=SUM(A2,A2B)'], // defined name on different sheet
+    ];


### PR DESCRIPTION
Summarizing:
MATCH with a static array should return the position of the found value based on the values submitted.
Returns #N/A, unless the element searched for is at the end of the array.

The problem is in Calculation.php line 4231:
                    if (!is_array($functionCall)) {
                        foreach ($args as &$arg) {
                            $arg = Functions::flattenSingleValue($arg);
                        }
                        unset($arg);
                    }

I believe this code is intended to handle functions where PhpSpreadsheet just passes
the call on to PHP without implementing the code on its own, e.g. for atan or acos.
In the bug report, the following code fails:
  $flat_rate = "=MATCH(6,{4,5,6,2}, 0)";
  $sheet->getCell('A1')->setValue($flat_rate);
The expected value is 3, but the actual result is "#N/A".
The reason for this result is that the parser replaces the braces with calls
to the MKMATRIX internal function, whose value for functioncall was:
'self::MKMATRIX'. Since this isn't an array, the flattening code is executed,
and the unintended result occurs. The fix is to change the definition for
functioncall in that case to [__CLASS__, 'mkMatrix'], avoiding the flattening.

However, there is also another part to this bug. The flattening should be
returning the first entry in the array, but is in fact returning the last.
This explains why the bug report specified "unless ... end of the array".
I confirmed that Excel does use the first item in the array rather than the last,
e.g. =atan({1,2,3}) entered into a cell will return atan(1), not atan(3).
The problem here is that flattenSingleValue, which says in its comments that
it is supposed to be returning the first item, uses array_pop rather than array_shift.
I have changed that as well. The same mistake was also present in
Cell.php function getCalculatedValue. The correct behavior can be verified
by entering =minverse({-2.5,1.5;2,-1}) into an Excel cell'
Excel flattens the result ({2,3;4,5}) to 2, and so should PhpSpreadsheet.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Bugfix, as described.
