### PR TITLE
Reconcile function discrepancies between the documented lists, and the Calculation Engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /analysis
 /vendor/
 /phpunit.xml
+/build
 
 ## IDE support
 *.buildpath

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /analysis
 /vendor/
 /phpunit.xml
-/build
 
 ## IDE support
 *.buildpath

--- a/docs/references/function-list-by-category.md
+++ b/docs/references/function-list-by-category.md
@@ -4,13 +4,13 @@
 
 Excel Function      | Excel Version | PhpSpreadsheet Function
 --------------------|---------------|-------------------------------------------
-CUBEKPIMEMBER       |               | **Not yet Implemented**
-CUBEMEMBER          |               | **Not yet Implemented**
-CUBEMEMBERPROPERTY  |               | **Not yet Implemented**
-CUBERANKEDMEMBER    |               | **Not yet Implemented**
-CUBESET             |               | **Not yet Implemented**
-CUBESETCOUNT        |               | **Not yet Implemented**
-CUBEVALUE           |               | **Not yet Implemented**
+CUBEKPIMEMBER       | 2007          | **Not yet Implemented**
+CUBEMEMBER          | 2007          | **Not yet Implemented**
+CUBEMEMBERPROPERTY  | 2007          | **Not yet Implemented**
+CUBERANKEDMEMBER    | 2007          | **Not yet Implemented**
+CUBESET             | 2007          | **Not yet Implemented**
+CUBESETCOUNT        | 2007          | **Not yet Implemented**
+CUBEVALUE           | 2007          | **Not yet Implemented**
 
 ## CATEGORY_DATABASE
 
@@ -211,12 +211,12 @@ Excel Function      | Excel Version | PhpSpreadsheet Function
 AND                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalAnd
 FALSE               |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::FALSE
 IF                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementIf
-IFERROR             |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFERROR
+IFERROR             | 2007          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFERROR
 IFNA                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFNA
 IFS                 | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFS
 NOT                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::NOT
 OR                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalOr
-SWITCH              | 2016          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementSwitch
+SWITCH              | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementSwitch
 TRUE                |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::TRUE
 XOR                 | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalXor
 
@@ -259,8 +259,8 @@ ACOS                |               | acos
 ACOSH               |               | acosh
 ACOT                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOT
 ACOTH               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOTH
-AGGREGATE           |               | **Not yet Implemented**
-ARABIC              |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ARABIC
+AGGREGATE           | 2010          | **Not yet Implemented**
+ARABIC              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ARABIC
 ASIN                |               | asin
 ASINH               |               | asinh
 ATAN                |               | atan
@@ -269,7 +269,7 @@ ATANH               |               | atanh
 BASE                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::BASE
 CEILING             |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CEILING
 CEILING.MATH        | 2013          | **Not yet Implemented**
-CEILING.PRECISE     |               | **Not yet Implemented**
+CEILING.PRECISE     | 2010          | **Not yet Implemented**
 COMBIN              |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COMBIN
 COMBINA             | 2013          | **Not yet Implemented**
 COS                 |               | cos
@@ -286,7 +286,7 @@ FACT                |               | \PhpOffice\PhpSpreadsheet\Calculation\Math
 FACTDOUBLE          |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACTDOUBLE
 FLOOR               | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOOR
 FLOOR.MATH          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORMATH
-FLOOR.PRECISE       |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORPRECISE
+FLOOR.PRECISE       | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORPRECISE
 GCD                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::GCD
 INT                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::INT
 ISO.CEILING         | 2013          | **Not yet Implemented**
@@ -343,7 +343,7 @@ Excel Function           | Excel Version | PhpSpreadsheet Function
 AVEDEV                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVEDEV
 AVERAGE                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGE
 AVERAGEA                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEA
-AVERAGEIF                |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEIF
+AVERAGEIF                | 2007          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEIF
 AVERAGEIFS               | 2019          | **Not yet Implemented**
 BETADIST                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
 BETA.DIST                | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST

--- a/docs/references/function-list-by-category.md
+++ b/docs/references/function-list-by-category.md
@@ -2,543 +2,543 @@
 
 ## CATEGORY_CUBE
 
-Excel Function      | Excel Version | PhpSpreadsheet Function
---------------------|---------------|-------------------------------------------
-CUBEKPIMEMBER       | 2007          | **Not yet Implemented**
-CUBEMEMBER          | 2007          | **Not yet Implemented**
-CUBEMEMBERPROPERTY  | 2007          | **Not yet Implemented**
-CUBERANKEDMEMBER    | 2007          | **Not yet Implemented**
-CUBESET             | 2007          | **Not yet Implemented**
-CUBESETCOUNT        | 2007          | **Not yet Implemented**
-CUBEVALUE           | 2007          | **Not yet Implemented**
+Excel Function      | PhpSpreadsheet Function
+--------------------|-------------------------------------------
+CUBEKPIMEMBER       | **Not yet Implemented**
+CUBEMEMBER          | **Not yet Implemented**
+CUBEMEMBERPROPERTY  | **Not yet Implemented**
+CUBERANKEDMEMBER    | **Not yet Implemented**
+CUBESET             | **Not yet Implemented**
+CUBESETCOUNT        | **Not yet Implemented**
+CUBEVALUE           | **Not yet Implemented**
 
 ## CATEGORY_DATABASE
 
-Excel Function      | Excel Version | PhpSpreadsheet Function                                      
---------------------|---------------|-------------------------------------------
-DAVERAGE            |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DAVERAGE
-DCOUNT              |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNT
-DCOUNTA             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNTA
-DGET                |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DGET
-DMAX                |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMAX
-DMIN                |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMIN
-DPRODUCT            |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DPRODUCT
-DSTDEV              |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEV
-DSTDEVP             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEVP
-DSUM                |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSUM
-DVAR                |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVAR
-DVARP               |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVARP
+Excel Function      | PhpSpreadsheet Function                                      
+--------------------|-------------------------------------------
+DAVERAGE            | \PhpOffice\PhpSpreadsheet\Calculation\Database::DAVERAGE
+DCOUNT              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNT
+DCOUNTA             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNTA
+DGET                | \PhpOffice\PhpSpreadsheet\Calculation\Database::DGET
+DMAX                | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMAX
+DMIN                | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMIN
+DPRODUCT            | \PhpOffice\PhpSpreadsheet\Calculation\Database::DPRODUCT
+DSTDEV              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEV
+DSTDEVP             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEVP
+DSUM                | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSUM
+DVAR                | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVAR
+DVARP               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVARP
 
 ## CATEGORY_DATE_AND_TIME
 
-Excel Function      | Excel Version | PhpSpreadsheet Function
---------------------|---------------|-------------------------------------------
-DATE                |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATE
-DATEDIF             |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEDIF
-DATEVALUE           |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEVALUE
-DAY                 |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYOFMONTH
-DAYS                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS
-DAYS360             |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS360
-EDATE               |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EDATE
-EOMONTH             |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EOMONTH
-HOUR                |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::HOUROFDAY
-ISOWEEKNUM          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::ISOWEEKNUM
-MINUTE              |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MINUTE
-MONTH               |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MONTHOFYEAR
-NETWORKDAYS         |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::NETWORKDAYS
-NETWORKDAYS.INTL    | 2010          | **Not yet Implemented**
-NOW                 |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATETIMENOW
-SECOND              |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::SECOND
-TIME                |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIME
-TIMEVALUE           |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIMEVALUE
-TODAY               |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATENOW
-WEEKDAY             |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKDAY
-WEEKNUM             |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKNUM
-WORKDAY             |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WORKDAY
-WORKDAY.INTL        | 2010          | **Not yet Implemented**
-YEAR                |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEAR
-YEARFRAC            |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEARFRAC
+Excel Function      | PhpSpreadsheet Function
+--------------------|-------------------------------------------
+DATE                | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATE
+DATEDIF             | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEDIF
+DATEVALUE           | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEVALUE
+DAY                 | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYOFMONTH
+DAYS                | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS
+DAYS360             | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS360
+EDATE               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EDATE
+EOMONTH             | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EOMONTH
+HOUR                | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::HOUROFDAY
+ISOWEEKNUM          | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::ISOWEEKNUM
+MINUTE              | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MINUTE
+MONTH               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MONTHOFYEAR
+NETWORKDAYS         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::NETWORKDAYS
+NETWORKDAYS.INTL    | **Not yet Implemented**
+NOW                 | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATETIMENOW
+SECOND              | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::SECOND
+TIME                | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIME
+TIMEVALUE           | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIMEVALUE
+TODAY               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATENOW
+WEEKDAY             | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKDAY
+WEEKNUM             | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKNUM
+WORKDAY             | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WORKDAY
+WORKDAY.INTL        | **Not yet Implemented**
+YEAR                | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEAR
+YEARFRAC            | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEARFRAC
 
 ## CATEGORY_ENGINEERING
 
-Excel Function      | Excel Version | PhpSpreadsheet Function
---------------------|---------------|-------------------------------------------
-BESSELI             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELI
-BESSELJ             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELJ
-BESSELK             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELK
-BESSELY             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELY
-BIN2DEC             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTODEC
-BIN2HEX             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOHEX
-BIN2OCT             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOOCT
-BITAND              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITAND
-BITLSHIFT           | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITLSHIFT
-BITOR               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
-BITRSHIFT           | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITRSHIFT
-BITXOR              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
-COMPLEX             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::COMPLEX
-CONVERT             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::CONVERTUOM
-DEC2BIN             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOBIN
-DEC2HEX             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOHEX
-DEC2OCT             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOOCT
-DELTA               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DELTA
-ERF                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERF
-ERF.PRECISE         | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFPRECISE
-ERFC                |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
-ERFC.PRECISE        | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
-GESTEP              |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::GESTEP
-HEX2BIN             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOBIN
-HEX2DEC             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTODEC
-HEX2OCT             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOOCT
-IMABS               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMABS
-IMAGINARY           |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMAGINARY
-IMARGUMENT          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMARGUMENT
-IMCONJUGATE         |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCONJUGATE
-IMCOS               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOS
-IMCOSH              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOSH
-IMCOT               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOT
-IMCSC               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSC
-IMCSCH              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSCH
-IMDIV               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMDIV
-IMEXP               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMEXP
-IMLN                |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLN
-IMLOG10             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG10
-IMLOG2              |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG2
-IMPOWER             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPOWER
-IMPRODUCT           |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPRODUCT
-IMREAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMREAL
-IMSEC               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSEC
-IMSECH              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSECH
-IMSIN               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSIN
-IMSINH              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSINH
-IMSQRT              |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSQRT
-IMSUB               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUB
-IMSUM               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUM
-IMTAN               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMTAN
-OCT2BIN             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOBIN
-OCT2DEC             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTODEC
-OCT2HEX             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOHEX
+Excel Function      | PhpSpreadsheet Function
+--------------------|-------------------------------------------
+BESSELI             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELI
+BESSELJ             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELJ
+BESSELK             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELK
+BESSELY             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELY
+BIN2DEC             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTODEC
+BIN2HEX             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOHEX
+BIN2OCT             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOOCT
+BITAND              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITAND
+BITLSHIFT           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITLSHIFT
+BITOR               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
+BITRSHIFT           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITRSHIFT
+BITXOR              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
+COMPLEX             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::COMPLEX
+CONVERT             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::CONVERTUOM
+DEC2BIN             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOBIN
+DEC2HEX             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOHEX
+DEC2OCT             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOOCT
+DELTA               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DELTA
+ERF                 | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERF
+ERF.PRECISE         | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFPRECISE
+ERFC                | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
+ERFC.PRECISE        | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
+GESTEP              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::GESTEP
+HEX2BIN             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOBIN
+HEX2DEC             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTODEC
+HEX2OCT             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOOCT
+IMABS               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMABS
+IMAGINARY           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMAGINARY
+IMARGUMENT          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMARGUMENT
+IMCONJUGATE         | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCONJUGATE
+IMCOS               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOS
+IMCOSH              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOSH
+IMCOT               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOT
+IMCSC               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSC
+IMCSCH              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSCH
+IMDIV               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMDIV
+IMEXP               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMEXP
+IMLN                | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLN
+IMLOG10             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG10
+IMLOG2              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG2
+IMPOWER             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPOWER
+IMPRODUCT           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPRODUCT
+IMREAL              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMREAL
+IMSEC               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSEC
+IMSECH              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSECH
+IMSIN               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSIN
+IMSINH              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSINH
+IMSQRT              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSQRT
+IMSUB               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUB
+IMSUM               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUM
+IMTAN               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMTAN
+OCT2BIN             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOBIN
+OCT2DEC             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTODEC
+OCT2HEX             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOHEX
 
 ## CATEGORY_FINANCIAL
 
-Excel Function      | Excel Version | PhpSpreadsheet Function
---------------------|---------------|-------------------------------------------
-ACCRINT             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINT
-ACCRINTM            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINTM
-AMORDEGRC           |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORDEGRC
-AMORLINC            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORLINC
-COUPDAYBS           |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYBS
-COUPDAYS            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYS
-COUPDAYSNC          |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYSNC
-COUPNCD             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNCD
-COUPNUM             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNUM
-COUPPCD             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPPCD
-CUMIPMT             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMIPMT
-CUMPRINC            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMPRINC
-DB                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DB
-DDB                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DDB
-DISC                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DISC
-DOLLARDE            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARDE
-DOLLARFR            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARFR
-DURATION            |               | **Not yet Implemented**
-EFFECT              |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::EFFECT
-FV                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FV
-FVSCHEDULE          |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FVSCHEDULE
-INTRATE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::INTRATE
-IPMT                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IPMT
-IRR                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IRR
-ISPMT               |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ISPMT
-MDURATION           |               | **Not yet Implemented**
-MIRR                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::MIRR
-NOMINAL             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NOMINAL
-NPER                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPER
-NPV                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPV
-ODDFPRICE           |               | **Not yet Implemented**
-ODDFYIELD           |               | **Not yet Implemented**
-ODDLPRICE           |               | **Not yet Implemented**
-ODDLYIELD           |               | **Not yet Implemented**
-PDURATION           | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PDURATION
-PMT                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PMT
-PPMT                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PPMT
-PRICE               |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICE
-PRICEDISC           |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEDISC
-PRICEMAT            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEMAT
-PV                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PV
-RATE                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RATE
-RECEIVED            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RECEIVED
-RRI                 | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RRI
-SLN                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SLN
-SYD                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SYD
-TBILLEQ             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLEQ
-TBILLPRICE          |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLPRICE
-TBILLYIELD          |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLYIELD
-USDOLLAR            |               | **Not yet Implemented**
-VDB                 |               | **Not yet Implemented**
-XIRR                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XIRR
-XNPV                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XNPV
-YIELD               |               | **Not yet Implemented**
-YIELDDISC           |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDDISC
-YIELDMAT            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDMAT
+Excel Function      | PhpSpreadsheet Function
+--------------------|-------------------------------------------
+ACCRINT             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINT
+ACCRINTM            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINTM
+AMORDEGRC           | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORDEGRC
+AMORLINC            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORLINC
+COUPDAYBS           | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYBS
+COUPDAYS            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYS
+COUPDAYSNC          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYSNC
+COUPNCD             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNCD
+COUPNUM             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNUM
+COUPPCD             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPPCD
+CUMIPMT             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMIPMT
+CUMPRINC            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMPRINC
+DB                  | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DB
+DDB                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DDB
+DISC                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DISC
+DOLLARDE            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARDE
+DOLLARFR            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARFR
+DURATION            | **Not yet Implemented**
+EFFECT              | \PhpOffice\PhpSpreadsheet\Calculation\Financial::EFFECT
+FV                  | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FV
+FVSCHEDULE          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FVSCHEDULE
+INTRATE             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::INTRATE
+IPMT                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IPMT
+IRR                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IRR
+ISPMT               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ISPMT
+MDURATION           | **Not yet Implemented**
+MIRR                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::MIRR
+NOMINAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NOMINAL
+NPER                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPER
+NPV                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPV
+ODDFPRICE           | **Not yet Implemented**
+ODDFYIELD           | **Not yet Implemented**
+ODDLPRICE           | **Not yet Implemented**
+ODDLYIELD           | **Not yet Implemented**
+PDURATION           | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PDURATION
+PMT                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PMT
+PPMT                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PPMT
+PRICE               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICE
+PRICEDISC           | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEDISC
+PRICEMAT            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEMAT
+PV                  | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PV
+RATE                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RATE
+RECEIVED            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RECEIVED
+RRI                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RRI
+SLN                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SLN
+SYD                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SYD
+TBILLEQ             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLEQ
+TBILLPRICE          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLPRICE
+TBILLYIELD          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLYIELD
+USDOLLAR            | **Not yet Implemented**
+VDB                 | **Not yet Implemented**
+XIRR                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XIRR
+XNPV                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XNPV
+YIELD               | **Not yet Implemented**
+YIELDDISC           | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDDISC
+YIELDMAT            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDMAT
 
 ## CATEGORY_INFORMATION
 
-Excel Function      | Excel Version | PhpSpreadsheet Function
---------------------|---------------|-------------------------------------------
-CELL                |               | **Not yet Implemented**
-ERROR.TYPE          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::errorType
-INFO                |               | **Not yet Implemented**
-ISBLANK             |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isBlank
-ISERR               |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isErr
-ISERROR             |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isError
-ISEVEN              |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isEven
-ISFORMULA           | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isFormula
-ISLOGICAL           |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isLogical
-ISNA                |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNa
-ISNONTEXT           |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNonText
-ISNUMBER            |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNumber
-ISODD               |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isOdd
-ISREF               |               | **Not yet Implemented**
-ISTEXT              |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isText
-N                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::n
-NA                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::NA
-SHEET               | 2013          | **Not yet Implemented**
-SHEETS              | 2013          | **Not yet Implemented**
-TYPE                |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::TYPE
+Excel Function      | PhpSpreadsheet Function
+--------------------|-------------------------------------------
+CELL                | **Not yet Implemented**
+ERROR.TYPE          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::errorType
+INFO                | **Not yet Implemented**
+ISBLANK             | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isBlank
+ISERR               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isErr
+ISERROR             | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isError
+ISEVEN              | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isEven
+ISFORMULA           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isFormula
+ISLOGICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isLogical
+ISNA                | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNa
+ISNONTEXT           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNonText
+ISNUMBER            | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNumber
+ISODD               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isOdd
+ISREF               | **Not yet Implemented**
+ISTEXT              | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isText
+N                   | \PhpOffice\PhpSpreadsheet\Calculation\Functions::n
+NA                  | \PhpOffice\PhpSpreadsheet\Calculation\Functions::NA
+SHEET               | **Not yet Implemented**
+SHEETS              | **Not yet Implemented**
+TYPE                | \PhpOffice\PhpSpreadsheet\Calculation\Functions::TYPE
 
 ## CATEGORY_LOGICAL
 
-Excel Function      | Excel Version | PhpSpreadsheet Function
---------------------|---------------|-------------------------------------------
-AND                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalAnd
-FALSE               |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::FALSE
-IF                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementIf
-IFERROR             | 2007          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFERROR
-IFNA                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFNA
-IFS                 | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFS
-NOT                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::NOT
-OR                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalOr
-SWITCH              | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementSwitch
-TRUE                |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::TRUE
-XOR                 | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalXor
+Excel Function      | PhpSpreadsheet Function
+--------------------|-------------------------------------------
+AND                 | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalAnd
+FALSE               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::FALSE
+IF                  | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementIf
+IFERROR             | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFERROR
+IFNA                | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFNA
+IFS                 | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFS
+NOT                 | \PhpOffice\PhpSpreadsheet\Calculation\Logical::NOT
+OR                  | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalOr
+SWITCH              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementSwitch
+TRUE                | \PhpOffice\PhpSpreadsheet\Calculation\Logical::TRUE
+XOR                 | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalXor
 
 ## CATEGORY_LOOKUP_AND_REFERENCE
 
-Excel Function      | Excel Version | PhpSpreadsheet Function
---------------------|---------------|-------------------------------------------
-ADDRESS             |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::cellAddress
-AREAS               |               | **Not yet Implemented**
-CHOOSE              |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::CHOOSE
-COLUMN              |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMN
-COLUMNS             |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMNS
-FILTER              | Office 365    | **Not yet Implemented**
-FORMULATEXT         | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::FORMULATEXT
-GETPIVOTDATA        |               | **Not yet Implemented**
-HLOOKUP             |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HLOOKUP
-HYPERLINK           |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HYPERLINK
-INDEX               |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDEX
-INDIRECT            |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDIRECT
-LOOKUP              |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::LOOKUP
-MATCH               |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::MATCH
-OFFSET              |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::OFFSET
-ROW                 |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROW
-ROWS                |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROWS
-RTD                 |               | **Not yet Implemented**
-SORT                | Office 365    | **Not yet Implemented**
-SORTBY              | Office 365    | **Not yet Implemented**
-TRANSPOSE           |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::TRANSPOSE
-UNIQUE              | Office 365    | **Not yet Implemented**
-VLOOKUP             |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::VLOOKUP
-XLOOKUP             | Office 365    | **Not yet Implemented**
-XMATCH              | Office 365    | **Not yet Implemented**
+Excel Function      | PhpSpreadsheet Function
+--------------------|-------------------------------------------
+ADDRESS             | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::cellAddress
+AREAS               | **Not yet Implemented**
+CHOOSE              | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::CHOOSE
+COLUMN              | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMN
+COLUMNS             | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMNS
+FILTER              | **Not yet Implemented**
+FORMULATEXT         | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::FORMULATEXT
+GETPIVOTDATA        | **Not yet Implemented**
+HLOOKUP             | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HLOOKUP
+HYPERLINK           | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HYPERLINK
+INDEX               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDEX
+INDIRECT            | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDIRECT
+LOOKUP              | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::LOOKUP
+MATCH               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::MATCH
+OFFSET              | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::OFFSET
+ROW                 | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROW
+ROWS                | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROWS
+RTD                 | **Not yet Implemented**
+SORT                | **Not yet Implemented**
+SORTBY              | **Not yet Implemented**
+TRANSPOSE           | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::TRANSPOSE
+UNIQUE              | **Not yet Implemented**
+VLOOKUP             | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::VLOOKUP
+XLOOKUP             | **Not yet Implemented**
+XMATCH              | **Not yet Implemented**
 
 ## CATEGORY_MATH_AND_TRIG
 
