### PR TITLE
#1504: Using non-UTC timezone corrupts dates imported from XML spreadsheet

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -516,7 +516,7 @@ class Xml extends BaseReader
                                         break;
                                     case 'DateTime':
                                         $type = DataType::TYPE_NUMERIC;
-                                        $cellValue = Date::PHPToExcel(strtotime($cellValue));
+                                        $cellValue = Date::PHPToExcel(strtotime($cellValue . ' UTC'));
 
                                         break;
                                     case 'Error':


### PR DESCRIPTION
This is:
- [X] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
To resolve #1504