### PR TITLE
Chart Samples Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Fix Chart samples by updating chart parameter from 0 to DataSeries::EMPTY_AS_GAP
 - Handle Error in Formula Processing Better for Xls [#1267](https://github.com/PHPOffice/PhpSpreadsheet/pull/1267)
 - Handle ConditionalStyle NumberFormat When Reading Xlsx File [#1296](https://github.com/PHPOffice/PhpSpreadsheet/pull/1296)
 - Fix Xlsx Writer's handling of decimal commas [#1282](https://github.com/PHPOffice/PhpSpreadsheet/pull/1282)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- Fix Chart samples by updating chart parameter from 0 to DataSeries::EMPTY_AS_GAP
+- Fix Chart samples by updating chart parameter from 0 to DataSeries::EMPTY_AS_GAP [#1448](https://github.com/PHPOffice/PhpSpreadsheet/pull/1448)
 - Handle Error in Formula Processing Better for Xls [#1267](https://github.com/PHPOffice/PhpSpreadsheet/pull/1267)
 - Handle ConditionalStyle NumberFormat When Reading Xlsx File [#1296](https://github.com/PHPOffice/PhpSpreadsheet/pull/1296)
 - Fix Xlsx Writer's handling of decimal commas [#1282](https://github.com/PHPOffice/PhpSpreadsheet/pull/1282)

--- a/samples/Chart/33_Chart_create_area.php
+++ b/samples/Chart/33_Chart_create_area.php
@@ -83,7 +83,7 @@ $chart = new Chart(
     $legend, // legend
     $plotArea, // plotArea
     true, // plotVisibleOnly
-    0, // displayBlanksAs
+    DataSeries::EMPTY_AS_GAP, // displayBlanksAs
     null, // xAxisLabel
     $yAxisLabel  // yAxisLabel
 );

--- a/samples/Chart/33_Chart_create_bar_stacked.php
+++ b/samples/Chart/33_Chart_create_bar_stacked.php
@@ -86,7 +86,7 @@ $chart = new Chart(
     $legend, // legend
     $plotArea, // plotArea
     true, // plotVisibleOnly
-    0, // displayBlanksAs
+    DataSeries::EMPTY_AS_GAP, // displayBlanksAs
     null, // xAxisLabel
     $yAxisLabel  // yAxisLabel
 );

--- a/samples/Chart/33_Chart_create_column.php
+++ b/samples/Chart/33_Chart_create_column.php
@@ -86,7 +86,7 @@ $chart = new Chart(
     $legend, // legend
     $plotArea, // plotArea
     true, // plotVisibleOnly
-    0, // displayBlanksAs
+    DataSeries::EMPTY_AS_GAP, // displayBlanksAs
     null, // xAxisLabel
     $yAxisLabel  // yAxisLabel
 );

--- a/samples/Chart/33_Chart_create_column_2.php
+++ b/samples/Chart/33_Chart_create_column_2.php
@@ -95,7 +95,7 @@ $chart = new Chart(
     $legend, // legend
     $plotArea, // plotArea
     true, // plotVisibleOnly
-    0, // displayBlanksAs
+    DataSeries::EMPTY_AS_GAP, // displayBlanksAs
     $xAxisLabel, // xAxisLabel
     $yAxisLabel  // yAxisLabel
 );

--- a/samples/Chart/33_Chart_create_composite.php
+++ b/samples/Chart/33_Chart_create_composite.php
@@ -139,7 +139,7 @@ $chart = new Chart(
     $legend, // legend
     $plotArea, // plotArea
     true, // plotVisibleOnly
-    0, // displayBlanksAs
+    DataSeries::EMPTY_AS_GAP, // displayBlanksAs
     null, // xAxisLabel
     null   // yAxisLabel
 );

--- a/samples/Chart/33_Chart_create_line.php
+++ b/samples/Chart/33_Chart_create_line.php
@@ -84,7 +84,7 @@ $chart = new Chart(
     $legend, // legend
     $plotArea, // plotArea
     true, // plotVisibleOnly
-    0, // displayBlanksAs
+    DataSeries::EMPTY_AS_GAP, // displayBlanksAs
     null, // xAxisLabel
     $yAxisLabel  // yAxisLabel
 );

--- a/samples/Chart/33_Chart_create_multiple_charts.php
+++ b/samples/Chart/33_Chart_create_multiple_charts.php
@@ -158,7 +158,7 @@ $chart2 = new Chart(
     $legend2, // legend
     $plotArea2, // plotArea
     true, // plotVisibleOnly
-    0, // displayBlanksAs
+    DataSeries::EMPTY_AS_GAP, // displayBlanksAs
     null, // xAxisLabel
     $yAxisLabel2 // yAxisLabel
 );

--- a/samples/Chart/33_Chart_create_pie.php
+++ b/samples/Chart/33_Chart_create_pie.php
@@ -84,7 +84,7 @@ $chart1 = new Chart(
     $legend1, // legend
     $plotArea1, // plotArea
     true, // plotVisibleOnly
-    0, // displayBlanksAs
+    DataSeries::EMPTY_AS_GAP, // displayBlanksAs
     null, // xAxisLabel
     null   // yAxisLabel - Pie charts don't have a Y-Axis
 );

--- a/samples/Chart/33_Chart_create_pie_custom_colors.php
+++ b/samples/Chart/33_Chart_create_pie_custom_colors.php
@@ -162,7 +162,7 @@ $chart2 = new Chart(
     null, // legend
     $plotArea2, // plotArea
     true, // plotVisibleOnly
-    0, // displayBlanksAs
+    DataSeries::EMPTY_AS_GAP, // displayBlanksAs
     null, // xAxisLabel
     null   // yAxisLabel - Like Pie charts, Donut charts don't have a Y-Axis
 );

--- a/samples/Chart/33_Chart_create_radar.php
+++ b/samples/Chart/33_Chart_create_radar.php
@@ -96,7 +96,7 @@ $chart = new Chart(
     $legend, // legend
     $plotArea, // plotArea
     true, // plotVisibleOnly
-    0, // displayBlanksAs
+    DataSeries::EMPTY_AS_GAP, // displayBlanksAs
     null, // xAxisLabel
     null   // yAxisLabel - Radar charts don't have a Y-Axis
 );

--- a/samples/Chart/33_Chart_create_scatter.php
+++ b/samples/Chart/33_Chart_create_scatter.php
@@ -80,7 +80,7 @@ $chart = new Chart(
     $legend, // legend
     $plotArea, // plotArea
     true, // plotVisibleOnly
-    0, // displayBlanksAs
+    DataSeries::EMPTY_AS_GAP, // displayBlanksAs
     null, // xAxisLabel
     $yAxisLabel  // yAxisLabel
 );

--- a/samples/Chart/33_Chart_create_stock.php
+++ b/samples/Chart/33_Chart_create_stock.php
@@ -92,7 +92,7 @@ $chart = new Chart(
     $legend, // legend
     $plotArea, // plotArea
     true, // plotVisibleOnly
-    0, // displayBlanksAs
+    DataSeries::EMPTY_AS_GAP, // displayBlanksAs
     $xAxisLabel, // xAxisLabel
     $yAxisLabel  // yAxisLabel
 );

--- a/src/PhpSpreadsheet/Chart/Chart.php
+++ b/src/PhpSpreadsheet/Chart/Chart.php
@@ -156,7 +156,7 @@ class Chart
      * @param null|GridLines $majorGridlines
      * @param null|GridLines $minorGridlines
      */
-    public function __construct($name, Title $title = null, Legend $legend = null, PlotArea $plotArea = null, $plotVisibleOnly = true, $displayBlanksAs = 'gap', Title $xAxisLabel = null, Title $yAxisLabel = null, Axis $xAxis = null, Axis $yAxis = null, GridLines $majorGridlines = null, GridLines $minorGridlines = null)
+    public function __construct($name, Title $title = null, Legend $legend = null, PlotArea $plotArea = null, $plotVisibleOnly = true, $displayBlanksAs = DataSeries::EMPTY_AS_GAP, Title $xAxisLabel = null, Title $yAxisLabel = null, Axis $xAxis = null, Axis $yAxis = null, GridLines $majorGridlines = null, GridLines $minorGridlines = null)
     {
         $this->name = $name;
         $this->title = $title;

--- a/src/PhpSpreadsheet/Chart/DataSeries.php
+++ b/src/PhpSpreadsheet/Chart/DataSeries.php
@@ -40,6 +40,8 @@ class DataSeries
     const STYLE_MARKER = 'marker';
     const STYLE_FILLED = 'filled';
 
+    const EMPTY_AS_GAP = 'gap';
+
     /**
      * Series Plot Type.
      *

--- a/src/PhpSpreadsheet/Chart/DataSeries.php
+++ b/src/PhpSpreadsheet/Chart/DataSeries.php
@@ -41,6 +41,8 @@ class DataSeries
     const STYLE_FILLED = 'filled';
 
     const EMPTY_AS_GAP = 'gap';
+    const EMPTY_AS_ZERO = 'zero';
+    const EMPTY_AS_SPAN = 'span';
 
     /**
      * Series Plot Type.


### PR DESCRIPTION
Update chart parameter from 0 to DataSeries::EMPTY_AS_GAP

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
All chart examples passed the displayBlanksAs parameter as 0 instead of 'gap'. I added a constant EMPTY_AS_GAP to the DataSeries and then change all chart samples to use this new constant.