### PR TITLE
S3 streaming support

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -178,7 +178,7 @@ class Xlsx extends BaseWriter
 
             // If $pFilename is php://output or php://stdout, make it a temporary file...
             $originalFilename = $pFilename;
-            if (strtolower($pFilename) == 'php://output' || strtolower($pFilename) == 'php://stdout') {
+            if (strtolower($pFilename) == 'php://output' || strtolower($pFilename) == 'php://stdout' || strstr($pFilename, 's3://')) {
                 $pFilename = @tempnam(File::sysGetTempDir(), 'phpxltmp');
                 if ($pFilename == '') {
                     $pFilename = $originalFilename;


### PR DESCRIPTION
Not sure if this is considered a bug fix or a new feature.

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Currently, it's impossible to stream the file to s3. The following is the error when someone attempts to do so:

`ZipArchive::close()`
`/var/www/application/vendor/phpoffice/phpspreadsheet/src/PhpSpreadsheet/Writer/Xlsx.php:409`

The solution provided in this PR is very naive, and not elegant at all, but it works.
Another option would be to extract `strtolower($pFilename) == 'php://output' || strtolower($pFilename) == 'php://stdout'` to a protected method, which could be overriden by the consumers.
There are more complex options as well, fe creating different adapters, but unfortunately I don't really have time to work on them.

But the main goal of this PR is to open a discussion around this. I am curious to know if you are willing to add S3 streaming support at all.