### PR TITLE
Restoring State After Static Changes in Tests

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -9,15 +9,23 @@ use PHPUnit\Framework\TestCase;
 
 class CalculationTest extends TestCase
 {
+    private $compatibilityMode;
+
+    private $locale;
+
     protected function setUp(): void
     {
+        $this->compatibilityMode = Functions::getCompatibilityMode();
+        $calculation = Calculation::getInstance();
+        $this->locale = $calculation->getLocale();
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
     }
 
     protected function tearDown(): void
     {
+        Functions::setCompatibilityMode($this->compatibilityMode);
         $calculation = Calculation::getInstance();
-        $calculation->setLocale('en_us');
+        $calculation->setLocale($this->locale);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DayTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DayTest.php
@@ -9,11 +9,27 @@ use PHPUnit\Framework\TestCase;
 
 class DayTest extends TestCase
 {
+    private $compatibilityMode;
+
+    private $returnDateType;
+
+    private $excelCalendar;
+
     protected function setUp(): void
     {
+        $this->compatibilityMode = Functions::getCompatibilityMode();
+        $this->returnDateType = Functions::getReturnDateType();
+        $this->excelCalendar = Date::getExcelCalendar();
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
         Functions::setReturnDateType(Functions::RETURNDATE_EXCEL);
         Date::setExcelCalendar(Date::CALENDAR_WINDOWS_1900);
+    }
+
+    protected function tearDown(): void
+    {
+        Functions::setCompatibilityMode($this->compatibilityMode);
+        Functions::setReturnDateType($this->returnDateType);
+        Date::setExcelCalendar($this->excelCalendar);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountTest.php
@@ -8,9 +8,17 @@ use PHPUnit\Framework\TestCase;
 
 class CountTest extends TestCase
 {
+    private $compatibilityMode;
+
     protected function setUp(): void
     {
+        $this->compatibilityMode = Functions::getCompatibilityMode();
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+    }
+
+    protected function tearDown(): void
+    {
+        Functions::setCompatibilityMode($this->compatibilityMode);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CharTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CharTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class CharTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerCHAR
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CleanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CleanTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class CleanTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerCLEAN
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CodeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CodeTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class CodeTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerCODE
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ConcatenateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ConcatenateTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class ConcatenateTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerCONCATENATE
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/DollarTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/DollarTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class DollarTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerDOLLAR
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ExactTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ExactTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class ExactTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerEXACT
      *
@@ -33,10 +15,6 @@ class ExactTest extends TestCase
      */
     public function testEXACT($expectedResult, ...$args): void
     {
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(' ');
-        StringHelper::setCurrencyCode('$');
-
         $result = TextData::EXACT(...$args);
         self::assertSame($expectedResult, $result);
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/FindTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/FindTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class FindTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerFIND
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/FixedTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/FixedTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class FixedTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerFIXED
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LeftTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LeftTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class LeftTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerLEFT
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LenTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class LenTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerLEN
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LowerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LowerTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class LowerTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerLOWER
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/MidTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/MidTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class MidTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerMID
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/NumberValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/NumberValueTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class NumberValueTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerNUMBERVALUE
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ProperTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ProperTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class ProperTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerPROPER
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ReplaceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ReplaceTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class ReplaceTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerREPLACE
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/RightTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/RightTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class RightTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerRIGHT
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/SearchTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/SearchTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class SearchTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerSEARCH
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/SubstituteTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/SubstituteTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class SubstituteTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerSUBSTITUTE
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class TTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerT
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextJoinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextJoinTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class TextJoinTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerTEXTJOIN
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class TextTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerTEXT
      *
@@ -32,11 +14,6 @@ class TextTest extends TestCase
      */
     public function testTEXT($expectedResult, ...$args): void
     {
-        //    Enforce decimal and thousands separator values to UK/US, and currency code to USD
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-
         $result = TextData::TEXTFORMAT(...$args);
         self::assertEquals($expectedResult, $result);
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TrimTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TrimTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class TrimTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerTRIM
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/UpperTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/UpperTest.php
@@ -2,29 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
-use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class UpperTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
-    }
-
     /**
      * @dataProvider providerUPPER
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ValueTest.php
@@ -2,27 +2,30 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\TextData;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class ValueTest extends TestCase
 {
+    private $currencyCode;
+
+    private $decimalSeparator;
+
+    private $thousandsSeparator;
+
     protected function setUp(): void
     {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
+        $this->currencyCode = StringHelper::getCurrencyCode();
+        $this->decimalSeparator = StringHelper::getDecimalSeparator();
+        $this->thousandsSeparator = StringHelper::getThousandsSeparator();
     }
 
     protected function tearDown(): void
     {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        StringHelper::setDecimalSeparator('.');
-        StringHelper::setThousandsSeparator(',');
-        StringHelper::setCurrencyCode('$');
+        StringHelper::setCurrencyCode($this->currencyCode);
+        StringHelper::setDecimalSeparator($this->decimalSeparator);
+        StringHelper::setThousandsSeparator($this->thousandsSeparator);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Calculation/FunctionsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/FunctionsTest.php
@@ -10,16 +10,22 @@ use PHPUnit\Framework\TestCase;
 
 class FunctionsTest extends TestCase
 {
+    private $compatibilityMode;
+
+    private $returnDate;
+
     protected function setUp(): void
     {
+        $this->compatibilityMode = Functions::getCompatibilityMode();
+        $this->returnDate = Functions::getReturnDateType();
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
         Functions::setReturnDateType(Functions::RETURNDATE_EXCEL);
     }
 
     protected function tearDown(): void
     {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        Functions::setReturnDateType(Functions::RETURNDATE_EXCEL);
+        Functions::setCompatibilityMode($this->compatibilityMode);
+        Functions::setReturnDateType($this->returnDate);
     }
 
     public function testCompatibilityMode(): void

--- a/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
@@ -13,6 +13,26 @@ use PHPUnit\Framework\TestCase;
 
 class AdvancedValueBinderTest extends TestCase
 {
+    private $currencyCode;
+
+    private $decimalSeparator;
+
+    private $thousandsSeparator;
+
+    protected function setUp(): void
+    {
+        $this->currencyCode = StringHelper::getCurrencyCode();
+        $this->decimalSeparator = StringHelper::getDecimalSeparator();
+        $this->thousandsSeparator = StringHelper::getThousandsSeparator();
+    }
+
+    protected function tearDown(): void
+    {
+        StringHelper::setCurrencyCode($this->currencyCode);
+        StringHelper::setDecimalSeparator($this->decimalSeparator);
+        StringHelper::setThousandsSeparator($this->thousandsSeparator);
+    }
+
     public function provider()
     {
         $currencyUSD = NumberFormat::FORMAT_CURRENCY_USD_SIMPLE;

--- a/tests/PhpSpreadsheetTests/Shared/StringHelperTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/StringHelperTest.php
@@ -7,12 +7,28 @@ use PHPUnit\Framework\TestCase;
 
 class StringHelperTest extends TestCase
 {
+    private $currencyCode;
+
+    private $decimalSeparator;
+
+    private $thousandsSeparator;
+
     protected function setUp(): void
     {
         parent::setUp();
+        $this->currencyCode = StringHelper::getCurrencyCode();
+        $this->decimalSeparator = StringHelper::getDecimalSeparator();
+        $this->thousandsSeparator = StringHelper::getThousandsSeparator();
 
         // Reset Currency Code
         StringHelper::setCurrencyCode(null);
+    }
+
+    protected function tearDown(): void
+    {
+        StringHelper::setCurrencyCode($this->currencyCode);
+        StringHelper::setDecimalSeparator($this->decimalSeparator);
+        StringHelper::setThousandsSeparator($this->thousandsSeparator);
     }
 
     public function testGetIsIconvEnabled(): void

--- a/tests/PhpSpreadsheetTests/Style/NumberFormatTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormatTest.php
@@ -8,10 +8,26 @@ use PHPUnit\Framework\TestCase;
 
 class NumberFormatTest extends TestCase
 {
+    private $currencyCode;
+
+    private $decimalSeparator;
+
+    private $thousandsSeparator;
+
     protected function setUp(): void
     {
+        $this->currencyCode = StringHelper::getCurrencyCode();
+        $this->decimalSeparator = StringHelper::getDecimalSeparator();
+        $this->thousandsSeparator = StringHelper::getThousandsSeparator();
         StringHelper::setDecimalSeparator('.');
         StringHelper::setThousandsSeparator(',');
+    }
+
+    protected function tearDown(): void
+    {
+        StringHelper::setCurrencyCode($this->currencyCode);
+        StringHelper::setDecimalSeparator($this->decimalSeparator);
+        StringHelper::setThousandsSeparator($this->thousandsSeparator);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Writer/Html/HtmlNumberFormatTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/HtmlNumberFormatTest.php
@@ -10,12 +10,16 @@ use PhpOffice\PhpSpreadsheetTests\Functional;
 
 class HtmlNumberFormatTest extends Functional\AbstractFunctional
 {
+    private $currency;
+
     private $decsep;
 
     private $thosep;
 
     protected function setUp(): void
     {
+        $this->currency = StringHelper::getCurrencyCode();
+        StringHelper::setCurrencyCode('$');
         $this->decsep = StringHelper::getDecimalSeparator();
         StringHelper::setDecimalSeparator('.');
         $this->thosep = StringHelper::getThousandsSeparator();
@@ -24,6 +28,7 @@ class HtmlNumberFormatTest extends Functional\AbstractFunctional
 
     protected function tearDown(): void
     {
+        StringHelper::setCurrencyCode($this->currency);
         StringHelper::setDecimalSeparator($this->decsep);
         StringHelper::setThousandsSeparator($this->thosep);
     }


### PR DESCRIPTION
This request does not change any source code, only tests.

For a change on which I was working, a test passed when run on its own,
but failed when run as part of the full test suite. It turned out that
an existing test had changed a static value,
thousands separator in this case, and failed to restore it.
The test turned out to be AdvancedBinderTest.

The search for the offending test was more difficult than it should have
been because 26 test scripts which had nothing to do with thousands
separator nevertheless changed that value. They all changed
decimal separator, currency code, and compatibility mode as well,
again for no reason. I changed all of those to eliminate those operations.

I changed the following tests, which actually do change the static
properties identified above for a reason, to restore them as part of teardown.
- CalculationTest sets compatibilityMode and locale
- DayTest sets compatibilityMode, returnDateType, and excelCalendar
- CountTest sets compatibilityMode
- FunctionsTest sets compatibilityMode and returnDateType
- AdvancedValueBinderTest sets currencyCode, decimalSeparator, thousandsSeparator
- StringHelperTest sets currencyCode, decimalSeparator, thousandsSeparator
- NumberFormatTest sets currencyCode, decimalSeparator, thousandsSeparator
- HtmlNumberFormatTest sets currencyCode, decimalSeparator, thousandsSeparator

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Improving test suite (see above for full explanation).
