### PR TITLE
Hide Axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ## [Unreleased]
 
 - Conditionals - Extend Support for (NOT)CONTAINSBLANKS [#1278](https://github.com/PHPOffice/PhpSpreadsheet/pull/1278)
+### Added
+
+- Allow chart axis to be fully hidden [#1446](https://github.com/PHPOffice/PhpSpreadsheet/issues/1446)
 
 ### Fixed
 

--- a/src/PhpSpreadsheet/Chart/Axis.php
+++ b/src/PhpSpreadsheet/Chart/Axis.php
@@ -26,6 +26,7 @@ class Axis extends Properties
      * @var array of mixed
      */
     private $axisOptions = [
+        'hide' => 0,
         'minimum' => null,
         'maximum' => null,
         'major_unit' => null,
@@ -191,6 +192,29 @@ class Axis extends Properties
         ($maximum !== null) ? $this->axisOptions['maximum'] = (string) $maximum : null;
         ($major_unit !== null) ? $this->axisOptions['major_unit'] = (string) $major_unit : null;
         ($minor_unit !== null) ? $this->axisOptions['minor_unit'] = (string) $minor_unit : null;
+    }
+
+    /**
+     * Set Axis Visibility to TRUE
+     */
+    public function showAxis () {
+        $this->axisOptions['hide'] = 0;
+    }
+
+    /**
+     * Set Axis Visibility to FALSE
+     */
+    public function hideAxis () {
+        $this->axisOptions['hide'] = 1;
+    }
+
+    /**
+     * Get Axis Visibility.
+     *
+     * @return int
+     */
+    public function getAxisVisibilty () {
+        return $this->axisOptions['hide'];
     }
 
     /**

--- a/src/PhpSpreadsheet/Chart/Axis.php
+++ b/src/PhpSpreadsheet/Chart/Axis.php
@@ -197,14 +197,16 @@ class Axis extends Properties
     /**
      * Set Axis Visibility to TRUE.
      */
-    public function showAxis() {
+    public function showAxis()
+    {
         $this->axisOptions['hide'] = 0;
     }
 
     /**
      * Set Axis Visibility to FALSE.
      */
-    public function hideAxis() {
+    public function hideAxis()
+    {
         $this->axisOptions['hide'] = 1;
     }
 
@@ -213,7 +215,8 @@ class Axis extends Properties
      *
      * @return int
      */
-    public function getAxisVisibilty() {
+    public function getAxisVisibilty()
+    {
         return $this->axisOptions['hide'];
     }
 

--- a/src/PhpSpreadsheet/Chart/Axis.php
+++ b/src/PhpSpreadsheet/Chart/Axis.php
@@ -195,16 +195,16 @@ class Axis extends Properties
     }
 
     /**
-     * Set Axis Visibility to TRUE
+     * Set Axis Visibility to TRUE.
      */
-    public function showAxis () {
+    public function showAxis() {
         $this->axisOptions['hide'] = 0;
     }
 
     /**
-     * Set Axis Visibility to FALSE
+     * Set Axis Visibility to FALSE.
      */
-    public function hideAxis () {
+    public function hideAxis() {
         $this->axisOptions['hide'] = 1;
     }
 
@@ -213,7 +213,7 @@ class Axis extends Properties
      *
      * @return int
      */
-    public function getAxisVisibilty () {
+    public function getAxisVisibilty() {
         return $this->axisOptions['hide'];
     }
 

--- a/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
@@ -541,7 +541,7 @@ class Chart extends WriterPart
 
         if ($xAxis->getAxisOptionsProperty('minimum') !== null) {
             $objWriter->startElement('c:min');
-            $objWriter->writeAttribute('val', $xAxis->getAxisOptionsProperty('minimum'));Chart.php
+            $objWriter->writeAttribute('val', $xAxis->getAxisOptionsProperty('minimum'));
             $objWriter->endElement();
         }
 

--- a/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
@@ -415,7 +415,7 @@ class Chart extends WriterPart
         $objWriter->endElement();
 
         $objWriter->startElement('c:delete');
-        $objWriter->writeAttribute('val', 0);
+        $objWriter->writeAttribute('val', $yAxis ? $yAxis->getAxisVisibilty() : 0);
         $objWriter->endElement();
 
         $objWriter->startElement('c:axPos');
@@ -552,7 +552,7 @@ class Chart extends WriterPart
         $objWriter->endElement();
 
         $objWriter->startElement('c:delete');
-        $objWriter->writeAttribute('val', 0);
+        $objWriter->writeAttribute('val', $xAxis ? $xAxis->getAxisVisibilty() : 0);
         $objWriter->endElement();
 
         $objWriter->startElement('c:axPos');

--- a/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
@@ -541,7 +541,7 @@ class Chart extends WriterPart
 
         if ($xAxis->getAxisOptionsProperty('minimum') !== null) {
             $objWriter->startElement('c:min');
-            $objWriter->writeAttribute('val', $xAxis->getAxisOptionsProperty('minimum'));
+            $objWriter->writeAttribute('val', $xAxis->getAxisOptionsProperty('minimum'));Chart.php
             $objWriter->endElement();
         }
 

--- a/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
@@ -415,7 +415,7 @@ class Chart extends WriterPart
         $objWriter->endElement();
 
         $objWriter->startElement('c:delete');
-        $objWriter->writeAttribute('val', $yAxis ? $yAxis->getAxisVisibilty() : 0);
+        $objWriter->writeAttribute('val', $yAxis->getAxisVisibilty());
         $objWriter->endElement();
 
         $objWriter->startElement('c:axPos');
@@ -552,7 +552,7 @@ class Chart extends WriterPart
         $objWriter->endElement();
 
         $objWriter->startElement('c:delete');
-        $objWriter->writeAttribute('val', $xAxis ? $xAxis->getAxisVisibilty() : 0);
+        $objWriter->writeAttribute('val', $xAxis->getAxisVisibilty());
         $objWriter->endElement();
 
         $objWriter->startElement('c:axPos');


### PR DESCRIPTION
Allows developer to hide an axis fully (by default it is shown).

This is:

```
- [ ] a bugfix
- [X] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
[Issue #1446](https://github.com/PHPOffice/PhpSpreadsheet/issues/1446)

Allows the developer to fully hide a chart axis.  Chart.php currently hardcodes axis to always be displayed.

        $objWriter->startElement('c:delete');
        $objWriter->writeAttribute('val', 0);
        $objWriter->endElement();

The updated code asks the axis if it is visible.

    // Inside the writeCategoryAxis method
    $objWriter->startElement('c:delete');
    $objWriter->writeAttribute('val', $yAxis ? $yAxis->getAxisVisibilty() : 0);
    $objWriter->endElement();

    // Inside the writeValueAxis method
    $objWriter->startElement('c:delete');
    $objWriter->writeAttribute('val', $xAxis ? $xAxis->getAxisVisibilty() : 0);
    $objWriter->endElement();


This is my first time submitting a pull request for PhpSpreadsheet.  I have several more I would like to provide.  Any suggestions to make the process smoother on both are ends would be appreciated.