### PR TITLE
Corrected date time detection

### DIFF
--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -387,6 +387,11 @@ class Date
         if ((substr($pFormatCode, 0, 1) == '_') || (substr($pFormatCode, 0, 2) == '0 ')) {
             return false;
         }
+        // Some "special formats" provided in German Excel versions were detected as date time value,
+        // so filter them out here - "\C\H\-00000" (Switzerland) and "\D-00000" (Germany).
+        if (\strpos($pFormatCode, '-00000') !== false) {
+            return false;
+        }
         // Try checking for any of the date formatting characters that don't appear within square braces
         if (preg_match('/(^|\])[^\[]*[' . self::$possibleDateFormatCharacters . ']/i', $pFormatCode)) {
             //    We might also have a format mask containing quoted strings...

--- a/tests/data/Shared/Date/FormatCodes.php
+++ b/tests/data/Shared/Date/FormatCodes.php
@@ -150,4 +150,12 @@ return [
         true,
         '"date " y-m-d',
     ],
+    [
+        false,
+        '\C\H\-00000',
+    ],
+    [
+        false,
+        '\D-00000',
+    ],
 ];


### PR DESCRIPTION
German and Swiss ZIP codes (special formats provided in German Excel versions) were detected as date time value, because the regular expression for date time formats falsely matched their formats ("\C\H\-00000" and "\D-00000").

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
