### PR TITLE
add array formula data type

### DIFF
--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -228,6 +228,10 @@ class Cell
                 $this->value = DataType::checkErrorCode($pValue);
 
                 break;
+            case DataType::TYPE_FORMULA_ARRAY:
+                $this->value = (string)$pValue;
+
+                break;
             default:
                 throw new Exception('Invalid datatype: ' . $pDataType);
 

--- a/src/PhpSpreadsheet/Cell/DataType.php
+++ b/src/PhpSpreadsheet/Cell/DataType.php
@@ -16,6 +16,7 @@ class DataType
     const TYPE_NULL = 'null';
     const TYPE_INLINE = 'inlineStr';
     const TYPE_ERROR = 'e';
+    const TYPE_FORMULA_ARRAY = 't';
 
     /**
      * List of error codes.

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1191,6 +1191,16 @@ class Worksheet extends WriterPart
                     $this->writeCellBoolean($objWriter, $mappedType, $cellValue);
 
                     break;
+                case 't':            // Array Formula
+                   $objWriter->startElement('f');
+                   $objWriter->writeAttribute('t', 'array');
+                   $objWriter->writeAttribute('ref', $pCellAddress);
+                   $objWriter->writeAttribute('aca', '1');
+                   $objWriter->writeAttribute('ca', '1');
+                   $objWriter->text($cellValue);
+                   $objWriter->endElement();
+
+                   break;
                 case 'e':            // Error
                     $this->writeCellError($objWriter, $mappedType, $cellValue);
             }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
to add array formula data type when formatting a cell