### PR TITLE
Initial work to handle Ranges formatted as 3-d ranges

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -3666,13 +3666,17 @@ class Calculation
                         if ($matches[2] == '') {
                             //    Otherwise, we 'inherit' the worksheet reference from the start cell reference
                             //    The start of the cell range reference should be the last entry in $output
-                            $startCellRef = $output[count($output) - 1]['value'];
-                            preg_match('/^' . self::CALCULATION_REGEXP_CELLREF . '$/i', $startCellRef, $startMatches);
-                            if ($startMatches[2] > '') {
-                                $val = $startMatches[2] . '!' . $val;
+                            $rangeStartCellRef = $output[count($output) - 1]['value'];
+                            preg_match('/^' . self::CALCULATION_REGEXP_CELLREF . '$/i', $rangeStartCellRef, $rangeStartMatches);
+                            if ($rangeStartMatches[2] > '') {
+                                $val = $rangeStartMatches[2] . '!' . $val;
                             }
                         } else {
-                            return $this->raiseFormulaError('3D Range references are not yet supported');
+                            $rangeStartCellRef = $output[count($output) - 1]['value'];
+                            preg_match('/^' . self::CALCULATION_REGEXP_CELLREF . '$/i', $rangeStartCellRef, $rangeStartMatches);
+                            if ($rangeStartMatches[2] !== $matches[2]) {
+                                return $this->raiseFormulaError('3D Range references are not yet supported');
+                            }
                         }
                     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Engine/RangeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Engine/RangeTest.php
@@ -60,7 +60,18 @@ class RangeTest extends TestCase
             ['=COUNT(A1:C1,A3:C3,B1:C3)', 12],
             ['=SUM(A1:C1,A3:C3 B1:C3)', 23],
             ['=COUNT(A1:C1,A3:C3 B1:C3)', 5],
+            ['=SUM(Worksheet!A1:B3,Worksheet!A1:C2)', 48],
+            ['=SUM(Worksheet!A1:Worksheet!B3,Worksheet!A1:Worksheet!C2)', 48],
         ];
+    }
+
+    public function test3dRangeEvaluation(): void
+    {
+        $workSheet = $this->spreadSheet->getActiveSheet();
+        $workSheet->setCellValue('E1', '=SUM(Worksheet!A1:Worksheet2!B3)');
+
+        $this->expectExceptionMessage('3D Range references are not yet supported');
+        $workSheet->getCell('E1')->getCalculatedValue();
     }
 
     /**


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Initial work to handle Ranges formatted as 3-d ranges, as long as both parts of the range are to the same worksheet. This is some preparatory work to support named ranges as they are defined in Ods files
