### PR TITLE
#1402 distinguish datatypes in VLOOKUP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Handle ConditionalStyle NumberFormat When Reading Xlsx File [#1296](https://github.com/PHPOffice/PhpSpreadsheet/pull/1296)
 - Fix Xlsx Writer's handling of decimal commas [#1282](https://github.com/PHPOffice/PhpSpreadsheet/pull/1282)
 - Fix for issue by removing test code mistakenly left in [#1328](https://github.com/PHPOffice/PhpSpreadsheet/pull/1328)
+- Distinguish between datatypes in VLOOKUP [#1403](https://github.com/PHPOffice/PhpSpreadsheet/pull/1403)
 
 ## [1.10.1] - 2019-12-02
 

--- a/src/PhpSpreadsheet/Calculation/LookupRef.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef.php
@@ -754,25 +754,26 @@ class LookupRef
         if (!$not_exact_match) {
             uasort($lookup_array, ['self', 'vlookupSort']);
         }
-
-        $lookupLower = StringHelper::strToLower($lookup_value);
+        if (is_string($lookup_value)) {
+            $lookup_value = StringHelper::strToLower($lookup_value);
+        }
         $rowNumber = $rowValue = false;
         foreach ($lookup_array as $rowKey => $rowData) {
-            $firstLower = StringHelper::strToLower($rowData[$firstColumn]);
+            if (is_string($rowData[$firstColumn])) {
+                $rowData[$firstColumn] = StringHelper::strToLower($rowData[$firstColumn]);
+            }
 
             // break if we have passed possible keys
-            if ((is_numeric($lookup_value) && is_numeric($rowData[$firstColumn]) && ($rowData[$firstColumn] > $lookup_value)) ||
-                (!is_numeric($lookup_value) && !is_numeric($rowData[$firstColumn]) && ($firstLower > $lookupLower))) {
+            if (is_string($lookup_value) == is_string($rowData[$firstColumn]) && $rowData[$firstColumn] > $lookup_value) {
                 break;
             }
             // remember the last key, but only if datatypes match
-            if ((is_numeric($lookup_value) && is_numeric($rowData[$firstColumn])) ||
-                (!is_numeric($lookup_value) && !is_numeric($rowData[$firstColumn]))) {
+            if ((is_string($lookup_value) == is_string($rowData[$firstColumn]))) {
                 if ($not_exact_match) {
                     $rowNumber = $rowKey;
 
                     continue;
-                } elseif (($firstLower == $lookupLower)
+                } elseif (($rowData[$firstColumn] === $lookup_value)
                     // Spreadsheets software returns first exact match,
                     // we have sorted and we might have broken key orders
                     // we want the first one (by its initial index)


### PR DESCRIPTION
Use is_string instead is_numeric to ensure datatypes are the same,
as is_numeric returns also true on stringified numbers.
Only strToLower $lookup_value if $lookup_value is actually a string.

This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
#1402 