-Excel Function      | Excel Version | PhpSpreadsheet Function
---------------------|---------------|-------------------------------------------
-ABS                 |               | abs
-ACOS                |               | acos
-ACOSH               |               | acosh
-ACOT                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOT
-ACOTH               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOTH
-AGGREGATE           | 2010          | **Not yet Implemented**
-ARABIC              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ARABIC
-ASIN                |               | asin
-ASINH               |               | asinh
-ATAN                |               | atan
-ATAN2               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ATAN2
-ATANH               |               | atanh
-BASE                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::BASE
-CEILING             |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CEILING
-CEILING.MATH        | 2013          | **Not yet Implemented**
-CEILING.PRECISE     | 2010          | **Not yet Implemented**
-COMBIN              |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COMBIN
-COMBINA             | 2013          | **Not yet Implemented**
-COS                 |               | cos
-COSH                |               | cosh
-COT                 | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COT
-COTH                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COTH
-CSC                 | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSC
-CSCH                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSCH
-DECIMAL             | 2013          | **Not yet Implemented**
-DEGREES             |               | rad2deg
-EVEN                |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::EVEN
-EXP                 |               | exp
-FACT                |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACT
-FACTDOUBLE          |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACTDOUBLE
-FLOOR               | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOOR
-FLOOR.MATH          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORMATH
-FLOOR.PRECISE       | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORPRECISE
-GCD                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::GCD
-INT                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::INT
-ISO.CEILING         | 2013          | **Not yet Implemented**
-LCM                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::LCM
-LN                  |               | log
-LOG                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::logBase
-LOG10               |               | log10
-MDETERM             |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MDETERM
-MINVERSE            |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MINVERSE
-MMULT               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MMULT
-MOD                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MOD
-MROUND              |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MROUND
-MULTINOMIAL         |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MULTINOMIAL
-MUNIT               | 2013          | **Not yet Implemented**
-ODD                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ODD
-PI                  |               | pi
-POWER               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::POWER
-PRODUCT             |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::PRODUCT
-QUOTIENT            |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::QUOTIENT
-RADIANS             |               | deg2rad
-RAND                |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
-RANDARRAY           | Office 365    | **Not yet Implemented**
-RANDBETWEEN         |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
-ROMAN               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROMAN
-ROUND               |               | round
-ROUNDDOWN           |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDDOWN
-ROUNDUP             |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDUP
-SEC                 | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SEC
-SECH                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SECH
-SERIESSUM           |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SERIESSUM
-SEQUENCE            | Office 365    | **Not yet Implemented**
-SIGN                |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SIGN
-SIN                 |               | sin
-SINH                |               | sinh
-SQRT                |               | sqrt
-SQRTPI              |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SQRTPI
-SUBTOTAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUBTOTAL
-SUM                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUM
-SUMIF               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIF
-SUMIFS              | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIFS
-SUMPRODUCT          |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMPRODUCT
-SUMSQ               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMSQ
-SUMX2MY2            |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2MY2
-SUMX2PY2            |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2PY2
-SUMXMY2             |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMXMY2
-TAN                 |               | tan
-TANH                |               | tanh
-TRUNC               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::TRUNC
+Excel Function      | PhpSpreadsheet Function
+--------------------|-------------------------------------------
+ABS                 | abs
+ACOS                | acos
+ACOSH               | acosh
+ACOT                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOT
+ACOTH               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOTH
+AGGREGATE           | **Not yet Implemented**
+ARABIC              | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ARABIC
+ASIN                | asin
+ASINH               | asinh
+ATAN                | atan
+ATAN2               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ATAN2
+ATANH               | atanh
+BASE                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::BASE
+CEILING             | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CEILING
+CEILING.MATH        | **Not yet Implemented**
+CEILING.PRECISE     | **Not yet Implemented**
+COMBIN              | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COMBIN
+COMBINA             | **Not yet Implemented**
+COS                 | cos
+COSH                | cosh
+COT                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COT
+COTH                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COTH
+CSC                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSC
+CSCH                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSCH
+DECIMAL             | **Not yet Implemented**
+DEGREES             | rad2deg
+EVEN                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::EVEN
+EXP                 | exp
+FACT                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACT
+FACTDOUBLE          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACTDOUBLE
+FLOOR               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOOR
+FLOOR.MATH          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORMATH
+FLOOR.PRECISE       | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORPRECISE
+GCD                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::GCD
+INT                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::INT
+ISO.CEILING         | **Not yet Implemented**
+LCM                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::LCM
+LN                  | log
+LOG                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::logBase
+LOG10               | log10
+MDETERM             | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MDETERM
+MINVERSE            | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MINVERSE
+MMULT               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MMULT
+MOD                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MOD
+MROUND              | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MROUND
+MULTINOMIAL         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MULTINOMIAL
+MUNIT               | **Not yet Implemented**
+ODD                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ODD
+PI                  | pi
+POWER               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::POWER
+PRODUCT             | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::PRODUCT
+QUOTIENT            | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::QUOTIENT
+RADIANS             | deg2rad
+RAND                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
+RANDARRAY           | **Not yet Implemented**
+RANDBETWEEN         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
+ROMAN               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROMAN
+ROUND               | round
+ROUNDDOWN           | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDDOWN
+ROUNDUP             | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDUP
+SEC                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SEC
+SECH                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SECH
+SERIESSUM           | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SERIESSUM
+SEQUENCE            | **Not yet Implemented**
+SIGN                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SIGN
+SIN                 | sin
+SINH                | sinh
+SQRT                | sqrt
+SQRTPI              | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SQRTPI
+SUBTOTAL            | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUBTOTAL
+SUM                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUM
+SUMIF               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIF
+SUMIFS              | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIFS
+SUMPRODUCT          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMPRODUCT
+SUMSQ               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMSQ
+SUMX2MY2            | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2MY2
+SUMX2PY2            | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2PY2
+SUMXMY2             | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMXMY2
+TAN                 | tan
+TANH                | tanh
+TRUNC               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::TRUNC
 
 ## CATEGORY_STATISTICAL
 
-Excel Function           | Excel Version | PhpSpreadsheet Function
--------------------------|---------------|-------------------------------------------
-AVEDEV                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVEDEV
-AVERAGE                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGE
-AVERAGEA                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEA
-AVERAGEIF                | 2007          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEIF
-AVERAGEIFS               | 2019          | **Not yet Implemented**
-BETADIST                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
-BETA.DIST                | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
-BETAINV                  | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
-BETA.INV                 | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
-BINOMDIST                | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
-BINOM.DIST               | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
-BINOM.DIST.RANGE         | 2013          | **Not yet Implemented**
-BINOM.INV                | 2010          | **Not yet Implemented**
-CHIDIST                  | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
-CHISQ.DIST               | 2010          | **Not yet Implemented**
-CHISQ.DIST.RT            | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
-CHIINV                   | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
-CHISQ.INV                | 2010          | **Not yet Implemented**
-CHISQ.INV.RT             | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
-CHITEST                  | Compatibility | **Not yet Implemented**
-CHISQ.TEST               | 2010          | **Not yet Implemented**
-CONFIDENCE               | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
-CONFIDENCE.NORM          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
-CONFIDENCE.T             | 2010          | **Not yet Implemented**
-CORREL                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
-COUNT                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNT
-COUNTA                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTA
-COUNTBLANK               |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTBLANK
-COUNTIF                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIF
-COUNTIFS                 | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIFS
-COVAR                    | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
-COVARIANCE.P             | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
-COVARIANCE.S             | 2010          | **Not yet Implemented**
-CRITBINOM                | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CRITBINOM
-DEVSQ                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::DEVSQ
-EXPONDIST                | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
-EXPON.DIST               | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
-FDIST                    | Compatibility | **Not yet Implemented**
-F.DIST                   | 2010          | **Not yet Implemented**
-F.DIST.RT                | 2010          | **Not yet Implemented**
-FINV                     | Compatibility | **Not yet Implemented**
-F.INV                    | 2010          | **Not yet Implemented**
-F.INV.RT                 | 2010          | **Not yet Implemented**
-F.TEST                   | 2010          | **Not yet Implemented**
-FISHER                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHER
-FISHERINV                |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHERINV
-FORECAST                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
-FORECAST.ETS             | 2016          | **Not yet Implemented**
-FORECAST.ETS.CONFINT     | 2016          | **Not yet Implemented**
-FORECAST.ETS.SEASONALITY | 2016          | **Not yet Implemented**
-FORECAST.ETS.STAT        | 2016          | **Not yet Implemented**
-FORECAST.LINEAR          | 2016          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
-FREQUENCY                |               | **Not yet Implemented**
-FTEST                    | Compatibility | **Not yet Implemented**
-GAMMA                    | 2013          | **Not yet Implemented**
-GAMMADIST                | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
-GAMMA.DIST               | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
-GAMMAINV                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
-GAMMA.INV                | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
-GAMMALN                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
-GAMMALN.PRECISE          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
-GAUSS                    | 2013          | **Not yet Implemented**
-GEOMEAN                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GEOMEAN
-GROWTH                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GROWTH
-HARMEAN                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HARMEAN
-HYPGEOMDIST              | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HYPGEOMDIST
-INTERCEPT                |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::INTERCEPT
-KURT                     |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::KURT
-LARGE                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LARGE
-LINEST                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LINEST
-LOGEST                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGEST
-LOGINV                   | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
-LOGNORMDIST              | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGNORMDIST
-LOGNORM.DIST             | 2010          | **Not yet Implemented**
-LOGNORM.INV              | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
-MAX                      |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAX
-MAXA                     |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXA
-MAXIFS                   | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXIFS
-MEDIAN                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MEDIAN
-MEDIANIF                 |               | **Not yet Implemented**
-MIN                      |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MIN
-MINA                     |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINA
-MINIFS                   | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINIFS
-MODE                     | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
-MODE.MULT                | 2010          | **Not yet Implemented**
-MODE.SNGL                | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
-NEGBINOMDIST             | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NEGBINOMDIST
-NEGBINOM.DIST            | 2010          | **Not yet Implemented**
-NORMDIST                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
-NORM.DIST                | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
-NORMINV                  | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
-NORM.INV                 | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
-NORMSDIST                | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSDIST
-NORM.S.DIST              | 2010          | **Not yet Implemented**
-NORMSINV                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
-NORM.S.INV               | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
-PEARSON                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
-PERCENTILE               | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
-PERCENTILE.EXC           | 2010          | **Not yet Implemented**
-PERCENTILE.INC           | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
-PERCENTRANK              | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
-PERCENTRANK.EXC          | 2010          | **Not yet Implemented**
-PERCENTRANK.INC          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
-PERMUT                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERMUT
-PERMUTATIONA             | 2013          | **Not yet Implemented**
-PHI                      | 2013          | **Not yet Implemented**
-POISSON                  | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
-POISSON.DIST             | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
-PROB                     |               | **Not yet Implemented**
-QUARTILE                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
-QUARTILE.EXC             | 2010          | **Not yet Implemented**
-QUARTILE.INC             | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
-RANK                     | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
-RANK.AVG                 | 2010          | **Not yet Implemented**
-RANK.EQ                  | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
-RSQ                      |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RSQ
-SKEW                     |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SKEW
-SKEW.P                   | 2013          | **Not yet Implemented**
-SLOPE                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SLOPE
-SMALL                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SMALL
-STANDARDIZE              |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STANDARDIZE
-STDEV                    | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
-STDEV.P                  | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
-STDEV.S                  | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
-STDEVA                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVA
-STDEVP                   | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
-STDEVPA                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVPA
-STEYX                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STEYX
-TDIST                    | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TDIST
-T.DIST                   | 2010          | **Not yet Implemented**
-T.DIST.2T                | 2010          | **Not yet Implemented**
-T.DIST.RT                | 2010          | **Not yet Implemented**
-TINV                     | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
-T.INV                    | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
-T.INV.2T                 | 2010          | **Not yet Implemented**
-TREND                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TREND
-TRIMMEAN                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TRIMMEAN
-TTEST                    | Compatibility | **Not yet Implemented**
-T.TEST                   | 2010          | **Not yet Implemented**
-VAR                      | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
-VAR.P                    | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
-VAR.S                    | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
-VARA                     |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARA
-VARP                     | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
-VARPA                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARPA
-WEIBULL                  | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
-WEIBULL.DIST             | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
-ZTEST                    | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST
-Z.TEST                   | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST
+Excel Function           | PhpSpreadsheet Function
+-------------------------|-------------------------------------------
+AVEDEV                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVEDEV
+AVERAGE                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGE
+AVERAGEA                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEA
+AVERAGEIF                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEIF
+AVERAGEIFS               | **Not yet Implemented**
+BETADIST                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
+BETA.DIST                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
+BETAINV                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
+BETA.INV                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
+BINOMDIST                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
+BINOM.DIST               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
+BINOM.DIST.RANGE         | **Not yet Implemented**
+BINOM.INV                | **Not yet Implemented**
+CHIDIST                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
+CHISQ.DIST               | **Not yet Implemented**
+CHISQ.DIST.RT            | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
+CHIINV                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
+CHISQ.INV                | **Not yet Implemented**
+CHISQ.INV.RT             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
+CHITEST                  | **Not yet Implemented**
+CHISQ.TEST               | **Not yet Implemented**
+CONFIDENCE               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
+CONFIDENCE.NORM          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
+CONFIDENCE.T             | **Not yet Implemented**
+CORREL                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
+COUNT                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNT
+COUNTA                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTA
+COUNTBLANK               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTBLANK
+COUNTIF                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIF
+COUNTIFS                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIFS
+COVAR                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
+COVARIANCE.P             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
+COVARIANCE.S             | **Not yet Implemented**
+CRITBINOM                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CRITBINOM
+DEVSQ                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::DEVSQ
+EXPONDIST                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
+EXPON.DIST               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
+FDIST                    | **Not yet Implemented**
+F.DIST                   | **Not yet Implemented**
+F.DIST.RT                | **Not yet Implemented**
+FINV                     | **Not yet Implemented**
+F.INV                    | **Not yet Implemented**
+F.INV.RT                 | **Not yet Implemented**
+F.TEST                   | **Not yet Implemented**
+FISHER                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHER
+FISHERINV                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHERINV
+FORECAST                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
+FORECAST.ETS             | **Not yet Implemented**
+FORECAST.ETS.CONFINT     | **Not yet Implemented**
+FORECAST.ETS.SEASONALITY | **Not yet Implemented**
+FORECAST.ETS.STAT        | **Not yet Implemented**
+FORECAST.LINEAR          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
+FREQUENCY                | **Not yet Implemented**
+FTEST                    | **Not yet Implemented**
+GAMMA                    | **Not yet Implemented**
+GAMMADIST                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
+GAMMA.DIST               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
+GAMMAINV                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
+GAMMA.INV                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
+GAMMALN                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
+GAMMALN.PRECISE          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
+GAUSS                    | **Not yet Implemented**
+GEOMEAN                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GEOMEAN
+GROWTH                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GROWTH
+HARMEAN                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HARMEAN
+HYPGEOMDIST              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HYPGEOMDIST
+INTERCEPT                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::INTERCEPT
+KURT                     | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::KURT
+LARGE                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LARGE
+LINEST                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LINEST
+LOGEST                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGEST
+LOGINV                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
+LOGNORMDIST              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGNORMDIST
+LOGNORM.DIST             | **Not yet Implemented**
+LOGNORM.INV              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
+MAX                      | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAX
+MAXA                     | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXA
+MAXIFS                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXIFS
+MEDIAN                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MEDIAN
+MEDIANIF                 | **Not yet Implemented**
+MIN                      | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MIN
+MINA                     | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINA
+MINIFS                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINIFS
+MODE                     | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
+MODE.MULT                | **Not yet Implemented**
+MODE.SNGL                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
+NEGBINOMDIST             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NEGBINOMDIST
+NEGBINOM.DIST            | **Not yet Implemented**
+NORMDIST                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
+NORM.DIST                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
+NORMINV                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
+NORM.INV                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
+NORMSDIST                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSDIST
+NORM.S.DIST              | **Not yet Implemented**
+NORMSINV                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
+NORM.S.INV               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
+PEARSON                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
+PERCENTILE               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
+PERCENTILE.EXC           | **Not yet Implemented**
+PERCENTILE.INC           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
+PERCENTRANK              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
+PERCENTRANK.EXC          | **Not yet Implemented**
+PERCENTRANK.INC          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
+PERMUT                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERMUT
+PERMUTATIONA             | **Not yet Implemented**
+PHI                      | **Not yet Implemented**
+POISSON                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
+POISSON.DIST             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
+PROB                     | **Not yet Implemented**
+QUARTILE                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
+QUARTILE.EXC             | **Not yet Implemented**
+QUARTILE.INC             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
+RANK                     | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
+RANK.AVG                 | **Not yet Implemented**
+RANK.EQ                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
+RSQ                      | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RSQ
+SKEW                     | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SKEW
+SKEW.P                   | **Not yet Implemented**
+SLOPE                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SLOPE
+SMALL                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SMALL
+STANDARDIZE              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STANDARDIZE
+STDEV                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
+STDEV.P                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
+STDEV.S                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
+STDEVA                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVA
+STDEVP                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
+STDEVPA                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVPA
+STEYX                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STEYX
+TDIST                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TDIST
+T.DIST                   | **Not yet Implemented**
+T.DIST.2T                | **Not yet Implemented**
+T.DIST.RT                | **Not yet Implemented**
+TINV                     | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
+T.INV                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
+T.INV.2T                 | **Not yet Implemented**
+TREND                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TREND
+TRIMMEAN                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TRIMMEAN
+TTEST                    | **Not yet Implemented**
+T.TEST                   | **Not yet Implemented**
+VAR                      | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
+VAR.P                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
+VAR.S                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
+VARA                     | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARA
+VARP                     | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
+VARPA                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARPA
+WEIBULL                  | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
+WEIBULL.DIST             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
+ZTEST                    | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST
+Z.TEST                   | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST
 
 ## CATEGORY_TEXT_AND_DATA
 
-Excel Function      | Excel Version | PhpSpreadsheet Function
---------------------|---------------|-------------------------------------------
-ASC                 |               | **Not yet Implemented**
-BAHTTEXT            |               | **Not yet Implemented**
-CHAR                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
-CLEAN               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMNONPRINTABLE
-CODE                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
-CONCAT              | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
-CONCATENATE         | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
-DBCS                | 2013          | **Not yet Implemented**
-DOLLAR              |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::DOLLAR
-EXACT               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::EXACT
-FIND                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
-FINDB               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
-FIXED               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::FIXEDFORMAT
-JIS                 |               | **Not yet Implemented**
-LEFT                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
-LEFTB               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
-LEN                 |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
-LENB                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
-LOWER               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LOWERCASE
-MID                 |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
-MIDB                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
-NUMBERVALUE         | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::NUMBERVALUE
-PHONETIC            |               | **Not yet Implemented**
-PROPER              |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::PROPERCASE
-REPLACE             |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
-REPLACEB            |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
-REPT                |               | str_repeat
-RIGHT               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
-RIGHTB              |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
-SEARCH              |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
-SEARCHB             |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
-SUBSTITUTE          |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SUBSTITUTE
-T                   |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RETURNSTRING
-TEXT                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTFORMAT
-TEXTJOIN            | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTJOIN
-TRIM                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMSPACES
-UNICHAR             | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
-UNICODE             | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
-UPPER               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::UPPERCASE
-VALUE               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::VALUE
+Excel Function      | PhpSpreadsheet Function
+--------------------|-------------------------------------------
+ASC                 | **Not yet Implemented**
+BAHTTEXT            | **Not yet Implemented**
+CHAR                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
+CLEAN               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMNONPRINTABLE
+CODE                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
+CONCAT              | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
+CONCATENATE         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
+DBCS                | **Not yet Implemented**
+DOLLAR              | \PhpOffice\PhpSpreadsheet\Calculation\TextData::DOLLAR
+EXACT               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::EXACT
+FIND                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
+FINDB               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
+FIXED               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::FIXEDFORMAT
+JIS                 | **Not yet Implemented**
+LEFT                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
+LEFTB               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
+LEN                 | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
+LENB                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
+LOWER               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LOWERCASE
+MID                 | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
+MIDB                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
+NUMBERVALUE         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::NUMBERVALUE
+PHONETIC            | **Not yet Implemented**
+PROPER              | \PhpOffice\PhpSpreadsheet\Calculation\TextData::PROPERCASE
+REPLACE             | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
+REPLACEB            | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
+REPT                | str_repeat
+RIGHT               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
+RIGHTB              | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
+SEARCH              | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
+SEARCHB             | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
+SUBSTITUTE          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SUBSTITUTE
+T                   | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RETURNSTRING
+TEXT                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTFORMAT
+TEXTJOIN            | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTJOIN
+TRIM                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMSPACES
+UNICHAR             | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
+UNICODE             | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
+UPPER               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::UPPERCASE
+VALUE               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::VALUE
 
-## CATEGORY_TEXT_AND_DATA
+## CATEGORY_WEB
 
-Excel Function      | Excel Version | PhpSpreadsheet Function
---------------------|---------------|-------------------------------------------
-ENCODEURL           | 2013          | **Not yet Implemented**
-FILTERXML           | 2013          | **Not yet Implemented**
-WEBSERVICE          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Web::WEBSERVICE
+Excel Function      | PhpSpreadsheet Function
+--------------------|-------------------------------------------
+ENCODEURL           | **Not yet Implemented**
+FILTERXML           | **Not yet Implemented**
+WEBSERVICE          | \PhpOffice\PhpSpreadsheet\Calculation\Web::WEBSERVICE

--- a/docs/references/function-list-by-category.md
+++ b/docs/references/function-list-by-category.md
@@ -2,461 +2,543 @@
 
 ## CATEGORY_CUBE
 
-Excel Function      | PhpSpreadsheet Function
---------------------|-------------------------------------------
-CUBEKPIMEMBER       | **Not yet Implemented**
-CUBEMEMBER          | **Not yet Implemented**
-CUBEMEMBERPROPERTY  | **Not yet Implemented**
-CUBERANKEDMEMBER    | **Not yet Implemented**
-CUBESET             | **Not yet Implemented**
-CUBESETCOUNT        | **Not yet Implemented**
-CUBEVALUE           | **Not yet Implemented**
+Excel Function      | Excel Version | PhpSpreadsheet Function
+--------------------|---------------|-------------------------------------------
+CUBEKPIMEMBER       |               | **Not yet Implemented**
+CUBEMEMBER          |               | **Not yet Implemented**
+CUBEMEMBERPROPERTY  |               | **Not yet Implemented**
+CUBERANKEDMEMBER    |               | **Not yet Implemented**
+CUBESET             |               | **Not yet Implemented**
+CUBESETCOUNT        |               | **Not yet Implemented**
+CUBEVALUE           |               | **Not yet Implemented**
 
 ## CATEGORY_DATABASE
 
-Excel Function      | PhpSpreadsheet Function
---------------------|-------------------------------------------
-DAVERAGE            | \PhpOffice\PhpSpreadsheet\Calculation\Database::DAVERAGE
-DCOUNT              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNT
-DCOUNTA             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNTA
-DGET                | \PhpOffice\PhpSpreadsheet\Calculation\Database::DGET
-DMAX                | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMAX
-DMIN                | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMIN
-DPRODUCT            | \PhpOffice\PhpSpreadsheet\Calculation\Database::DPRODUCT
-DSTDEV              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEV
-DSTDEVP             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEVP
-DSUM                | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSUM
-DVAR                | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVAR
-DVARP               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVARP
+Excel Function      | Excel Version | PhpSpreadsheet Function                                      
+--------------------|---------------|-------------------------------------------
+DAVERAGE            |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DAVERAGE
+DCOUNT              |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNT
+DCOUNTA             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNTA
+DGET                |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DGET
+DMAX                |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMAX
+DMIN                |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMIN
+DPRODUCT            |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DPRODUCT
+DSTDEV              |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEV
+DSTDEVP             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEVP
+DSUM                |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSUM
+DVAR                |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVAR
+DVARP               |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVARP
 
 ## CATEGORY_DATE_AND_TIME
 
-Excel Function      | PhpSpreadsheet Function
---------------------|-------------------------------------------
-DATE                | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATE
-DATEDIF             | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEDIF
-DATEVALUE           | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEVALUE
-DAY                 | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYOFMONTH
-DAYS                | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS
-DAYS360             | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS360
-EDATE               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EDATE
-EOMONTH             | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EOMONTH
-HOUR                | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::HOUROFDAY
-ISOWEEKNUM          | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::ISOWEEKNUM
-MINUTE              | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MINUTE
-MONTH               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MONTHOFYEAR
-NETWORKDAYS         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::NETWORKDAYS
-NETWORKDAYS.INTL    | **Not yet Implemented**
-NOW                 | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATETIMENOW
-SECOND              | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::SECOND
-TIME                | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIME
-TIMEVALUE           | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIMEVALUE
-TODAY               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATENOW
-WEEKDAY             | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKDAY
-WEEKNUM             | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKNUM
-WORKDAY             | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WORKDAY
-WORKDAY.INTL        | **Not yet Implemented**
-YEAR                | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEAR
-YEARFRAC            | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEARFRAC
+Excel Function      | Excel Version | PhpSpreadsheet Function
+--------------------|---------------|-------------------------------------------
+DATE                |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATE
+DATEDIF             |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEDIF
+DATEVALUE           |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEVALUE
+DAY                 |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYOFMONTH
+DAYS                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS
+DAYS360             |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS360
+EDATE               |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EDATE
+EOMONTH             |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EOMONTH
+HOUR                |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::HOUROFDAY
+ISOWEEKNUM          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::ISOWEEKNUM
+MINUTE              |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MINUTE
+MONTH               |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MONTHOFYEAR
+NETWORKDAYS         |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::NETWORKDAYS
+NETWORKDAYS.INTL    | 2010          | **Not yet Implemented**
+NOW                 |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATETIMENOW
+SECOND              |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::SECOND
+TIME                |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIME
+TIMEVALUE           |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIMEVALUE
+TODAY               |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATENOW
+WEEKDAY             |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKDAY
+WEEKNUM             |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKNUM
+WORKDAY             |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WORKDAY
+WORKDAY.INTL        | 2010          | **Not yet Implemented**
+YEAR                |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEAR
+YEARFRAC            |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEARFRAC
 
 ## CATEGORY_ENGINEERING
 
