### PR TITLE
Bug Setting Superscript/Subscript to False

### DIFF
--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -363,15 +363,16 @@ class Font extends Supervisor
      */
     public function setSuperscript($pValue)
     {
-        if ($pValue == '') {
-            $pValue = false;
-        }
+        $pValu2 = !$pValue;
+        $pValue = !$pValu2;
         if ($this->isSupervisor) {
             $styleArray = $this->getStyleArray(['superscript' => $pValue]);
             $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($styleArray);
         } else {
             $this->superscript = $pValue;
-            $this->subscript = !$pValue;
+            if ($this->superscript) {
+                $this->subscript = false;
+            }
         }
 
         return $this;
@@ -400,15 +401,16 @@ class Font extends Supervisor
      */
     public function setSubscript($pValue)
     {
-        if ($pValue == '') {
-            $pValue = false;
-        }
+        $pValu2 = !$pValue;
+        $pValue = !$pValu2;
         if ($this->isSupervisor) {
             $styleArray = $this->getStyleArray(['subscript' => $pValue]);
             $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($styleArray);
         } else {
             $this->subscript = $pValue;
-            $this->superscript = !$pValue;
+            if ($this->subscript) {
+                $this->superscript = false;
+            }
         }
 
         return $this;

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -391,14 +391,10 @@ class Font extends Supervisor
     /**
      * Set Subscript.
      *
-     * @param bool $pValue
-     *
      * @return $this
      */
-    public function setSubscript($pValue)
+    public function setSubscript(bool $pValue)
     {
-        $pValu2 = !$pValue;
-        $pValue = !$pValu2;
         if ($this->isSupervisor) {
             $styleArray = $this->getStyleArray(['subscript' => $pValue]);
             $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($styleArray);

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -357,14 +357,10 @@ class Font extends Supervisor
     /**
      * Set Superscript.
      *
-     * @param bool $pValue
-     *
      * @return $this
      */
-    public function setSuperscript($pValue)
+    public function setSuperscript(bool $pValue)
     {
-        $pValu2 = !$pValue;
-        $pValue = !$pValu2;
         if ($this->isSupervisor) {
             $styleArray = $this->getStyleArray(['superscript' => $pValue]);
             $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($styleArray);

--- a/tests/PhpSpreadsheetTests/Style/FontTest.php
+++ b/tests/PhpSpreadsheetTests/Style/FontTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Style;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+class FontTest extends TestCase
+{
+    public function testSuperSubScript(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $cell = $sheet->getCell('A1');
+        $cell->setValue('Cell A1');
+        $font = $cell->getStyle()->getFont();
+        $font->setSuperscript(true);
+        $font->setSubscript(true);
+        self::assertFalse($font->getSuperscript(), 'Earlier set true loses');
+        self::assertTrue($font->getSubscript(), 'Last set true wins');
+        $font->setSubscript(true);
+        $font->setSuperscript(true);
+        self::assertTrue($font->getSuperscript(), 'Last set true wins');
+        self::assertFalse($font->getSubscript(), 'Earlier set true loses');
+        $font->setSuperscript(false);
+        $font->setSubscript(false);
+        self::assertFalse($font->getSuperscript(), 'False remains unchanged');
+        self::assertFalse($font->getSubscript(), 'False remains unchanged');
+        $font->setSubscript(false);
+        $font->setSuperscript(false);
+        self::assertFalse($font->getSuperscript(), 'False remains unchanged');
+        self::assertFalse($font->getSubscript(), 'False remains unchanged');
+        $font->setSubscript(true);
+        $font->setSuperscript(false);
+        self::assertFalse($font->getSuperscript(), 'False remains unchanged');
+        self::assertTrue($font->getSubscript(), 'True remains unchanged');
+        $font->setSubscript(false);
+        $font->setSuperscript(true);
+        self::assertTrue($font->getSuperscript());
+        self::assertFalse($font->getSubscript(), 'False remains unchanged');
+    }
+}


### PR DESCRIPTION
If font style Superscript is set to true, Subscript is set to false.
Likewise, setting Subscript to true sets Superscript to false.
Both of these are working as they should. However,
setting Superscript to false causes Subscript to be set to true,
and setting Subscript to false causes Superscript to be set to true.
I believe that is an error in both cases. This change fixes it.

There seem to be no existing tests for Font styles.
I added the tests necessary to validate this change.
I will put adding more on my to-do list.

I faced a conundrum changing setSuperscript and setSubscript.
The parameter is described as bool in the DocBlock.
It is not typed in the function declaration, and changing the function
declaration to type it runs a serious risk of breaking existing
applications for no good reason. So I want to cast it on entry.
But I believe Scrutinizer would object to casting to bool a parameter
declared as bool in the DocBlock. I tried !!, but Phpunit objected
to this, suggesting using a cast to bool instead. So I did this
as two separate assignments, which satisfies Phpunit, and which
I hope satisfies Scrutinizer.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
