### PR TITLE
Replace spaces from style string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
-### Added
-
-- Improved the ARABIC function to also hande short-hand roman numerals
-
-### Fixed
-
-- Fix ROUNDUP and ROUNDDOWN for floating-point rounding error [#1404](https://github.com/PHPOffice/PhpSpreadsheet/pull/1404)
-
-## [1.11.0] - 2020-03-02
-
-### Added
-
-- Added support for the BASE function
-- Added support for the ARABIC function
 - Conditionals - Extend Support for (NOT)CONTAINSBLANKS [#1278](https://github.com/PHPOffice/PhpSpreadsheet/pull/1278)
 
 ### Fixed
@@ -33,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Fix active cell when freeze pane is used [#1323](https://github.com/PHPOffice/PhpSpreadsheet/pull/1323)
 - Fix XLSX file loading with autofilter containing '$' [#1326](https://github.com/PHPOffice/PhpSpreadsheet/pull/1326)
 - PHPDoc - Use `@return $this` for fluent methods [#1362](https://github.com/PHPOffice/PhpSpreadsheet/pull/1362)
+- Fix loading styles from vmlDrawings when containing whitespace [#1347](https://github.com/PHPOffice/PhpSpreadsheet/issues/1347)
 
 ## [1.10.1] - 2019-12-02
 

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1828,7 +1828,7 @@ class Xlsx extends BaseReader
 
     private static function toCSSArray($style)
     {
-        $style = trim(str_replace(["\r", "\n"], '', $style), ';');
+        $style = self::stripWhiteSpaceFromStyleString($style);
 
         $temp = explode(';', $style);
         $style = [];
@@ -1855,6 +1855,11 @@ class Xlsx extends BaseReader
         }
 
         return $style;
+    }
+
+    public static function stripWhiteSpaceFromStyleString($string)
+    {
+        return trim(str_replace(["\r", "\n", ' '], '', $string), ';');
     }
 
     private static function boolean($value)

--- a/tests/PhpSpreadsheetTests/Reader/XlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XlsxTest.php
@@ -228,4 +228,29 @@ class XlsxTest extends TestCase
         // Fake assert. The only thing we need is to ensure the file is loaded without exception
         $this->assertNotNull($excel);
     }
+
+    /**
+     * Test if all whitespace is removed from a style definition string.
+     * This is needed to parse it into properties with the correct keys.
+     *
+     * @param $string
+     * @dataProvider providerStripsWhiteSpaceFromStyleString
+     */
+    public function testStripsWhiteSpaceFromStyleString($string)
+    {
+        $string = Xlsx::stripWhiteSpaceFromStyleString($string);
+        $this->assertEquals(preg_match('/\s/', $string), 0);
+    }
+
+    public function providerStripsWhiteSpaceFromStyleString()
+    {
+        return [
+            ['position:absolute;margin-left:424.5pt;margin-top:169.5pt;width:67.5pt;
+        height:13.5pt;z-index:5;mso-wrap-style:tight'],
+            ['position:absolute;margin-left:424.5pt;margin-top:169.5pt;width:67.5pt;
+height:13.5pt;z-index:5;mso-wrap-style:tight'],
+            ['position:absolute; margin-left:424.5pt; margin-top:169.5pt; width:67.5pt;
+            height:13.5pt;z-index:5;mso-wrap-style:tight'],
+        ];
+    }
 }


### PR DESCRIPTION
Fixes #1347. Indentation in the xml leaves spaces in style string even after replacing newlines. Replacing the spaces ensures no spaces in keys of the resulting style-array

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

See #1347 