-Excel Function      | PhpSpreadsheet Function
---------------------|-------------------------------------------
-BESSELI             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELI
-BESSELJ             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELJ
-BESSELK             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELK
-BESSELY             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELY
-BIN2DEC             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTODEC
-BIN2HEX             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOHEX
-BIN2OCT             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOOCT
-BITAND              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITAND
-BITLSHIFT           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITLSHIFT
-BITOR               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
-BITRSHIFT           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITRSHIFT
-BITXOR              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
-COMPLEX             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::COMPLEX
-CONVERT             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::CONVERTUOM
-DEC2BIN             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOBIN
-DEC2HEX             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOHEX
-DEC2OCT             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOOCT
-DELTA               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DELTA
-ERF                 | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERF
-ERF.PRECISE         | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFPRECISE
-ERFC                | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
-ERFC.PRECISE        | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
-GESTEP              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::GESTEP
-HEX2BIN             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOBIN
-HEX2DEC             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTODEC
-HEX2OCT             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOOCT
-IMABS               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMABS
-IMAGINARY           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMAGINARY
-IMARGUMENT          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMARGUMENT
-IMCONJUGATE         | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCONJUGATE
-IMCOS               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOS
-IMCOSH              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOSH
-IMCOT               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOT
-IMCSC               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSC
-IMCSCH              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSCH
-IMDIV               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMDIV
-IMEXP               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMEXP
-IMLN                | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLN
-IMLOG10             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG10
-IMLOG2              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG2
-IMPOWER             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPOWER
-IMPRODUCT           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPRODUCT
-IMREAL              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMREAL
-IMSEC               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSEC
-IMSECH              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSECH
-IMSIN               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSIN
-IMSINH              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSINH
-IMSQRT              | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSQRT
-IMSUB               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUB
-IMSUM               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUM
-IMTAN               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMTAN
-OCT2BIN             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOBIN
-OCT2DEC             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTODEC
-OCT2HEX             | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOHEX
+Excel Function      | Excel Version | PhpSpreadsheet Function
+--------------------|---------------|-------------------------------------------
+BESSELI             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELI
+BESSELJ             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELJ
+BESSELK             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELK
+BESSELY             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELY
+BIN2DEC             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTODEC
+BIN2HEX             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOHEX
+BIN2OCT             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOOCT
+BITAND              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITAND
+BITLSHIFT           | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITLSHIFT
+BITOR               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
+BITRSHIFT           | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITRSHIFT
+BITXOR              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
+COMPLEX             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::COMPLEX
+CONVERT             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::CONVERTUOM
+DEC2BIN             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOBIN
+DEC2HEX             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOHEX
+DEC2OCT             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOOCT
+DELTA               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DELTA
+ERF                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERF
+ERF.PRECISE         | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFPRECISE
+ERFC                |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
+ERFC.PRECISE        | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
+GESTEP              |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::GESTEP
+HEX2BIN             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOBIN
+HEX2DEC             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTODEC
+HEX2OCT             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOOCT
+IMABS               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMABS
+IMAGINARY           |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMAGINARY
+IMARGUMENT          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMARGUMENT
+IMCONJUGATE         |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCONJUGATE
+IMCOS               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOS
+IMCOSH              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOSH
+IMCOT               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOT
+IMCSC               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSC
+IMCSCH              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSCH
+IMDIV               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMDIV
+IMEXP               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMEXP
+IMLN                |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLN
+IMLOG10             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG10
+IMLOG2              |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG2
+IMPOWER             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPOWER
+IMPRODUCT           |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPRODUCT
+IMREAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMREAL
+IMSEC               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSEC
+IMSECH              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSECH
+IMSIN               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSIN
+IMSINH              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSINH
+IMSQRT              |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSQRT
+IMSUB               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUB
+IMSUM               |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUM
+IMTAN               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMTAN
+OCT2BIN             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOBIN
+OCT2DEC             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTODEC
+OCT2HEX             |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOHEX
 
 ## CATEGORY_FINANCIAL
 
-Excel Function      | PhpSpreadsheet Function
---------------------|-------------------------------------------
-ACCRINT             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINT
-ACCRINTM            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINTM
-AMORDEGRC           | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORDEGRC
-AMORLINC            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORLINC
-COUPDAYBS           | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYBS
-COUPDAYS            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYS
-COUPDAYSNC          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYSNC
-COUPNCD             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNCD
-COUPNUM             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNUM
-COUPPCD             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPPCD
-CUMIPMT             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMIPMT
-CUMPRINC            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMPRINC
-DB                  | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DB
-DDB                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DDB
-DISC                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DISC
-DOLLARDE            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARDE
-DOLLARFR            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARFR
-DURATION            | **Not yet Implemented**
-EFFECT              | \PhpOffice\PhpSpreadsheet\Calculation\Financial::EFFECT
-FV                  | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FV
-FVSCHEDULE          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FVSCHEDULE
-INTRATE             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::INTRATE
-IPMT                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IPMT
-IRR                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IRR
-ISPMT               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ISPMT
-MDURATION           | **Not yet Implemented**
-MIRR                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::MIRR
-NOMINAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NOMINAL
-NPER                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPER
-NPV                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPV
-ODDFPRICE           | **Not yet Implemented**
-ODDFYIELD           | **Not yet Implemented**
-ODDLPRICE           | **Not yet Implemented**
-ODDLYIELD           | **Not yet Implemented**
-PDURATION           | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PDURATION
-PMT                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PMT
-PPMT                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PPMT
-PRICE               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICE
-PRICEDISC           | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEDISC
-PRICEMAT            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEMAT
-PV                  | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PV
-RATE                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RATE
-RECEIVED            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RECEIVED
-RRI                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RRI
-SLN                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SLN
-SYD                 | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SYD
-TBILLEQ             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLEQ
-TBILLPRICE          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLPRICE
-TBILLYIELD          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLYIELD
-USDOLLAR            | **Not yet Implemented**
-VDB                 | **Not yet Implemented**
-XIRR                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XIRR
-XNPV                | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XNPV
-YIELD               | **Not yet Implemented**
-YIELDDISC           | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDDISC
-YIELDMAT            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDMAT
+Excel Function      | Excel Version | PhpSpreadsheet Function
+--------------------|---------------|-------------------------------------------
+ACCRINT             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINT
+ACCRINTM            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINTM
+AMORDEGRC           |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORDEGRC
+AMORLINC            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORLINC
+COUPDAYBS           |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYBS
+COUPDAYS            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYS
+COUPDAYSNC          |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYSNC
+COUPNCD             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNCD
+COUPNUM             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNUM
+COUPPCD             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPPCD
+CUMIPMT             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMIPMT
+CUMPRINC            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMPRINC
+DB                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DB
+DDB                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DDB
+DISC                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DISC
+DOLLARDE            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARDE
+DOLLARFR            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARFR
+DURATION            |               | **Not yet Implemented**
+EFFECT              |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::EFFECT
+FV                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FV
+FVSCHEDULE          |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FVSCHEDULE
+INTRATE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::INTRATE
+IPMT                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IPMT
+IRR                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IRR
+ISPMT               |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ISPMT
+MDURATION           |               | **Not yet Implemented**
+MIRR                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::MIRR
+NOMINAL             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NOMINAL
+NPER                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPER
+NPV                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPV
+ODDFPRICE           |               | **Not yet Implemented**
+ODDFYIELD           |               | **Not yet Implemented**
+ODDLPRICE           |               | **Not yet Implemented**
+ODDLYIELD           |               | **Not yet Implemented**
+PDURATION           | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PDURATION
+PMT                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PMT
+PPMT                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PPMT
+PRICE               |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICE
+PRICEDISC           |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEDISC
+PRICEMAT            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEMAT
+PV                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PV
+RATE                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RATE
+RECEIVED            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RECEIVED
+RRI                 | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RRI
+SLN                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SLN
+SYD                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SYD
+TBILLEQ             |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLEQ
+TBILLPRICE          |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLPRICE
+TBILLYIELD          |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLYIELD
+USDOLLAR            |               | **Not yet Implemented**
+VDB                 |               | **Not yet Implemented**
+XIRR                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XIRR
+XNPV                |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XNPV
+YIELD               |               | **Not yet Implemented**
+YIELDDISC           |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDDISC
+YIELDMAT            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDMAT
 
 ## CATEGORY_INFORMATION
 
-Excel Function      | PhpSpreadsheet Function
---------------------|-------------------------------------------
-CELL                | **Not yet Implemented**
-ERROR.TYPE          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::errorType
-INFO                | **Not yet Implemented**
-ISBLANK             | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isBlank
-ISERR               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isErr
-ISERROR             | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isError
-ISEVEN              | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isEven
-ISFORMULA           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isFormula
-ISLOGICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isLogical
-ISNA                | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNa
-ISNONTEXT           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNonText
-ISNUMBER            | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNumber
-ISODD               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isOdd
-ISREF               | **Not yet Implemented**
-ISTEXT              | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isText
-N                   | \PhpOffice\PhpSpreadsheet\Calculation\Functions::n
-NA                  | \PhpOffice\PhpSpreadsheet\Calculation\Functions::NA
-SHEET               | **Not yet Implemented**
-SHEETS              | **Not yet Implemented**
-TYPE                | \PhpOffice\PhpSpreadsheet\Calculation\Functions::TYPE
+Excel Function      | Excel Version | PhpSpreadsheet Function
+--------------------|---------------|-------------------------------------------
+CELL                |               | **Not yet Implemented**
+ERROR.TYPE          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::errorType
+INFO                |               | **Not yet Implemented**
+ISBLANK             |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isBlank
+ISERR               |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isErr
+ISERROR             |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isError
+ISEVEN              |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isEven
+ISFORMULA           | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isFormula
+ISLOGICAL           |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isLogical
+ISNA                |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNa
+ISNONTEXT           |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNonText
+ISNUMBER            |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNumber
+ISODD               |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isOdd
+ISREF               |               | **Not yet Implemented**
+ISTEXT              |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isText
+N                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::n
+NA                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::NA
+SHEET               | 2013          | **Not yet Implemented**
+SHEETS              | 2013          | **Not yet Implemented**
+TYPE                |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::TYPE
 
 ## CATEGORY_LOGICAL
 
-Excel Function      | PhpSpreadsheet Function
---------------------|-------------------------------------------
-AND                 | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalAnd
-FALSE               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::FALSE
-IF                  | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementIf
-IFERROR             | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFERROR
-IFNA                | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFNA
-IFS                 | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFS
-NOT                 | \PhpOffice\PhpSpreadsheet\Calculation\Logical::NOT
-OR                  | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalOr
-SWITCH              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementSwitch
-TRUE                | \PhpOffice\PhpSpreadsheet\Calculation\Logical::TRUE
-XOR                 | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalXor
+Excel Function      | Excel Version | PhpSpreadsheet Function
+--------------------|---------------|-------------------------------------------
+AND                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalAnd
+FALSE               |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::FALSE
+IF                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementIf
+IFERROR             |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFERROR
+IFNA                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFNA
+IFS                 | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFS
+NOT                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::NOT
+OR                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalOr
+SWITCH              | 2016          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementSwitch
+TRUE                |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::TRUE
+XOR                 | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalXor
 
 ## CATEGORY_LOOKUP_AND_REFERENCE
 
-Excel Function      | PhpSpreadsheet Function
---------------------|-------------------------------------------
-ADDRESS             | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::cellAddress
-AREAS               | **Not yet Implemented**
-CHOOSE              | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::CHOOSE
-COLUMN              | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMN
-COLUMNS             | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMNS
-FORMULATEXT         | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::FORMULATEXT
-GETPIVOTDATA        | **Not yet Implemented**
-HLOOKUP             | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HLOOKUP
-HYPERLINK           | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HYPERLINK
-INDEX               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDEX
-INDIRECT            | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDIRECT
-LOOKUP              | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::LOOKUP
-MATCH               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::MATCH
-OFFSET              | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::OFFSET
-ROW                 | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROW
-ROWS                | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROWS
-RTD                 | **Not yet Implemented**
-TRANSPOSE           | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::TRANSPOSE
-VLOOKUP             | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::VLOOKUP
+Excel Function      | Excel Version | PhpSpreadsheet Function
+--------------------|---------------|-------------------------------------------
+ADDRESS             |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::cellAddress
+AREAS               |               | **Not yet Implemented**
+CHOOSE              |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::CHOOSE
+COLUMN              |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMN
+COLUMNS             |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMNS
+FILTER              | Office 365    | **Not yet Implemented**
+FORMULATEXT         | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::FORMULATEXT
+GETPIVOTDATA        |               | **Not yet Implemented**
+HLOOKUP             |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HLOOKUP
+HYPERLINK           |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HYPERLINK
+INDEX               |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDEX
+INDIRECT            |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDIRECT
+LOOKUP              |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::LOOKUP
+MATCH               |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::MATCH
+OFFSET              |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::OFFSET
+ROW                 |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROW
+ROWS                |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROWS
+RTD                 |               | **Not yet Implemented**
+SORT                | Office 365    | **Not yet Implemented**
+SORTBY              | Office 365    | **Not yet Implemented**
+TRANSPOSE           |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::TRANSPOSE
+UNIQUE              | Office 365    | **Not yet Implemented**
+VLOOKUP             |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::VLOOKUP
+XLOOKUP             | Office 365    | **Not yet Implemented**
+XMATCH              | Office 365    | **Not yet Implemented**
 
 ## CATEGORY_MATH_AND_TRIG
 
-Excel Function      | PhpSpreadsheet Function
---------------------|-------------------------------------------
-ABS                 | abs
-ACOS                | acos
-ACOSH               | acosh
-ACOT                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOT
-ACOTH               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOTH
-ARABIC              | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ARABIC
-ASIN                | asin
-ASINH               | asinh
-ATAN                | atan
-ATAN2               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ATAN2
-ATANH               | atanh
-BASE                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::BASE
-CEILING             | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CEILING
-COMBIN              | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COMBIN
-COS                 | cos
-COSH                | cosh
-COT                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COT
-COTH                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COTH
-CSC                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSC
-CSCH                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSCH
-DEGREES             | rad2deg
-EVEN                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::EVEN
-EXP                 | exp
-FACT                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACT
-FACTDOUBLE          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACTDOUBLE
-FLOOR               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOOR
-FLOOR.MATH          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORMATH
-FLOOR.PRECISE       | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORPRECISE
-GCD                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::GCD
-INT                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::INT
-LCM                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::LCM
-LN                  | log
-LOG                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::logBase
-LOG10               | log10
-MDETERM             | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MDETERM
-MINVERSE            | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MINVERSE
-MMULT               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MMULT
-MOD                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MOD
-MROUND              | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MROUND
-MULTINOMIAL         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MULTINOMIAL
-ODD                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ODD
-PI                  | pi
-POWER               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::POWER
-PRODUCT             | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::PRODUCT
-QUOTIENT            | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::QUOTIENT
-RADIANS             | deg2rad
-RAND                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
-RANDBETWEEN         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
-ROMAN               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROMAN
-ROUND               | round
-ROUNDDOWN           | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDDOWN
-ROUNDUP             | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDUP
-SEC                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SEC
-SECH                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SECH
-SERIESSUM           | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SERIESSUM
-SIGN                | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SIGN
-SIN                 | sin
-SINH                | sinh
-SQRT                | sqrt
-SQRTPI              | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SQRTPI
-SUBTOTAL            | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUBTOTAL
-SUM                 | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUM
-SUMIF               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIF
-SUMIFS              | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIFS
-SUMPRODUCT          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMPRODUCT
-SUMSQ               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMSQ
-SUMX2MY2            | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2MY2
-SUMX2PY2            | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2PY2
-SUMXMY2             | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMXMY2
-TAN                 | tan
-TANH                | tanh
-TRUNC               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::TRUNC
+Excel Function      | Excel Version | PhpSpreadsheet Function
+--------------------|---------------|-------------------------------------------
+ABS                 |               | abs
+ACOS                |               | acos
+ACOSH               |               | acosh
+ACOT                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOT
+ACOTH               | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOTH
+AGGREGATE           |               | **Not yet Implemented**
+ARABIC              |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ARABIC
+ASIN                |               | asin
+ASINH               |               | asinh
+ATAN                |               | atan
+ATAN2               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ATAN2
+ATANH               |               | atanh
+BASE                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::BASE
+CEILING             |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CEILING
+CEILING.MATH        | 2013          | **Not yet Implemented**
+CEILING.PRECISE     |               | **Not yet Implemented**
+COMBIN              |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COMBIN
+COMBINA             | 2013          | **Not yet Implemented**
+COS                 |               | cos
+COSH                |               | cosh
+COT                 | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COT
+COTH                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COTH
+CSC                 | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSC
+CSCH                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSCH
+DECIMAL             | 2013          | **Not yet Implemented**
+DEGREES             |               | rad2deg
+EVEN                |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::EVEN
+EXP                 |               | exp
+FACT                |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACT
+FACTDOUBLE          |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACTDOUBLE
+FLOOR               | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOOR
+FLOOR.MATH          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORMATH
+FLOOR.PRECISE       |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORPRECISE
+GCD                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::GCD
+INT                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::INT
+ISO.CEILING         | 2013          | **Not yet Implemented**
+LCM                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::LCM
+LN                  |               | log
+LOG                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::logBase
+LOG10               |               | log10
+MDETERM             |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MDETERM
+MINVERSE            |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MINVERSE
+MMULT               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MMULT
+MOD                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MOD
+MROUND              |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MROUND
+MULTINOMIAL         |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MULTINOMIAL
+MUNIT               | 2013          | **Not yet Implemented**
+ODD                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ODD
+PI                  |               | pi
+POWER               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::POWER
+PRODUCT             |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::PRODUCT
+QUOTIENT            |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::QUOTIENT
+RADIANS             |               | deg2rad
+RAND                |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
+RANDARRAY           | Office 365    | **Not yet Implemented**
+RANDBETWEEN         |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
+ROMAN               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROMAN
+ROUND               |               | round
+ROUNDDOWN           |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDDOWN
+ROUNDUP             |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDUP
+SEC                 | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SEC
+SECH                | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SECH
+SERIESSUM           |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SERIESSUM
+SEQUENCE            | Office 365    | **Not yet Implemented**
+SIGN                |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SIGN
+SIN                 |               | sin
+SINH                |               | sinh
+SQRT                |               | sqrt
+SQRTPI              |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SQRTPI
+SUBTOTAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUBTOTAL
+SUM                 |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUM
+SUMIF               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIF
+SUMIFS              | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIFS
+SUMPRODUCT          |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMPRODUCT
+SUMSQ               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMSQ
+SUMX2MY2            |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2MY2
+SUMX2PY2            |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2PY2
+SUMXMY2             |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMXMY2
+TAN                 |               | tan
+TANH                |               | tanh
+TRUNC               |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::TRUNC
 
 ## CATEGORY_STATISTICAL
 
-Excel Function      | PhpSpreadsheet Function
---------------------|-------------------------------------------
-AVEDEV              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVEDEV
-AVERAGE             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGE
-AVERAGEA            | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEA
-AVERAGEIF           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEIF
-AVERAGEIFS          | **Not yet Implemented**
-BETADIST            | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
-BETAINV             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
-BINOMDIST           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
-CHIDIST             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
-CHIINV              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
-CHITEST             | **Not yet Implemented**
-CONFIDENCE          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
-CORREL              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
-COUNT               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNT
-COUNTA              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTA
-COUNTBLANK          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTBLANK
-COUNTIF             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIF
-COUNTIFS            | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIFS
-COVAR               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
-CRITBINOM           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CRITBINOM
-DEVSQ               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::DEVSQ
-EXPONDIST           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
-FDIST               | **Not yet Implemented**
-FINV                | **Not yet Implemented**
-FISHER              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHER
-FISHERINV           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHERINV
-FORECAST            | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
-FREQUENCY           | **Not yet Implemented**
-FTEST               | **Not yet Implemented**
-GAMMADIST           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
-GAMMAINV            | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
-GAMMALN             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
-GEOMEAN             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GEOMEAN
-GROWTH              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GROWTH
-HARMEAN             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HARMEAN
-HYPGEOMDIST         | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HYPGEOMDIST
-INTERCEPT           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::INTERCEPT
-KURT                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::KURT
-LARGE               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LARGE
-LINEST              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LINEST
-LOGEST              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGEST
-LOGINV              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
-LOGNORMDIST         | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGNORMDIST
-MAX                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAX
-MAXA                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXA
-MAXIFS              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXIFS
-MEDIAN              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MEDIAN
-MEDIANIF            | **Not yet Implemented**
-MIN                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MIN
-MINA                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINA
-MINIFS              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINIFS
-MODE                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
-MODE.SNGL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
-NEGBINOMDIST        | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NEGBINOMDIST
-NORMDIST            | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
-NORMINV             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
-NORMSDIST           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSDIST
-NORMSINV            | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
-PEARSON             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
-PERCENTILE          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
-PERCENTRANK         | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
-PERMUT              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERMUT
-POISSON             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
-PROB                | **Not yet Implemented**
-QUARTILE            | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
-RANK                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
-RSQ                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RSQ
-SKEW                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SKEW
-SLOPE               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SLOPE
-SMALL               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SMALL
-STANDARDIZE         | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STANDARDIZE
-STDEV               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
-STDEV.P             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
-STDEV.S             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
-STDEVA              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVA
-STDEVP              | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
-STDEVPA             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVPA
-STEYX               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STEYX
-TDIST               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TDIST
-TINV                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
-TREND               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TREND
-TRIMMEAN            | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TRIMMEAN
-TTEST               | **Not yet Implemented**
-VAR                 | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
-VAR.P               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
-VAR.S               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
-VARA                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARA
-VARP                | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
-VARPA               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARPA
-WEIBULL             | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
-ZTEST               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST
+Excel Function           | Excel Version | PhpSpreadsheet Function
+-------------------------|---------------|-------------------------------------------
+AVEDEV                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVEDEV
+AVERAGE                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGE
+AVERAGEA                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEA
+AVERAGEIF                |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEIF
+AVERAGEIFS               | 2019          | **Not yet Implemented**
+BETADIST                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
+BETA.DIST                | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
+BETAINV                  | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
+BETA.INV                 | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
+BINOMDIST                | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
+BINOM.DIST               | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
+BINOM.DIST.RANGE         | 2013          | **Not yet Implemented**
+BINOM.INV                | 2010          | **Not yet Implemented**
+CHIDIST                  | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
+CHISQ.DIST               | 2010          | **Not yet Implemented**
+CHISQ.DIST.RT            | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
+CHIINV                   | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
+CHISQ.INV                | 2010          | **Not yet Implemented**
+CHISQ.INV.RT             | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
+CHITEST                  | Compatibility | **Not yet Implemented**
+CHISQ.TEST               | 2010          | **Not yet Implemented**
+CONFIDENCE               | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
+CONFIDENCE.NORM          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
+CONFIDENCE.T             | 2010          | **Not yet Implemented**
+CORREL                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
+COUNT                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNT
+COUNTA                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTA
+COUNTBLANK               |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTBLANK
+COUNTIF                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIF
+COUNTIFS                 | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIFS
+COVAR                    | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
+COVARIANCE.P             | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
+COVARIANCE.S             | 2010          | **Not yet Implemented**
+CRITBINOM                | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CRITBINOM
+DEVSQ                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::DEVSQ
+EXPONDIST                | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
+EXPON.DIST               | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
+FDIST                    | Compatibility | **Not yet Implemented**
+F.DIST                   | 2010          | **Not yet Implemented**
+F.DIST.RT                | 2010          | **Not yet Implemented**
+FINV                     | Compatibility | **Not yet Implemented**
+F.INV                    | 2010          | **Not yet Implemented**
+F.INV.RT                 | 2010          | **Not yet Implemented**
+F.TEST                   | 2010          | **Not yet Implemented**
+FISHER                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHER
+FISHERINV                |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHERINV
+FORECAST                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
+FORECAST.ETS             | 2016          | **Not yet Implemented**
+FORECAST.ETS.CONFINT     | 2016          | **Not yet Implemented**
+FORECAST.ETS.SEASONALITY | 2016          | **Not yet Implemented**
+FORECAST.ETS.STAT        | 2016          | **Not yet Implemented**
+FORECAST.LINEAR          | 2016          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
+FREQUENCY                |               | **Not yet Implemented**
+FTEST                    | Compatibility | **Not yet Implemented**
+GAMMA                    | 2013          | **Not yet Implemented**
+GAMMADIST                | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
+GAMMA.DIST               | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
+GAMMAINV                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
+GAMMA.INV                | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
+GAMMALN                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
+GAMMALN.PRECISE          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
+GAUSS                    | 2013          | **Not yet Implemented**
+GEOMEAN                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GEOMEAN
+GROWTH                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GROWTH
+HARMEAN                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HARMEAN
+HYPGEOMDIST              | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HYPGEOMDIST
+INTERCEPT                |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::INTERCEPT
+KURT                     |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::KURT
+LARGE                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LARGE
+LINEST                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LINEST
+LOGEST                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGEST
+LOGINV                   | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
+LOGNORMDIST              | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGNORMDIST
+LOGNORM.DIST             | 2010          | **Not yet Implemented**
+LOGNORM.INV              | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
+MAX                      |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAX
+MAXA                     |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXA
+MAXIFS                   | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXIFS
+MEDIAN                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MEDIAN
+MEDIANIF                 |               | **Not yet Implemented**
+MIN                      |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MIN
+MINA                     |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINA
+MINIFS                   | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINIFS
+MODE                     | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
+MODE.MULT                | 2010          | **Not yet Implemented**
+MODE.SNGL                | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
+NEGBINOMDIST             | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NEGBINOMDIST
+NEGBINOM.DIST            | 2010          | **Not yet Implemented**
+NORMDIST                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
+NORM.DIST                | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
+NORMINV                  | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
+NORM.INV                 | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
+NORMSDIST                | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSDIST
+NORM.S.DIST              | 2010          | **Not yet Implemented**
+NORMSINV                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
+NORM.S.INV               | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
+PEARSON                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
+PERCENTILE               | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
+PERCENTILE.EXC           | 2010          | **Not yet Implemented**
+PERCENTILE.INC           | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
+PERCENTRANK              | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
+PERCENTRANK.EXC          | 2010          | **Not yet Implemented**
+PERCENTRANK.INC          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
+PERMUT                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERMUT
+PERMUTATIONA             | 2013          | **Not yet Implemented**
+PHI                      | 2013          | **Not yet Implemented**
+POISSON                  | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
+POISSON.DIST             | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
+PROB                     |               | **Not yet Implemented**
+QUARTILE                 | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
+QUARTILE.EXC             | 2010          | **Not yet Implemented**
+QUARTILE.INC             | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
+RANK                     | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
+RANK.AVG                 | 2010          | **Not yet Implemented**
+RANK.EQ                  | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
+RSQ                      |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RSQ
+SKEW                     |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SKEW
+SKEW.P                   | 2013          | **Not yet Implemented**
+SLOPE                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SLOPE
+SMALL                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SMALL
+STANDARDIZE              |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STANDARDIZE
+STDEV                    | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
+STDEV.P                  | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
+STDEV.S                  | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
+STDEVA                   |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVA
+STDEVP                   | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
+STDEVPA                  |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVPA
+STEYX                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STEYX
+TDIST                    | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TDIST
+T.DIST                   | 2010          | **Not yet Implemented**
+T.DIST.2T                | 2010          | **Not yet Implemented**
+T.DIST.RT                | 2010          | **Not yet Implemented**
+TINV                     | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
+T.INV                    | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
+T.INV.2T                 | 2010          | **Not yet Implemented**
+TREND                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TREND
+TRIMMEAN                 |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TRIMMEAN
+TTEST                    | Compatibility | **Not yet Implemented**
+T.TEST                   | 2010          | **Not yet Implemented**
+VAR                      | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
+VAR.P                    | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
+VAR.S                    | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
+VARA                     |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARA
+VARP                     | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
+VARPA                    |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARPA
+WEIBULL                  | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
+WEIBULL.DIST             | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
+ZTEST                    | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST
+Z.TEST                   | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST
 
 ## CATEGORY_TEXT_AND_DATA
 
-Excel Function      | PhpSpreadsheet Function
---------------------|-------------------------------------------
-ASC                 | **Not yet Implemented**
-BAHTTEXT            | **Not yet Implemented**
-CHAR                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
-CLEAN               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMNONPRINTABLE
-CODE                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
-CONCAT              | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
-CONCATENATE         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
-DOLLAR              | \PhpOffice\PhpSpreadsheet\Calculation\TextData::DOLLAR
-EXACT               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::EXACT
-FIND                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
-FINDB               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
-FIXED               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::FIXEDFORMAT
-JIS                 | **Not yet Implemented**
-LEFT                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
-LEFTB               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
-LEN                 | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
-LENB                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
-LOWER               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LOWERCASE
-MID                 | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
-MIDB                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
-NUMBERVALUE         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::NUMBERVALUE
-PHONETIC            | **Not yet Implemented**
-PROPER              | \PhpOffice\PhpSpreadsheet\Calculation\TextData::PROPERCASE
-REPLACE             | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
-REPLACEB            | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
-REPT                | str_repeat
-RIGHT               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
-RIGHTB              | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
-SEARCH              | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
-SEARCHB             | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
-SUBSTITUTE          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SUBSTITUTE
-T                   | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RETURNSTRING
-TEXT                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTFORMAT
-TEXTJOIN            | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTJOIN
-TRIM                | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMSPACES
-UNICHAR             | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
-UNICODE             | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
-UPPER               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::UPPERCASE
-VALUE               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::VALUE
+Excel Function      | Excel Version | PhpSpreadsheet Function
+--------------------|---------------|-------------------------------------------
+ASC                 |               | **Not yet Implemented**
+BAHTTEXT            |               | **Not yet Implemented**
+CHAR                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
+CLEAN               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMNONPRINTABLE
+CODE                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
+CONCAT              | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
+CONCATENATE         | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
+DBCS                | 2013          | **Not yet Implemented**
+DOLLAR              |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::DOLLAR
+EXACT               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::EXACT
+FIND                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
+FINDB               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
+FIXED               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::FIXEDFORMAT
+JIS                 |               | **Not yet Implemented**
+LEFT                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
+LEFTB               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
+LEN                 |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
+LENB                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
+LOWER               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LOWERCASE
+MID                 |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
+MIDB                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
+NUMBERVALUE         | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::NUMBERVALUE
+PHONETIC            |               | **Not yet Implemented**
+PROPER              |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::PROPERCASE
+REPLACE             |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
+REPLACEB            |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
+REPT                |               | str_repeat
+RIGHT               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
+RIGHTB              |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
+SEARCH              |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
+SEARCHB             |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
+SUBSTITUTE          |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SUBSTITUTE
+T                   |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RETURNSTRING
+TEXT                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTFORMAT
+TEXTJOIN            | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTJOIN
+TRIM                |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMSPACES
+UNICHAR             | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
+UNICODE             | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
+UPPER               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::UPPERCASE
+VALUE               |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::VALUE
+
+## CATEGORY_TEXT_AND_DATA
+
+Excel Function      | Excel Version | PhpSpreadsheet Function
+--------------------|---------------|-------------------------------------------
+ENCODEURL           | 2013          | **Not yet Implemented**
+FILTERXML           | 2013          | **Not yet Implemented**
+WEBSERVICE          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Web::WEBSERVICE

--- a/docs/references/function-list-by-name.md
+++ b/docs/references/function-list-by-name.md
@@ -12,11 +12,11 @@ ACOSH                    | CATEGORY_MATH_AND_TRIG        |               | acosh
 ACOT                     | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOT
 ACOTH                    | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOTH
 ADDRESS                  | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::cellAddress
-AGGREGATE                | CATEGORY_MATH_AND_TRIG        |               | **Not yet Implemented**
+AGGREGATE                | CATEGORY_MATH_AND_TRIG        | 2010          | **Not yet Implemented**
 AMORDEGRC                | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORDEGRC
 AMORLINC                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORLINC
 AND                      | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalAnd
-ARABIC                   | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ARABIC
+ARABIC                   | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ARABIC
 AREAS                    | CATEGORY_LOOKUP_AND_REFERENCE |               | **Not yet Implemented**
 ASC                      | CATEGORY_TEXT_AND_DATA        |               | **Not yet Implemented**
 ASIN                     | CATEGORY_MATH_AND_TRIG        |               | asin
@@ -27,7 +27,7 @@ ATANH                    | CATEGORY_MATH_AND_TRIG        |               | atanh
 AVEDEV                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVEDEV
 AVERAGE                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGE
 AVERAGEA                 | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEA
-AVERAGEIF                | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEIF
+AVERAGEIF                | CATEGORY_STATISTICAL          | 2007          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEIF
 AVERAGEIFS               | CATEGORY_STATISTICAL          | 2019          | **Not yet Implemented**
 
 ## B
@@ -63,7 +63,7 @@ Excel Function           | Category                      | Excel Version | PhpSp
 -------------------------|-------------------------------|---------------|-------------------------
 CEILING                  | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CEILING
 CEILING.MATH             | CATEGORY_MATH_AND_TRIG        | 2013          | **Not yet Implemented**
-CEILING.PRECISE          | CATEGORY_MATH_AND_TRIG        |               | **Not yet Implemented**
+CEILING.PRECISE          | CATEGORY_MATH_AND_TRIG        | 2010          | **Not yet Implemented**
 CELL                     | CATEGORY_INFORMATION          |               | **Not yet Implemented**
 CHAR                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
 CHIDIST                  | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
@@ -110,13 +110,13 @@ COVARIANCE.S             | CATEGORY_STATISTICAL          | 2010          | **Not
 CRITBINOM                | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CRITBINOM
 CSC                      | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSC
 CSCH                     | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSCH
-CUBEKPIMEMBER            | CATEGORY_CUBE                 |               | **Not yet Implemented**
-CUBEMEMBER               | CATEGORY_CUBE                 |               | **Not yet Implemented**
-CUBEMEMBERPROPERTY       | CATEGORY_CUBE                 |               | **Not yet Implemented**
-CUBERANKEDMEMBER         | CATEGORY_CUBE                 |               | **Not yet Implemented**
-CUBESET                  | CATEGORY_CUBE                 |               | **Not yet Implemented**
-CUBESETCOUNT             | CATEGORY_CUBE                 |               | **Not yet Implemented**
-CUBEVALUE                | CATEGORY_CUBE                 |               | **Not yet Implemented**
+CUBEKPIMEMBER            | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
+CUBEMEMBER               | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
+CUBEMEMBERPROPERTY       | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
+CUBERANKEDMEMBER         | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
+CUBESET                  | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
+CUBESETCOUNT             | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
+CUBEVALUE                | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
 CUMIPMT                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMIPMT
 CUMPRINC                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMPRINC
 
@@ -199,7 +199,7 @@ FISHERINV                | CATEGORY_STATISTICAL          |               | \PhpO
 FIXED                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::FIXEDFORMAT
 FLOOR                    | CATEGORY_MATH_AND_TRIG        | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOOR
 FLOOR.MATH               | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORMATH
-FLOOR.PRECISE            | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORPRECISE
+FLOOR.PRECISE            | CATEGORY_MATH_AND_TRIG        | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORPRECISE
 FORECAST                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
 FORECAST.ETS             | CATEGORY_STATISTICAL          | 2016          | **Not yet Implemented**
 FORECAST.ETS.CONFINT     | CATEGORY_STATISTICAL          | 2016          | **Not yet Implemented**
@@ -249,7 +249,7 @@ HYPGEOMDIST              | CATEGORY_STATISTICAL          | Compatibility | \PhpO
 Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
 -------------------------|-------------------------------|---------------|-------------------------
 IF                       | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementIf
-IFERROR                  | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFERROR
+IFERROR                  | CATEGORY_LOGICAL              | 2007          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFERROR
 IFNA                     | CATEGORY_LOGICAL              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFNA
 IFS                      | CATEGORY_LOGICAL              | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFS
 IMABS                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMABS
@@ -515,7 +515,7 @@ SUMSQ                    | CATEGORY_MATH_AND_TRIG        |               | \PhpO
 SUMX2MY2                 | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2MY2
 SUMX2PY2                 | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2PY2
 SUMXMY2                  | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMXMY2
-SWITCH                   | CATEGORY_LOGICAL              | 2016          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementSwitch
+SWITCH                   | CATEGORY_LOGICAL              | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementSwitch
 SYD                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SYD
 
 ## T

