### PR TITLE
README - add link to migration path to show people easier way

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PhpSpreadsheet is the next version of PHPExcel. It breaks compatibility to drama
 
 Because all efforts have shifted to PhpSpreadsheet, PHPExcel will no longer be maintained. All contributions for PHPExcel, patches and new features, should target PhpSpreadsheet `master` branch.
 
-Do you need to migrate? [Here is how](/docs/topics/migration-from-PHPExcel.md)
+Do you need to migrate? There is [an automated tool](/docs/topics/migration-from-PHPExcel.md) for that.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ PhpSpreadsheet is the next version of PHPExcel. It breaks compatibility to drama
 
 Because all efforts have shifted to PhpSpreadsheet, PHPExcel will no longer be maintained. All contributions for PHPExcel, patches and new features, should target PhpSpreadsheet `master` branch.
 
+Do you need to migrate? [Here is how](/docs/topics/migration-from-PHPExcel.md)
+
 ## License
 
 PhpSpreadsheet is licensed under [MIT](https://github.com/PHPOffice/PhpSpreadsheet/blob/master/LICENSE).


### PR DESCRIPTION
I've notice the README contains what has happened with PHPExcel, but actually doesn't tell user what to do about it.

I think most people would not assume there exists some magic powerful tool that will handle most of the migration for them. They might start to rewrite it manually, which is terrible waste of time.

Saying that, there should be at least small link to already existing documentation
