### PR TITLE
Limit composer dist to src/, bin/ and a few informative files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,14 @@
-/tests export-ignore
-README.md export-ignore
-*.min.js binary
 /.github export-ignore
+/docs export-ignore
+/samples export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs.dist export-ignore
+/.sami.php export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml export-ignore
+/composer.lock export-ignore
+/mkdocs.yml export-ignore
+/phpunit.xml.dist export-ignore
+*.min.js binary


### PR DESCRIPTION
While the docs and samples are great, i do not need them in my vendor directory. The same is true for the many configuration files.

A few select files such as the readme, changelog and contributing information were deliberately left in. We can remove those too if you think that is better.