--- a/docs/references/function-list-by-name.md
+++ b/docs/references/function-list-by-name.md
@@ -2,613 +2,613 @@
 
 ## A
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-ABS                      | CATEGORY_MATH_AND_TRIG        |               | abs
-ACCRINT                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINT
-ACCRINTM                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINTM
-ACOS                     | CATEGORY_MATH_AND_TRIG        |               | acos
-ACOSH                    | CATEGORY_MATH_AND_TRIG        |               | acosh
-ACOT                     | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOT
-ACOTH                    | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOTH
-ADDRESS                  | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::cellAddress
-AGGREGATE                | CATEGORY_MATH_AND_TRIG        | 2010          | **Not yet Implemented**
-AMORDEGRC                | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORDEGRC
-AMORLINC                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORLINC
-AND                      | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalAnd
-ARABIC                   | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ARABIC
-AREAS                    | CATEGORY_LOOKUP_AND_REFERENCE |               | **Not yet Implemented**
-ASC                      | CATEGORY_TEXT_AND_DATA        |               | **Not yet Implemented**
-ASIN                     | CATEGORY_MATH_AND_TRIG        |               | asin
-ASINH                    | CATEGORY_MATH_AND_TRIG        |               | asinh
-ATAN                     | CATEGORY_MATH_AND_TRIG        |               | atan
-ATAN2                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ATAN2
-ATANH                    | CATEGORY_MATH_AND_TRIG        |               | atanh
-AVEDEV                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVEDEV
-AVERAGE                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGE
-AVERAGEA                 | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEA
-AVERAGEIF                | CATEGORY_STATISTICAL          | 2007          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEIF
-AVERAGEIFS               | CATEGORY_STATISTICAL          | 2019          | **Not yet Implemented**
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+ABS                      | CATEGORY_MATH_AND_TRIG        | abs
+ACCRINT                  | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINT
+ACCRINTM                 | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINTM
+ACOS                     | CATEGORY_MATH_AND_TRIG        | acos
+ACOSH                    | CATEGORY_MATH_AND_TRIG        | acosh
+ACOT                     | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOT
+ACOTH                    | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOTH
+ADDRESS                  | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::cellAddress
+AGGREGATE                | CATEGORY_MATH_AND_TRIG        | **Not yet Implemented**
+AMORDEGRC                | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORDEGRC
+AMORLINC                 | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORLINC
+AND                      | CATEGORY_LOGICAL              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalAnd
+ARABIC                   | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ARABIC
+AREAS                    | CATEGORY_LOOKUP_AND_REFERENCE | **Not yet Implemented**
+ASC                      | CATEGORY_TEXT_AND_DATA        | **Not yet Implemented**
+ASIN                     | CATEGORY_MATH_AND_TRIG        | asin
+ASINH                    | CATEGORY_MATH_AND_TRIG        | asinh
+ATAN                     | CATEGORY_MATH_AND_TRIG        | atan
+ATAN2                    | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ATAN2
+ATANH                    | CATEGORY_MATH_AND_TRIG        | atanh
+AVEDEV                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVEDEV
+AVERAGE                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGE
+AVERAGEA                 | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEA
+AVERAGEIF                | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEIF
+AVERAGEIFS               | CATEGORY_STATISTICAL          | **Not yet Implemented**
 
 ## B
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-BAHTTEXT                 | CATEGORY_TEXT_AND_DATA        |               | **Not yet Implemented**
-BASE                     | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::BASE
-BESSELI                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELI
-BESSELJ                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELJ
-BESSELK                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELK
-BESSELY                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELY
-BETADIST                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
-BETA.DIST                | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
-BETAINV                  | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
-BETA.INV                 | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
-BIN2DEC                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTODEC
-BIN2HEX                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOHEX
-BIN2OCT                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOOCT
-BINOMDIST                | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
-BINOM.DIST               | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
-BINOM.DIST.RANGE         | CATEGORY_STATISTICAL          | 2013          | **Not yet Implemented**
-BINOM.INV                | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-BITAND                   | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITAND
-BITLSHIFT                | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITLSHIFT
-BITOR                    | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
-BITRSHIFT                | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITRSHIFT
-BITXOR                   | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+BAHTTEXT                 | CATEGORY_TEXT_AND_DATA        | **Not yet Implemented**
+BASE                     | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::BASE
+BESSELI                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELI
+BESSELJ                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELJ
+BESSELK                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELK
+BESSELY                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELY
+BETADIST                 | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
+BETA.DIST                | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
+BETAINV                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
+BETA.INV                 | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
+BIN2DEC                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTODEC
+BIN2HEX                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOHEX
+BIN2OCT                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOOCT
+BINOMDIST                | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
+BINOM.DIST               | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
+BINOM.DIST.RANGE         | CATEGORY_STATISTICAL          | **Not yet Implemented**
+BINOM.INV                | CATEGORY_STATISTICAL          | **Not yet Implemented**
+BITAND                   | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITAND
+BITLSHIFT                | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITLSHIFT
+BITOR                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
+BITRSHIFT                | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITRSHIFT
+BITXOR                   | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
 
 ## C
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-CEILING                  | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CEILING
-CEILING.MATH             | CATEGORY_MATH_AND_TRIG        | 2013          | **Not yet Implemented**
-CEILING.PRECISE          | CATEGORY_MATH_AND_TRIG        | 2010          | **Not yet Implemented**
-CELL                     | CATEGORY_INFORMATION          |               | **Not yet Implemented**
-CHAR                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
-CHIDIST                  | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
-CHIINV                   | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
-CHISQ.DIST               | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-CHISQ.DIST.RT            | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
-CHISQ.INV                | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-CHISQ.INV.RT             | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
-CHISQ.TEST               | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-CHITEST                  | CATEGORY_STATISTICAL          | Compatibility | **Not yet Implemented**
-CHOOSE                   | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::CHOOSE
-CLEAN                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMNONPRINTABLE
-CODE                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
-COLUMN                   | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMN
-COLUMNS                  | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMNS
-COMBIN                   | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COMBIN
-COMBINA                  | CATEGORY_MATH_AND_TRIG        | 2013          | **Not yet Implemented**
-COMPLEX                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::COMPLEX
-CONCAT                   | CATEGORY_TEXT_AND_DATA        | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
-CONCATENATE              | CATEGORY_TEXT_AND_DATA        | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
-CONFIDENCE               | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
-CONFIDENCE.NORM          | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
-CONFIDENCE.T             | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-CONVERT                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::CONVERTUOM
-CORREL                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
-COS                      | CATEGORY_MATH_AND_TRIG        |               | cos
-COSH                     | CATEGORY_MATH_AND_TRIG        |               | cosh
-COT                      | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COT
-COTH                     | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COTH
-COUNT                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNT
-COUNTA                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTA
-COUNTBLANK               | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTBLANK
-COUNTIF                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIF
-COUNTIFS                 | CATEGORY_STATISTICAL          | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIFS
-COUPDAYBS                | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYBS
-COUPDAYS                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYS
-COUPDAYSNC               | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYSNC
-COUPNCD                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNCD
-COUPNUM                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNUM
-COUPPCD                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPPCD
-COVAR                    | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
-COVARIANCE.P             | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
-COVARIANCE.S             | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-CRITBINOM                | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CRITBINOM
-CSC                      | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSC
-CSCH                     | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSCH
-CUBEKPIMEMBER            | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
-CUBEMEMBER               | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
-CUBEMEMBERPROPERTY       | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
-CUBERANKEDMEMBER         | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
-CUBESET                  | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
-CUBESETCOUNT             | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
-CUBEVALUE                | CATEGORY_CUBE                 | 2007          | **Not yet Implemented**
-CUMIPMT                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMIPMT
-CUMPRINC                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMPRINC
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+CEILING                  | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CEILING
+CEILING.MATH             | CATEGORY_MATH_AND_TRIG        | **Not yet Implemented**
+CEILING.PRECISE          | CATEGORY_MATH_AND_TRIG        | **Not yet Implemented**
+CELL                     | CATEGORY_INFORMATION          | **Not yet Implemented**
+CHAR                     | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
+CHIDIST                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
+CHIINV                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
+CHISQ.DIST               | CATEGORY_STATISTICAL          | **Not yet Implemented**
+CHISQ.DIST.RT            | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
+CHISQ.INV                | CATEGORY_STATISTICAL          | **Not yet Implemented**
+CHISQ.INV.RT             | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
+CHISQ.TEST               | CATEGORY_STATISTICAL          | **Not yet Implemented**
+CHITEST                  | CATEGORY_STATISTICAL          | **Not yet Implemented**
+CHOOSE                   | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::CHOOSE
+CLEAN                    | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMNONPRINTABLE
+CODE                     | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
+COLUMN                   | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMN
+COLUMNS                  | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMNS
+COMBIN                   | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COMBIN
+COMBINA                  | CATEGORY_MATH_AND_TRIG        | **Not yet Implemented**
+COMPLEX                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::COMPLEX
+CONCAT                   | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
+CONCATENATE              | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
+CONFIDENCE               | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
+CONFIDENCE.NORM          | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
+CONFIDENCE.T             | CATEGORY_STATISTICAL          | **Not yet Implemented**
+CONVERT                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::CONVERTUOM
+CORREL                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
+COS                      | CATEGORY_MATH_AND_TRIG        | cos
+COSH                     | CATEGORY_MATH_AND_TRIG        | cosh
+COT                      | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COT
+COTH                     | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COTH
+COUNT                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNT
+COUNTA                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTA
+COUNTBLANK               | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTBLANK
+COUNTIF                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIF
+COUNTIFS                 | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIFS
+COUPDAYBS                | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYBS
+COUPDAYS                 | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYS
+COUPDAYSNC               | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYSNC
+COUPNCD                  | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNCD
+COUPNUM                  | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNUM
+COUPPCD                  | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPPCD
+COVAR                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
+COVARIANCE.P             | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
+COVARIANCE.S             | CATEGORY_STATISTICAL          | **Not yet Implemented**
+CRITBINOM                | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CRITBINOM
+CSC                      | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSC
+CSCH                     | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSCH
+CUBEKPIMEMBER            | CATEGORY_CUBE                 | **Not yet Implemented**
+CUBEMEMBER               | CATEGORY_CUBE                 | **Not yet Implemented**
+CUBEMEMBERPROPERTY       | CATEGORY_CUBE                 | **Not yet Implemented**
+CUBERANKEDMEMBER         | CATEGORY_CUBE                 | **Not yet Implemented**
+CUBESET                  | CATEGORY_CUBE                 | **Not yet Implemented**
+CUBESETCOUNT             | CATEGORY_CUBE                 | **Not yet Implemented**
+CUBEVALUE                | CATEGORY_CUBE                 | **Not yet Implemented**
+CUMIPMT                  | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMIPMT
+CUMPRINC                 | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMPRINC
 
 ## D
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-DATE                     | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATE
-DATEDIF                  | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEDIF
-DATEVALUE                | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEVALUE
-DAVERAGE                 | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DAVERAGE
-DAY                      | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYOFMONTH
-DAYS                     | CATEGORY_DATE_AND_TIME        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS
-DAYS360                  | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS360
-DB                       | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DB
-DBCS                     | CATEGORY_TEXT_AND_DATA        | 2013          | **Not yet Implemented**
-DCOUNT                   | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNT
-DCOUNTA                  | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNTA
-DDB                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DDB
-DEC2BIN                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOBIN
-DEC2HEX                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOHEX
-DEC2OCT                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOOCT
-DECIMAL                  | CATEGORY_MATH_AND_TRIG        | 2013          | **Not yet Implemented**
-DEGREES                  | CATEGORY_MATH_AND_TRIG        |               | rad2deg
-DELTA                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DELTA
-DEVSQ                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::DEVSQ
-DGET                     | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DGET
-DISC                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DISC
-DMAX                     | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMAX
-DMIN                     | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMIN
-DOLLAR                   | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::DOLLAR
-DOLLARDE                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARDE
-DOLLARFR                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARFR
-DPRODUCT                 | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DPRODUCT
-DSTDEV                   | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEV
-DSTDEVP                  | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEVP
-DSUM                     | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSUM
-DURATION                 | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
-DVAR                     | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVAR
-DVARP                    | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVARP
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+DATE                     | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATE
+DATEDIF                  | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEDIF
+DATEVALUE                | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEVALUE
+DAVERAGE                 | CATEGORY_DATABASE             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DAVERAGE
+DAY                      | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYOFMONTH
+DAYS                     | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS
+DAYS360                  | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS360
+DB                       | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DB
+DBCS                     | CATEGORY_TEXT_AND_DATA        | **Not yet Implemented**
+DCOUNT                   | CATEGORY_DATABASE             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNT
+DCOUNTA                  | CATEGORY_DATABASE             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNTA
+DDB                      | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DDB
+DEC2BIN                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOBIN
+DEC2HEX                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOHEX
+DEC2OCT                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOOCT
+DECIMAL                  | CATEGORY_MATH_AND_TRIG        | **Not yet Implemented**
+DEGREES                  | CATEGORY_MATH_AND_TRIG        | rad2deg
+DELTA                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DELTA
+DEVSQ                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::DEVSQ
+DGET                     | CATEGORY_DATABASE             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DGET
+DISC                     | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DISC
+DMAX                     | CATEGORY_DATABASE             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMAX
+DMIN                     | CATEGORY_DATABASE             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMIN
+DOLLAR                   | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::DOLLAR
+DOLLARDE                 | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARDE
+DOLLARFR                 | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARFR
+DPRODUCT                 | CATEGORY_DATABASE             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DPRODUCT
+DSTDEV                   | CATEGORY_DATABASE             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEV
+DSTDEVP                  | CATEGORY_DATABASE             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEVP
+DSUM                     | CATEGORY_DATABASE             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSUM
+DURATION                 | CATEGORY_FINANCIAL            | **Not yet Implemented**
+DVAR                     | CATEGORY_DATABASE             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVAR
+DVARP                    | CATEGORY_DATABASE             | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVARP
 
 ## E
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-EDATE                    | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EDATE
-EFFECT                   | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::EFFECT
-ENCODEURL                | CATEGORY_TEXT_AND_DATA        | 2013          | **Not yet Implemented**
-EOMONTH                  | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EOMONTH
-ERF                      | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERF
-ERFC                     | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
-ERFC.PRECISE             | CATEGORY_ENGINEERING          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
-ERF.PRECISE              | CATEGORY_ENGINEERING          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFPRECISE
-ERROR.TYPE               | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::errorType
-EVEN                     | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::EVEN
-EXACT                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::EXACT
-EXP                      | CATEGORY_MATH_AND_TRIG        |               | exp
-EXPONDIST                | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
-EXPON.DIST               | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+EDATE                    | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EDATE
+EFFECT                   | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::EFFECT
+ENCODEURL                | CATEGORY_TEXT_AND_DATA        | **Not yet Implemented**
+EOMONTH                  | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EOMONTH
+ERF                      | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERF
+ERFC                     | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
+ERFC.PRECISE             | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
+ERF.PRECISE              | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFPRECISE
+ERROR.TYPE               | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::errorType
+EVEN                     | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::EVEN
+EXACT                    | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::EXACT
+EXP                      | CATEGORY_MATH_AND_TRIG        | exp
+EXPONDIST                | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
+EXPON.DIST               | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
 
 ## F
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-FACT                     | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACT
-FACTDOUBLE               | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACTDOUBLE
-FALSE                    | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::FALSE
-FDIST                    | CATEGORY_STATISTICAL          | Compatibility | **Not yet Implemented**
-F.DIST                   | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-F.DIST.RT                | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-FILTER                   | CATEGORY_LOOKUP_AND_REFERENCE | Office 365    | **Not yet Implemented**
-FILTERXML                | CATEGORY_TEXT_AND_DATA        | 2013          | **Not yet Implemented**
-FIND                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
-FINDB                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
-FINV                     | CATEGORY_STATISTICAL          | Compatibility | **Not yet Implemented**
-F.INV                    | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-F.INV.RT                 | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-FISHER                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHER
-FISHERINV                | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHERINV
-FIXED                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::FIXEDFORMAT
-FLOOR                    | CATEGORY_MATH_AND_TRIG        | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOOR
-FLOOR.MATH               | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORMATH
-FLOOR.PRECISE            | CATEGORY_MATH_AND_TRIG        | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORPRECISE
-FORECAST                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
-FORECAST.ETS             | CATEGORY_STATISTICAL          | 2016          | **Not yet Implemented**
-FORECAST.ETS.CONFINT     | CATEGORY_STATISTICAL          | 2016          | **Not yet Implemented**
-FORECAST.ETS.SEASONALITY | CATEGORY_STATISTICAL          | 2016          | **Not yet Implemented**
-FORECAST.ETS.STAT        | CATEGORY_STATISTICAL          | 2016          | **Not yet Implemented**
-FORECAST.LINEAR          | CATEGORY_STATISTICAL          | 2016          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
-FORMULATEXT              | CATEGORY_LOOKUP_AND_REFERENCE | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::FORMULATEXT
-FREQUENCY                | CATEGORY_STATISTICAL          |               | **Not yet Implemented**
-FTEST                    | CATEGORY_STATISTICAL          | Compatibility | **Not yet Implemented**
-F.TEST                   | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-FV                       | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FV
-FVSCHEDULE               | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FVSCHEDULE
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+FACT                     | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACT
+FACTDOUBLE               | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACTDOUBLE
+FALSE                    | CATEGORY_LOGICAL              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::FALSE
+FDIST                    | CATEGORY_STATISTICAL          | **Not yet Implemented**
+F.DIST                   | CATEGORY_STATISTICAL          | **Not yet Implemented**
+F.DIST.RT                | CATEGORY_STATISTICAL          | **Not yet Implemented**
+FILTER                   | CATEGORY_LOOKUP_AND_REFERENCE | **Not yet Implemented**
+FILTERXML                | CATEGORY_TEXT_AND_DATA        | **Not yet Implemented**
+FIND                     | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
+FINDB                    | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
+FINV                     | CATEGORY_STATISTICAL          | **Not yet Implemented**
+F.INV                    | CATEGORY_STATISTICAL          | **Not yet Implemented**
+F.INV.RT                 | CATEGORY_STATISTICAL          | **Not yet Implemented**
+FISHER                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHER
+FISHERINV                | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHERINV
+FIXED                    | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::FIXEDFORMAT
+FLOOR                    | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOOR
+FLOOR.MATH               | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORMATH
+FLOOR.PRECISE            | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORPRECISE
+FORECAST                 | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
+FORECAST.ETS             | CATEGORY_STATISTICAL          | **Not yet Implemented**
+FORECAST.ETS.CONFINT     | CATEGORY_STATISTICAL          | **Not yet Implemented**
+FORECAST.ETS.SEASONALITY | CATEGORY_STATISTICAL          | **Not yet Implemented**
+FORECAST.ETS.STAT        | CATEGORY_STATISTICAL          | **Not yet Implemented**
+FORECAST.LINEAR          | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
+FORMULATEXT              | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::FORMULATEXT
+FREQUENCY                | CATEGORY_STATISTICAL          | **Not yet Implemented**
+FTEST                    | CATEGORY_STATISTICAL          | **Not yet Implemented**
+F.TEST                   | CATEGORY_STATISTICAL          | **Not yet Implemented**
+FV                       | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FV
+FVSCHEDULE               | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FVSCHEDULE
 
 ## G
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-GAMMA                    | CATEGORY_STATISTICAL          | 2013          | **Not yet Implemented**
-GAMMADIST                | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
-GAMMA.DIST               | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
-GAMMAINV                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
-GAMMA.INV                | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
-GAMMALN                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
-GAMMALN.PRECISE          | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
-GAUSS                    | CATEGORY_STATISTICAL          | 2013          | **Not yet Implemented**
-GCD                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::GCD
-GEOMEAN                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GEOMEAN
-GESTEP                   | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::GESTEP
-GETPIVOTDATA             | CATEGORY_LOOKUP_AND_REFERENCE |               | **Not yet Implemented**
-GROWTH                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GROWTH
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+GAMMA                    | CATEGORY_STATISTICAL          | **Not yet Implemented**
+GAMMADIST                | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
+GAMMA.DIST               | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
+GAMMAINV                 | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
+GAMMA.INV                | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
+GAMMALN                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
+GAMMALN.PRECISE          | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
+GAUSS                    | CATEGORY_STATISTICAL          | **Not yet Implemented**
+GCD                      | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::GCD
+GEOMEAN                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GEOMEAN
+GESTEP                   | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::GESTEP
+GETPIVOTDATA             | CATEGORY_LOOKUP_AND_REFERENCE | **Not yet Implemented**
+GROWTH                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GROWTH
 
 ## H
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-HARMEAN                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HARMEAN
-HEX2BIN                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOBIN
-HEX2DEC                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTODEC
-HEX2OCT                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOOCT
-HLOOKUP                  | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HLOOKUP
-HOUR                     | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::HOUROFDAY
-HYPERLINK                | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HYPERLINK
-HYPGEOMDIST              | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HYPGEOMDIST
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+HARMEAN                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HARMEAN
+HEX2BIN                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOBIN
+HEX2DEC                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTODEC
+HEX2OCT                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOOCT
+HLOOKUP                  | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HLOOKUP
+HOUR                     | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::HOUROFDAY
+HYPERLINK                | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HYPERLINK
+HYPGEOMDIST              | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HYPGEOMDIST
 
 ## I
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-IF                       | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementIf
-IFERROR                  | CATEGORY_LOGICAL              | 2007          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFERROR
-IFNA                     | CATEGORY_LOGICAL              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFNA
-IFS                      | CATEGORY_LOGICAL              | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFS
-IMABS                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMABS
-IMAGINARY                | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMAGINARY
-IMARGUMENT               | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMARGUMENT
-IMCONJUGATE              | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCONJUGATE
-IMCOS                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOS
-IMCOSH                   | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOSH
-IMCOT                    | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOT
-IMCSC                    | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSC
-IMCSCH                   | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSCH
-IMDIV                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMDIV
-IMEXP                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMEXP
-IMLN                     | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLN
-IMLOG10                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG10
-IMLOG2                   | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG2
-IMPOWER                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPOWER
-IMPRODUCT                | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPRODUCT
-IMREAL                   | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMREAL
-IMSEC                    | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSEC
-IMSECH                   | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSECH
-IMSIN                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSIN
-IMSINH                   | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSINH
-IMSQRT                   | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSQRT
-IMSUB                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUB
-IMSUM                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUM
-IMTAN                    | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMTAN
-INDEX                    | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDEX
-INDIRECT                 | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDIRECT
-INFO                     | CATEGORY_INFORMATION          |               | **Not yet Implemented**
-INT                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::INT
-INTERCEPT                | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::INTERCEPT
-INTRATE                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::INTRATE
-IPMT                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IPMT
-IRR                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IRR
-ISBLANK                  | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isBlank
-ISERR                    | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isErr
-ISERROR                  | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isError
-ISEVEN                   | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isEven
-ISFORMULA                | CATEGORY_INFORMATION          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isFormula
-ISLOGICAL                | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isLogical
-ISNA                     | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNa
-ISNONTEXT                | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNonText
-ISNUMBER                 | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNumber
-ISO.CEILING              | CATEGORY_MATH_AND_TRIG        | 2013          | **Not yet Implemented**
-ISODD                    | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isOdd
-ISOWEEKNUM               | CATEGORY_DATE_AND_TIME        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::ISOWEEKNUM
-ISPMT                    | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ISPMT
-ISREF                    | CATEGORY_INFORMATION          |               | **Not yet Implemented**
-ISTEXT                   | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isText
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+IF                       | CATEGORY_LOGICAL              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementIf
+IFERROR                  | CATEGORY_LOGICAL              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFERROR
+IFNA                     | CATEGORY_LOGICAL              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFNA
+IFS                      | CATEGORY_LOGICAL              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFS
+IMABS                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMABS
+IMAGINARY                | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMAGINARY
+IMARGUMENT               | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMARGUMENT
+IMCONJUGATE              | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCONJUGATE
+IMCOS                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOS
+IMCOSH                   | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOSH
+IMCOT                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOT
+IMCSC                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSC
+IMCSCH                   | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSCH
+IMDIV                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMDIV
+IMEXP                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMEXP
+IMLN                     | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLN
+IMLOG10                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG10
+IMLOG2                   | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG2
+IMPOWER                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPOWER
+IMPRODUCT                | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPRODUCT
+IMREAL                   | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMREAL
+IMSEC                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSEC
+IMSECH                   | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSECH
+IMSIN                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSIN
+IMSINH                   | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSINH
+IMSQRT                   | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSQRT
+IMSUB                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUB
+IMSUM                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUM
+IMTAN                    | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMTAN
+INDEX                    | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDEX
+INDIRECT                 | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDIRECT
+INFO                     | CATEGORY_INFORMATION          | **Not yet Implemented**
+INT                      | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::INT
+INTERCEPT                | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::INTERCEPT
+INTRATE                  | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::INTRATE
+IPMT                     | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IPMT
+IRR                      | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IRR
+ISBLANK                  | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isBlank
+ISERR                    | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isErr
+ISERROR                  | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isError
+ISEVEN                   | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isEven
+ISFORMULA                | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isFormula
+ISLOGICAL                | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isLogical
+ISNA                     | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNa
+ISNONTEXT                | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNonText
+ISNUMBER                 | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNumber
+ISO.CEILING              | CATEGORY_MATH_AND_TRIG        | **Not yet Implemented**
+ISODD                    | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isOdd
+ISOWEEKNUM               | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::ISOWEEKNUM
+ISPMT                    | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ISPMT
+ISREF                    | CATEGORY_INFORMATION          | **Not yet Implemented**
+ISTEXT                   | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isText
 
 ## J
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-JIS                      | CATEGORY_TEXT_AND_DATA        |               | **Not yet Implemented**
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+JIS                      | CATEGORY_TEXT_AND_DATA        | **Not yet Implemented**
 
 ## K
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-KURT                     | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::KURT
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+KURT                     | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::KURT
 
 ## L
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-LARGE                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LARGE
-LCM                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::LCM
-LEFT                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
-LEFTB                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
-LEN                      | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
-LENB                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
-LINEST                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LINEST
-LN                       | CATEGORY_MATH_AND_TRIG        |               | log
-LOG                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::logBase
-LOG10                    | CATEGORY_MATH_AND_TRIG        |               | log10
-LOGEST                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGEST
-LOGINV                   | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
-LOGNORMDIST              | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGNORMDIST
-LOGNORM.DIST             | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-LOGNORM.INV              | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
-LOOKUP                   | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::LOOKUP
-LOWER                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LOWERCASE
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+LARGE                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LARGE
+LCM                      | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::LCM
+LEFT                     | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
+LEFTB                    | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
+LEN                      | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
+LENB                     | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
+LINEST                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LINEST
+LN                       | CATEGORY_MATH_AND_TRIG        | log
+LOG                      | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::logBase
+LOG10                    | CATEGORY_MATH_AND_TRIG        | log10
+LOGEST                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGEST
+LOGINV                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
+LOGNORMDIST              | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGNORMDIST
+LOGNORM.DIST             | CATEGORY_STATISTICAL          | **Not yet Implemented**
+LOGNORM.INV              | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
+LOOKUP                   | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::LOOKUP
+LOWER                    | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LOWERCASE
 
 ## M
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-MATCH                    | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::MATCH
-MAX                      | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAX
-MAXA                     | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXA
-MAXIFS                   | CATEGORY_STATISTICAL          | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXIFS
-MDETERM                  | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MDETERM
-MDURATION                | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
-MEDIAN                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MEDIAN
-MEDIANIF                 | CATEGORY_STATISTICAL          |               | **Not yet Implemented**
-MID                      | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
-MIDB                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
-MIN                      | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MIN
-MINA                     | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINA
-MINIFS                   | CATEGORY_STATISTICAL          | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINIFS
-MINUTE                   | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MINUTE
-MINVERSE                 | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MINVERSE
-MIRR                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::MIRR
-MMULT                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MMULT
-MOD                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MOD
-MODE                     | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
-MODE.MULT                | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-MODE.SNGL                | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
-MONTH                    | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MONTHOFYEAR
-MROUND                   | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MROUND
-MULTINOMIAL              | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MULTINOMIAL
-MUNIT                    | CATEGORY_MATH_AND_TRIG        | 2013          | **Not yet Implemented**
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+MATCH                    | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::MATCH
+MAX                      | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAX
+MAXA                     | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXA
+MAXIFS                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXIFS
+MDETERM                  | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MDETERM
+MDURATION                | CATEGORY_FINANCIAL            | **Not yet Implemented**
+MEDIAN                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MEDIAN
+MEDIANIF                 | CATEGORY_STATISTICAL          | **Not yet Implemented**
+MID                      | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
+MIDB                     | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
+MIN                      | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MIN
+MINA                     | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINA
+MINIFS                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINIFS
+MINUTE                   | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MINUTE
+MINVERSE                 | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MINVERSE
+MIRR                     | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::MIRR
+MMULT                    | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MMULT
+MOD                      | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MOD
+MODE                     | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
+MODE.MULT                | CATEGORY_STATISTICAL          | **Not yet Implemented**
+MODE.SNGL                | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
+MONTH                    | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MONTHOFYEAR
+MROUND                   | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MROUND
+MULTINOMIAL              | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MULTINOMIAL
+MUNIT                    | CATEGORY_MATH_AND_TRIG        | **Not yet Implemented**
 
 ## N
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-N                        | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::n
-NA                       | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::NA
-NEGBINOMDIST             | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NEGBINOMDIST
-NEGBINOM.DIST            | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-NETWORKDAYS              | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::NETWORKDAYS
-NETWORKDAYS.INTL         | CATEGORY_DATE_AND_TIME        | 2010          | **Not yet Implemented**
-NOMINAL                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NOMINAL
-NORMDIST                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
-NORM.DIST                | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
-NORMINV                  | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
-NORM.INV                 | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
-NORMSDIST                | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSDIST
-NORM.S.DIST              | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-NORMSINV                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
-NORM.S.INV               | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
-NOT                      | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::NOT
-NOW                      | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATETIMENOW
-NPER                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPER
-NPV                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPV
-NUMBERVALUE              | CATEGORY_TEXT_AND_DATA        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::NUMBERVALUE
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+N                        | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::n
+NA                       | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::NA
+NEGBINOMDIST             | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NEGBINOMDIST
+NEGBINOM.DIST            | CATEGORY_STATISTICAL          | **Not yet Implemented**
+NETWORKDAYS              | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::NETWORKDAYS
+NETWORKDAYS.INTL         | CATEGORY_DATE_AND_TIME        | **Not yet Implemented**
+NOMINAL                  | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NOMINAL
+NORMDIST                 | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
+NORM.DIST                | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
+NORMINV                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
+NORM.INV                 | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
+NORMSDIST                | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSDIST
+NORM.S.DIST              | CATEGORY_STATISTICAL          | **Not yet Implemented**
+NORMSINV                 | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
+NORM.S.INV               | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
+NOT                      | CATEGORY_LOGICAL              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::NOT
+NOW                      | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATETIMENOW
+NPER                     | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPER
+NPV                      | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPV
+NUMBERVALUE              | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::NUMBERVALUE
 
 ## O
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-OCT2BIN                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOBIN
-OCT2DEC                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTODEC
-OCT2HEX                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOHEX
-ODD                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ODD
-ODDFPRICE                | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
-ODDFYIELD                | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
-ODDLPRICE                | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
-ODDLYIELD                | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
-OFFSET                   | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::OFFSET
-OR                       | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalOr
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+OCT2BIN                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOBIN
+OCT2DEC                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTODEC
+OCT2HEX                  | CATEGORY_ENGINEERING          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOHEX
+ODD                      | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ODD
+ODDFPRICE                | CATEGORY_FINANCIAL            | **Not yet Implemented**
+ODDFYIELD                | CATEGORY_FINANCIAL            | **Not yet Implemented**
+ODDLPRICE                | CATEGORY_FINANCIAL            | **Not yet Implemented**
+ODDLYIELD                | CATEGORY_FINANCIAL            | **Not yet Implemented**
+OFFSET                   | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::OFFSET
+OR                       | CATEGORY_LOGICAL              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalOr
 
 ## P
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-PDURATION                | CATEGORY_FINANCIAL            | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PDURATION
-PEARSON                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
-PERCENTILE               | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
-PERCENTILE.EXC           | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-PERCENTILE.INC           | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
-PERCENTRANK              | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
-PERCENTRANK.EXC          | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-PERCENTRANK.INC          | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
-PERMUT                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERMUT
-PERMUTATIONA             | CATEGORY_STATISTICAL          | 2013          | **Not yet Implemented**
-PHI                      | CATEGORY_STATISTICAL          | 2013          | **Not yet Implemented**
-PHONETIC                 | CATEGORY_TEXT_AND_DATA        |               | **Not yet Implemented**
-PI                       | CATEGORY_MATH_AND_TRIG        |               | pi
-PMT                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PMT
-POISSON                  | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
-POISSON.DIST             | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
-POWER                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::POWER
-PPMT                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PPMT
-PRICE                    | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICE
-PRICEDISC                | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEDISC
-PRICEMAT                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEMAT
-PROB                     | CATEGORY_STATISTICAL          |               | **Not yet Implemented**
-PRODUCT                  | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::PRODUCT
-PROPER                   | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::PROPERCASE
-PV                       | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PV
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+PDURATION                | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PDURATION
+PEARSON                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
+PERCENTILE               | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
+PERCENTILE.EXC           | CATEGORY_STATISTICAL          | **Not yet Implemented**
+PERCENTILE.INC           | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
+PERCENTRANK              | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
+PERCENTRANK.EXC          | CATEGORY_STATISTICAL          | **Not yet Implemented**
+PERCENTRANK.INC          | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
+PERMUT                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERMUT
+PERMUTATIONA             | CATEGORY_STATISTICAL          | **Not yet Implemented**
+PHI                      | CATEGORY_STATISTICAL          | **Not yet Implemented**
+PHONETIC                 | CATEGORY_TEXT_AND_DATA        | **Not yet Implemented**
+PI                       | CATEGORY_MATH_AND_TRIG        | pi
+PMT                      | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PMT
+POISSON                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
+POISSON.DIST             | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
+POWER                    | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::POWER
+PPMT                     | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PPMT
+PRICE                    | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICE
+PRICEDISC                | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEDISC
+PRICEMAT                 | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEMAT
+PROB                     | CATEGORY_STATISTICAL          | **Not yet Implemented**
+PRODUCT                  | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::PRODUCT
+PROPER                   | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::PROPERCASE
+PV                       | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PV
 
 ## Q
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-QUARTILE                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
-QUARTILE.EXC             | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-QUARTILE.INC             | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
-QUOTIENT                 | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::QUOTIENT
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+QUARTILE                 | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
+QUARTILE.EXC             | CATEGORY_STATISTICAL          | **Not yet Implemented**
+QUARTILE.INC             | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
+QUOTIENT                 | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::QUOTIENT
 
 ## R
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-RADIANS                  | CATEGORY_MATH_AND_TRIG        |               | deg2rad
-RAND                     | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
-RANDARRAY                | CATEGORY_MATH_AND_TRIG        | Office 365    | **Not yet Implemented**
-RANDBETWEEN              | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
-RANK                     | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
-RANK.AVG                 | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-RANK.EQ                  | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
-RATE                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RATE
-RECEIVED                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RECEIVED
-REPLACE                  | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
-REPLACEB                 | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
-REPT                     | CATEGORY_TEXT_AND_DATA        |               | str_repeat
-RIGHT                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
-RIGHTB                   | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
-ROMAN                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROMAN
-ROUND                    | CATEGORY_MATH_AND_TRIG        |               | round
-ROUNDDOWN                | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDDOWN
-ROUNDUP                  | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDUP
-ROW                      | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROW
-ROWS                     | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROWS
-RRI                      | CATEGORY_FINANCIAL            | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RRI
-RSQ                      | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RSQ
-RTD                      | CATEGORY_LOOKUP_AND_REFERENCE |               | **Not yet Implemented**
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+RADIANS                  | CATEGORY_MATH_AND_TRIG        | deg2rad
+RAND                     | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
+RANDARRAY                | CATEGORY_MATH_AND_TRIG        | **Not yet Implemented**
+RANDBETWEEN              | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
+RANK                     | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
+RANK.AVG                 | CATEGORY_STATISTICAL          | **Not yet Implemented**
+RANK.EQ                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
+RATE                     | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RATE
+RECEIVED                 | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RECEIVED
+REPLACE                  | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
+REPLACEB                 | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
+REPT                     | CATEGORY_TEXT_AND_DATA        | str_repeat
+RIGHT                    | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
+RIGHTB                   | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
+ROMAN                    | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROMAN
+ROUND                    | CATEGORY_MATH_AND_TRIG        | round
+ROUNDDOWN                | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDDOWN
+ROUNDUP                  | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDUP
+ROW                      | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROW
+ROWS                     | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROWS
+RRI                      | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RRI
+RSQ                      | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RSQ
+RTD                      | CATEGORY_LOOKUP_AND_REFERENCE | **Not yet Implemented**
 
 ## S
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-SEARCH                   | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
-SEARCHB                  | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
-SEC                      | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SEC
-SECH                     | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SECH
-SECOND                   | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::SECOND
-SEQUENCE                 | CATEGORY_MATH_AND_TRIG        | Office 365    | **Not yet Implemented**
-SERIESSUM                | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SERIESSUM
-SHEET                    | CATEGORY_INFORMATION          | 2013          | **Not yet Implemented**
-SHEETS                   | CATEGORY_INFORMATION          | 2013          | **Not yet Implemented**
-SIGN                     | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SIGN
-SIN                      | CATEGORY_MATH_AND_TRIG        |               | sin
-SINH                     | CATEGORY_MATH_AND_TRIG        |               | sinh
-SKEW                     | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SKEW
-SKEW.P                   | CATEGORY_STATISTICAL          | 2013          | **Not yet Implemented**
-SLN                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SLN
-SLOPE                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SLOPE
-SMALL                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SMALL
-SORT                     | CATEGORY_LOOKUP_AND_REFERENCE | Office 365    | **Not yet Implemented**
-SORTBY                   | CATEGORY_LOOKUP_AND_REFERENCE | Office 365    | **Not yet Implemented**
-SQRT                     | CATEGORY_MATH_AND_TRIG        |               | sqrt
-SQRTPI                   | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SQRTPI
-STANDARDIZE              | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STANDARDIZE
-STDEV                    | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
-STDEVA                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVA
-STDEVP                   | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
-STDEV.P                  | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
-STDEVPA                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVPA
-STDEV.S                  | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
-STEYX                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STEYX
-SUBSTITUTE               | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SUBSTITUTE
-SUBTOTAL                 | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUBTOTAL
-SUM                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUM
-SUMIF                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIF
-SUMIFS                   | CATEGORY_MATH_AND_TRIG        | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIFS
-SUMPRODUCT               | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMPRODUCT
-SUMSQ                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMSQ
-SUMX2MY2                 | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2MY2
-SUMX2PY2                 | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2PY2
-SUMXMY2                  | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMXMY2
-SWITCH                   | CATEGORY_LOGICAL              | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementSwitch
-SYD                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SYD
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+SEARCH                   | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
+SEARCHB                  | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
+SEC                      | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SEC
+SECH                     | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SECH
+SECOND                   | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::SECOND
+SEQUENCE                 | CATEGORY_MATH_AND_TRIG        | **Not yet Implemented**
+SERIESSUM                | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SERIESSUM
+SHEET                    | CATEGORY_INFORMATION          | **Not yet Implemented**
+SHEETS                   | CATEGORY_INFORMATION          | **Not yet Implemented**
+SIGN                     | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SIGN
+SIN                      | CATEGORY_MATH_AND_TRIG        | sin
+SINH                     | CATEGORY_MATH_AND_TRIG        | sinh
+SKEW                     | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SKEW
+SKEW.P                   | CATEGORY_STATISTICAL          | **Not yet Implemented**
+SLN                      | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SLN
+SLOPE                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SLOPE
+SMALL                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SMALL
+SORT                     | CATEGORY_LOOKUP_AND_REFERENCE | **Not yet Implemented**
+SORTBY                   | CATEGORY_LOOKUP_AND_REFERENCE | **Not yet Implemented**
+SQRT                     | CATEGORY_MATH_AND_TRIG        | sqrt
+SQRTPI                   | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SQRTPI
+STANDARDIZE              | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STANDARDIZE
+STDEV                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
+STDEVA                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVA
+STDEVP                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
+STDEV.P                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
+STDEVPA                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVPA
+STDEV.S                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
+STEYX                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STEYX
+SUBSTITUTE               | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SUBSTITUTE
+SUBTOTAL                 | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUBTOTAL
+SUM                      | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUM
+SUMIF                    | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIF
+SUMIFS                   | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIFS
+SUMPRODUCT               | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMPRODUCT
+SUMSQ                    | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMSQ
+SUMX2MY2                 | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2MY2
+SUMX2PY2                 | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2PY2
+SUMXMY2                  | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMXMY2
+SWITCH                   | CATEGORY_LOGICAL              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementSwitch
+SYD                      | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SYD
 
 ## T
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-T                        | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RETURNSTRING
-TAN                      | CATEGORY_MATH_AND_TRIG        |               | tan
-TANH                     | CATEGORY_MATH_AND_TRIG        |               | tanh
-TBILLEQ                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLEQ
-TBILLPRICE               | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLPRICE
-TBILLYIELD               | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLYIELD
-TDIST                    | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TDIST
-T.DIST                   | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-T.DIST.2T                | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-T.DIST.RT                | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-TEXT                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTFORMAT
-TEXTJOIN                 | CATEGORY_TEXT_AND_DATA        | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTJOIN
-TIME                     | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIME
-TIMEVALUE                | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIMEVALUE
-TINV                     | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
-T.INV                    | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
-T.INV.2T                 | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-TODAY                    | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATENOW
-TRANSPOSE                | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::TRANSPOSE
-TREND                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TREND
-TRIM                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMSPACES
-TRIMMEAN                 | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TRIMMEAN
-TRUE                     | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::TRUE
-TRUNC                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::TRUNC
-TTEST                    | CATEGORY_STATISTICAL          | Compatibility | **Not yet Implemented**
-T.TEST                   | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
-TYPE                     | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::TYPE
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+T                        | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RETURNSTRING
+TAN                      | CATEGORY_MATH_AND_TRIG        | tan
+TANH                     | CATEGORY_MATH_AND_TRIG        | tanh
+TBILLEQ                  | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLEQ
+TBILLPRICE               | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLPRICE
+TBILLYIELD               | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLYIELD
+TDIST                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TDIST
+T.DIST                   | CATEGORY_STATISTICAL          | **Not yet Implemented**
+T.DIST.2T                | CATEGORY_STATISTICAL          | **Not yet Implemented**
+T.DIST.RT                | CATEGORY_STATISTICAL          | **Not yet Implemented**
+TEXT                     | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTFORMAT
+TEXTJOIN                 | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTJOIN
+TIME                     | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIME
+TIMEVALUE                | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIMEVALUE
+TINV                     | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
+T.INV                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
+T.INV.2T                 | CATEGORY_STATISTICAL          | **Not yet Implemented**
+TODAY                    | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATENOW
+TRANSPOSE                | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::TRANSPOSE
+TREND                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TREND
+TRIM                     | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMSPACES
+TRIMMEAN                 | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TRIMMEAN
+TRUE                     | CATEGORY_LOGICAL              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::TRUE
+TRUNC                    | CATEGORY_MATH_AND_TRIG        | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::TRUNC
+TTEST                    | CATEGORY_STATISTICAL          | **Not yet Implemented**
+T.TEST                   | CATEGORY_STATISTICAL          | **Not yet Implemented**
+TYPE                     | CATEGORY_INFORMATION          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::TYPE
 
 ## U
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-UNICHAR                  | CATEGORY_TEXT_AND_DATA        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
-UNICODE                  | CATEGORY_TEXT_AND_DATA        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
-UNIQUE                   | CATEGORY_LOOKUP_AND_REFERENCE | Office 365    | **Not yet Implemented**
-UPPER                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::UPPERCASE
-USDOLLAR                 | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+UNICHAR                  | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
+UNICODE                  | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
+UNIQUE                   | CATEGORY_LOOKUP_AND_REFERENCE | **Not yet Implemented**
+UPPER                    | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::UPPERCASE
+USDOLLAR                 | CATEGORY_FINANCIAL            | **Not yet Implemented**
 
 ## V
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-VALUE                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::VALUE
-VAR                      | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
-VARA                     | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARA
-VARP                     | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
-VAR.P                    | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
-VARPA                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARPA
-VAR.S                    | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
-VDB                      | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
-VLOOKUP                  | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::VLOOKUP
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+VALUE                    | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\TextData::VALUE
+VAR                      | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
+VARA                     | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARA
+VARP                     | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
+VAR.P                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
+VARPA                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARPA
+VAR.S                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
+VDB                      | CATEGORY_FINANCIAL            | **Not yet Implemented**
+VLOOKUP                  | CATEGORY_LOOKUP_AND_REFERENCE | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::VLOOKUP
 
 ## W
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-WEBSERVICE               | CATEGORY_TEXT_AND_DATA        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Web::WEBSERVICE
-WEEKDAY                  | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKDAY
-WEEKNUM                  | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKNUM
-WEIBULL                  | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
-WEIBULL.DIST             | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
-WORKDAY                  | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WORKDAY
-WORKDAY.INTL             | CATEGORY_DATE_AND_TIME        | 2010          | **Not yet Implemented**
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+WEBSERVICE               | CATEGORY_TEXT_AND_DATA        | \PhpOffice\PhpSpreadsheet\Calculation\Web::WEBSERVICE
+WEEKDAY                  | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKDAY
+WEEKNUM                  | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKNUM
+WEIBULL                  | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
+WEIBULL.DIST             | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
+WORKDAY                  | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WORKDAY
+WORKDAY.INTL             | CATEGORY_DATE_AND_TIME        | **Not yet Implemented**
 
 ## X
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-XIRR                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XIRR
-XLOOKUP                  | CATEGORY_LOOKUP_AND_REFERENCE | Office 365    | **Not yet Implemented**
-XMATCH                   | CATEGORY_LOOKUP_AND_REFERENCE | Office 365    | **Not yet Implemented**
-XNPV                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XNPV
-XOR                      | CATEGORY_LOGICAL              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalXor
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+XIRR                     | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XIRR
+XLOOKUP                  | CATEGORY_LOOKUP_AND_REFERENCE | **Not yet Implemented**
+XMATCH                   | CATEGORY_LOOKUP_AND_REFERENCE | **Not yet Implemented**
+XNPV                     | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XNPV
+XOR                      | CATEGORY_LOGICAL              | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalXor
 
 ## Y
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-YEAR                     | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEAR
-YEARFRAC                 | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEARFRAC
-YIELD                    | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
-YIELDDISC                | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDDISC
-YIELDMAT                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDMAT
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+YEAR                     | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEAR
+YEARFRAC                 | CATEGORY_DATE_AND_TIME        | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEARFRAC
+YIELD                    | CATEGORY_FINANCIAL            | **Not yet Implemented**
+YIELDDISC                | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDDISC
+YIELDMAT                 | CATEGORY_FINANCIAL            | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDMAT
 
 ## Z
 
-Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
--------------------------|-------------------------------|---------------|-------------------------
-ZTEST                    | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST
-Z.TEST                   | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST
+Excel Function           | Category                      | PhpSpreadsheet Function 
+-------------------------|-------------------------------|-------------------------
+ZTEST                    | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST
+Z.TEST                   | CATEGORY_STATISTICAL          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST

--- a/docs/references/function-list-by-name.md
+++ b/docs/references/function-list-by-name.md
@@ -2,536 +2,613 @@
 
 ## A
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-ABS                 | CATEGORY_MATH_AND_TRIG         | abs
-ACCRINT             | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINT
-ACCRINTM            | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINTM
-ACOS                | CATEGORY_MATH_AND_TRIG         | acos
-ACOSH               | CATEGORY_MATH_AND_TRIG         | acosh
-ACOT                | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOT
-ACOTH               | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOTH
-ADDRESS             | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::cellAddress
-AMORDEGRC           | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORDEGRC
-AMORLINC            | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORLINC
-AND                 | CATEGORY_LOGICAL               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalAnd
-ARABIC              | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ARABIC
-AREAS               | CATEGORY_LOOKUP_AND_REFERENCE  | **Not yet Implemented**
-ASC                 | CATEGORY_TEXT_AND_DATA         | **Not yet Implemented**
-ASIN                | CATEGORY_MATH_AND_TRIG         | asin
-ASINH               | CATEGORY_MATH_AND_TRIG         | asinh
-ATAN                | CATEGORY_MATH_AND_TRIG         | atan
-ATAN2               | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ATAN2
-ATANH               | CATEGORY_MATH_AND_TRIG         | atanh
-AVEDEV              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVEDEV
-AVERAGE             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGE
-AVERAGEA            | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEA
-AVERAGEIF           | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEIF
-AVERAGEIFS          | CATEGORY_STATISTICAL           | **Not yet Implemented**
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+ABS                      | CATEGORY_MATH_AND_TRIG        |               | abs
+ACCRINT                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINT
+ACCRINTM                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ACCRINTM
+ACOS                     | CATEGORY_MATH_AND_TRIG        |               | acos
+ACOSH                    | CATEGORY_MATH_AND_TRIG        |               | acosh
+ACOT                     | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOT
+ACOTH                    | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ACOTH
+ADDRESS                  | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::cellAddress
+AGGREGATE                | CATEGORY_MATH_AND_TRIG        |               | **Not yet Implemented**
+AMORDEGRC                | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORDEGRC
+AMORLINC                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::AMORLINC
+AND                      | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalAnd
+ARABIC                   | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ARABIC
+AREAS                    | CATEGORY_LOOKUP_AND_REFERENCE |               | **Not yet Implemented**
+ASC                      | CATEGORY_TEXT_AND_DATA        |               | **Not yet Implemented**
+ASIN                     | CATEGORY_MATH_AND_TRIG        |               | asin
+ASINH                    | CATEGORY_MATH_AND_TRIG        |               | asinh
+ATAN                     | CATEGORY_MATH_AND_TRIG        |               | atan
+ATAN2                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ATAN2
+ATANH                    | CATEGORY_MATH_AND_TRIG        |               | atanh
+AVEDEV                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVEDEV
+AVERAGE                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGE
+AVERAGEA                 | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEA
+AVERAGEIF                | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::AVERAGEIF
+AVERAGEIFS               | CATEGORY_STATISTICAL          | 2019          | **Not yet Implemented**
 
 ## B
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-BAHTTEXT            | CATEGORY_TEXT_AND_DATA         | **Not yet Implemented**
-BASE                | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::BASE
-BESSELI             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELI
-BESSELJ             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELJ
-BESSELK             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELK
-BESSELY             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELY
-BETADIST            | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
-BETAINV             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
-BIN2DEC             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTODEC
-BIN2HEX             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOHEX
-BIN2OCT             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOOCT
-BINOMDIST           | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
-BITAND              | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITAND
-BITLSHIFT           | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITLSHIFT
-BITOR               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
-BITRSHIFT           | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITRSHIFT
-BITXOR              | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+BAHTTEXT                 | CATEGORY_TEXT_AND_DATA        |               | **Not yet Implemented**
+BASE                     | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::BASE
+BESSELI                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELI
+BESSELJ                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELJ
+BESSELK                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELK
+BESSELY                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BESSELY
+BETADIST                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
+BETA.DIST                | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETADIST
+BETAINV                  | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
+BETA.INV                 | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BETAINV
+BIN2DEC                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTODEC
+BIN2HEX                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOHEX
+BIN2OCT                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BINTOOCT
+BINOMDIST                | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
+BINOM.DIST               | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::BINOMDIST
+BINOM.DIST.RANGE         | CATEGORY_STATISTICAL          | 2013          | **Not yet Implemented**
+BINOM.INV                | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+BITAND                   | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITAND
+BITLSHIFT                | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITLSHIFT
+BITOR                    | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
+BITRSHIFT                | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITRSHIFT
+BITXOR                   | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::BITOR
 
 ## C
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-CEILING             | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CEILING
-CELL                | CATEGORY_INFORMATION           | **Not yet Implemented**
-CHAR                | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
-CHIDIST             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
-CHIINV              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
-CHITEST             | CATEGORY_STATISTICAL           | **Not yet Implemented**
-CHOOSE              | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::CHOOSE
-CLEAN               | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMNONPRINTABLE
-CODE                | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
-COLUMN              | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMN
-COLUMNS             | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMNS
-COMBIN              | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COMBIN
-COMPLEX             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::COMPLEX
-CONCAT              | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
-CONCATENATE         | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
-CONFIDENCE          | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
-CONVERT             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::CONVERTUOM
-CORREL              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
-COS                 | CATEGORY_MATH_AND_TRIG         | cos
-COSH                | CATEGORY_MATH_AND_TRIG         | cosh
-COT                 | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COT
-COTH                | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COTH
-COUNT               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNT
-COUNTA              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTA
-COUNTBLANK          | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTBLANK
-COUNTIF             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIF
-COUNTIFS            | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIFS
-COUPDAYBS           | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYBS
-COUPDAYS            | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYS
-COUPDAYSNC          | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYSNC
-COUPNCD             | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNCD
-COUPNUM             | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNUM
-COUPPCD             | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPPCD
-COVAR               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
-CRITBINOM           | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CRITBINOM
-CSC                 | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSC
-CSCH                | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSCH
-CUBEKPIMEMBER       | CATEGORY_CUBE                  | **Not yet Implemented**
-CUBEMEMBER          | CATEGORY_CUBE                  | **Not yet Implemented**
-CUBEMEMBERPROPERTY  | CATEGORY_CUBE                  | **Not yet Implemented**
-CUBERANKEDMEMBER    | CATEGORY_CUBE                  | **Not yet Implemented**
-CUBESET             | CATEGORY_CUBE                  | **Not yet Implemented**
-CUBESETCOUNT        | CATEGORY_CUBE                  | **Not yet Implemented**
-CUBEVALUE           | CATEGORY_CUBE                  | **Not yet Implemented**
-CUMIPMT             | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMIPMT
-CUMPRINC            | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMPRINC
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+CEILING                  | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CEILING
+CEILING.MATH             | CATEGORY_MATH_AND_TRIG        | 2013          | **Not yet Implemented**
+CEILING.PRECISE          | CATEGORY_MATH_AND_TRIG        |               | **Not yet Implemented**
+CELL                     | CATEGORY_INFORMATION          |               | **Not yet Implemented**
+CHAR                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
+CHIDIST                  | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
+CHIINV                   | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
+CHISQ.DIST               | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+CHISQ.DIST.RT            | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIDIST
+CHISQ.INV                | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+CHISQ.INV.RT             | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CHIINV
+CHISQ.TEST               | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+CHITEST                  | CATEGORY_STATISTICAL          | Compatibility | **Not yet Implemented**
+CHOOSE                   | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::CHOOSE
+CLEAN                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMNONPRINTABLE
+CODE                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
+COLUMN                   | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMN
+COLUMNS                  | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::COLUMNS
+COMBIN                   | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COMBIN
+COMBINA                  | CATEGORY_MATH_AND_TRIG        | 2013          | **Not yet Implemented**
+COMPLEX                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::COMPLEX
+CONCAT                   | CATEGORY_TEXT_AND_DATA        | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
+CONCATENATE              | CATEGORY_TEXT_AND_DATA        | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CONCATENATE
+CONFIDENCE               | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
+CONFIDENCE.NORM          | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CONFIDENCE
+CONFIDENCE.T             | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+CONVERT                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::CONVERTUOM
+CORREL                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
+COS                      | CATEGORY_MATH_AND_TRIG        |               | cos
+COSH                     | CATEGORY_MATH_AND_TRIG        |               | cosh
+COT                      | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COT
+COTH                     | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::COTH
+COUNT                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNT
+COUNTA                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTA
+COUNTBLANK               | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTBLANK
+COUNTIF                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIF
+COUNTIFS                 | CATEGORY_STATISTICAL          | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COUNTIFS
+COUPDAYBS                | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYBS
+COUPDAYS                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYS
+COUPDAYSNC               | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPDAYSNC
+COUPNCD                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNCD
+COUPNUM                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPNUM
+COUPPCD                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::COUPPCD
+COVAR                    | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
+COVARIANCE.P             | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::COVAR
+COVARIANCE.S             | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+CRITBINOM                | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CRITBINOM
+CSC                      | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSC
+CSCH                     | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::CSCH
+CUBEKPIMEMBER            | CATEGORY_CUBE                 |               | **Not yet Implemented**
+CUBEMEMBER               | CATEGORY_CUBE                 |               | **Not yet Implemented**
+CUBEMEMBERPROPERTY       | CATEGORY_CUBE                 |               | **Not yet Implemented**
+CUBERANKEDMEMBER         | CATEGORY_CUBE                 |               | **Not yet Implemented**
+CUBESET                  | CATEGORY_CUBE                 |               | **Not yet Implemented**
+CUBESETCOUNT             | CATEGORY_CUBE                 |               | **Not yet Implemented**
+CUBEVALUE                | CATEGORY_CUBE                 |               | **Not yet Implemented**
+CUMIPMT                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMIPMT
+CUMPRINC                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::CUMPRINC
 
 ## D
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-DATE                | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATE
-DATEDIF             | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEDIF
-DATEVALUE           | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEVALUE
-DAVERAGE            | CATEGORY_DATABASE              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DAVERAGE
-DAY                 | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYOFMONTH
-DAYS                | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS
-DAYS360             | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS360
-DB                  | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DB
-DCOUNT              | CATEGORY_DATABASE              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNT
-DCOUNTA             | CATEGORY_DATABASE              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNTA
-DDB                 | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DDB
-DEC2BIN             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOBIN
-DEC2HEX             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOHEX
-DEC2OCT             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOOCT
-DEGREES             | CATEGORY_MATH_AND_TRIG         | rad2deg
-DELTA               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DELTA
-DEVSQ               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::DEVSQ
-DGET                | CATEGORY_DATABASE              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DGET
-DISC                | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DISC
-DMAX                | CATEGORY_DATABASE              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMAX
-DMIN                | CATEGORY_DATABASE              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMIN
-DOLLAR              | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::DOLLAR
-DOLLARDE            | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARDE
-DOLLARFR            | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARFR
-DPRODUCT            | CATEGORY_DATABASE              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DPRODUCT
-DSTDEV              | CATEGORY_DATABASE              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEV
-DSTDEVP             | CATEGORY_DATABASE              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEVP
-DSUM                | CATEGORY_DATABASE              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSUM
-DURATION            | CATEGORY_FINANCIAL             | **Not yet Implemented**
-DVAR                | CATEGORY_DATABASE              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVAR
-DVARP               | CATEGORY_DATABASE              | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVARP
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+DATE                     | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATE
+DATEDIF                  | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEDIF
+DATEVALUE                | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATEVALUE
+DAVERAGE                 | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DAVERAGE
+DAY                      | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYOFMONTH
+DAYS                     | CATEGORY_DATE_AND_TIME        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS
+DAYS360                  | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DAYS360
+DB                       | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DB
+DBCS                     | CATEGORY_TEXT_AND_DATA        | 2013          | **Not yet Implemented**
+DCOUNT                   | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNT
+DCOUNTA                  | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DCOUNTA
+DDB                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DDB
+DEC2BIN                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOBIN
+DEC2HEX                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOHEX
+DEC2OCT                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DECTOOCT
+DECIMAL                  | CATEGORY_MATH_AND_TRIG        | 2013          | **Not yet Implemented**
+DEGREES                  | CATEGORY_MATH_AND_TRIG        |               | rad2deg
+DELTA                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::DELTA
+DEVSQ                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::DEVSQ
+DGET                     | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DGET
+DISC                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DISC
+DMAX                     | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMAX
+DMIN                     | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DMIN
+DOLLAR                   | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::DOLLAR
+DOLLARDE                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARDE
+DOLLARFR                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::DOLLARFR
+DPRODUCT                 | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DPRODUCT
+DSTDEV                   | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEV
+DSTDEVP                  | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSTDEVP
+DSUM                     | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DSUM
+DURATION                 | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
+DVAR                     | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVAR
+DVARP                    | CATEGORY_DATABASE             |               | \PhpOffice\PhpSpreadsheet\Calculation\Database::DVARP
 
 ## E
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-EDATE               | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EDATE
-EFFECT              | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::EFFECT
-EOMONTH             | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EOMONTH
-ERF                 | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERF
-ERF.PRECISE         | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFPRECISE
-ERFC                | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
-ERFC.PRECISE        | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
-ERROR.TYPE          | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::errorType
-EVEN                | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::EVEN
-EXACT               | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::EXACT
-EXP                 | CATEGORY_MATH_AND_TRIG         | exp
-EXPONDIST           | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+EDATE                    | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EDATE
+EFFECT                   | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::EFFECT
+ENCODEURL                | CATEGORY_TEXT_AND_DATA        | 2013          | **Not yet Implemented**
+EOMONTH                  | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::EOMONTH
+ERF                      | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERF
+ERFC                     | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
+ERFC.PRECISE             | CATEGORY_ENGINEERING          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFC
+ERF.PRECISE              | CATEGORY_ENGINEERING          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::ERFPRECISE
+ERROR.TYPE               | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::errorType
+EVEN                     | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::EVEN
+EXACT                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::EXACT
+EXP                      | CATEGORY_MATH_AND_TRIG        |               | exp
+EXPONDIST                | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
+EXPON.DIST               | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::EXPONDIST
 
 ## F
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-FACT                | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACT
-FACTDOUBLE          | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACTDOUBLE
-FALSE               | CATEGORY_LOGICAL               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::FALSE
-FDIST               | CATEGORY_STATISTICAL           | **Not yet Implemented**
-FIND                | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
-FINDB               | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
-FINV                | CATEGORY_STATISTICAL           | **Not yet Implemented**
-FISHER              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHER
-FISHERINV           | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHERINV
-FIXED               | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::FIXEDFORMAT
-FLOOR               | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOOR
-FLOOR.MATH          | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORMATH
-FLOOR.PRECISE       | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORPRECISE
-FORECAST            | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
-FORMULATEXT         | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::FORMULATEXT
-FREQUENCY           | CATEGORY_STATISTICAL           | **Not yet Implemented**
-FTEST               | CATEGORY_STATISTICAL           | **Not yet Implemented**
-FV                  | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FV
-FVSCHEDULE          | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FVSCHEDULE
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+FACT                     | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACT
+FACTDOUBLE               | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FACTDOUBLE
+FALSE                    | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::FALSE
+FDIST                    | CATEGORY_STATISTICAL          | Compatibility | **Not yet Implemented**
+F.DIST                   | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+F.DIST.RT                | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+FILTER                   | CATEGORY_LOOKUP_AND_REFERENCE | Office 365    | **Not yet Implemented**
+FILTERXML                | CATEGORY_TEXT_AND_DATA        | 2013          | **Not yet Implemented**
+FIND                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
+FINDB                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHSENSITIVE
+FINV                     | CATEGORY_STATISTICAL          | Compatibility | **Not yet Implemented**
+F.INV                    | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+F.INV.RT                 | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+FISHER                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHER
+FISHERINV                | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FISHERINV
+FIXED                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::FIXEDFORMAT
+FLOOR                    | CATEGORY_MATH_AND_TRIG        | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOOR
+FLOOR.MATH               | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORMATH
+FLOOR.PRECISE            | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::FLOORPRECISE
+FORECAST                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
+FORECAST.ETS             | CATEGORY_STATISTICAL          | 2016          | **Not yet Implemented**
+FORECAST.ETS.CONFINT     | CATEGORY_STATISTICAL          | 2016          | **Not yet Implemented**
+FORECAST.ETS.SEASONALITY | CATEGORY_STATISTICAL          | 2016          | **Not yet Implemented**
+FORECAST.ETS.STAT        | CATEGORY_STATISTICAL          | 2016          | **Not yet Implemented**
+FORECAST.LINEAR          | CATEGORY_STATISTICAL          | 2016          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::FORECAST
+FORMULATEXT              | CATEGORY_LOOKUP_AND_REFERENCE | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::FORMULATEXT
+FREQUENCY                | CATEGORY_STATISTICAL          |               | **Not yet Implemented**
+FTEST                    | CATEGORY_STATISTICAL          | Compatibility | **Not yet Implemented**
+F.TEST                   | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+FV                       | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FV
+FVSCHEDULE               | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::FVSCHEDULE
 
 ## G
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-GAMMADIST           | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
-GAMMAINV            | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
-GAMMALN             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
-GCD                 | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::GCD
-GEOMEAN             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GEOMEAN
-GESTEP              | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::GESTEP
-GETPIVOTDATA        | CATEGORY_LOOKUP_AND_REFERENCE  | **Not yet Implemented**
-GROWTH              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GROWTH
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+GAMMA                    | CATEGORY_STATISTICAL          | 2013          | **Not yet Implemented**
+GAMMADIST                | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
+GAMMA.DIST               | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMADIST
+GAMMAINV                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
+GAMMA.INV                | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMAINV
+GAMMALN                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
+GAMMALN.PRECISE          | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GAMMALN
+GAUSS                    | CATEGORY_STATISTICAL          | 2013          | **Not yet Implemented**
+GCD                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::GCD
+GEOMEAN                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GEOMEAN
+GESTEP                   | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::GESTEP
+GETPIVOTDATA             | CATEGORY_LOOKUP_AND_REFERENCE |               | **Not yet Implemented**
+GROWTH                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::GROWTH
 
 ## H
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-HARMEAN             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HARMEAN
-HEX2BIN             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOBIN
-HEX2DEC             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTODEC
-HEX2OCT             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOOCT
-HLOOKUP             | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HLOOKUP
-HOUR                | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::HOUROFDAY
-HYPERLINK           | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HYPERLINK
-HYPGEOMDIST         | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HYPGEOMDIST
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+HARMEAN                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HARMEAN
+HEX2BIN                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOBIN
+HEX2DEC                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTODEC
+HEX2OCT                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::HEXTOOCT
+HLOOKUP                  | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HLOOKUP
+HOUR                     | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::HOUROFDAY
+HYPERLINK                | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::HYPERLINK
+HYPGEOMDIST              | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::HYPGEOMDIST
 
 ## I
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-IF                  | CATEGORY_LOGICAL               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementIf
-IFERROR             | CATEGORY_LOGICAL               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFERROR
-IFNA                | CATEGORY_LOGICAL               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFNA
-IFS                 | CATEGORY_LOGICAL               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFS
-IMABS               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMABS
-IMAGINARY           | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMAGINARY
-IMARGUMENT          | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMARGUMENT
-IMCONJUGATE         | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCONJUGATE
-IMCOS               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOS
-IMCOSH              | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOSH
-IMCOT               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOT
-IMCSC               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSC
-IMCSCH              | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSCH
-IMDIV               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMDIV
-IMEXP               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMEXP
-IMLN                | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLN
-IMLOG10             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG10
-IMLOG2              | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG2
-IMPOWER             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPOWER
-IMPRODUCT           | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPRODUCT
-IMREAL              | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMREAL
-IMSEC               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSEC
-IMSECH              | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSECH
-IMSIN               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSIN
-IMSINH              | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSINH
-IMSQRT              | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSQRT
-IMSUB               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUB
-IMSUM               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUM
-IMTAN               | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMTAN
-INDEX               | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDEX
-INDIRECT            | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDIRECT
-INFO                | CATEGORY_INFORMATION           | **Not yet Implemented**
-INT                 | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::INT
-INTERCEPT           | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::INTERCEPT
-INTRATE             | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::INTRATE
-IPMT                | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IPMT
-IRR                 | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IRR
-ISBLANK             | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isBlank
-ISERR               | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isErr
-ISERROR             | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isError
-ISEVEN              | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isEven
-ISFORMULA           | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isFormula
-ISLOGICAL           | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isLogical
-ISNA                | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNa
-ISNONTEXT           | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNonText
-ISNUMBER            | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNumber
-ISODD               | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isOdd
-ISOWEEKNUM          | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::ISOWEEKNUM
-ISPMT               | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ISPMT
-ISREF               | CATEGORY_INFORMATION           | **Not yet Implemented**
-ISTEXT              | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isText
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+IF                       | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementIf
+IFERROR                  | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFERROR
+IFNA                     | CATEGORY_LOGICAL              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFNA
+IFS                      | CATEGORY_LOGICAL              | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::IFS
+IMABS                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMABS
+IMAGINARY                | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMAGINARY
+IMARGUMENT               | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMARGUMENT
+IMCONJUGATE              | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCONJUGATE
+IMCOS                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOS
+IMCOSH                   | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOSH
+IMCOT                    | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCOT
+IMCSC                    | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSC
+IMCSCH                   | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMCSCH
+IMDIV                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMDIV
+IMEXP                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMEXP
+IMLN                     | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLN
+IMLOG10                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG10
+IMLOG2                   | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMLOG2
+IMPOWER                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPOWER
+IMPRODUCT                | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMPRODUCT
+IMREAL                   | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMREAL
+IMSEC                    | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSEC
+IMSECH                   | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSECH
+IMSIN                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSIN
+IMSINH                   | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSINH
+IMSQRT                   | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSQRT
+IMSUB                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUB
+IMSUM                    | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMSUM
+IMTAN                    | CATEGORY_ENGINEERING          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::IMTAN
+INDEX                    | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDEX
+INDIRECT                 | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::INDIRECT
+INFO                     | CATEGORY_INFORMATION          |               | **Not yet Implemented**
+INT                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::INT
+INTERCEPT                | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::INTERCEPT
+INTRATE                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::INTRATE
+IPMT                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IPMT
+IRR                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::IRR
+ISBLANK                  | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isBlank
+ISERR                    | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isErr
+ISERROR                  | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isError
+ISEVEN                   | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isEven
+ISFORMULA                | CATEGORY_INFORMATION          | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isFormula
+ISLOGICAL                | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isLogical
+ISNA                     | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNa
+ISNONTEXT                | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNonText
+ISNUMBER                 | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isNumber
+ISO.CEILING              | CATEGORY_MATH_AND_TRIG        | 2013          | **Not yet Implemented**
+ISODD                    | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isOdd
+ISOWEEKNUM               | CATEGORY_DATE_AND_TIME        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::ISOWEEKNUM
+ISPMT                    | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::ISPMT
+ISREF                    | CATEGORY_INFORMATION          |               | **Not yet Implemented**
+ISTEXT                   | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::isText
 
 ## J
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-JIS                 | CATEGORY_TEXT_AND_DATA         | **Not yet Implemented**
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+JIS                      | CATEGORY_TEXT_AND_DATA        |               | **Not yet Implemented**
 
 ## K
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-KURT                | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::KURT
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+KURT                     | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::KURT
 
 ## L
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-LARGE               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LARGE
-LCM                 | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::LCM
-LEFT                | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
-LEFTB               | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
-LEN                 | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
-LENB                | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
-LINEST              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LINEST
-LN                  | CATEGORY_MATH_AND_TRIG         | log
-LOG                 | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::logBase
-LOG10               | CATEGORY_MATH_AND_TRIG         | log10
-LOGEST              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGEST
-LOGINV              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
-LOGNORMDIST         | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGNORMDIST
-LOOKUP              | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::LOOKUP
-LOWER               | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LOWERCASE
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+LARGE                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LARGE
+LCM                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::LCM
+LEFT                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
+LEFTB                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LEFT
+LEN                      | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
+LENB                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::STRINGLENGTH
+LINEST                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LINEST
+LN                       | CATEGORY_MATH_AND_TRIG        |               | log
+LOG                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::logBase
+LOG10                    | CATEGORY_MATH_AND_TRIG        |               | log10
+LOGEST                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGEST
+LOGINV                   | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
+LOGNORMDIST              | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGNORMDIST
+LOGNORM.DIST             | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+LOGNORM.INV              | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::LOGINV
+LOOKUP                   | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::LOOKUP
+LOWER                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::LOWERCASE
 
 ## M
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-MATCH               | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::MATCH
-MAX                 | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAX
-MAXA                | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXA
-MAXIFS              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXIFS
-MDETERM             | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MDETERM
-MDURATION           | CATEGORY_FINANCIAL             | **Not yet Implemented**
-MEDIAN              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MEDIAN
-MEDIANIF            | CATEGORY_STATISTICAL           | **Not yet Implemented**
-MID                 | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
-MIDB                | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
-MIN                 | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MIN
-MINA                | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINA
-MINIFS              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINIFS
-MINUTE              | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MINUTE
-MINVERSE            | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MINVERSE
-MIRR                | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::MIRR
-MMULT               | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MMULT
-MOD                 | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MOD
-MODE                | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
-MODE.SNGL           | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
-MONTH               | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MONTHOFYEAR
-MROUND              | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MROUND
-MULTINOMIAL         | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MULTINOMIAL
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+MATCH                    | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::MATCH
+MAX                      | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAX
+MAXA                     | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXA
+MAXIFS                   | CATEGORY_STATISTICAL          | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MAXIFS
+MDETERM                  | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MDETERM
+MDURATION                | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
+MEDIAN                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MEDIAN
+MEDIANIF                 | CATEGORY_STATISTICAL          |               | **Not yet Implemented**
+MID                      | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
+MIDB                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::MID
+MIN                      | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MIN
+MINA                     | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINA
+MINIFS                   | CATEGORY_STATISTICAL          | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MINIFS
+MINUTE                   | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MINUTE
+MINVERSE                 | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MINVERSE
+MIRR                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::MIRR
+MMULT                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MMULT
+MOD                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MOD
+MODE                     | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
+MODE.MULT                | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+MODE.SNGL                | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::MODE
+MONTH                    | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::MONTHOFYEAR
+MROUND                   | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MROUND
+MULTINOMIAL              | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::MULTINOMIAL
+MUNIT                    | CATEGORY_MATH_AND_TRIG        | 2013          | **Not yet Implemented**
 
 ## N
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-N                   | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::n
-NA                  | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::NA
-NEGBINOMDIST        | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NEGBINOMDIST
-NETWORKDAYS         | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::NETWORKDAYS
-NETWORKDAYS.INTL    | CATEGORY_DATE_AND_TIME         | **Not yet Implemented**
-NOMINAL             | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NOMINAL
-NORMDIST            | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
-NORMINV             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
-NORMSDIST           | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSDIST
-NORMSINV            | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
-NOT                 | CATEGORY_LOGICAL               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::NOT
-NOW                 | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATETIMENOW
-NPER                | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPER
-NPV                 | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPV
-NUMBERVALUE         | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::NUMBERVALUE
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+N                        | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::n
+NA                       | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::NA
+NEGBINOMDIST             | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NEGBINOMDIST
+NEGBINOM.DIST            | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+NETWORKDAYS              | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::NETWORKDAYS
+NETWORKDAYS.INTL         | CATEGORY_DATE_AND_TIME        | 2010          | **Not yet Implemented**
+NOMINAL                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NOMINAL
+NORMDIST                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
+NORM.DIST                | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMDIST
+NORMINV                  | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
+NORM.INV                 | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMINV
+NORMSDIST                | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSDIST
+NORM.S.DIST              | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+NORMSINV                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
+NORM.S.INV               | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::NORMSINV
+NOT                      | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::NOT
+NOW                      | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATETIMENOW
+NPER                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPER
+NPV                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::NPV
+NUMBERVALUE              | CATEGORY_TEXT_AND_DATA        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::NUMBERVALUE
 
 ## O
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-OCT2BIN             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOBIN
-OCT2DEC             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTODEC
-OCT2HEX             | CATEGORY_ENGINEERING           | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOHEX
-ODD                 | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ODD
-ODDFPRICE           | CATEGORY_FINANCIAL             | **Not yet Implemented**
-ODDFYIELD           | CATEGORY_FINANCIAL             | **Not yet Implemented**
-ODDLPRICE           | CATEGORY_FINANCIAL             | **Not yet Implemented**
-ODDLYIELD           | CATEGORY_FINANCIAL             | **Not yet Implemented**
-OFFSET              | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::OFFSET
-OR                  | CATEGORY_LOGICAL               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalOr
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+OCT2BIN                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOBIN
+OCT2DEC                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTODEC
+OCT2HEX                  | CATEGORY_ENGINEERING          |               | \PhpOffice\PhpSpreadsheet\Calculation\Engineering::OCTTOHEX
+ODD                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ODD
+ODDFPRICE                | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
+ODDFYIELD                | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
+ODDLPRICE                | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
+ODDLYIELD                | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
+OFFSET                   | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::OFFSET
+OR                       | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalOr
 
 ## P
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-PDURATION           | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PDURATION
-PEARSON             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
-PERCENTILE          | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
-PERCENTRANK         | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
-PERMUT              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERMUT
-PHONETIC            | CATEGORY_TEXT_AND_DATA         | **Not yet Implemented**
-PI                  | CATEGORY_MATH_AND_TRIG         | pi
-PMT                 | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PMT
-POISSON             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
-POWER               | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::POWER
-PPMT                | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PPMT
-PRICE               | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICE
-PRICEDISC           | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEDISC
-PRICEMAT            | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEMAT
-PROB                | CATEGORY_STATISTICAL           | **Not yet Implemented**
-PRODUCT             | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::PRODUCT
-PROPER              | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::PROPERCASE
-PV                  | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PV
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+PDURATION                | CATEGORY_FINANCIAL            | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PDURATION
+PEARSON                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::CORREL
+PERCENTILE               | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
+PERCENTILE.EXC           | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+PERCENTILE.INC           | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTILE
+PERCENTRANK              | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
+PERCENTRANK.EXC          | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+PERCENTRANK.INC          | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERCENTRANK
+PERMUT                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::PERMUT
+PERMUTATIONA             | CATEGORY_STATISTICAL          | 2013          | **Not yet Implemented**
+PHI                      | CATEGORY_STATISTICAL          | 2013          | **Not yet Implemented**
+PHONETIC                 | CATEGORY_TEXT_AND_DATA        |               | **Not yet Implemented**
+PI                       | CATEGORY_MATH_AND_TRIG        |               | pi
+PMT                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PMT
+POISSON                  | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
+POISSON.DIST             | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::POISSON
+POWER                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::POWER
+PPMT                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PPMT
+PRICE                    | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICE
+PRICEDISC                | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEDISC
+PRICEMAT                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PRICEMAT
+PROB                     | CATEGORY_STATISTICAL          |               | **Not yet Implemented**
+PRODUCT                  | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::PRODUCT
+PROPER                   | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::PROPERCASE
+PV                       | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::PV
 
 ## Q
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-QUARTILE            | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
-QUOTIENT            | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::QUOTIENT
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+QUARTILE                 | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
+QUARTILE.EXC             | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+QUARTILE.INC             | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::QUARTILE
+QUOTIENT                 | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::QUOTIENT
 
 ## R
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-RADIANS             | CATEGORY_MATH_AND_TRIG         | deg2rad
-RAND                | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
-RANDBETWEEN         | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
-RANK                | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
-RATE                | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RATE
-RECEIVED            | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RECEIVED
-REPLACE             | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
-REPLACEB            | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
-REPT                | CATEGORY_TEXT_AND_DATA         | str_repeat
-RIGHT               | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
-RIGHTB              | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
-ROMAN               | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROMAN
-ROUND               | CATEGORY_MATH_AND_TRIG         | round
-ROUNDDOWN           | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDDOWN
-ROUNDUP             | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDUP
-ROW                 | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROW
-ROWS                | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROWS
-RRI                 | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RRI
-RSQ                 | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RSQ
-RTD                 | CATEGORY_LOOKUP_AND_REFERENCE  | **Not yet Implemented**
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+RADIANS                  | CATEGORY_MATH_AND_TRIG        |               | deg2rad
+RAND                     | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
+RANDARRAY                | CATEGORY_MATH_AND_TRIG        | Office 365    | **Not yet Implemented**
+RANDBETWEEN              | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::RAND
+RANK                     | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
+RANK.AVG                 | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+RANK.EQ                  | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RANK
+RATE                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RATE
+RECEIVED                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RECEIVED
+REPLACE                  | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
+REPLACEB                 | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::REPLACE
+REPT                     | CATEGORY_TEXT_AND_DATA        |               | str_repeat
+RIGHT                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
+RIGHTB                   | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RIGHT
+ROMAN                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROMAN
+ROUND                    | CATEGORY_MATH_AND_TRIG        |               | round
+ROUNDDOWN                | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDDOWN
+ROUNDUP                  | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::ROUNDUP
+ROW                      | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROW
+ROWS                     | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::ROWS
+RRI                      | CATEGORY_FINANCIAL            | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Financial::RRI
+RSQ                      | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::RSQ
+RTD                      | CATEGORY_LOOKUP_AND_REFERENCE |               | **Not yet Implemented**
 
 ## S
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-SEARCH              | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
-SEARCHB             | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
-SEC                 | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SEC
-SECH                | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SECH
-SECOND              | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::SECOND
-SERIESSUM           | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SERIESSUM
-SHEET               | CATEGORY_INFORMATION           | **Not yet Implemented**
-SHEETS              | CATEGORY_INFORMATION           | **Not yet Implemented**
-SIGN                | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SIGN
-SIN                 | CATEGORY_MATH_AND_TRIG         | sin
-SINH                | CATEGORY_MATH_AND_TRIG         | sinh
-SKEW                | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SKEW
-SLN                 | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SLN
-SLOPE               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SLOPE
-SMALL               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SMALL
-SQRT                | CATEGORY_MATH_AND_TRIG         | sqrt
-SQRTPI              | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SQRTPI
-STANDARDIZE         | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STANDARDIZE
-STDEV               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
-STDEV.P             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
-STDEV.S             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
-STDEVA              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVA
-STDEVP              | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
-STDEVPA             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVPA
-STEYX               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STEYX
-SUBSTITUTE          | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SUBSTITUTE
-SUBTOTAL            | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUBTOTAL
-SUM                 | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUM
-SUMIF               | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIF
-SUMIFS              | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIFS
-SUMPRODUCT          | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMPRODUCT
-SUMSQ               | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMSQ
-SUMX2MY2            | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2MY2
-SUMX2PY2            | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2PY2
-SUMXMY2             | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMXMY2
-SWITCH              | CATEGORY_LOGICAL               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementSwitch
-SYD                 | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SYD
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+SEARCH                   | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
+SEARCHB                  | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SEARCHINSENSITIVE
+SEC                      | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SEC
+SECH                     | CATEGORY_MATH_AND_TRIG        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SECH
+SECOND                   | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::SECOND
+SEQUENCE                 | CATEGORY_MATH_AND_TRIG        | Office 365    | **Not yet Implemented**
+SERIESSUM                | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SERIESSUM
+SHEET                    | CATEGORY_INFORMATION          | 2013          | **Not yet Implemented**
+SHEETS                   | CATEGORY_INFORMATION          | 2013          | **Not yet Implemented**
+SIGN                     | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SIGN
+SIN                      | CATEGORY_MATH_AND_TRIG        |               | sin
+SINH                     | CATEGORY_MATH_AND_TRIG        |               | sinh
+SKEW                     | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SKEW
+SKEW.P                   | CATEGORY_STATISTICAL          | 2013          | **Not yet Implemented**
+SLN                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SLN
+SLOPE                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SLOPE
+SMALL                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::SMALL
+SORT                     | CATEGORY_LOOKUP_AND_REFERENCE | Office 365    | **Not yet Implemented**
+SORTBY                   | CATEGORY_LOOKUP_AND_REFERENCE | Office 365    | **Not yet Implemented**
+SQRT                     | CATEGORY_MATH_AND_TRIG        |               | sqrt
+SQRTPI                   | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SQRTPI
+STANDARDIZE              | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STANDARDIZE
+STDEV                    | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
+STDEVA                   | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVA
+STDEVP                   | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
+STDEV.P                  | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVP
+STDEVPA                  | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEVPA
+STDEV.S                  | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STDEV
+STEYX                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::STEYX
+SUBSTITUTE               | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::SUBSTITUTE
+SUBTOTAL                 | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUBTOTAL
+SUM                      | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUM
+SUMIF                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIF
+SUMIFS                   | CATEGORY_MATH_AND_TRIG        | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMIFS
+SUMPRODUCT               | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMPRODUCT
+SUMSQ                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMSQ
+SUMX2MY2                 | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2MY2
+SUMX2PY2                 | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMX2PY2
+SUMXMY2                  | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::SUMXMY2
+SWITCH                   | CATEGORY_LOGICAL              | 2016          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::statementSwitch
+SYD                      | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::SYD
 
 ## T
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-T                   | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RETURNSTRING
-TAN                 | CATEGORY_MATH_AND_TRIG         | tan
-TANH                | CATEGORY_MATH_AND_TRIG         | tanh
-TBILLEQ             | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLEQ
-TBILLPRICE          | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLPRICE
-TBILLYIELD          | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLYIELD
-TDIST               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TDIST
-TEXT                | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTFORMAT
-TEXTJOIN            | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTJOIN
-TIME                | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIME
-TIMEVALUE           | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIMEVALUE
-TINV                | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
-TODAY               | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATENOW
-TRANSPOSE           | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::TRANSPOSE
-TREND               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TREND
-TRIM                | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMSPACES
-TRIMMEAN            | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TRIMMEAN
-TRUE                | CATEGORY_LOGICAL               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::TRUE
-TRUNC               | CATEGORY_MATH_AND_TRIG         | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::TRUNC
-TTEST               | CATEGORY_STATISTICAL           | **Not yet Implemented**
-TYPE                | CATEGORY_INFORMATION           | \PhpOffice\PhpSpreadsheet\Calculation\Functions::TYPE
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+T                        | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::RETURNSTRING
+TAN                      | CATEGORY_MATH_AND_TRIG        |               | tan
+TANH                     | CATEGORY_MATH_AND_TRIG        |               | tanh
+TBILLEQ                  | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLEQ
+TBILLPRICE               | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLPRICE
+TBILLYIELD               | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::TBILLYIELD
+TDIST                    | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TDIST
+T.DIST                   | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+T.DIST.2T                | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+T.DIST.RT                | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+TEXT                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTFORMAT
+TEXTJOIN                 | CATEGORY_TEXT_AND_DATA        | 2019          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TEXTJOIN
+TIME                     | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIME
+TIMEVALUE                | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::TIMEVALUE
+TINV                     | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
+T.INV                    | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TINV
+T.INV.2T                 | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+TODAY                    | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::DATENOW
+TRANSPOSE                | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::TRANSPOSE
+TREND                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TREND
+TRIM                     | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::TRIMSPACES
+TRIMMEAN                 | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::TRIMMEAN
+TRUE                     | CATEGORY_LOGICAL              |               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::TRUE
+TRUNC                    | CATEGORY_MATH_AND_TRIG        |               | \PhpOffice\PhpSpreadsheet\Calculation\MathTrig::TRUNC
+TTEST                    | CATEGORY_STATISTICAL          | Compatibility | **Not yet Implemented**
+T.TEST                   | CATEGORY_STATISTICAL          | 2010          | **Not yet Implemented**
+TYPE                     | CATEGORY_INFORMATION          |               | \PhpOffice\PhpSpreadsheet\Calculation\Functions::TYPE
 
 ## U
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-UNICHAR             | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
-UNICODE             | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
-UPPER               | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::UPPERCASE
-USDOLLAR            | CATEGORY_FINANCIAL             | **Not yet Implemented**
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+UNICHAR                  | CATEGORY_TEXT_AND_DATA        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::CHARACTER
+UNICODE                  | CATEGORY_TEXT_AND_DATA        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\TextData::ASCIICODE
+UNIQUE                   | CATEGORY_LOOKUP_AND_REFERENCE | Office 365    | **Not yet Implemented**
+UPPER                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::UPPERCASE
+USDOLLAR                 | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
 
 ## V
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-VALUE               | CATEGORY_TEXT_AND_DATA         | \PhpOffice\PhpSpreadsheet\Calculation\TextData::VALUE
-VAR                 | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
-VAR.P               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
-VAR.S               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
-VARA                | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARA
-VARP                | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
-VARPA               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARPA
-VDB                 | CATEGORY_FINANCIAL             | **Not yet Implemented**
-VLOOKUP             | CATEGORY_LOOKUP_AND_REFERENCE  | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::VLOOKUP
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+VALUE                    | CATEGORY_TEXT_AND_DATA        |               | \PhpOffice\PhpSpreadsheet\Calculation\TextData::VALUE
+VAR                      | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
+VARA                     | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARA
+VARP                     | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
+VAR.P                    | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARP
+VARPA                    | CATEGORY_STATISTICAL          |               | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARPA
+VAR.S                    | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::VARFunc
+VDB                      | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
+VLOOKUP                  | CATEGORY_LOOKUP_AND_REFERENCE |               | \PhpOffice\PhpSpreadsheet\Calculation\LookupRef::VLOOKUP
 
 ## W
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-WEEKDAY             | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKDAY
-WEEKNUM             | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKNUM
-WEIBULL             | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
-WORKDAY             | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WORKDAY
-WORKDAY.INTL        | CATEGORY_DATE_AND_TIME         | **Not yet Implemented**
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+WEBSERVICE               | CATEGORY_TEXT_AND_DATA        | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Web::WEBSERVICE
+WEEKDAY                  | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKDAY
+WEEKNUM                  | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WEEKNUM
+WEIBULL                  | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
+WEIBULL.DIST             | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::WEIBULL
+WORKDAY                  | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::WORKDAY
+WORKDAY.INTL             | CATEGORY_DATE_AND_TIME        | 2010          | **Not yet Implemented**
 
 ## X
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-XIRR                | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XIRR
-XNPV                | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XNPV
-XOR                 | CATEGORY_LOGICAL               | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalXor
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+XIRR                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XIRR
+XLOOKUP                  | CATEGORY_LOOKUP_AND_REFERENCE | Office 365    | **Not yet Implemented**
+XMATCH                   | CATEGORY_LOOKUP_AND_REFERENCE | Office 365    | **Not yet Implemented**
+XNPV                     | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::XNPV
+XOR                      | CATEGORY_LOGICAL              | 2013          | \PhpOffice\PhpSpreadsheet\Calculation\Logical::logicalXor
 
 ## Y
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-YEAR                | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEAR
-YEARFRAC            | CATEGORY_DATE_AND_TIME         | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEARFRAC
-YIELD               | CATEGORY_FINANCIAL             | **Not yet Implemented**
-YIELDDISC           | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDDISC
-YIELDMAT            | CATEGORY_FINANCIAL             | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDMAT
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+YEAR                     | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEAR
+YEARFRAC                 | CATEGORY_DATE_AND_TIME        |               | \PhpOffice\PhpSpreadsheet\Calculation\DateTime::YEARFRAC
+YIELD                    | CATEGORY_FINANCIAL            |               | **Not yet Implemented**
+YIELDDISC                | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDDISC
+YIELDMAT                 | CATEGORY_FINANCIAL            |               | \PhpOffice\PhpSpreadsheet\Calculation\Financial::YIELDMAT
 
 ## Z
 
