### PR TITLE
Fix typo in PHPDocs

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1747,7 +1747,7 @@ class Worksheet implements IComparable
     /**
      * Get merge cells array.
      *
-     * @return array[]
+     * @return array
      */
     public function getMergeCells()
     {


### PR DESCRIPTION
If you want it's may be array of strings like `@return string[]`

This is a typofix

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary
