### PR TITLE
Feature/csv variable columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Added
 
 - Improved the ARABIC function to also hande short-hand roman numerals
+- Option for CSV files to have varying numbers of columns for each individual row
 
 ### Fixed
 

--- a/docs/topics/reading-and-writing-to-file.md
+++ b/docs/topics/reading-and-writing-to-file.md
@@ -544,6 +544,18 @@ $writer->setUseBOM(true);
 $writer->save("05featuredemo.csv");
 ```
 
+#### Writing CSV files with varying numbers of columns
+
+A CSV file can have a different number of columns in each row. This
+differs from the default behavior when saving as a .csv in Excel, but
+can be enabled in PhpSpreadsheet by using the following code:
+
+``` php
+$writer = new \PhpOffice\PhpSpreadsheet\Writer\Csv($spreadsheet);
+$writer->setVariableColumns(true);
+$writer->save("05featuredemo.csv");
+```
+
 #### Decimal and thousands separators
 
 If the worksheet you are exporting contains numbers with decimal or

--- a/src/PhpSpreadsheet/Writer/Csv.php
+++ b/src/PhpSpreadsheet/Writer/Csv.php
@@ -65,6 +65,15 @@ class Csv extends BaseWriter
     private $excelCompatibility = false;
 
     /**
+     * Whether number of columns should be allowed to vary
+     * between rows, or use a fixed range based on the max
+     * column overall.
+     * 
+     * @var bool
+     */
+    private $variableColumns = false;
+
+    /**
      * Create a new CSV.
      *
      * @param Spreadsheet $spreadsheet Spreadsheet object
@@ -119,6 +128,9 @@ class Csv extends BaseWriter
 
         // Write rows to file
         for ($row = 1; $row <= $maxRow; ++$row) {
+            if ($this->variableColumns) {
+                $maxCol = $sheet->getHighestDataColumn($row);
+            }
             // Convert the row to an array...
             $cellsArray = $sheet->rangeToArray('A' . $row . ':' . $maxCol . $row, '', $this->preCalculateFormulas);
             // ... and write to the file
@@ -278,6 +290,34 @@ class Csv extends BaseWriter
         $this->excelCompatibility = $pValue;
 
         return $this;
+    }
+
+    /**
+     * Get whether number of columns should be allowed to vary
+     * between rows, or use a fixed range based on the max
+     * column overall.
+     *
+     * @return bool
+     */
+    public function getVariableColumns()
+    {
+        return $this->variableColumns;
+    }
+
+    /**
+     * Set whether number of columns should be allowed to vary
+     * between rows, or use a fixed range based on the max
+     * column overall.
+     *
+     * @param bool $pValue Set the writer to allow variable column counts
+     * 
+     * @return $this
+     */
+    public function setVariableColumns($pValue)
+    {
+        $this->variableColumns = $pValue;
+
+        return  $this;
     }
 
     /**

--- a/src/PhpSpreadsheet/Writer/Csv.php
+++ b/src/PhpSpreadsheet/Writer/Csv.php
@@ -68,7 +68,7 @@ class Csv extends BaseWriter
      * Whether number of columns should be allowed to vary
      * between rows, or use a fixed range based on the max
      * column overall.
-     * 
+     *
      * @var bool
      */
     private $variableColumns = false;
@@ -310,7 +310,7 @@ class Csv extends BaseWriter
      * column overall.
      *
      * @param bool $pValue Set the writer to allow variable column counts
-     * 
+     *
      * @return $this
      */
     public function setVariableColumns($pValue)

--- a/tests/PhpSpreadsheetTests/Writer/Csv/VariableColumnsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Csv/VariableColumnsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Csv;
+
+use PHPUnit\Framework\TestCase;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Shared\File;
+
+class VariableColumnsTest extends TestCase
+{
+    public function testVariableColumns()
+    {
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->setActiveSheetIndex(0);
+        $spreadsheet->getActiveSheet()->setCellValue('A1', 'A1');
+        $spreadsheet->getActiveSheet()->setCellValue('B1', 'B1');
+        $spreadsheet->getActiveSheet()->setCellValue('A2', 'A2');
+        $spreadsheet->getActiveSheet()->setCellValue('B2', 'B2');
+        $spreadsheet->getActiveSheet()->setCellValue('C2', 'C2');
+        $spreadsheet->getActiveSheet()->setCellValue('A3', 'A3');
+
+        $filename = tempnam(File::sysGetTempDir(), 'phpspreadsheet-test');
+        $writer = IOFactory::createWriter($spreadsheet, 'Csv');
+        $writer->setVariableColumns(true);
+        $writer->save($filename);
+
+        $contents = file_get_contents($filename);
+
+        $rows = explode(PHP_EOL, $contents);
+
+        $this->assertEquals('"A1","B1"', $rows[0]);
+        $this->assertEquals('"A2","B2","C2"', $rows[1]);
+        $this->assertEquals('"A3"', $rows[2]);
+    }
+}

--- a/tests/PhpSpreadsheetTests/Writer/Csv/VariableColumnsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Csv/VariableColumnsTest.php
@@ -2,10 +2,10 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Writer\Csv;
 
-use PHPUnit\Framework\TestCase;
 use PhpOffice\PhpSpreadsheet\IOFactory;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
 
 class VariableColumnsTest extends TestCase
 {


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [x] a new feature

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

https://github.com/PHPOffice/PhpSpreadsheet/issues/1414

Sometimes CSV files contain content that isn't intended as a column header, and
may not align with proceeding values as columns. In this case it's likely undesirable
to have proceeding rows filled with blanks to match the column count of the longest row.