-Excel Function      | Category                       | PhpSpreadsheet Function
---------------------|--------------------------------|-------------------------------------------
-ZTEST               | CATEGORY_STATISTICAL           | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST
+Excel Function           | Category                      | Excel Version | PhpSpreadsheet Function 
+-------------------------|-------------------------------|---------------|-------------------------
+ZTEST                    | CATEGORY_STATISTICAL          | Compatibility | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST
+Z.TEST                   | CATEGORY_STATISTICAL          | 2010          | \PhpOffice\PhpSpreadsheet\Calculation\Statistical::ZTEST

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -253,6 +253,11 @@ class Calculation
             'functionCall' => [LookupRef::class, 'cellAddress'],
             'argumentCount' => '2-5',
         ],
+        'AGGREGATE' => [
+            'category' => Category::CATEGORY_MATH_AND_TRIG,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3+',
+        ],
         'AMORDEGRC' => [
             'category' => Category::CATEGORY_FINANCIAL,
             'functionCall' => [Financial::class, 'AMORDEGRC'],
@@ -368,7 +373,17 @@ class Calculation
             'functionCall' => [Statistical::class, 'BETADIST'],
             'argumentCount' => '3-5',
         ],
+        'BETA.DIST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '4-6',
+        ],
         'BETAINV' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'BETAINV'],
