### PR TITLE
Fix #687: strip $ when converting a string to a coordinate

### DIFF
--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -31,7 +31,7 @@ abstract class Coordinate
      */
     public static function coordinateFromString($pCoordinateString)
     {
-        if (preg_match('/^([$]?[A-Z]{1,3})([$]?\\d{1,7})$/', $pCoordinateString, $matches)) {
+        if (preg_match('/^[$]?([A-Z]{1,3})[$]?(\\d{1,7})$/', $pCoordinateString, $matches)) {
             return [$matches[1], $matches[2]];
         } elseif (self::coordinateIsRange($pCoordinateString)) {
             throw new Exception('Cell coordinate string can not be a range of cells');


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Fixes https://github.com/PHPOffice/PhpSpreadsheet/issues/687
