### PR TITLE
BIFF8 E_NOTICE undefined offset fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Fixed
 
 - Ensure that the list of shared formulae is maintained when an xlsx file is chunked with readFilter[Issue #169](https://github.com/PHPOffice/PhpSpreadsheet/issues/1669).
+- Fix for notice during accessing "cached magnification factor" offset [#1354](https://github.com/PHPOffice/PhpSpreadsheet/pull/1354)
 
 ## 1.15.0 - 2020-10-11
 

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -4377,11 +4377,22 @@ class Xls extends BaseReader
             // offset: 10; size: 2; cached magnification factor in page break preview (in percent); 0 = Default (60%)
             // offset: 12; size: 2; cached magnification factor in normal view (in percent); 0 = Default (100%)
             // offset: 14; size: 4; not used
-            $zoomscaleInPageBreakPreview = self::getUInt2d($recordData, 10);
+            if (!isset($recordData[10])) {
+                $zoomscaleInPageBreakPreview = 0;
+            } else {
+                $zoomscaleInPageBreakPreview = self::getUInt2d($recordData, 10);
+            }
+
             if ($zoomscaleInPageBreakPreview === 0) {
                 $zoomscaleInPageBreakPreview = 60;
             }
-            $zoomscaleInNormalView = self::getUInt2d($recordData, 12);
+
+            if (!isset($recordData[12])) {
+                $zoomscaleInNormalView = 0;
+            } else {
+                $zoomscaleInNormalView = self::getUInt2d($recordData, 12);
+            }
+
             if ($zoomscaleInNormalView === 0) {
                 $zoomscaleInNormalView = 100;
             }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Sheet View Settings Block should be 8-14 bytes long in BIFF8 Excel 97 according to the open office file format documentation. However access to byte 10 and 12  is not possible when record data is malformed, so  `getUInt2d`  throws notice.
![image](https://user-images.githubusercontent.com/60773818/74047890-5f0e8100-49d1-11ea-9f16-d970448f5d02.png)


### Summary 

Test access to byte offsets for "cached magnification factor" before using it. Use default values otherwise to avoid notices