+            'argumentCount' => '3-5',
+        ],
+        'BETA.INV' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'BETAINV'],
             'argumentCount' => '3-5',
@@ -392,6 +407,21 @@ class Calculation
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'BINOMDIST'],
             'argumentCount' => '4',
+        ],
+        'BINOM.DIST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'BINOMDIST'],
+            'argumentCount' => '4',
+        ],
+        'BINOM.DIST.RANGE' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3,4',
+        ],
+        'BINOM.INV' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3',
         ],
         'BITAND' => [
             'category' => Category::CATEGORY_ENGINEERING,
@@ -423,6 +453,16 @@ class Calculation
             'functionCall' => [MathTrig::class, 'CEILING'],
             'argumentCount' => '2',
         ],
+        'CEILING.MATH' => [
+            'category' => Category::CATEGORY_MATH_AND_TRIG,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3',
+        ],
+        'CEILING.PRECISE' => [
+            'category' => Category::CATEGORY_MATH_AND_TRIG,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
+        ],
         'CELL' => [
             'category' => Category::CATEGORY_INFORMATION,
             'functionCall' => [Functions::class, 'DUMMY'],
@@ -438,12 +478,37 @@ class Calculation
             'functionCall' => [Statistical::class, 'CHIDIST'],
             'argumentCount' => '2',
         ],
+        'CHISQ.DIST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3',
+        ],
+        'CHISQ.DIST.RT' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'CHIDIST'],
+            'argumentCount' => '2',
+        ],
         'CHIINV' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'CHIINV'],
             'argumentCount' => '2',
         ],
+        'CHISQ.INV' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
+        ],
+        'CHISQ.INV.RT' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'CHIINV'],
+            'argumentCount' => '2',
+        ],
         'CHITEST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
+        ],
+        'CHISQ.TEST' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Functions::class, 'DUMMY'],
             'argumentCount' => '2',
@@ -479,6 +544,11 @@ class Calculation
             'functionCall' => [MathTrig::class, 'COMBIN'],
             'argumentCount' => '2',
         ],
+        'COMBINA' => [
+            'category' => Category::CATEGORY_MATH_AND_TRIG,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
+        ],
         'COMPLEX' => [
             'category' => Category::CATEGORY_ENGINEERING,
             'functionCall' => [Engineering::class, 'COMPLEX'],
@@ -497,6 +567,16 @@ class Calculation
         'CONFIDENCE' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'CONFIDENCE'],
+            'argumentCount' => '3',
+        ],
+        'CONFIDENCE.NORM' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'CONFIDENCE'],
+            'argumentCount' => '3',
+        ],
+        'CONFIDENCE.T' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
             'argumentCount' => '3',
         ],
         'CONVERT' => [
@@ -587,6 +667,16 @@ class Calculation
         'COVAR' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'COVAR'],
+            'argumentCount' => '2',
+        ],
+        'COVARIANCE.P' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'COVAR'],
+            'argumentCount' => '2',
+        ],
+        'COVARIANCE.S' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
             'argumentCount' => '2',
         ],
         'CRITBINOM' => [
@@ -689,6 +779,11 @@ class Calculation
             'functionCall' => [Financial::class, 'DB'],
             'argumentCount' => '4,5',
         ],
+        'DBCS' => [
+            'category' => Category::CATEGORY_TEXT_AND_DATA,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '1',
+        ],
         'DCOUNT' => [
             'category' => Category::CATEGORY_DATABASE,
             'functionCall' => [Database::class, 'DCOUNT'],
@@ -718,6 +813,11 @@ class Calculation
             'category' => Category::CATEGORY_ENGINEERING,
             'functionCall' => [Engineering::class, 'DECTOOCT'],
             'argumentCount' => '1,2',
+        ],
+        'DECIMAL' => [
+            'category' => Category::CATEGORY_MATH_AND_TRIG,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
         ],
         'DEGREES' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
@@ -814,6 +914,11 @@ class Calculation
             'functionCall' => [Financial::class, 'EFFECT'],
             'argumentCount' => '2',
         ],
+        'ENCODEURL' => [
+            'category' => Category::CATEGORY_WEB,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '1',
+        ],
         'EOMONTH' => [
             'category' => Category::CATEGORY_DATE_AND_TIME,
             'functionCall' => [DateTime::class, 'EOMONTH'],
@@ -864,6 +969,11 @@ class Calculation
             'functionCall' => [Statistical::class, 'EXPONDIST'],
             'argumentCount' => '3',
         ],
+        'EXPON.DIST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'EXPONDIST'],
+            'argumentCount' => '3',
+        ],
         'FACT' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
             'functionCall' => [MathTrig::class, 'FACT'],
@@ -884,6 +994,26 @@ class Calculation
             'functionCall' => [Functions::class, 'DUMMY'],
             'argumentCount' => '3',
         ],
+        'F.DIST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '4',
+        ],
+        'F.DIST.RT' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3',
+        ],
+        'FILTER' => [
+            'category' => Category::CATEGORY_LOOKUP_AND_REFERENCE,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3+',
+        ],
+        'FILTERXML' => [
+            'category' => Category::CATEGORY_WEB,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
+        ],
         'FIND' => [
             'category' => Category::CATEGORY_TEXT_AND_DATA,
             'functionCall' => [TextData::class, 'SEARCHSENSITIVE'],
@@ -895,6 +1025,16 @@ class Calculation
             'argumentCount' => '2,3',
         ],
         'FINV' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3',
+        ],
+        'F.INV' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3',
+        ],
+        'F.INV.RT' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Functions::class, 'DUMMY'],
             'argumentCount' => '3',
@@ -934,6 +1074,31 @@ class Calculation
             'functionCall' => [Statistical::class, 'FORECAST'],
             'argumentCount' => '3',
         ],
+        'FORECAST.ETS' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3-6',
+        ],
+        'FORECAST.ETS.CONFINT' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3-6',
+        ],
+        'FORECAST.ETS.SEASONALITY' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2-4',
+        ],
+        'FORECAST.ETS.STAT' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3-6',
+        ],
+        'FORECAST.LINEAR' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'FORECAST'],
+            'argumentCount' => '3',
+        ],
         'FORMULATEXT' => [
             'category' => Category::CATEGORY_LOOKUP_AND_REFERENCE,
             'functionCall' => [LookupRef::class, 'FORMULATEXT'],
@@ -951,6 +1116,11 @@ class Calculation
             'functionCall' => [Functions::class, 'DUMMY'],
             'argumentCount' => '2',
         ],
+        'F.TEST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
+        ],
         'FV' => [
             'category' => Category::CATEGORY_FINANCIAL,
             'functionCall' => [Financial::class, 'FV'],
@@ -961,7 +1131,17 @@ class Calculation
             'functionCall' => [Financial::class, 'FVSCHEDULE'],
             'argumentCount' => '2',
         ],
+        'GAMMA' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '1',
+        ],
         'GAMMADIST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'GAMMADIST'],
+            'argumentCount' => '4',
+        ],
+        'GAMMA.DIST' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'GAMMADIST'],
             'argumentCount' => '4',
@@ -971,9 +1151,24 @@ class Calculation
             'functionCall' => [Statistical::class, 'GAMMAINV'],
             'argumentCount' => '3',
         ],
+        'GAMMA.INV' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'GAMMAINV'],
+            'argumentCount' => '3',
+        ],
         'GAMMALN' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'GAMMALN'],
+            'argumentCount' => '1',
+        ],
+        'GAMMALN.PRECISE' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'GAMMALN'],
+            'argumentCount' => '1',
+        ],
+        'GAUSS' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
             'argumentCount' => '1',
         ],
         'GCD' => [
@@ -1275,6 +1470,11 @@ class Calculation
             'functionCall' => [Functions::class, 'isNumber'],
             'argumentCount' => '1',
         ],
+        'ISO.CEILING' => [
+            'category' => Category::CATEGORY_MATH_AND_TRIG,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '1,2',
+        ],
         'ISODD' => [
             'category' => Category::CATEGORY_INFORMATION,
             'functionCall' => [Functions::class, 'isOdd'],
@@ -1373,6 +1573,16 @@ class Calculation
         'LOGNORMDIST' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'LOGNORMDIST'],
+            'argumentCount' => '3',
+        ],
+        'LOGNORM.DIST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '4',
+        ],
+        'LOGNORM.INV' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'LOGINV'],
             'argumentCount' => '3',
         ],
         'LOOKUP' => [
@@ -1480,6 +1690,11 @@ class Calculation
             'functionCall' => [Statistical::class, 'MODE'],
             'argumentCount' => '1+',
         ],
+        'MODE.MULT' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '1+',
+        ],
         'MODE.SNGL' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'MODE'],
@@ -1500,6 +1715,11 @@ class Calculation
             'functionCall' => [MathTrig::class, 'MULTINOMIAL'],
             'argumentCount' => '1+',
         ],
+        'MUNIT' => [
+            'category' => Category::CATEGORY_MATH_AND_TRIG,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '1',
+        ],
         'N' => [
             'category' => Category::CATEGORY_INFORMATION,
             'functionCall' => [Functions::class, 'n'],
@@ -1514,6 +1734,11 @@ class Calculation
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'NEGBINOMDIST'],
             'argumentCount' => '3',
+        ],
+        'NEGBINOM.DIST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '4',
         ],
         'NETWORKDAYS' => [
             'category' => Category::CATEGORY_DATE_AND_TIME,
@@ -1535,7 +1760,17 @@ class Calculation
             'functionCall' => [Statistical::class, 'NORMDIST'],
             'argumentCount' => '4',
         ],
+        'NORM.DIST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'NORMDIST'],
+            'argumentCount' => '4',
+        ],
         'NORMINV' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'NORMINV'],
+            'argumentCount' => '3',
+        ],
+        'NORM.INV' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'NORMINV'],
             'argumentCount' => '3',
@@ -1545,7 +1780,17 @@ class Calculation
             'functionCall' => [Statistical::class, 'NORMSDIST'],
             'argumentCount' => '1',
         ],
+        'NORM.S.DIST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '1,2',
+        ],
         'NORMSINV' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'NORMSINV'],
+            'argumentCount' => '1',
+        ],
+        'NORM.S.INV' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'NORMSINV'],
             'argumentCount' => '1',
@@ -1642,7 +1887,27 @@ class Calculation
             'functionCall' => [Statistical::class, 'PERCENTILE'],
             'argumentCount' => '2',
         ],
+        'PERCENTILE.EXC' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
+        ],
+        'PERCENTILE.INC' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'PERCENTILE'],
+            'argumentCount' => '2',
+        ],
         'PERCENTRANK' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'PERCENTRANK'],
+            'argumentCount' => '2,3',
+        ],
+        'PERCENTRANK.EXC' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2,3',
+        ],
+        'PERCENTRANK.INC' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'PERCENTRANK'],
             'argumentCount' => '2,3',
@@ -1652,8 +1917,18 @@ class Calculation
             'functionCall' => [Statistical::class, 'PERMUT'],
             'argumentCount' => '2',
         ],
+        'PERMUTATIONA' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
+        ],
         'PHONETIC' => [
             'category' => Category::CATEGORY_TEXT_AND_DATA,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '1',
+        ],
+        'PHI' => [
+            'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Functions::class, 'DUMMY'],
             'argumentCount' => '1',
         ],
@@ -1668,6 +1943,11 @@ class Calculation
             'argumentCount' => '3-5',
         ],
         'POISSON' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'POISSON'],
+            'argumentCount' => '3',
+        ],
+        'POISSON.DIST' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'POISSON'],
             'argumentCount' => '3',
@@ -1722,6 +2002,16 @@ class Calculation
             'functionCall' => [Statistical::class, 'QUARTILE'],
             'argumentCount' => '2',
         ],
+        'QUARTILE.EXC' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
+        ],
+        'QUARTILE.INC' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'QUARTILE'],
+            'argumentCount' => '2',
+        ],
         'QUOTIENT' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
             'functionCall' => [MathTrig::class, 'QUOTIENT'],
@@ -1737,12 +2027,27 @@ class Calculation
             'functionCall' => [MathTrig::class, 'RAND'],
             'argumentCount' => '0',
         ],
+        'RANDARRAY' => [
+            'category' => Category::CATEGORY_MATH_AND_TRIG,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '0-5',
+        ],
         'RANDBETWEEN' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
             'functionCall' => [MathTrig::class, 'RAND'],
             'argumentCount' => '2',
         ],
         'RANK' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'RANK'],
+            'argumentCount' => '2,3',
+        ],
+        'RANK.AVG' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2,3',
+        ],
+        'RANK.EQ' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'RANK'],
             'argumentCount' => '2,3',
@@ -1853,6 +2158,11 @@ class Calculation
             'functionCall' => [DateTime::class, 'SECOND'],
             'argumentCount' => '1',
         ],
+        'SEQUENCE' => [
+            'category' => Category::CATEGORY_MATH_AND_TRIG,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
+        ],
         'SERIESSUM' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
             'functionCall' => [MathTrig::class, 'SERIESSUM'],
@@ -1888,6 +2198,11 @@ class Calculation
             'functionCall' => [Statistical::class, 'SKEW'],
             'argumentCount' => '1+',
         ],
+        'SKEW.P' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '1+',
+        ],
         'SLN' => [
             'category' => Category::CATEGORY_FINANCIAL,
             'functionCall' => [Financial::class, 'SLN'],
@@ -1902,6 +2217,16 @@ class Calculation
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'SMALL'],
             'argumentCount' => '2',
+        ],
+        'SORT' => [
+            'category' => Category::CATEGORY_LOOKUP_AND_REFERENCE,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '1+',
+        ],
+        'SORTBY' => [
+            'category' => Category::CATEGORY_LOOKUP_AND_REFERENCE,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2+',
         ],
         'SQRT' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
@@ -2049,6 +2374,21 @@ class Calculation
             'functionCall' => [Statistical::class, 'TDIST'],
             'argumentCount' => '3',
         ],
+        'T.DIST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3',
+        ],
+        'T.DIST.2T' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
+        ],
+        'T.DIST.RT' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2',
+        ],
         'TEXT' => [
             'category' => Category::CATEGORY_TEXT_AND_DATA,
             'functionCall' => [TextData::class, 'TEXTFORMAT'],
@@ -2072,6 +2412,16 @@ class Calculation
         'TINV' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'TINV'],
+            'argumentCount' => '2',
+        ],
+        'T.INV' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'TINV'],
+            'argumentCount' => '2',
+        ],
+        'T.INV.2T' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
             'argumentCount' => '2',
         ],
         'TODAY' => [
@@ -2114,6 +2464,11 @@ class Calculation
             'functionCall' => [Functions::class, 'DUMMY'],
             'argumentCount' => '4',
         ],
+        'T.TEST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '4',
+        ],
         'TYPE' => [
             'category' => Category::CATEGORY_INFORMATION,
             'functionCall' => [Functions::class, 'TYPE'],
@@ -2128,6 +2483,11 @@ class Calculation
             'category' => Category::CATEGORY_TEXT_AND_DATA,
             'functionCall' => [TextData::class, 'ASCIICODE'],
             'argumentCount' => '1',
+        ],
+        'UNIQUE' => [
+            'category' => Category::CATEGORY_LOOKUP_AND_REFERENCE,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '1+',
         ],
         'UPPER' => [
             'category' => Category::CATEGORY_TEXT_AND_DATA,
@@ -2204,6 +2564,11 @@ class Calculation
             'functionCall' => [Statistical::class, 'WEIBULL'],
             'argumentCount' => '4',
         ],
+        'WEIBULL.DIST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'WEIBULL'],
+            'argumentCount' => '4',
+        ],
         'WORKDAY' => [
             'category' => Category::CATEGORY_DATE_AND_TIME,
             'functionCall' => [DateTime::class, 'WORKDAY'],
@@ -2219,10 +2584,20 @@ class Calculation
             'functionCall' => [Financial::class, 'XIRR'],
             'argumentCount' => '2,3',
         ],
+        'XLOOKUP' => [
+            'category' => Category::CATEGORY_LOOKUP_AND_REFERENCE,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '3-6',
+        ],
         'XNPV' => [
             'category' => Category::CATEGORY_FINANCIAL,
             'functionCall' => [Financial::class, 'XNPV'],
             'argumentCount' => '3',
+        ],
+        'XMATCH' => [
+            'category' => Category::CATEGORY_LOOKUP_AND_REFERENCE,
+            'functionCall' => [Functions::class, 'DUMMY'],
+            'argumentCount' => '2,3',
         ],
         'XOR' => [
             'category' => Category::CATEGORY_LOGICAL,
@@ -2255,6 +2630,11 @@ class Calculation
             'argumentCount' => '5,6',
         ],
         'ZTEST' => [
+            'category' => Category::CATEGORY_STATISTICAL,
+            'functionCall' => [Statistical::class, 'ZTEST'],
+            'argumentCount' => '2-3',
+        ],
+        'Z.TEST' => [
             'category' => Category::CATEGORY_STATISTICAL,
             'functionCall' => [Statistical::class, 'ZTEST'],
             'argumentCount' => '2-3',


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] a documentation update
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [X] Documentation is updated as necessary

### Why this change is needed?

Reconcile discrepancies between the documented lists of functions (by category and alphabetic), and the Calculation engine. Update them all to reflect the complete set of current standard Excel functions (including those introduced in "Office 365").

All existing Excel functions are now defined within the Calculation Engine code, even if tagged as "Not Yet Implemented". Where a new Excel function has replaced an older one, both are defined, and if this is simply an alias, then it is flagged as implemented if the old function had been implemented (e.g. `CHISQ.DIST.RT()` replacing `CHIDIST()`). If the replacement function has a different signature (e.g. `LOGNORMDIST()` has been replaced by `LOGNORM.DIST()`, but with a new optional argument), then the new function is treated as "Not Yet Implemented" until the change of functionality to handle the additional argument has been implemented. Completely new functions are simply flagged as "Not Yet Implemented".

In many cases, the new functions (or the behavioural changes) are easy to implement,but outside the scope of this PR
  