### PR TITLE
Remove cache from cells collection on (de)serialization process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- Nothing.
+- Remove cache from cells collection on serialization [#1590](https://github.com/PHPOffice/PhpSpreadsheet/pull/1590).
 
 ## 1.14.1 - 2020-07-19
 


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

When the cache adapter contains a `Closure` function (like [Psr16Cache from Symfony](https://github.com/symfony/symfony/blob/28e072a8ec95a9fd574d85d45d3fe16160913286/src/Symfony/Component/Cache/Psr16Cache.php#L44)), the serialization process of the cells collection fails wih a PHP error: « Serialization of 'Closure' is not allowed »

In addition, when using several thousand cells, the default memory adapter uses too much memory due to the serialization and deserialization of the entire memory cache (more than 4GB).

Without testing, and hypothetically, the problem can also occur when serializing resources, such as a Redis connection.

Removing the cache during (de)serialization saves a lot of resources.