### PR TITLE
Writer\Html output is much too large

### DIFF
--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -428,7 +428,7 @@ class Html extends BaseWriter
             // Write table header
             $html .= $this->generateTableHeader($sheet);
             // Get worksheet dimension
-            $dimension = explode(':', $sheet->calculateWorksheetDimension());
+            $dimension = explode(':', $sheet->calculateWorksheetDataDimension());
             $dimension[0] = Coordinate::coordinateFromString($dimension[0]);
             $dimension[0][0] = Coordinate::columnIndexFromString($dimension[0][0]);
             $dimension[1] = Coordinate::coordinateFromString($dimension[1]);


### PR DESCRIPTION
…stDataColumn() which seems to be more adequate than Worksheet::calculateWorksheetDimension which uses Worksheet::getHighestColumn(). This latest one includes all available columns not those with effective data.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

When using the save method from **PhpOffice\PhpSpreadsheet\Writer\Html**, we could expect that only the usefull data is being outputed. This works fine for **PhpOffice\PhpSpreadsheet\Writer\Csv*
