### PR TITLE
XLSX: always write code names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+- Xlsx writer respects code names regardless of whether the spreadsheet contains macros [#1358](https://github.com/PHPOffice/PhpSpreadsheet/pull/1358)
 - Conditionals - Extend Support for (NOT)CONTAINSBLANKS [#1278](https://github.com/PHPOffice/PhpSpreadsheet/pull/1278)
 - Handle Error in Formula Processing Better for Xls [#1267](https://github.com/PHPOffice/PhpSpreadsheet/pull/1267)
 - Handle ConditionalStyle NumberFormat When Reading Xlsx File [#1296](https://github.com/PHPOffice/PhpSpreadsheet/pull/1296)

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -139,13 +139,11 @@ class Worksheet extends WriterPart
     {
         // sheetPr
         $objWriter->startElement('sheetPr');
-        if ($pSheet->getParent()->hasMacros()) {
-            //if the workbook have macros, we need to have codeName for the sheet
-            if (!$pSheet->hasCodeName()) {
-                $pSheet->setCodeName($pSheet->getTitle());
-            }
-            $objWriter->writeAttribute('codeName', $pSheet->getCodeName());
+        // Set the codeName for the sheet regardless of whether the workbook has macros or not.
+        if (!$pSheet->hasCodeName()) {
+            $pSheet->setCodeName($pSheet->getTitle());
         }
+        $objWriter->writeAttribute('codeName', $pSheet->getCodeName());
         $autoFilterRange = $pSheet->getAutoFilter()->getRange();
         if (!empty($autoFilterRange)) {
             $objWriter->writeAttribute('filterMode', 1);

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/CodeNamesRespectedTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/CodeNamesRespectedTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Reader\Xlsx as Reader;
+use PhpOffice\PhpSpreadsheet\Settings;
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as Writer;
+use PHPUnit\Framework\TestCase;
+
+class CodeNamesRespectedTest extends TestCase
+{
+    public function testCodeNamesRespected()
+    {
+        $outputFilename = tempnam(File::sysGetTempDir(), 'phpspreadsheet-test');
+        Settings::setLibXmlLoaderOptions(null);
+
+        try {
+            $sheet = new Spreadsheet();
+            $sheet->getActiveSheet()->setCodeName($expected = 'respecting_code_names');
+
+            $writer = new Writer($sheet);
+            $writer->save($outputFilename);
+
+            $reader = new Reader();
+            $sheet = $reader->load($outputFilename);
+
+            $this->assertSame($expected, $sheet->getActiveSheet()->getCodeName());
+        } finally {
+            unlink($outputFilename);
+        }
+    }
+}


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] ~~Documentation is updated as necessary~~ I don't think there is anything to update in documentation.

### Why this change is needed?

Previously the XLSX writer would only add code names to worksheets, if the spreadsheet had any macros. However, sometimes code names are useful on their own. Closes #1357.