### PR TITLE
Move ext-gd to suggest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
         "php": "^7.1",
         "ext-ctype": "*",
         "ext-dom": "*",
-        "ext-gd": "*",
         "ext-iconv": "*",
         "ext-fileinfo": "*",
         "ext-libxml": "*",
@@ -68,6 +67,7 @@
         "tecnickcom/tcpdf": "^6.3"
     },
     "suggest": {
+        "ext-gd": "Required for graphing, and exact column wide calculation",
         "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
         "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
         "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0fd32acfbb0d21f168f495840ffc8d7e",
+    "content-hash": "e4b0745428f3edb93d41c0109f143c57",
     "packages": [
         {
             "name": "markbaker/complex",
@@ -3487,7 +3487,6 @@
         "php": "^7.1",
         "ext-ctype": "*",
         "ext-dom": "*",
-        "ext-gd": "*",
         "ext-iconv": "*",
         "ext-fileinfo": "*",
         "ext-libxml": "*",

--- a/docs/topics/recipes.md
+++ b/docs/topics/recipes.md
@@ -1250,6 +1250,8 @@ $drawing->setHeight(36);
 $drawing->setWorksheet($spreadsheet->getActiveSheet());
 ```
 
+**Note: For this to work, the [`ext-gd`](https://www.php.net/manual/en/book.image.php) extension has to be installed on your system.**
+
 ## Reading Images from a worksheet
 
 A commonly asked question is how to retrieve the images from a workbook
@@ -1441,6 +1443,8 @@ $drawing->setMimeType(\PhpOffice\PhpSpreadsheet\Worksheet\MemoryDrawing::MIMETYP
 $drawing->setHeight(36);
 $drawing->setWorksheet($spreadsheet->getActiveSheet());
 ```
+
+**Note: For this to work, the [`ext-gd`](https://www.php.net/manual/en/book.image.php) extension has to be installed on your system.**
 
 ## Setting worksheet zoom level
 


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [ ] a new feature
- [X] Both depending on how you look at it

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

ext-gd is only used in a few specific cases. Moving it to suggest only requires users using it to install the extension. Where others that don't won't have to.

