### PR TITLE
Fix exact MATCH on ranges with empty cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Fixed
 
 - Resolve evaluation of utf-8 named ranges in calculation engine [#1522](https://github.com/PHPOffice/PhpSpreadsheet/pull/1522)
+- Fix exact MATCH on ranges with empty cells [#1520](https://github.com/PHPOffice/PhpSpreadsheet/pull/1520)
 
 ## [1.13.0] - 2020-05-31
 

--- a/src/PhpSpreadsheet/Calculation/LookupRef.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef.php
@@ -485,6 +485,13 @@ class LookupRef
             return Functions::NA();
         }
 
+        if ($matchType == 1) {
+            // If match_type is 1 the list has to be processed from last to first
+
+            $lookupArray = array_reverse($lookupArray);
+            $keySet = array_reverse(array_keys($lookupArray));
+        }
+
         // Lookup_array should contain only number, text, or logical values, or empty (null) cells
         foreach ($lookupArray as $i => $lookupArrayValue) {
             //    check the type of the value
@@ -498,15 +505,8 @@ class LookupRef
                 $lookupArray[$i] = StringHelper::strToLower($lookupArrayValue);
             }
             if (($lookupArrayValue === null) && (($matchType == 1) || ($matchType == -1))) {
-                $lookupArray = array_slice($lookupArray, 0, $i - 1);
+                unset($lookupArray[$i]);
             }
-        }
-
-        if ($matchType == 1) {
-            // If match_type is 1 the list has to be processed from last to first
-
-            $lookupArray = array_reverse($lookupArray);
-            $keySet = array_reverse(array_keys($lookupArray));
         }
 
         // **

--- a/tests/data/Calculation/LookupRef/MATCH.php
+++ b/tests/data/Calculation/LookupRef/MATCH.php
@@ -97,6 +97,20 @@ return [
         -1,
     ],
 
+    // match on ranges with empty cells
+    [
+        3, // Expected
+        4, // Input
+        [1, null, 4, null, 8],
+        1,
+    ],
+    [
+        3, // Expected
+        5, // Input
+        [1, null, 4, null, null],
+        1,
+    ],
+
     // 0s are causing errors, because things like 0 == 'x' is true. Thanks PHP!
     [
         3,


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

Fixes a bug when doing exact match on ranges with empty cells.

```php
<?php

require 'vendor/autoload.php';

use PhpOffice\PhpSpreadsheet\Spreadsheet;

$spreadsheet = new Spreadsheet();
$sheet = $spreadsheet->getActiveSheet();

// Row: 1, null, 4, null, 8.
$sheet->getCell('A1')->setValue(1);
$sheet->getCell('A3')->setValue(4);
$sheet->getCell('A5')->setValue(8);

$sheet->getCell('B1')->setValue('=MATCH(4, A1:A5, 1)');

// Should echo 3, but echos '#N/A'.
echo $sheet->getCell('B1')->getCalculatedValue() . PHP_EOL;

// Row: 1, null, 4, null, null.
$sheet->getCell('C1')->setValue(1);
$sheet->getCell('C3')->setValue(4);

$sheet->getCell('D1')->setValue('=MATCH(5, C1:C5, 1)');

// Should echo 3, but echos '#N/A'.
echo $sheet->getCell('D1')->getCalculatedValue() . PHP_EOL;
```
Before fix:
```
#N/A
#N/A
```

After fix:
```
3
3
```