### PR TITLE
escape bom

### DIFF
--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -161,8 +161,13 @@ class Html extends BaseReader
     private function readBeginning()
     {
         fseek($this->fileHandle, 0);
-
-        return fread($this->fileHandle, self::TEST_SAMPLE_SIZE);
+        
+        $str = fread($this->fileHandle, self::TEST_SAMPLE_SIZE);
+        //escape bom
+        $bom = implode('', array_map(function($ascii) {
+            return chr($ascii);
+        }, [0xEF, 0xBB, 0xBF]));
+        return substr($str, 0, 3) == $bom ? substr($str, 3) : $str;
     }
 
     private function readEnding()

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -161,12 +161,13 @@ class Html extends BaseReader
     private function readBeginning()
     {
         fseek($this->fileHandle, 0);
-        
+
         $str = fread($this->fileHandle, self::TEST_SAMPLE_SIZE);
         //escape bom
-        $bom = implode('', array_map(function($ascii) {
+        $bom = implode('', array_map(function ($ascii) {
             return chr($ascii);
         }, [0xEF, 0xBB, 0xBF]));
+
         return substr($str, 0, 3) == $bom ? substr($str, 3) : $str;
     }
 


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

To escape bom while html file is from windows