### PR TITLE
Fix "Maximum function nesting level"

### DIFF
--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -242,27 +242,26 @@ class Csv extends BaseReader
      */
     private function getNextLine($line = '')
     {
-        // Get the next line in the file
-        $newLine = fgets($this->fileHandle);
+        do {
+            // Get the next line in the file
+            $newLine = fgets($this->fileHandle);
 
-        // Return false if there is no next line
-        if ($newLine === false) {
-            return false;
-        }
+            // Return false if there is no next line
+            if ($newLine === false) {
+                return false;
+            }
 
-        // Add the new line to the line passed in
-        $line = $line . $newLine;
+            // Add the new line to the line passed in
+            $line = $line . $newLine;
 
-        // Drop everything that is enclosed to avoid counting false positives in enclosures
-        $enclosure = '(?<!' . preg_quote($this->escapeCharacter, '/') . ')'
-            . preg_quote($this->enclosure, '/');
-        $line = preg_replace('/(' . $enclosure . '.*' . $enclosure . ')/Us', '', $line);
+            // Drop everything that is enclosed to avoid counting false positives in enclosures
+            $enclosure = '(?<!' . preg_quote($this->escapeCharacter, '/') . ')'
+                . preg_quote($this->enclosure, '/');
+            $line = preg_replace('/(' . $enclosure . '.*' . $enclosure . ')/Us', '', $line);
 
-        // See if we have any enclosures left in the line
-        // if we still have an enclosure then we need to read the next line as well
-        if (preg_match('/(' . $enclosure . ')/', $line) > 0) {
-            $line = $this->getNextLine($line);
-        }
+            // See if we have any enclosures left in the line
+            // if we still have an enclosure then we need to read the next line as well
+        } while (preg_match('/(' . $enclosure . ')/', $line) > 0);
 
         return $line;
     }


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

If there is "line" splited on lot of lines we can reach limit of recursion nesting. It's better to use while instead of recursion