### PR TITLE
PHPDoc: use @return $this for fluent methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Fix for Xls writer wrong selected cells and active sheet [#1256](https://github.com/PHPOffice/PhpSpreadsheet/pull/1256)
 - Fix active cell when freeze pane is used [#1323](https://github.com/PHPOffice/PhpSpreadsheet/pull/1323)
 - Fix XLSX file loading with autofilter containing '$' [#1326](https://github.com/PHPOffice/PhpSpreadsheet/pull/1326)
+- PHPDoc - Use `@return $this` for fluent methods [#1362](https://github.com/PHPOffice/PhpSpreadsheet/pull/1362)
 
 ## [1.10.1] - 2019-12-02
 

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -67,7 +67,7 @@ class Cell
     /**
      * Update the cell into the cell collection.
      *
-     * @return self
+     * @return $this
      */
     public function updateInCollection()
     {
@@ -177,7 +177,7 @@ class Cell
      *
      * @throws Exception
      *
-     * @return Cell
+     * @return $this
      */
     public function setValue($pValue)
     {
@@ -672,7 +672,7 @@ class Cell
      *
      * @param mixed $pAttributes
      *
-     * @return Cell
+     * @return $this
      */
     public function setFormulaAttributes($pAttributes)
     {

--- a/src/PhpSpreadsheet/Cell/DataValidation.php
+++ b/src/PhpSpreadsheet/Cell/DataValidation.php
@@ -142,7 +142,7 @@ class DataValidation
      *
      * @param string $value
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setFormula1($value)
     {
@@ -166,7 +166,7 @@ class DataValidation
      *
      * @param string $value
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setFormula2($value)
     {
@@ -190,7 +190,7 @@ class DataValidation
      *
      * @param string $value
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setType($value)
     {
@@ -214,7 +214,7 @@ class DataValidation
      *
      * @param string $value see self::STYLE_*
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setErrorStyle($value)
     {
@@ -238,7 +238,7 @@ class DataValidation
      *
      * @param string $value
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setOperator($value)
     {
@@ -262,7 +262,7 @@ class DataValidation
      *
      * @param bool $value
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setAllowBlank($value)
     {
@@ -286,7 +286,7 @@ class DataValidation
      *
      * @param bool $value
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setShowDropDown($value)
     {
@@ -310,7 +310,7 @@ class DataValidation
      *
      * @param bool $value
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setShowInputMessage($value)
     {
@@ -334,7 +334,7 @@ class DataValidation
      *
      * @param bool $value
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setShowErrorMessage($value)
     {
@@ -358,7 +358,7 @@ class DataValidation
      *
      * @param string $value
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setErrorTitle($value)
     {
@@ -382,7 +382,7 @@ class DataValidation
      *
      * @param string $value
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setError($value)
     {
@@ -406,7 +406,7 @@ class DataValidation
      *
      * @param string $value
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setPromptTitle($value)
     {
@@ -430,7 +430,7 @@ class DataValidation
      *
      * @param string $value
      *
-     * @return DataValidation
+     * @return $this
      */
     public function setPrompt($value)
     {

--- a/src/PhpSpreadsheet/Cell/Hyperlink.php
+++ b/src/PhpSpreadsheet/Cell/Hyperlink.php
@@ -46,7 +46,7 @@ class Hyperlink
      *
      * @param string $value
      *
-     * @return Hyperlink
+     * @return $this
      */
     public function setUrl($value)
     {
@@ -70,7 +70,7 @@ class Hyperlink
      *
      * @param string $value
      *
-     * @return Hyperlink
+     * @return $this
      */
     public function setTooltip($value)
     {

--- a/src/PhpSpreadsheet/Chart/Axis.php
+++ b/src/PhpSpreadsheet/Chart/Axis.php
@@ -354,7 +354,7 @@ class Axis extends Properties
      *
      * @param int $shadow_presets
      *
-     * @return Axis
+     * @return $this
      */
     private function setShadowPresetsProperties($shadow_presets)
     {
@@ -370,7 +370,7 @@ class Axis extends Properties
      * @param array $properties_map
      * @param mixed &$reference
      *
-     * @return Axis
+     * @return $this
      */
     private function setShadowProperiesMapValues(array $properties_map, &$reference = null)
     {
@@ -402,7 +402,7 @@ class Axis extends Properties
      * @param int $alpha
      * @param string $type
      *
-     * @return Axis
+     * @return $this
      */
     private function setShadowColor($color, $alpha, $type)
     {
@@ -416,7 +416,7 @@ class Axis extends Properties
      *
      * @param float $blur
      *
-     * @return Axis
+     * @return $this
      */
     private function setShadowBlur($blur)
     {
@@ -432,7 +432,7 @@ class Axis extends Properties
      *
      * @param int $angle
      *
-     * @return Axis
+     * @return $this
      */
     private function setShadowAngle($angle)
     {
@@ -448,7 +448,7 @@ class Axis extends Properties
      *
      * @param float $distance
      *
-     * @return Axis
+     * @return $this
      */
     private function setShadowDistance($distance)
     {
@@ -506,7 +506,7 @@ class Axis extends Properties
      *
      * @param float $size
      *
-     * @return Axis
+     * @return $this
      */
     private function setGlowSize($size)
     {
@@ -524,7 +524,7 @@ class Axis extends Properties
      * @param int $alpha
      * @param string $type
      *
-     * @return Axis
+     * @return $this
      */
     private function setGlowColor($color, $alpha, $type)
     {

--- a/src/PhpSpreadsheet/Chart/Chart.php
+++ b/src/PhpSpreadsheet/Chart/Chart.php
@@ -197,7 +197,7 @@ class Chart
      *
      * @param Worksheet $pValue
      *
-     * @return Chart
+     * @return $this
      */
     public function setWorksheet(Worksheet $pValue = null)
     {
@@ -221,7 +221,7 @@ class Chart
      *
      * @param Title $title
      *
-     * @return Chart
+     * @return $this
      */
     public function setTitle(Title $title)
     {
@@ -245,7 +245,7 @@ class Chart
      *
      * @param Legend $legend
      *
-     * @return Chart
+     * @return $this
      */
     public function setLegend(Legend $legend)
     {
@@ -269,7 +269,7 @@ class Chart
      *
      * @param Title $label
      *
-     * @return Chart
+     * @return $this
      */
     public function setXAxisLabel(Title $label)
     {
@@ -293,7 +293,7 @@ class Chart
      *
      * @param Title $label
      *
-     * @return Chart
+     * @return $this
      */
     public function setYAxisLabel(Title $label)
     {
@@ -327,7 +327,7 @@ class Chart
      *
      * @param bool $plotVisibleOnly
      *
-     * @return Chart
+     * @return $this
      */
     public function setPlotVisibleOnly($plotVisibleOnly)
     {
@@ -351,7 +351,7 @@ class Chart
      *
      * @param string $displayBlanksAs
      *
-     * @return Chart
+     * @return $this
      */
     public function setDisplayBlanksAs($displayBlanksAs)
     {
@@ -423,7 +423,7 @@ class Chart
      * @param int $xOffset
      * @param int $yOffset
      *
-     * @return Chart
+     * @return $this
      */
     public function setTopLeftPosition($cell, $xOffset = null, $yOffset = null)
     {
@@ -467,7 +467,7 @@ class Chart
      *
      * @param string $cell
      *
-     * @return Chart
+     * @return $this
      */
     public function setTopLeftCell($cell)
     {
@@ -482,7 +482,7 @@ class Chart
      * @param int $xOffset
      * @param int $yOffset
      *
-     * @return Chart
+     * @return $this
      */
     public function setTopLeftOffset($xOffset, $yOffset)
     {
@@ -541,7 +541,7 @@ class Chart
      * @param int $xOffset
      * @param int $yOffset
      *
-     * @return Chart
+     * @return $this
      */
     public function setBottomRightPosition($cell, $xOffset = null, $yOffset = null)
     {
@@ -593,7 +593,7 @@ class Chart
      * @param int $xOffset
      * @param int $yOffset
      *
-     * @return Chart
+     * @return $this
      */
     public function setBottomRightOffset($xOffset, $yOffset)
     {

--- a/src/PhpSpreadsheet/Chart/DataSeries.php
+++ b/src/PhpSpreadsheet/Chart/DataSeries.php
@@ -157,7 +157,7 @@ class DataSeries
      *
      * @param string $plotType
      *
-     * @return DataSeries
+     * @return $this
      */
     public function setPlotType($plotType)
     {
@@ -181,7 +181,7 @@ class DataSeries
      *
      * @param string $groupingType
      *
-     * @return DataSeries
+     * @return $this
      */
     public function setPlotGrouping($groupingType)
     {
@@ -205,7 +205,7 @@ class DataSeries
      *
      * @param string $plotDirection
      *
-     * @return DataSeries
+     * @return $this
      */
     public function setPlotDirection($plotDirection)
     {
@@ -297,7 +297,7 @@ class DataSeries
      *
      * @param null|string $plotStyle
      *
-     * @return DataSeries
+     * @return $this
      */
     public function setPlotStyle($plotStyle)
     {
@@ -360,7 +360,7 @@ class DataSeries
      *
      * @param bool $smoothLine
      *
-     * @return DataSeries
+     * @return $this
      */
     public function setSmoothLine($smoothLine)
     {

--- a/src/PhpSpreadsheet/Chart/DataSeriesValues.php
+++ b/src/PhpSpreadsheet/Chart/DataSeriesValues.php
@@ -117,7 +117,7 @@ class DataSeriesValues
      *
      * @throws Exception
      *
-     * @return DataSeriesValues
+     * @return $this
      */
     public function setDataType($dataType)
     {
@@ -144,7 +144,7 @@ class DataSeriesValues
      *
      * @param string $dataSource
      *
-     * @return DataSeriesValues
+     * @return $this
      */
     public function setDataSource($dataSource)
     {
@@ -168,7 +168,7 @@ class DataSeriesValues
      *
      * @param string $marker
      *
-     * @return DataSeriesValues
+     * @return $this
      */
     public function setPointMarker($marker)
     {
@@ -192,7 +192,7 @@ class DataSeriesValues
      *
      * @param string $formatCode
      *
-     * @return DataSeriesValues
+     * @return $this
      */
     public function setFormatCode($formatCode)
     {
@@ -275,7 +275,7 @@ class DataSeriesValues
      *
      * @param int $width
      *
-     * @return DataSeriesValues
+     * @return $this
      */
     public function setLineWidth($width)
     {
@@ -346,7 +346,7 @@ class DataSeriesValues
      *
      * @param array $dataValues
      *
-     * @return DataSeriesValues
+     * @return $this
      */
     public function setDataValues($dataValues)
     {

--- a/src/PhpSpreadsheet/Chart/GridLines.php
+++ b/src/PhpSpreadsheet/Chart/GridLines.php
@@ -91,7 +91,7 @@ class GridLines extends Properties
     /**
      * Change Object State to True.
      *
-     * @return GridLines
+     * @return $this
      */
     private function activateObject()
     {
@@ -229,7 +229,7 @@ class GridLines extends Properties
      *
      * @param float $size
      *
-     * @return GridLines
+     * @return $this
      */
     private function setGlowSize($size)
     {
@@ -245,7 +245,7 @@ class GridLines extends Properties
      * @param int $alpha
      * @param string $type
      *
-     * @return GridLines
+     * @return $this
      */
     private function setGlowColor($color, $alpha, $type)
     {
@@ -305,7 +305,7 @@ class GridLines extends Properties
      *
      * @param int $shadow_presets
      *
-     * @return GridLines
+     * @return $this
      */
     private function setShadowPresetsProperties($shadow_presets)
     {
@@ -321,7 +321,7 @@ class GridLines extends Properties
      * @param array $properties_map
      * @param mixed &$reference
      *
-     * @return GridLines
+     * @return $this
      */
     private function setShadowProperiesMapValues(array $properties_map, &$reference = null)
     {
@@ -353,7 +353,7 @@ class GridLines extends Properties
      * @param int $alpha
      * @param string $type
      *
-     * @return GridLines
+     * @return $this
      */
     private function setShadowColor($color, $alpha, $type)
     {
@@ -375,7 +375,7 @@ class GridLines extends Properties
      *
      * @param float $blur
      *
-     * @return GridLines
+     * @return $this
      */
     private function setShadowBlur($blur)
     {
@@ -391,7 +391,7 @@ class GridLines extends Properties
      *
      * @param int $angle
      *
-     * @return GridLines
+     * @return $this
      */
     private function setShadowAngle($angle)
     {
@@ -407,7 +407,7 @@ class GridLines extends Properties
      *
      * @param float $distance
      *
-     * @return GridLines
+     * @return $this
      */
     private function setShadowDistance($distance)
     {

--- a/src/PhpSpreadsheet/Chart/Layout.php
+++ b/src/PhpSpreadsheet/Chart/Layout.php
@@ -153,7 +153,7 @@ class Layout
      *
      * @param string $value
      *
-     * @return Layout
+     * @return $this
      */
     public function setLayoutTarget($value)
     {
@@ -177,7 +177,7 @@ class Layout
      *
      * @param string $value
      *
-     * @return Layout
+     * @return $this
      */
     public function setXMode($value)
     {
@@ -201,7 +201,7 @@ class Layout
      *
      * @param string $value
      *
-     * @return Layout
+     * @return $this
      */
     public function setYMode($value)
     {
@@ -225,7 +225,7 @@ class Layout
      *
      * @param float $value
      *
-     * @return Layout
+     * @return $this
      */
     public function setXPosition($value)
     {
@@ -249,7 +249,7 @@ class Layout
      *
      * @param float $value
      *
-     * @return Layout
+     * @return $this
      */
     public function setYPosition($value)
     {
@@ -273,7 +273,7 @@ class Layout
      *
      * @param float $value
      *
-     * @return Layout
+     * @return $this
      */
     public function setWidth($value)
     {
@@ -297,7 +297,7 @@ class Layout
      *
      * @param float $value
      *
-     * @return Layout
+     * @return $this
      */
     public function setHeight($value)
     {
@@ -322,7 +322,7 @@ class Layout
      *
      * @param bool $value Show legend key
      *
-     * @return Layout
+     * @return $this
      */
     public function setShowLegendKey($value)
     {
@@ -347,7 +347,7 @@ class Layout
      *
      * @param bool $value Show val
      *
-     * @return Layout
+     * @return $this
      */
     public function setShowVal($value)
     {
@@ -372,7 +372,7 @@ class Layout
      *
      * @param bool $value Show cat name
      *
-     * @return Layout
+     * @return $this
      */
     public function setShowCatName($value)
     {
@@ -397,7 +397,7 @@ class Layout
      *
      * @param bool $value Show series name
      *
-     * @return Layout
+     * @return $this
      */
     public function setShowSerName($value)
     {
@@ -422,7 +422,7 @@ class Layout
      *
      * @param bool $value Show percentage
      *
-     * @return Layout
+     * @return $this
      */
     public function setShowPercent($value)
     {
@@ -447,7 +447,7 @@ class Layout
      *
      * @param bool $value Show bubble size
      *
-     * @return Layout
+     * @return $this
      */
     public function setShowBubbleSize($value)
     {
@@ -472,7 +472,7 @@ class Layout
      *
      * @param bool $value Show leader lines
      *
-     * @return Layout
+     * @return $this
      */
     public function setShowLeaderLines($value)
     {

--- a/src/PhpSpreadsheet/Chart/PlotArea.php
+++ b/src/PhpSpreadsheet/Chart/PlotArea.php
@@ -94,7 +94,7 @@ class PlotArea
      *
      * @param DataSeries[] $plotSeries
      *
-     * @return PlotArea
+     * @return $this
      */
     public function setPlotSeries(array $plotSeries)
     {

--- a/src/PhpSpreadsheet/Chart/Title.php
+++ b/src/PhpSpreadsheet/Chart/Title.php
@@ -45,7 +45,7 @@ class Title
      *
      * @param string $caption
      *
-     * @return Title
+     * @return $this
      */
     public function setCaption($caption)
     {

--- a/src/PhpSpreadsheet/Comment.php
+++ b/src/PhpSpreadsheet/Comment.php
@@ -96,7 +96,7 @@ class Comment implements IComparable
      *
      * @param string $author
      *
-     * @return Comment
+     * @return $this
      */
     public function setAuthor($author)
     {
@@ -120,7 +120,7 @@ class Comment implements IComparable
      *
      * @param RichText $pValue
      *
-     * @return Comment
+     * @return $this
      */
     public function setText(RichText $pValue)
     {
@@ -144,7 +144,7 @@ class Comment implements IComparable
      *
      * @param string $width
      *
-     * @return Comment
+     * @return $this
      */
     public function setWidth($width)
     {
@@ -168,7 +168,7 @@ class Comment implements IComparable
      *
      * @param string $value
      *
-     * @return Comment
+     * @return $this
      */
     public function setHeight($value)
     {
@@ -192,7 +192,7 @@ class Comment implements IComparable
      *
      * @param string $value
      *
-     * @return Comment
+     * @return $this
      */
     public function setMarginLeft($value)
     {
@@ -216,7 +216,7 @@ class Comment implements IComparable
      *
      * @param string $value
      *
-     * @return Comment
+     * @return $this
      */
     public function setMarginTop($value)
     {
@@ -240,7 +240,7 @@ class Comment implements IComparable
      *
      * @param bool $value
      *
-     * @return Comment
+     * @return $this
      */
     public function setVisible($value)
     {
@@ -264,7 +264,7 @@ class Comment implements IComparable
      *
      * @param string $alignment see Style\Alignment::HORIZONTAL_*
      *
-     * @return Comment
+     * @return $this
      */
     public function setAlignment($alignment)
     {

--- a/src/PhpSpreadsheet/Document/Properties.php
+++ b/src/PhpSpreadsheet/Document/Properties.php
@@ -122,7 +122,7 @@ class Properties
      *
      * @param string $creator
      *
-     * @return Properties
+     * @return $this
      */
     public function setCreator($creator)
     {
@@ -146,7 +146,7 @@ class Properties
      *
      * @param string $pValue
      *
-     * @return Properties
+     * @return $this
      */
     public function setLastModifiedBy($pValue)
     {
@@ -170,7 +170,7 @@ class Properties
      *
      * @param int|string $time
      *
-     * @return Properties
+     * @return $this
      */
     public function setCreated($time)
     {
@@ -204,7 +204,7 @@ class Properties
      *
      * @param int|string $time
      *
-     * @return Properties
+     * @return $this
      */
     public function setModified($time)
     {
@@ -238,7 +238,7 @@ class Properties
      *
      * @param string $title
      *
-     * @return Properties
+     * @return $this
      */
     public function setTitle($title)
     {
@@ -262,7 +262,7 @@ class Properties
      *
      * @param string $description
      *
-     * @return Properties
+     * @return $this
      */
     public function setDescription($description)
     {
@@ -286,7 +286,7 @@ class Properties
      *
      * @param string $subject
      *
-     * @return Properties
+     * @return $this
      */
     public function setSubject($subject)
     {
@@ -310,7 +310,7 @@ class Properties
      *
      * @param string $keywords
      *
-     * @return Properties
+     * @return $this
      */
     public function setKeywords($keywords)
     {
@@ -334,7 +334,7 @@ class Properties
      *
      * @param string $category
      *
-     * @return Properties
+     * @return $this
      */
     public function setCategory($category)
     {
@@ -358,7 +358,7 @@ class Properties
      *
      * @param string $company
      *
-     * @return Properties
+     * @return $this
      */
     public function setCompany($company)
     {
@@ -382,7 +382,7 @@ class Properties
      *
      * @param string $manager
      *
-     * @return Properties
+     * @return $this
      */
     public function setManager($manager)
     {
@@ -453,7 +453,7 @@ class Properties
      *   'd' : Date/Time
      *   'b' : Boolean
      *
-     * @return Properties
+     * @return $this
      */
     public function setCustomProperty($propertyName, $propertyValue = '', $propertyType = null)
     {

--- a/src/PhpSpreadsheet/Document/Security.php
+++ b/src/PhpSpreadsheet/Document/Security.php
@@ -75,7 +75,7 @@ class Security
      *
      * @param bool $pValue
      *
-     * @return Security
+     * @return $this
      */
     public function setLockRevision($pValue)
     {
@@ -99,7 +99,7 @@ class Security
      *
      * @param bool $pValue
      *
-     * @return Security
+     * @return $this
      */
     public function setLockStructure($pValue)
     {
@@ -123,7 +123,7 @@ class Security
      *
      * @param bool $pValue
      *
-     * @return Security
+     * @return $this
      */
     public function setLockWindows($pValue)
     {
@@ -148,7 +148,7 @@ class Security
      * @param string $pValue
      * @param bool $pAlreadyHashed If the password has already been hashed, set this to true
      *
-     * @return Security
+     * @return $this
      */
     public function setRevisionsPassword($pValue, $pAlreadyHashed = false)
     {
@@ -176,7 +176,7 @@ class Security
      * @param string $pValue
      * @param bool $pAlreadyHashed If the password has already been hashed, set this to true
      *
-     * @return Security
+     * @return $this
      */
     public function setWorkbookPassword($pValue, $pAlreadyHashed = false)
     {

--- a/src/PhpSpreadsheet/NamedRange.php
+++ b/src/PhpSpreadsheet/NamedRange.php
@@ -82,7 +82,7 @@ class NamedRange
      *
      * @param string $value
      *
-     * @return NamedRange
+     * @return $this
      */
     public function setName($value)
     {
@@ -123,7 +123,7 @@ class NamedRange
      *
      * @param Worksheet $value
      *
-     * @return NamedRange
+     * @return $this
      */
     public function setWorksheet(Worksheet $value = null)
     {
@@ -149,7 +149,7 @@ class NamedRange
      *
      * @param string $value
      *
-     * @return NamedRange
+     * @return $this
      */
     public function setRange($value)
     {
@@ -175,7 +175,7 @@ class NamedRange
      *
      * @param bool $value
      *
-     * @return NamedRange
+     * @return $this
      */
     public function setLocalOnly($value)
     {
@@ -200,7 +200,7 @@ class NamedRange
      *
      * @param null|Worksheet $value
      *
-     * @return NamedRange
+     * @return $this
      */
     public function setScope(Worksheet $value = null)
     {

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -70,7 +70,7 @@ class Csv extends BaseReader
      *
      * @param string $pValue Input encoding, eg: 'UTF-8'
      *
-     * @return Csv
+     * @return $this
      */
     public function setInputEncoding($pValue)
     {
@@ -415,7 +415,7 @@ class Csv extends BaseReader
      *
      * @param string $delimiter Delimiter, eg: ','
      *
-     * @return CSV
+     * @return $this
      */
     public function setDelimiter($delimiter)
     {
@@ -439,7 +439,7 @@ class Csv extends BaseReader
      *
      * @param string $enclosure Enclosure, defaults to "
      *
-     * @return CSV
+     * @return $this
      */
     public function setEnclosure($enclosure)
     {
@@ -466,7 +466,7 @@ class Csv extends BaseReader
      *
      * @param int $pValue Sheet index
      *
-     * @return CSV
+     * @return $this
      */
     public function setSheetIndex($pValue)
     {
@@ -480,7 +480,7 @@ class Csv extends BaseReader
      *
      * @param bool $contiguous
      *
-     * @return Csv
+     * @return $this
      */
     public function setContiguous($contiguous)
     {

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -223,7 +223,7 @@ class Html extends BaseReader
      *
      * @param string $pValue Input encoding, eg: 'ANSI'
      *
-     * @return Html
+     * @return $this
      */
     public function setInputEncoding($pValue)
     {
@@ -669,7 +669,7 @@ class Html extends BaseReader
      *
      * @param int $pValue Sheet index
      *
-     * @return HTML
+     * @return $this
      */
     public function setSheetIndex($pValue)
     {

--- a/src/PhpSpreadsheet/Reader/Slk.php
+++ b/src/PhpSpreadsheet/Reader/Slk.php
@@ -83,7 +83,7 @@ class Slk extends BaseReader
      *
      * @param string $pValue Input encoding, eg: 'ANSI'
      *
-     * @return Slk
+     * @return $this
      */
     public function setInputEncoding($pValue)
     {
@@ -485,7 +485,7 @@ class Slk extends BaseReader
      *
      * @param int $pValue Sheet index
      *
-     * @return Slk
+     * @return $this
      */
     public function setSheetIndex($pValue)
     {

--- a/src/PhpSpreadsheet/RichText/RichText.php
+++ b/src/PhpSpreadsheet/RichText/RichText.php
@@ -47,7 +47,7 @@ class RichText implements IComparable
      *
      * @param ITextElement $pText Rich text element
      *
-     * @return RichText
+     * @return $this
      */
     public function addText(ITextElement $pText)
     {
@@ -133,7 +133,7 @@ class RichText implements IComparable
      *
      * @param ITextElement[] $textElements Array of elements
      *
-     * @return RichText
+     * @return $this
      */
     public function setRichTextElements(array $textElements)
     {

--- a/src/PhpSpreadsheet/RichText/Run.php
+++ b/src/PhpSpreadsheet/RichText/Run.php
@@ -40,7 +40,7 @@ class Run extends TextElement implements ITextElement
      *
      * @param Font $pFont Font
      *
-     * @return ITextElement
+     * @return $this
      */
     public function setFont(Font $pFont = null)
     {

--- a/src/PhpSpreadsheet/RichText/TextElement.php
+++ b/src/PhpSpreadsheet/RichText/TextElement.php
@@ -37,7 +37,7 @@ class TextElement implements ITextElement
      *
      * @param $text string Text
      *
-     * @return ITextElement
+     * @return $this
      */
     public function setText($text)
     {

--- a/src/PhpSpreadsheet/Shared/JAMA/Matrix.php
+++ b/src/PhpSpreadsheet/Shared/JAMA/Matrix.php
@@ -524,7 +524,7 @@ class Matrix
      *
      * @param mixed $B Matrix/Array
      *
-     * @return Matrix Sum
+     * @return $this
      */
     public function plusEquals(...$args)
     {
@@ -628,7 +628,7 @@ class Matrix
      *
      * @param mixed $B Matrix/Array
      *
-     * @return Matrix Sum
+     * @return $this
      */
     public function minusEquals(...$args)
     {
@@ -734,7 +734,7 @@ class Matrix
      *
      * @param mixed $B Matrix/Array
      *
-     * @return Matrix Matrix Aij
+     * @return $this
      */
     public function arrayTimesEquals(...$args)
     {
@@ -1091,7 +1091,7 @@ class Matrix
      *
      * @param mixed $B Matrix/Array
      *
-     * @return Matrix Sum
+     * @return $this
      */
     public function power(...$args)
     {
@@ -1150,7 +1150,7 @@ class Matrix
      *
      * @param mixed $B Matrix/Array
      *
-     * @return Matrix Sum
+     * @return $this
      */
     public function concat(...$args)
     {

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -955,7 +955,7 @@ class Spreadsheet
      * @param string $namedRange
      * @param null|Worksheet $pSheet scope: use null for global scope
      *
-     * @return Spreadsheet
+     * @return $this
      */
     public function removeNamedRange($namedRange, Worksheet $pSheet = null)
     {

--- a/src/PhpSpreadsheet/Style/Alignment.php
+++ b/src/PhpSpreadsheet/Style/Alignment.php
@@ -140,7 +140,7 @@ class Alignment extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Alignment
+     * @return $this
      */
     public function applyFromArray(array $pStyles)
     {
@@ -193,7 +193,7 @@ class Alignment extends Supervisor
      *
      * @param string $pValue see self::HORIZONTAL_*
      *
-     * @return Alignment
+     * @return $this
      */
     public function setHorizontal($pValue)
     {
@@ -230,7 +230,7 @@ class Alignment extends Supervisor
      *
      * @param string $pValue see self::VERTICAL_*
      *
-     * @return Alignment
+     * @return $this
      */
     public function setVertical($pValue)
     {
@@ -269,7 +269,7 @@ class Alignment extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Alignment
+     * @return $this
      */
     public function setTextRotation($pValue)
     {
@@ -312,7 +312,7 @@ class Alignment extends Supervisor
      *
      * @param bool $pValue
      *
-     * @return Alignment
+     * @return $this
      */
     public function setWrapText($pValue)
     {
@@ -348,7 +348,7 @@ class Alignment extends Supervisor
      *
      * @param bool $pValue
      *
-     * @return Alignment
+     * @return $this
      */
     public function setShrinkToFit($pValue)
     {
@@ -384,7 +384,7 @@ class Alignment extends Supervisor
      *
      * @param int $pValue
      *
-     * @return Alignment
+     * @return $this
      */
     public function setIndent($pValue)
     {
@@ -424,7 +424,7 @@ class Alignment extends Supervisor
      *
      * @param int $pValue
      *
-     * @return Alignment
+     * @return $this
      */
     public function setReadOrder($pValue)
     {

--- a/src/PhpSpreadsheet/Style/Border.php
+++ b/src/PhpSpreadsheet/Style/Border.php
@@ -127,7 +127,7 @@ class Border extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Border
+     * @return $this
      */
     public function applyFromArray(array $pStyles)
     {
@@ -166,7 +166,7 @@ class Border extends Supervisor
      *                            When passing a boolean, FALSE equates Border::BORDER_NONE
      *                                and TRUE to Border::BORDER_MEDIUM
      *
-     * @return Border
+     * @return $this
      */
     public function setBorderStyle($pValue)
     {
@@ -202,7 +202,7 @@ class Border extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Border
+     * @return $this
      */
     public function setColor(Color $pValue)
     {

--- a/src/PhpSpreadsheet/Style/Borders.php
+++ b/src/PhpSpreadsheet/Style/Borders.php
@@ -197,7 +197,7 @@ class Borders extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Borders
+     * @return $this
      */
     public function applyFromArray(array $pStyles)
     {
@@ -382,7 +382,7 @@ class Borders extends Supervisor
      *
      * @param int $pValue see self::DIAGONAL_*
      *
-     * @return Borders
+     * @return $this
      */
     public function setDiagonalDirection($pValue)
     {

--- a/src/PhpSpreadsheet/Style/Color.php
+++ b/src/PhpSpreadsheet/Style/Color.php
@@ -106,7 +106,7 @@ class Color extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Color
+     * @return $this
      */
     public function applyFromArray(array $pStyles)
     {
@@ -143,7 +143,7 @@ class Color extends Supervisor
      *
      * @param string $pValue see self::COLOR_*
      *
-     * @return Color
+     * @return $this
      */
     public function setARGB($pValue)
     {
@@ -179,7 +179,7 @@ class Color extends Supervisor
      *
      * @param string $pValue RGB value
      *
-     * @return Color
+     * @return $this
      */
     public function setRGB($pValue)
     {
@@ -312,7 +312,7 @@ class Color extends Supervisor
      * @param bool $background Flag to indicate whether default background or foreground colour
      *                                            should be returned if the indexed colour doesn't exist
      *
-     * @return Color
+     * @return self
      */
     public static function indexedColor($pIndex, $background = false)
     {

--- a/src/PhpSpreadsheet/Style/Conditional.php
+++ b/src/PhpSpreadsheet/Style/Conditional.php
@@ -94,7 +94,7 @@ class Conditional implements IComparable
      *
      * @param string $pValue Condition type, see self::CONDITION_*
      *
-     * @return Conditional
+     * @return $this
      */
     public function setConditionType($pValue)
     {
@@ -118,7 +118,7 @@ class Conditional implements IComparable
      *
      * @param string $pValue Conditional operator type, see self::OPERATOR_*
      *
-     * @return Conditional
+     * @return $this
      */
     public function setOperatorType($pValue)
     {
@@ -142,7 +142,7 @@ class Conditional implements IComparable
      *
      * @param string $value
      *
-     * @return Conditional
+     * @return $this
      */
     public function setText($value)
     {
@@ -166,7 +166,7 @@ class Conditional implements IComparable
      *
      * @param bool $value
      *
-     * @return Conditional
+     * @return $this
      */
     public function setStopIfTrue($value)
     {
@@ -190,7 +190,7 @@ class Conditional implements IComparable
      *
      * @param string[] $pValue Condition
      *
-     * @return Conditional
+     * @return $this
      */
     public function setConditions($pValue)
     {
@@ -207,7 +207,7 @@ class Conditional implements IComparable
      *
      * @param string $pValue Condition
      *
-     * @return Conditional
+     * @return $this
      */
     public function addCondition($pValue)
     {
@@ -231,7 +231,7 @@ class Conditional implements IComparable
      *
      * @param Style $pValue
      *
-     * @return Conditional
+     * @return $this
      */
     public function setStyle(Style $pValue = null)
     {

--- a/src/PhpSpreadsheet/Style/Fill.php
+++ b/src/PhpSpreadsheet/Style/Fill.php
@@ -141,7 +141,7 @@ class Fill extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Fill
+     * @return $this
      */
     public function applyFromArray(array $pStyles)
     {
@@ -188,7 +188,7 @@ class Fill extends Supervisor
      *
      * @param string $pValue Fill type, see self::FILL_*
      *
-     * @return Fill
+     * @return $this
      */
     public function setFillType($pValue)
     {
@@ -221,7 +221,7 @@ class Fill extends Supervisor
      *
      * @param float $pValue
      *
-     * @return Fill
+     * @return $this
      */
     public function setRotation($pValue)
     {
@@ -252,7 +252,7 @@ class Fill extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Fill
+     * @return $this
      */
     public function setStartColor(Color $pValue)
     {
@@ -286,7 +286,7 @@ class Fill extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Fill
+     * @return $this
      */
     public function setEndColor(Color $pValue)
     {

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -161,7 +161,7 @@ class Font extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Font
+     * @return $this
      */
     public function applyFromArray(array $pStyles)
     {
@@ -219,7 +219,7 @@ class Font extends Supervisor
      *
      * @param string $pValue
      *
-     * @return Font
+     * @return $this
      */
     public function setName($pValue)
     {
@@ -255,7 +255,7 @@ class Font extends Supervisor
      *
      * @param float $pValue
      *
-     * @return Font
+     * @return $this
      */
     public function setSize($pValue)
     {
@@ -291,7 +291,7 @@ class Font extends Supervisor
      *
      * @param bool $pValue
      *
-     * @return Font
+     * @return $this
      */
     public function setBold($pValue)
     {
@@ -327,7 +327,7 @@ class Font extends Supervisor
      *
      * @param bool $pValue
      *
-     * @return Font
+     * @return $this
      */
     public function setItalic($pValue)
     {
@@ -363,7 +363,7 @@ class Font extends Supervisor
      *
      * @param bool $pValue
      *
-     * @return Font
+     * @return $this
      */
     public function setSuperscript($pValue)
     {
@@ -400,7 +400,7 @@ class Font extends Supervisor
      *
      * @param bool $pValue
      *
-     * @return Font
+     * @return $this
      */
     public function setSubscript($pValue)
     {
@@ -439,7 +439,7 @@ class Font extends Supervisor
      *                                    If a boolean is passed, then TRUE equates to UNDERLINE_SINGLE,
      *                                        false equates to UNDERLINE_NONE
      *
-     * @return Font
+     * @return $this
      */
     public function setUnderline($pValue)
     {
@@ -477,7 +477,7 @@ class Font extends Supervisor
      *
      * @param bool $pValue
      *
-     * @return Font
+     * @return $this
      */
     public function setStrikethrough($pValue)
     {
@@ -512,7 +512,7 @@ class Font extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Font
+     * @return $this
      */
     public function setColor(Color $pValue)
     {

--- a/src/PhpSpreadsheet/Style/NumberFormat.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat.php
@@ -139,7 +139,7 @@ class NumberFormat extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return NumberFormat
+     * @return $this
      */
     public function applyFromArray(array $pStyles)
     {
@@ -176,7 +176,7 @@ class NumberFormat extends Supervisor
      *
      * @param string $pValue see self::FORMAT_*
      *
-     * @return NumberFormat
+     * @return $this
      */
     public function setFormatCode($pValue)
     {
@@ -213,7 +213,7 @@ class NumberFormat extends Supervisor
      *
      * @param int $pValue
      *
-     * @return NumberFormat
+     * @return $this
      */
     public function setBuiltInFormatCode($pValue)
     {

--- a/src/PhpSpreadsheet/Style/Protection.php
+++ b/src/PhpSpreadsheet/Style/Protection.php
@@ -86,7 +86,7 @@ class Protection extends Supervisor
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Protection
+     * @return $this
      */
     public function applyFromArray(array $pStyles)
     {
@@ -123,7 +123,7 @@ class Protection extends Supervisor
      *
      * @param string $pValue see self::PROTECTION_*
      *
-     * @return Protection
+     * @return $this
      */
     public function setLocked($pValue)
     {
@@ -156,7 +156,7 @@ class Protection extends Supervisor
      *
      * @param string $pValue see self::PROTECTION_*
      *
-     * @return Protection
+     * @return $this
      */
     public function setHidden($pValue)
     {

--- a/src/PhpSpreadsheet/Style/Style.php
+++ b/src/PhpSpreadsheet/Style/Style.php
@@ -189,7 +189,7 @@ class Style extends Supervisor
      * @param array $pStyles Array containing style information
      * @param bool $pAdvanced advanced mode for setting borders
      *
-     * @return Style
+     * @return $this
      */
     public function applyFromArray(array $pStyles, $pAdvanced = true)
     {
@@ -485,7 +485,7 @@ class Style extends Supervisor
      *
      * @param Font $font
      *
-     * @return Style
+     * @return $this
      */
     public function setFont(Font $font)
     {
@@ -539,7 +539,7 @@ class Style extends Supervisor
      *
      * @param Conditional[] $pValue Array of conditional styles
      *
-     * @return Style
+     * @return $this
      */
     public function setConditionalStyles(array $pValue)
     {
@@ -577,7 +577,7 @@ class Style extends Supervisor
      *
      * @param bool $pValue
      *
-     * @return Style
+     * @return $this
      */
     public function setQuotePrefix($pValue)
     {

--- a/src/PhpSpreadsheet/Style/Supervisor.php
+++ b/src/PhpSpreadsheet/Style/Supervisor.php
@@ -48,7 +48,7 @@ abstract class Supervisor implements IComparable
      * @param Spreadsheet|Style $parent
      * @param null|string $parentPropertyName
      *
-     * @return Supervisor
+     * @return $this
      */
     public function bindParent($parent, $parentPropertyName = null)
     {

--- a/src/PhpSpreadsheet/Worksheet/AutoFilter.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter.php
@@ -59,7 +59,7 @@ class AutoFilter
      *
      * @param Worksheet $pSheet
      *
-     * @return AutoFilter
+     * @return $this
      */
     public function setParent(Worksheet $pSheet = null)
     {
@@ -85,7 +85,7 @@ class AutoFilter
      *
      * @throws PhpSpreadsheetException
      *
-     * @return AutoFilter
+     * @return $this
      */
     public function setRange($pRange)
     {
@@ -210,7 +210,7 @@ class AutoFilter
      *
      * @throws PhpSpreadsheetException
      *
-     * @return AutoFilter
+     * @return $this
      */
     public function setColumn($pColumn)
     {
@@ -241,7 +241,7 @@ class AutoFilter
      *
      * @throws PhpSpreadsheetException
      *
-     * @return AutoFilter
+     * @return $this
      */
     public function clearColumn($pColumn)
     {
@@ -264,7 +264,7 @@ class AutoFilter
      * @param string $fromColumn Column name (e.g. A)
      * @param string $toColumn Column name (e.g. B)
      *
-     * @return AutoFilter
+     * @return $this
      */
     public function shiftColumn($fromColumn, $toColumn)
     {
@@ -617,7 +617,7 @@ class AutoFilter
      *
      * @throws PhpSpreadsheetException
      *
-     * @return AutoFilter
+     * @return $this
      */
     public function showHideRows()
     {

--- a/src/PhpSpreadsheet/Worksheet/AutoFilter/Column.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter/Column.php
@@ -117,7 +117,7 @@ class Column
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Column
+     * @return $this
      */
     public function setColumnIndex($pColumn)
     {
@@ -147,7 +147,7 @@ class Column
      *
      * @param AutoFilter $pParent
      *
-     * @return Column
+     * @return $this
      */
     public function setParent(AutoFilter $pParent = null)
     {
@@ -173,7 +173,7 @@ class Column
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Column
+     * @return $this
      */
     public function setFilterType($pFilterType)
     {
@@ -203,7 +203,7 @@ class Column
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Column
+     * @return $this
      */
     public function setJoin($pJoin)
     {
@@ -223,7 +223,7 @@ class Column
      *
      * @param string[] $attributes
      *
-     * @return Column
+     * @return $this
      */
     public function setAttributes(array $attributes)
     {
@@ -238,7 +238,7 @@ class Column
      * @param string $pName Attribute Name
      * @param string $pValue Attribute Value
      *
-     * @return Column
+     * @return $this
      */
     public function setAttribute($pName, $pValue)
     {
@@ -316,7 +316,7 @@ class Column
      *
      * @param Column\Rule $pRule
      *
-     * @return Column
+     * @return $this
      */
     public function addRule(Column\Rule $pRule)
     {
@@ -332,7 +332,7 @@ class Column
      *
      * @param int $pIndex Rule index in the ruleset array
      *
-     * @return Column
+     * @return $this
      */
     public function deleteRule($pIndex)
     {
@@ -350,7 +350,7 @@ class Column
     /**
      * Delete all AutoFilter Column Rules.
      *
-     * @return Column
+     * @return $this
      */
     public function clearRules()
     {

--- a/src/PhpSpreadsheet/Worksheet/AutoFilter/Column/Rule.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter/Column/Rule.php
@@ -262,7 +262,7 @@ class Rule
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Rule
+     * @return $this
      */
     public function setRuleType($pRuleType)
     {
@@ -292,7 +292,7 @@ class Rule
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Rule
+     * @return $this
      */
     public function setValue($pValue)
     {
@@ -336,7 +336,7 @@ class Rule
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Rule
+     * @return $this
      */
     public function setOperator($pOperator)
     {
@@ -369,7 +369,7 @@ class Rule
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Rule
+     * @return $this
      */
     public function setGrouping($pGrouping)
     {
@@ -393,7 +393,7 @@ class Rule
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Rule
+     * @return $this
      */
     public function setRule($pOperator, $pValue, $pGrouping = null)
     {
@@ -424,7 +424,7 @@ class Rule
      *
      * @param Column $pParent
      *
-     * @return Rule
+     * @return $this
      */
     public function setParent(Column $pParent = null)
     {

--- a/src/PhpSpreadsheet/Worksheet/BaseDrawing.php
+++ b/src/PhpSpreadsheet/Worksheet/BaseDrawing.php
@@ -154,7 +154,7 @@ class BaseDrawing implements IComparable
      *
      * @param string $pValue
      *
-     * @return BaseDrawing
+     * @return $this
      */
     public function setName($pValue)
     {
@@ -178,7 +178,7 @@ class BaseDrawing implements IComparable
      *
      * @param string $description
      *
-     * @return BaseDrawing
+     * @return $this
      */
     public function setDescription($description)
     {
@@ -205,7 +205,7 @@ class BaseDrawing implements IComparable
      *
      * @throws PhpSpreadsheetException
      *
-     * @return BaseDrawing
+     * @return $this
      */
     public function setWorksheet(Worksheet $pValue = null, $pOverrideOld = false)
     {
@@ -253,7 +253,7 @@ class BaseDrawing implements IComparable
      *
      * @param string $pValue eg: 'A1'
      *
-     * @return BaseDrawing
+     * @return $this
      */
     public function setCoordinates($pValue)
     {
@@ -277,7 +277,7 @@ class BaseDrawing implements IComparable
      *
      * @param int $pValue
      *
-     * @return BaseDrawing
+     * @return $this
      */
     public function setOffsetX($pValue)
     {
@@ -301,7 +301,7 @@ class BaseDrawing implements IComparable
      *
      * @param int $pValue
      *
-     * @return BaseDrawing
+     * @return $this
      */
     public function setOffsetY($pValue)
     {
@@ -325,7 +325,7 @@ class BaseDrawing implements IComparable
      *
      * @param int $pValue
      *
-     * @return BaseDrawing
+     * @return $this
      */
     public function setWidth($pValue)
     {
@@ -356,7 +356,7 @@ class BaseDrawing implements IComparable
      *
      * @param int $pValue
      *
-     * @return BaseDrawing
+     * @return $this
      */
     public function setHeight($pValue)
     {
@@ -386,7 +386,7 @@ class BaseDrawing implements IComparable
      * @param int $width
      * @param int $height
      *
-     * @return BaseDrawing
+     * @return $this
      */
     public function setWidthAndHeight($width, $height)
     {
@@ -423,7 +423,7 @@ class BaseDrawing implements IComparable
      *
      * @param bool $pValue
      *
-     * @return BaseDrawing
+     * @return $this
      */
     public function setResizeProportional($pValue)
     {
@@ -447,7 +447,7 @@ class BaseDrawing implements IComparable
      *
      * @param int $pValue
      *
-     * @return BaseDrawing
+     * @return $this
      */
     public function setRotation($pValue)
     {
@@ -471,7 +471,7 @@ class BaseDrawing implements IComparable
      *
      * @param Drawing\Shadow $pValue
      *
-     * @return BaseDrawing
+     * @return $this
      */
     public function setShadow(Drawing\Shadow $pValue = null)
     {

--- a/src/PhpSpreadsheet/Worksheet/ColumnCellIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/ColumnCellIterator.php
@@ -59,7 +59,7 @@ class ColumnCellIterator extends CellIterator
      *
      * @throws PhpSpreadsheetException
      *
-     * @return ColumnCellIterator
+     * @return $this
      */
     public function resetStart($startRow = 1)
     {
@@ -77,7 +77,7 @@ class ColumnCellIterator extends CellIterator
      *
      * @throws PhpSpreadsheetException
      *
-     * @return ColumnCellIterator
+     * @return $this
      */
     public function resetEnd($endRow = null)
     {
@@ -94,7 +94,7 @@ class ColumnCellIterator extends CellIterator
      *
      * @throws PhpSpreadsheetException
      *
-     * @return ColumnCellIterator
+     * @return $this
      */
     public function seek($row = 1)
     {

--- a/src/PhpSpreadsheet/Worksheet/ColumnDimension.php
+++ b/src/PhpSpreadsheet/Worksheet/ColumnDimension.php
@@ -56,7 +56,7 @@ class ColumnDimension extends Dimension
      *
      * @param string $pValue
      *
-     * @return ColumnDimension
+     * @return $this
      */
     public function setColumnIndex($pValue)
     {
@@ -80,7 +80,7 @@ class ColumnDimension extends Dimension
      *
      * @param float $pValue
      *
-     * @return ColumnDimension
+     * @return $this
      */
     public function setWidth($pValue)
     {
@@ -104,7 +104,7 @@ class ColumnDimension extends Dimension
      *
      * @param bool $pValue
      *
-     * @return ColumnDimension
+     * @return $this
      */
     public function setAutoSize($pValue)
     {

--- a/src/PhpSpreadsheet/Worksheet/ColumnIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/ColumnIterator.php
@@ -66,7 +66,7 @@ class ColumnIterator implements \Iterator
      *
      * @throws Exception
      *
-     * @return ColumnIterator
+     * @return $this
      */
     public function resetStart($startColumn = 'A')
     {
@@ -89,7 +89,7 @@ class ColumnIterator implements \Iterator
      *
      * @param string $endColumn The column address at which to stop iterating
      *
-     * @return ColumnIterator
+     * @return $this
      */
     public function resetEnd($endColumn = null)
     {
@@ -106,7 +106,7 @@ class ColumnIterator implements \Iterator
      *
      * @throws PhpSpreadsheetException
      *
-     * @return ColumnIterator
+     * @return $this
      */
     public function seek($column = 'A')
     {

--- a/src/PhpSpreadsheet/Worksheet/Dimension.php
+++ b/src/PhpSpreadsheet/Worksheet/Dimension.php
@@ -60,7 +60,7 @@ abstract class Dimension
      *
      * @param bool $pValue
      *
-     * @return Dimension
+     * @return $this
      */
     public function setVisible($pValue)
     {
@@ -87,7 +87,7 @@ abstract class Dimension
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Dimension
+     * @return $this
      */
     public function setOutlineLevel($pValue)
     {
@@ -115,7 +115,7 @@ abstract class Dimension
      *
      * @param bool $pValue
      *
-     * @return Dimension
+     * @return $this
      */
     public function setCollapsed($pValue)
     {
@@ -139,7 +139,7 @@ abstract class Dimension
      *
      * @param int $pValue
      *
-     * @return Dimension
+     * @return $this
      */
     public function setXfIndex($pValue)
     {

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -78,7 +78,7 @@ class Drawing extends BaseDrawing
      *
      * @throws PhpSpreadsheetException
      *
-     * @return Drawing
+     * @return $this
      */
     public function setPath($pValue, $pVerifyFile = true)
     {

--- a/src/PhpSpreadsheet/Worksheet/Drawing/Shadow.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing/Shadow.php
@@ -100,7 +100,7 @@ class Shadow implements IComparable
      *
      * @param bool $pValue
      *
-     * @return Shadow
+     * @return $this
      */
     public function setVisible($pValue)
     {
@@ -124,7 +124,7 @@ class Shadow implements IComparable
      *
      * @param int $pValue
      *
-     * @return Shadow
+     * @return $this
      */
     public function setBlurRadius($pValue)
     {
@@ -148,7 +148,7 @@ class Shadow implements IComparable
      *
      * @param int $pValue
      *
-     * @return Shadow
+     * @return $this
      */
     public function setDistance($pValue)
     {
@@ -172,7 +172,7 @@ class Shadow implements IComparable
      *
      * @param int $pValue
      *
-     * @return Shadow
+     * @return $this
      */
     public function setDirection($pValue)
     {
@@ -196,7 +196,7 @@ class Shadow implements IComparable
      *
      * @param int $pValue
      *
-     * @return Shadow
+     * @return $this
      */
     public function setAlignment($pValue)
     {
@@ -220,7 +220,7 @@ class Shadow implements IComparable
      *
      * @param Color $pValue
      *
-     * @return Shadow
+     * @return $this
      */
     public function setColor(Color $pValue = null)
     {
@@ -244,7 +244,7 @@ class Shadow implements IComparable
      *
      * @param int $pValue
      *
-     * @return Shadow
+     * @return $this
      */
     public function setAlpha($pValue)
     {

--- a/src/PhpSpreadsheet/Worksheet/HeaderFooter.php
+++ b/src/PhpSpreadsheet/Worksheet/HeaderFooter.php
@@ -172,7 +172,7 @@ class HeaderFooter
      *
      * @param string $pValue
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function setOddHeader($pValue)
     {
@@ -196,7 +196,7 @@ class HeaderFooter
      *
      * @param string $pValue
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function setOddFooter($pValue)
     {
@@ -220,7 +220,7 @@ class HeaderFooter
      *
      * @param string $pValue
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function setEvenHeader($pValue)
     {
@@ -244,7 +244,7 @@ class HeaderFooter
      *
      * @param string $pValue
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function setEvenFooter($pValue)
     {
@@ -268,7 +268,7 @@ class HeaderFooter
      *
      * @param string $pValue
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function setFirstHeader($pValue)
     {
@@ -292,7 +292,7 @@ class HeaderFooter
      *
      * @param string $pValue
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function setFirstFooter($pValue)
     {
@@ -316,7 +316,7 @@ class HeaderFooter
      *
      * @param bool $pValue
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function setDifferentOddEven($pValue)
     {
@@ -340,7 +340,7 @@ class HeaderFooter
      *
      * @param bool $pValue
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function setDifferentFirst($pValue)
     {
@@ -364,7 +364,7 @@ class HeaderFooter
      *
      * @param bool $pValue
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function setScaleWithDocument($pValue)
     {
@@ -388,7 +388,7 @@ class HeaderFooter
      *
      * @param bool $pValue
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function setAlignWithMargins($pValue)
     {
@@ -403,7 +403,7 @@ class HeaderFooter
      * @param HeaderFooterDrawing $image
      * @param string $location
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function addImage(HeaderFooterDrawing $image, $location = self::IMAGE_HEADER_LEFT)
     {
@@ -417,7 +417,7 @@ class HeaderFooter
      *
      * @param string $location
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function removeImage($location = self::IMAGE_HEADER_LEFT)
     {
@@ -433,7 +433,7 @@ class HeaderFooter
      *
      * @param HeaderFooterDrawing[] $images
      *
-     * @return HeaderFooter
+     * @return $this
      */
     public function setImages(array $images)
     {

--- a/src/PhpSpreadsheet/Worksheet/MemoryDrawing.php
+++ b/src/PhpSpreadsheet/Worksheet/MemoryDrawing.php
@@ -74,7 +74,7 @@ class MemoryDrawing extends BaseDrawing
      *
      * @param resource $value
      *
-     * @return MemoryDrawing
+     * @return $this
      */
     public function setImageResource($value)
     {
@@ -104,7 +104,7 @@ class MemoryDrawing extends BaseDrawing
      *
      * @param string $value see self::RENDERING_*
      *
-     * @return MemoryDrawing
+     * @return $this
      */
     public function setRenderingFunction($value)
     {
@@ -128,7 +128,7 @@ class MemoryDrawing extends BaseDrawing
      *
      * @param string $value see self::MIMETYPE_*
      *
-     * @return MemoryDrawing
+     * @return $this
      */
     public function setMimeType($value)
     {

--- a/src/PhpSpreadsheet/Worksheet/PageMargins.php
+++ b/src/PhpSpreadsheet/Worksheet/PageMargins.php
@@ -68,7 +68,7 @@ class PageMargins
      *
      * @param float $pValue
      *
-     * @return PageMargins
+     * @return $this
      */
     public function setLeft($pValue)
     {
@@ -92,7 +92,7 @@ class PageMargins
      *
      * @param float $pValue
      *
-     * @return PageMargins
+     * @return $this
      */
     public function setRight($pValue)
     {
@@ -116,7 +116,7 @@ class PageMargins
      *
      * @param float $pValue
      *
-     * @return PageMargins
+     * @return $this
      */
     public function setTop($pValue)
     {
@@ -140,7 +140,7 @@ class PageMargins
      *
      * @param float $pValue
      *
-     * @return PageMargins
+     * @return $this
      */
     public function setBottom($pValue)
     {
@@ -164,7 +164,7 @@ class PageMargins
      *
      * @param float $pValue
      *
-     * @return PageMargins
+     * @return $this
      */
     public function setHeader($pValue)
     {
@@ -188,7 +188,7 @@ class PageMargins
      *
      * @param float $pValue
      *
-     * @return PageMargins
+     * @return $this
      */
     public function setFooter($pValue)
     {

--- a/src/PhpSpreadsheet/Worksheet/PageSetup.php
+++ b/src/PhpSpreadsheet/Worksheet/PageSetup.php
@@ -272,7 +272,7 @@ class PageSetup
      *
      * @param int $pValue see self::PAPERSIZE_*
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setPaperSize($pValue)
     {
@@ -296,7 +296,7 @@ class PageSetup
      *
      * @param string $pValue see self::ORIENTATION_*
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setOrientation($pValue)
     {
@@ -325,7 +325,7 @@ class PageSetup
      *
      * @throws PhpSpreadsheetException
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setScale($pValue, $pUpdate = true)
     {
@@ -358,7 +358,7 @@ class PageSetup
      *
      * @param bool $pValue
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setFitToPage($pValue)
     {
@@ -383,7 +383,7 @@ class PageSetup
      * @param null|int $pValue
      * @param bool $pUpdate Update fitToPage so it applies rather than scaling
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setFitToHeight($pValue, $pUpdate = true)
     {
@@ -411,7 +411,7 @@ class PageSetup
      * @param null|int $pValue
      * @param bool $pUpdate Update fitToPage so it applies rather than scaling
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setFitToWidth($pValue, $pUpdate = true)
     {
@@ -454,7 +454,7 @@ class PageSetup
      *
      * @param array $pValue Containing start column and end column, empty array if option unset
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setColumnsToRepeatAtLeft(array $pValue)
     {
@@ -469,7 +469,7 @@ class PageSetup
      * @param string $pStart eg: 'A'
      * @param string $pEnd eg: 'B'
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setColumnsToRepeatAtLeftByStartAndEnd($pStart, $pEnd)
     {
@@ -509,7 +509,7 @@ class PageSetup
      *
      * @param array $pValue Containing start column and end column, empty array if option unset
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setRowsToRepeatAtTop(array $pValue)
     {
@@ -524,7 +524,7 @@ class PageSetup
      * @param int $pStart eg: 1
      * @param int $pEnd eg: 1
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setRowsToRepeatAtTopByStartAndEnd($pStart, $pEnd)
     {
@@ -548,7 +548,7 @@ class PageSetup
      *
      * @param bool $value
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setHorizontalCentered($value)
     {
@@ -572,7 +572,7 @@ class PageSetup
      *
      * @param bool $value
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setVerticalCentered($value)
     {
@@ -634,7 +634,7 @@ class PageSetup
      *                            Otherwise, the range identified by the value of $index will be removed from the series
      *                            Print areas are numbered from 1
      *
-     * @return PageSetup
+     * @return $this
      */
     public function clearPrintArea($index = 0)
     {
@@ -671,7 +671,7 @@ class PageSetup
      *
      * @throws PhpSpreadsheetException
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setPrintArea($value, $index = 0, $method = self::SETPRINTRANGE_OVERWRITE)
     {
@@ -732,7 +732,7 @@ class PageSetup
      *
      * @throws PhpSpreadsheetException
      *
-     * @return PageSetup
+     * @return $this
      */
     public function addPrintArea($value, $index = -1)
     {
@@ -762,7 +762,7 @@ class PageSetup
      *
      * @throws PhpSpreadsheetException
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setPrintAreaByColumnAndRow($column1, $row1, $column2, $row2, $index = 0, $method = self::SETPRINTRANGE_OVERWRITE)
     {
@@ -789,7 +789,7 @@ class PageSetup
      *
      * @throws PhpSpreadsheetException
      *
-     * @return PageSetup
+     * @return $this
      */
     public function addPrintAreaByColumnAndRow($column1, $row1, $column2, $row2, $index = -1)
     {
@@ -815,7 +815,7 @@ class PageSetup
      *
      * @param int $value
      *
-     * @return PageSetup
+     * @return $this
      */
     public function setFirstPageNumber($value)
     {
@@ -827,7 +827,7 @@ class PageSetup
     /**
      * Reset first page number.
      *
-     * @return PageSetup
+     * @return $this
      */
     public function resetFirstPageNumber()
     {

--- a/src/PhpSpreadsheet/Worksheet/Protection.php
+++ b/src/PhpSpreadsheet/Worksheet/Protection.php
@@ -172,7 +172,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setSheet($pValue)
     {
@@ -196,7 +196,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setObjects($pValue)
     {
@@ -220,7 +220,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setScenarios($pValue)
     {
@@ -244,7 +244,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setFormatCells($pValue)
     {
@@ -268,7 +268,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setFormatColumns($pValue)
     {
@@ -292,7 +292,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setFormatRows($pValue)
     {
@@ -316,7 +316,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setInsertColumns($pValue)
     {
@@ -340,7 +340,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setInsertRows($pValue)
     {
@@ -364,7 +364,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setInsertHyperlinks($pValue)
     {
@@ -388,7 +388,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setDeleteColumns($pValue)
     {
@@ -412,7 +412,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setDeleteRows($pValue)
     {
@@ -436,7 +436,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setSelectLockedCells($pValue)
     {
@@ -460,7 +460,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setSort($pValue)
     {
@@ -484,7 +484,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setAutoFilter($pValue)
     {
@@ -508,7 +508,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setPivotTables($pValue)
     {
@@ -532,7 +532,7 @@ class Protection
      *
      * @param bool $pValue
      *
-     * @return Protection
+     * @return $this
      */
     public function setSelectUnlockedCells($pValue)
     {
@@ -557,7 +557,7 @@ class Protection
      * @param string $pValue
      * @param bool $pAlreadyHashed If the password has already been hashed, set this to true
      *
-     * @return Protection
+     * @return $this
      */
     public function setPassword($pValue, $pAlreadyHashed = false)
     {

--- a/src/PhpSpreadsheet/Worksheet/RowCellIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/RowCellIterator.php
@@ -59,7 +59,7 @@ class RowCellIterator extends CellIterator
      *
      * @throws PhpSpreadsheetException
      *
-     * @return RowCellIterator
+     * @return $this
      */
     public function resetStart($startColumn = 'A')
     {
@@ -77,7 +77,7 @@ class RowCellIterator extends CellIterator
      *
      * @throws PhpSpreadsheetException
      *
-     * @return RowCellIterator
+     * @return $this
      */
     public function resetEnd($endColumn = null)
     {
@@ -95,7 +95,7 @@ class RowCellIterator extends CellIterator
      *
      * @throws PhpSpreadsheetException
      *
-     * @return RowCellIterator
+     * @return $this
      */
     public function seek($column = 'A')
     {

--- a/src/PhpSpreadsheet/Worksheet/RowDimension.php
+++ b/src/PhpSpreadsheet/Worksheet/RowDimension.php
@@ -56,7 +56,7 @@ class RowDimension extends Dimension
      *
      * @param int $pValue
      *
-     * @return RowDimension
+     * @return $this
      */
     public function setRowIndex($pValue)
     {
@@ -80,7 +80,7 @@ class RowDimension extends Dimension
      *
      * @param float $pValue
      *
-     * @return RowDimension
+     * @return $this
      */
     public function setRowHeight($pValue)
     {
@@ -104,7 +104,7 @@ class RowDimension extends Dimension
      *
      * @param bool $pValue
      *
-     * @return RowDimension
+     * @return $this
      */
     public function setZeroHeight($pValue)
     {

--- a/src/PhpSpreadsheet/Worksheet/RowIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/RowIterator.php
@@ -64,7 +64,7 @@ class RowIterator implements \Iterator
      *
      * @throws PhpSpreadsheetException
      *
-     * @return RowIterator
+     * @return $this
      */
     public function resetStart($startRow = 1)
     {
@@ -86,7 +86,7 @@ class RowIterator implements \Iterator
      *
      * @param int $endRow The row number at which to stop iterating
      *
-     * @return RowIterator
+     * @return $this
      */
     public function resetEnd($endRow = null)
     {
@@ -102,7 +102,7 @@ class RowIterator implements \Iterator
      *
      * @throws PhpSpreadsheetException
      *
-     * @return RowIterator
+     * @return $this
      */
     public function seek($row = 1)
     {

--- a/src/PhpSpreadsheet/Worksheet/SheetView.php
+++ b/src/PhpSpreadsheet/Worksheet/SheetView.php
@@ -79,7 +79,7 @@ class SheetView
      *
      * @throws PhpSpreadsheetException
      *
-     * @return SheetView
+     * @return $this
      */
     public function setZoomScale($pValue)
     {
@@ -112,7 +112,7 @@ class SheetView
      *
      * @throws PhpSpreadsheetException
      *
-     * @return SheetView
+     * @return $this
      */
     public function setZoomScaleNormal($pValue)
     {
@@ -165,7 +165,7 @@ class SheetView
      *
      * @throws PhpSpreadsheetException
      *
-     * @return SheetView
+     * @return $this
      */
     public function setView($pValue)
     {

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -647,7 +647,7 @@ class Worksheet implements IComparable
     /**
      * Refresh column dimensions.
      *
-     * @return Worksheet
+     * @return $this
      */
     public function refreshColumnDimensions()
     {
@@ -666,7 +666,7 @@ class Worksheet implements IComparable
     /**
      * Refresh row dimensions.
      *
-     * @return Worksheet
+     * @return $this
      */
     public function refreshRowDimensions()
     {
@@ -707,7 +707,7 @@ class Worksheet implements IComparable
     /**
      * Calculate widths for auto-size columns.
      *
-     * @return Worksheet;
+     * @return $this
      */
     public function calculateColumnWidths()
     {
@@ -797,7 +797,7 @@ class Worksheet implements IComparable
      *
      * @param Spreadsheet $parent
      *
-     * @return Worksheet
+     * @return $this
      */
     public function rebindParent(Spreadsheet $parent)
     {
@@ -838,7 +838,7 @@ class Worksheet implements IComparable
      * @param bool $validate False to skip validation of new title. WARNING: This should only be set
      *                       at parse time (by Readers), where titles can be assumed to be valid.
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setTitle($pValue, $updateFormulaCellReferences = true, $validate = true)
     {
@@ -913,7 +913,7 @@ class Worksheet implements IComparable
      *
      * @param string $value Sheet state (visible, hidden, veryHidden)
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setSheetState($value)
     {
@@ -937,7 +937,7 @@ class Worksheet implements IComparable
      *
      * @param PageSetup $pValue
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setPageSetup(PageSetup $pValue)
     {
@@ -961,7 +961,7 @@ class Worksheet implements IComparable
      *
      * @param PageMargins $pValue
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setPageMargins(PageMargins $pValue)
     {
@@ -985,7 +985,7 @@ class Worksheet implements IComparable
      *
      * @param HeaderFooter $pValue
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setHeaderFooter(HeaderFooter $pValue)
     {
@@ -1009,7 +1009,7 @@ class Worksheet implements IComparable
      *
      * @param SheetView $pValue
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setSheetView(SheetView $pValue)
     {
@@ -1033,7 +1033,7 @@ class Worksheet implements IComparable
      *
      * @param Protection $pValue
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setProtection(Protection $pValue)
     {
@@ -1119,7 +1119,7 @@ class Worksheet implements IComparable
      * @param string $pCoordinate Coordinate of the cell, eg: 'A1'
      * @param mixed $pValue Value of the cell
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setCellValue($pCoordinate, $pValue)
     {
@@ -1135,7 +1135,7 @@ class Worksheet implements IComparable
      * @param int $row Numeric row coordinate of the cell
      * @param mixed $value Value of the cell
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setCellValueByColumnAndRow($columnIndex, $row, $value)
     {
@@ -1151,7 +1151,7 @@ class Worksheet implements IComparable
      * @param mixed $pValue Value of the cell
      * @param string $pDataType Explicit data type, see DataType::TYPE_*
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setCellValueExplicit($pCoordinate, $pValue, $pDataType)
     {
@@ -1169,7 +1169,7 @@ class Worksheet implements IComparable
      * @param mixed $value Value of the cell
      * @param string $dataType Explicit data type, see DataType::TYPE_*
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setCellValueExplicitByColumnAndRow($columnIndex, $row, $value, $dataType)
     {
@@ -1480,7 +1480,7 @@ class Worksheet implements IComparable
      *
      * @param string $pCoordinate eg: 'A1'
      *
-     * @return Worksheet
+     * @return $this
      */
     public function removeConditionalStyles($pCoordinate)
     {
@@ -1505,7 +1505,7 @@ class Worksheet implements IComparable
      * @param string $pCoordinate eg: 'A1'
      * @param $pValue Conditional[]
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setConditionalStyles($pCoordinate, $pValue)
     {
@@ -1545,7 +1545,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function duplicateStyle(Style $pCellStyle, $pRange)
     {
@@ -1590,7 +1590,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function duplicateConditionalStyle(array $pCellStyle, $pRange = '')
     {
@@ -1628,7 +1628,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setBreak($pCoordinate, $pBreak)
     {
@@ -1657,7 +1657,7 @@ class Worksheet implements IComparable
      * @param int $row Numeric row coordinate of the cell
      * @param int $break Break type (type of Worksheet::BREAK_*)
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setBreakByColumnAndRow($columnIndex, $row, $break)
     {
@@ -1681,7 +1681,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function mergeCells($pRange)
     {
@@ -1726,7 +1726,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function mergeCellsByColumnAndRow($columnIndex1, $row1, $columnIndex2, $row2)
     {
@@ -1742,7 +1742,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function unmergeCells($pRange)
     {
@@ -1772,7 +1772,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function unmergeCellsByColumnAndRow($columnIndex1, $row1, $columnIndex2, $row2)
     {
@@ -1797,7 +1797,7 @@ class Worksheet implements IComparable
      *
      * @param array $pValue
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setMergeCells(array $pValue)
     {
@@ -1813,7 +1813,7 @@ class Worksheet implements IComparable
      * @param string $pPassword Password to unlock the protection
      * @param bool $pAlreadyHashed If the password has already been hashed, set this to true
      *
-     * @return Worksheet
+     * @return $this
      */
     public function protectCells($pRange, $pPassword, $pAlreadyHashed = false)
     {
@@ -1838,7 +1838,7 @@ class Worksheet implements IComparable
      * @param string $password Password to unlock the protection
      * @param bool $alreadyHashed If the password has already been hashed, set this to true
      *
-     * @return Worksheet
+     * @return $this
      */
     public function protectCellsByColumnAndRow($columnIndex1, $row1, $columnIndex2, $row2, $password, $alreadyHashed = false)
     {
@@ -1854,7 +1854,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function unprotectCells($pRange)
     {
@@ -1880,7 +1880,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function unprotectCellsByColumnAndRow($columnIndex1, $row1, $columnIndex2, $row2)
     {
@@ -1917,7 +1917,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setAutoFilter($pValue)
     {
@@ -1940,7 +1940,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setAutoFilterByColumnAndRow($columnIndex1, $row1, $columnIndex2, $row2)
     {
@@ -1954,7 +1954,7 @@ class Worksheet implements IComparable
     /**
      * Remove autofilter.
      *
-     * @return Worksheet
+     * @return $this
      */
     public function removeAutoFilter()
     {
@@ -1987,7 +1987,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function freezePane($cell, $topLeftCell = null)
     {
@@ -2012,7 +2012,7 @@ class Worksheet implements IComparable
      * @param int $columnIndex Numeric column coordinate of the cell
      * @param int $row Numeric row coordinate of the cell
      *
-     * @return Worksheet
+     * @return $this
      */
     public function freezePaneByColumnAndRow($columnIndex, $row)
     {
@@ -2022,7 +2022,7 @@ class Worksheet implements IComparable
     /**
      * Unfreeze Pane.
      *
-     * @return Worksheet
+     * @return $this
      */
     public function unfreezePane()
     {
@@ -2047,7 +2047,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function insertNewRowBefore($pBefore, $pNumRows = 1)
     {
@@ -2069,7 +2069,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function insertNewColumnBefore($pBefore, $pNumCols = 1)
     {
@@ -2091,7 +2091,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function insertNewColumnBeforeByIndex($beforeColumnIndex, $pNumCols = 1)
     {
@@ -2110,7 +2110,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function removeRow($pRow, $pNumRows = 1)
     {
@@ -2141,7 +2141,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function removeColumn($pColumn, $pNumCols = 1)
     {
@@ -2181,7 +2181,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function removeColumnByIndex($columnIndex, $numColumns = 1)
     {
@@ -2207,7 +2207,7 @@ class Worksheet implements IComparable
      *
      * @param bool $pValue Show gridlines (true/false)
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setShowGridlines($pValue)
     {
@@ -2231,7 +2231,7 @@ class Worksheet implements IComparable
      *
      * @param bool $pValue Print gridlines (true/false)
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setPrintGridlines($pValue)
     {
@@ -2255,7 +2255,7 @@ class Worksheet implements IComparable
      *
      * @param bool $pValue Show row and column headers (true/false)
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setShowRowColHeaders($pValue)
     {
@@ -2279,7 +2279,7 @@ class Worksheet implements IComparable
      *
      * @param bool $pValue Show summary below (true/false)
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setShowSummaryBelow($pValue)
     {
@@ -2303,7 +2303,7 @@ class Worksheet implements IComparable
      *
      * @param bool $pValue Show summary right (true/false)
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setShowSummaryRight($pValue)
     {
@@ -2327,7 +2327,7 @@ class Worksheet implements IComparable
      *
      * @param Comment[] $pValue
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setComments(array $pValue)
     {
@@ -2408,7 +2408,7 @@ class Worksheet implements IComparable
      *
      * @param string $pCoordinate Cell (i.e. A1)
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setSelectedCell($pCoordinate)
     {
@@ -2420,7 +2420,7 @@ class Worksheet implements IComparable
      *
      * @param string $pCoordinate Cell range, examples: 'A1', 'B2:G5', 'A:C', '3:6'
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setSelectedCells($pCoordinate)
     {
@@ -2458,7 +2458,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setSelectedCellByColumnAndRow($columnIndex, $row)
     {
@@ -2480,7 +2480,7 @@ class Worksheet implements IComparable
      *
      * @param bool $value Right-to-left true/false
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setRightToLeft($value)
     {
@@ -2499,7 +2499,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function fromArray(array $source, $nullValue = null, $startCell = 'A1', $strictNullComparison = false)
     {
@@ -2684,7 +2684,7 @@ class Worksheet implements IComparable
     /**
      * Run PhpSpreadsheet garbage collector.
      *
-     * @return Worksheet
+     * @return $this
      */
     public function garbageCollect()
     {
@@ -2784,7 +2784,7 @@ class Worksheet implements IComparable
      * @param string $pCellCoordinate Cell coordinate to insert hyperlink, eg: 'A1'
      * @param null|Hyperlink $pHyperlink
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setHyperlink($pCellCoordinate, Hyperlink $pHyperlink = null)
     {
@@ -2845,7 +2845,7 @@ class Worksheet implements IComparable
      * @param string $pCellCoordinate Cell coordinate to insert data validation, eg: 'A1'
      * @param null|DataValidation $pDataValidation
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setDataValidation($pCellCoordinate, DataValidation $pDataValidation = null)
     {
@@ -2933,7 +2933,7 @@ class Worksheet implements IComparable
     /**
      * Reset tab color.
      *
-     * @return Worksheet
+     * @return $this
      */
     public function resetTabColor()
     {
@@ -2956,7 +2956,7 @@ class Worksheet implements IComparable
     /**
      * Copy worksheet (!= clone!).
      *
-     * @return Worksheet
+     * @return static
      */
     public function copy()
     {
@@ -3007,7 +3007,7 @@ class Worksheet implements IComparable
      *
      * @throws Exception
      *
-     * @return Worksheet
+     * @return $this
      */
     public function setCodeName($pValue, $validate = true)
     {

--- a/src/PhpSpreadsheet/Writer/Csv.php
+++ b/src/PhpSpreadsheet/Writer/Csv.php
@@ -147,7 +147,7 @@ class Csv extends BaseWriter
      *
      * @param string $pValue Delimiter, defaults to ','
      *
-     * @return CSV
+     * @return $this
      */
     public function setDelimiter($pValue)
     {
@@ -171,7 +171,7 @@ class Csv extends BaseWriter
      *
      * @param string $pValue Enclosure, defaults to "
      *
-     * @return CSV
+     * @return $this
      */
     public function setEnclosure($pValue)
     {
@@ -198,7 +198,7 @@ class Csv extends BaseWriter
      *
      * @param string $pValue Line ending, defaults to OS line ending (PHP_EOL)
      *
-     * @return CSV
+     * @return $this
      */
     public function setLineEnding($pValue)
     {
@@ -222,7 +222,7 @@ class Csv extends BaseWriter
      *
      * @param bool $pValue Use UTF-8 byte-order mark? Defaults to false
      *
-     * @return CSV
+     * @return $this
      */
     public function setUseBOM($pValue)
     {
@@ -246,7 +246,7 @@ class Csv extends BaseWriter
      *
      * @param bool $pValue Use separator line? Defaults to false
      *
-     * @return CSV
+     * @return $this
      */
     public function setIncludeSeparatorLine($pValue)
     {
@@ -271,7 +271,7 @@ class Csv extends BaseWriter
      * @param bool $pValue Set the file to be written as a fully Excel compatible csv file
      *                                Note that this overrides other settings such as useBOM, enclosure and delimiter
      *
-     * @return CSV
+     * @return $this
      */
     public function setExcelCompatibility($pValue)
     {
@@ -295,7 +295,7 @@ class Csv extends BaseWriter
      *
      * @param int $pValue Sheet index
      *
-     * @return CSV
+     * @return $this
      */
     public function setSheetIndex($pValue)
     {

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -297,7 +297,7 @@ class Html extends BaseWriter
      *
      * @param int $pValue Sheet index
      *
-     * @return HTML
+     * @return $this
      */
     public function setSheetIndex($pValue)
     {
@@ -321,7 +321,7 @@ class Html extends BaseWriter
      *
      * @param bool $pValue Flag indicating whether the sheet navigation block should be generated or not
      *
-     * @return HTML
+     * @return $this
      */
     public function setGenerateSheetNavigationBlock($pValue)
     {
@@ -332,6 +332,8 @@ class Html extends BaseWriter
 
     /**
      * Write all sheets (resets sheetIndex to NULL).
+     *
+     * @return $this
      */
     public function writeAllSheets()
     {
@@ -1438,7 +1440,7 @@ class Html extends BaseWriter
      *
      * @param string $pValue
      *
-     * @return HTML
+     * @return $this
      */
     public function setImagesRoot($pValue)
     {
@@ -1462,7 +1464,7 @@ class Html extends BaseWriter
      *
      * @param bool $pValue
      *
-     * @return HTML
+     * @return $this
      */
     public function setEmbedImages($pValue)
     {
@@ -1486,7 +1488,7 @@ class Html extends BaseWriter
      *
      * @param bool $pValue
      *
-     * @return HTML
+     * @return $this
      */
     public function setUseInlineCss($pValue)
     {
@@ -1510,7 +1512,7 @@ class Html extends BaseWriter
      *
      * @param bool $pValue
      *
-     * @return HTML
+     * @return $this
      */
     public function setUseEmbeddedCSS($pValue)
     {

--- a/src/PhpSpreadsheet/Writer/Ods.php
+++ b/src/PhpSpreadsheet/Writer/Ods.php
@@ -167,7 +167,7 @@ class Ods extends BaseWriter
      *
      * @param Spreadsheet $spreadsheet PhpSpreadsheet object
      *
-     * @return self
+     * @return $this
      */
     public function setSpreadsheet(Spreadsheet $spreadsheet)
     {

--- a/src/PhpSpreadsheet/Writer/Pdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf.php
@@ -150,7 +150,7 @@ abstract class Pdf extends Html
      *
      * @param string $fontName
      *
-     * @return Pdf
+     * @return $this
      */
     public function setFont($fontName)
     {

--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -443,7 +443,7 @@ class Xlsx extends BaseWriter
      *
      * @param Spreadsheet $spreadsheet PhpSpreadsheet object
      *
-     * @return Xlsx
+     * @return $this
      */
     public function setSpreadsheet(Spreadsheet $spreadsheet)
     {
@@ -547,7 +547,7 @@ class Xlsx extends BaseWriter
      *
      * @param bool $pValue Office2003 compatibility?
      *
-     * @return Xlsx
+     * @return $this
      */
     public function setOffice2003Compatibility($pValue)
     {


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

* Some `@return` annotations used wrong casing (e.g. `@return CSV` instead of `@return Csv`)
* Most classes can be extended and therefore the annotation `@return static` would be more appropriate to avoid inadvertent type narrowing.
* The `@return $this` annotation is more explicit than `@return static`.