### PR TITLE
Return an ExcelException object rather than a string to represent MS Excel formula errors

### DIFF
--- a/src/PhpSpreadsheet/Calculation/ExcelException.php
+++ b/src/PhpSpreadsheet/Calculation/ExcelException.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Calculation;
+
+use PhpOffice\PhpSpreadsheet\Exception as SpreadsheetException;
+
+class ExcelException
+{
+    public const EXCEL_ERROR_NULL = '#NULL!';
+    public const EXCEL_ERROR_DIVISION_BY_ZERO = '#DIV/0!';
+    public const EXCEL_ERROR_VALUE = '#VALUE!';
+    public const EXCEL_ERROR_REFERENCE = '#REF!';
+    public const EXCEL_ERROR_NAME = '#NAME?';
+    public const EXCEL_ERROR_NUM = '#NUM!';
+    public const EXCEL_ERROR_NA = '#N/A';
+    public const EXCEL_ERROR_GETTING_DATA = '#GETTING_DATA';
+
+    public const ERROR_CODES = [
+        self::EXCEL_ERROR_NULL => 1,
+        self::EXCEL_ERROR_DIVISION_BY_ZERO => 2,
+        self::EXCEL_ERROR_VALUE => 3,
+        self::EXCEL_ERROR_REFERENCE => 4,
+        self::EXCEL_ERROR_NAME => 5,
+        self::EXCEL_ERROR_NUM => 6,
+        self::EXCEL_ERROR_NA => 7,
+        self::EXCEL_ERROR_GETTING_DATA => 8,
+    ];
+
+    protected const ERROR_TYPES = [
+        self::EXCEL_ERROR_NULL => [self::class, 'NULL'],
+        self::EXCEL_ERROR_DIVISION_BY_ZERO => [self::class, 'DIV0'],
+        self::EXCEL_ERROR_VALUE => [self::class, 'VALUE'],
+        self::EXCEL_ERROR_REFERENCE => [self::class, 'REF'],
+        self::EXCEL_ERROR_NAME => [self::class, 'NAME'],
+        self::EXCEL_ERROR_NUM => [self::class, 'NUM'],
+        self::EXCEL_ERROR_NA => [self::class, 'NA'],
+        self::EXCEL_ERROR_GETTING_DATA => [self::class, 'DATA'],
+    ];
+
+    private $errorName;
+
+    private $code;
+
+    private function __construct($errorName)
+    {
+        $this->errorName = $errorName;
+        $this->code = self::ERROR_CODES[$errorName];
+    }
+
+    public static function fromErrorName(string $value): self
+    {
+        if (!in_array($value, array_keys(self::ERROR_TYPES), true)) {
+            throw new SpreadsheetException(sprintf('Invalid Excel Error Code "%s"', $value));
+        }
+
+        $errorType = self::ERROR_TYPES[$value];
+        return $errorType();
+    }
+
+    public static function NULL(): self
+    {
+        return new self(self::EXCEL_ERROR_NULL);
+    }
+
+    public static function DIV0(): self
+    {
+        return new self(self::EXCEL_ERROR_DIVISION_BY_ZERO);
+    }
+
+    public static function VALUE(): self
+    {
+        return new self(self::EXCEL_ERROR_VALUE);
+    }
+
+    public static function REF(): self
+    {
+        return new self(self::EXCEL_ERROR_REFERENCE);
+    }
+
+    public static function NAME(): self
+    {
+        return new self(self::EXCEL_ERROR_NAME);
+    }
+
+    public static function NUM(): self
+    {
+        return new self(self::EXCEL_ERROR_NUM);
+    }
+
+    public static function NA(): self
+    {
+        return new self(self::EXCEL_ERROR_NA);
+    }
+
+    public static function DATA(): self
+    {
+        return new self(self::EXCEL_ERROR_GETTING_DATA);
+    }
+
+    public function code(): int
+    {
+        return $this->code;
+    }
+
+    public function errorName(): string
+    {
+        return $this->errorName;
+    }
+
+    public function __toString()
+    {
+        return $this->errorName;
+    }
+}

--- a/src/PhpSpreadsheet/Calculation/Financial.php
+++ b/src/PhpSpreadsheet/Calculation/Financial.php
@@ -388,10 +388,12 @@ class Financial
         $frequency = (int) Functions::flattenSingleValue($frequency);
         $basis = ($basis === null) ? 0 : (int) Functions::flattenSingleValue($basis);
 
-        if (is_string($settlement = DateTime::getDateValue($settlement))) {
+        $settlement = DateTime::getDateValue($settlement);
+        if ($settlement instanceof ExcelException) {
             return Functions::VALUE();
         }
-        if (is_string($maturity = DateTime::getDateValue($maturity))) {
+        $maturity = DateTime::getDateValue($maturity);
+        if ($maturity instanceof ExcelException) {
             return Functions::VALUE();
         }
 
@@ -447,10 +449,12 @@ class Financial
         $frequency = (int) Functions::flattenSingleValue($frequency);
         $basis = ($basis === null) ? 0 : (int) Functions::flattenSingleValue($basis);
 
-        if (is_string($settlement = DateTime::getDateValue($settlement))) {
+        $settlement = DateTime::getDateValue($settlement);
+        if ($settlement instanceof ExcelException) {
             return Functions::VALUE();
         }
-        if (is_string($maturity = DateTime::getDateValue($maturity))) {
+        $maturity = DateTime::getDateValue($maturity);
+        if ($maturity instanceof ExcelException) {
             return Functions::VALUE();
         }
 
@@ -517,10 +521,12 @@ class Financial
         $frequency = (int) Functions::flattenSingleValue($frequency);
         $basis = ($basis === null) ? 0 : (int) Functions::flattenSingleValue($basis);
 
-        if (is_string($settlement = DateTime::getDateValue($settlement))) {
+        $settlement = DateTime::getDateValue($settlement);
+        if ($settlement instanceof ExcelException) {
             return Functions::VALUE();
         }
-        if (is_string($maturity = DateTime::getDateValue($maturity))) {
+        $maturity = DateTime::getDateValue($maturity);
+        if ($maturity instanceof ExcelException) {
             return Functions::VALUE();
         }
 
@@ -573,10 +579,12 @@ class Financial
         $frequency = (int) Functions::flattenSingleValue($frequency);
         $basis = ($basis === null) ? 0 : (int) Functions::flattenSingleValue($basis);
 
-        if (is_string($settlement = DateTime::getDateValue($settlement))) {
+        $settlement = DateTime::getDateValue($settlement);
+        if ($settlement instanceof ExcelException) {
             return Functions::VALUE();
         }
-        if (is_string($maturity = DateTime::getDateValue($maturity))) {
+        $maturity = DateTime::getDateValue($maturity);
+        if ($maturity instanceof ExcelException) {
             return Functions::VALUE();
         }
 
@@ -626,10 +634,12 @@ class Financial
         $frequency = (int) Functions::flattenSingleValue($frequency);
         $basis = ($basis === null) ? 0 : (int) Functions::flattenSingleValue($basis);
 
-        if (is_string($settlement = DateTime::getDateValue($settlement))) {
+        $settlement = DateTime::getDateValue($settlement);
+        if ($settlement instanceof ExcelException) {
             return Functions::VALUE();
         }
-        if (is_string($maturity = DateTime::getDateValue($maturity))) {
+        $maturity = DateTime::getDateValue($maturity);
+        if ($maturity instanceof ExcelException) {
             return Functions::VALUE();
         }
 
@@ -681,10 +691,12 @@ class Financial
         $frequency = (int) Functions::flattenSingleValue($frequency);
         $basis = ($basis === null) ? 0 : (int) Functions::flattenSingleValue($basis);
 
-        if (is_string($settlement = DateTime::getDateValue($settlement))) {
+        $settlement = DateTime::getDateValue($settlement);
+        if ($settlement instanceof ExcelException) {
             return Functions::VALUE();
         }
-        if (is_string($maturity = DateTime::getDateValue($maturity))) {
+        $maturity = DateTime::getDateValue($maturity);
+        if ($maturity instanceof ExcelException) {
             return Functions::VALUE();
         }
 
@@ -1584,10 +1596,10 @@ class Financial
 
     private static function validatePrice($settlement, $maturity, $rate, $yield, $redemption, $frequency, $basis)
     {
-        if (is_string($settlement)) {
+        if ($settlement instanceof ExcelException) {
             return Functions::VALUE();
         }
-        if (is_string($maturity)) {
+        if ($maturity instanceof ExcelException) {
             return Functions::VALUE();
         }
         if (!is_numeric($rate)) {
@@ -1622,7 +1634,7 @@ class Financial
         $settlement = DateTime::getDateValue($settlement);
         $maturity = DateTime::getDateValue($maturity);
         $rslt = self::validatePrice($settlement, $maturity, $rate, $yield, $redemption, $frequency, $basis);
-        if ($rslt) {
+        if ($rslt instanceof ExcelException) {
             return $rslt;
         }
         $rate = (float) $rate;
@@ -2066,7 +2078,12 @@ class Financial
         $maturity = Functions::flattenSingleValue($maturity);
         $discount = Functions::flattenSingleValue($discount);
 
-        if (is_string($maturity = DateTime::getDateValue($maturity))) {
+        $settlement = DateTime::getDateValue($settlement);
+        if ($settlement instanceof ExcelException) {
+            return Functions::VALUE();
+        }
+        $maturity = DateTime::getDateValue($maturity);
+        if ($maturity instanceof ExcelException) {
             return Functions::VALUE();
         }
 
@@ -2315,9 +2332,12 @@ class Financial
         if ($valCount > 1 && ((min($values) > 0) || (max($values) < 0))) {
             return Functions::NAN();
         }
-        $date0 = DateTime::getDateValue($dates[0]);
-        if (is_string($date0)) {
-            return Functions::VALUE();
+
+        foreach($dates as $date) {
+            $date = DateTime::getDateValue($date);
+            if ($date instanceof ExcelException) {
+                return Functions::VALUE();
+            }
         }
 
         return '';

--- a/src/PhpSpreadsheet/Calculation/Logical.php
+++ b/src/PhpSpreadsheet/Calculation/Logical.php
@@ -94,7 +94,7 @@ class Logical
         $argCount = count($args);
 
         $returnValue = self::countTrueValues($args);
-        if (is_string($returnValue)) {
+        if ($returnValue instanceof ExcelException) {
             return $returnValue;
         }
 
@@ -134,7 +134,7 @@ class Logical
         });
 
         $returnValue = self::countTrueValues($args);
-        if (is_string($returnValue)) {
+        if ($returnValue instanceof ExcelException) {
             return $returnValue;
         }
 
@@ -175,7 +175,7 @@ class Logical
         });
 
         $returnValue = self::countTrueValues($args);
-        if (is_string($returnValue)) {
+        if ($returnValue instanceof ExcelException) {
             return $returnValue;
         }
 

--- a/src/PhpSpreadsheet/Calculation/Statistical.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical.php
@@ -581,14 +581,20 @@ class Statistical
         $returnValue = 0;
 
         $aMean = self::AVERAGE(...$args);
-        if ($aMean === Functions::DIV0()) {
-            return Functions::NAN();
-        } elseif ($aMean === Functions::VALUE()) {
-            return Functions::VALUE();
+        if ($aMean instanceof ExcelException) {
+            if ($aMean === Functions::DIV0()) {
+                return Functions::NAN();
+            } elseif ($aMean === Functions::VALUE()) {
+                return Functions::VALUE();
+            }
+            return $aMean;
         }
 
         $aCount = 0;
         foreach ($aArgs as $k => $arg) {
+            if ($arg instanceof ExcelException) {
+                return $arg;
+            }
             $arg = self::testAcceptedBoolean($arg, $k);
             // Is it a numeric value?
             // Strings containing numeric values are only counted if they are string literals (not cell values)
@@ -628,6 +634,9 @@ class Statistical
 
         // Loop through arguments
         foreach (Functions::flattenArrayIndexed($args) as $k => $arg) {
+            if ($arg instanceof ExcelException) {
+                return $arg;
+            }
             $arg = self::testAcceptedBoolean($arg, $k);
             // Is it a numeric value?
             // Strings containing numeric values are only counted if they are string literals (not cell values)
@@ -1416,7 +1425,7 @@ class Statistical
         $returnValue = null;
 
         $aMean = self::AVERAGE($aArgs);
-        if ($aMean != Functions::DIV0()) {
+        if (!($aMean instanceof ExcelException)) {
             $aCount = -1;
             foreach ($aArgs as $k => $arg) {
                 // Is it a numeric value?

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -268,7 +268,6 @@ class Cell
                 } elseif (strpos($ex->getMessage(), 'undefined name') !== false) {
                     return \PhpOffice\PhpSpreadsheet\Calculation\Functions::NAME();
                 }
-
                 throw new \PhpOffice\PhpSpreadsheet\Calculation\Exception(
                     $this->getWorksheet()->getTitle() . '!' . $this->getCoordinate() . ' -> ' . $ex->getMessage()
                 );

--- a/src/PhpSpreadsheet/Cell/DataType.php
+++ b/src/PhpSpreadsheet/Cell/DataType.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Cell;
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 
@@ -18,28 +19,13 @@ class DataType
     const TYPE_ERROR = 'e';
 
     /**
-     * List of error codes.
-     *
-     * @var array
-     */
-    private static $errorCodes = [
-        '#NULL!' => 0,
-        '#DIV/0!' => 1,
-        '#VALUE!' => 2,
-        '#REF!' => 3,
-        '#NAME?' => 4,
-        '#NUM!' => 5,
-        '#N/A' => 6,
-    ];
-
-    /**
      * Get list of error codes.
      *
      * @return array
      */
     public static function getErrorCodes()
     {
-        return self::$errorCodes;
+        return ExcelException::ERROR_CODES;
     }
 
     /**
@@ -66,20 +52,22 @@ class DataType
     }
 
     /**
-     * Check a value that it is a valid error code.
+     * Check that a value is a valid error object.
      *
-     * @param mixed $pValue Value to sanitize to an Excel error code
+     * @param ExcelException|string $errorCode Value to sanitize as an Excel error object
      *
-     * @return string Sanitized value
+     * @return ExcelException Sanitized value
      */
-    public static function checkErrorCode($pValue)
+    public static function checkErrorCode($errorCode): ExcelException
     {
-        $pValue = (string) $pValue;
-
-        if (!isset(self::$errorCodes[$pValue])) {
-            $pValue = '#NULL!';
+        if ($errorCode instanceof ExcelException) {
+            return $errorCode;
         }
 
-        return $pValue;
+        if (!isset(ExcelException::ERROR_CODES[$errorCode])) {
+            $errorCode = ExcelException::NULL();
+        }
+
+        return $errorCode;
     }
 }

--- a/src/PhpSpreadsheet/Cell/DataValidator.php
+++ b/src/PhpSpreadsheet/Cell/DataValidator.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheet\Cell;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Exception;
 
@@ -65,7 +66,9 @@ class DataValidator
                 try {
                     $result = $calculation->calculateFormula($matchFormula, $cell->getCoordinate(), $cell);
 
-                    return $result !== Functions::NA();
+                    if ($result instanceof ExcelException) {
+                        return $result != Functions::NA();
+                    }
                 } catch (Exception $ex) {
                     return false;
                 }

--- a/src/PhpSpreadsheet/Reader/Xls/ErrorCode.php
+++ b/src/PhpSpreadsheet/Reader/Xls/ErrorCode.php
@@ -2,6 +2,9 @@
 
 namespace PhpOffice\PhpSpreadsheet\Reader\Xls;
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+use PhpOffice\PhpSpreadsheet\Exception;
+
 class ErrorCode
 {
     protected static $map = [
@@ -19,12 +22,13 @@ class ErrorCode
      *
      * @param int $code
      *
-     * @return bool|string
+     * @return bool|ExcelException
+     * @throws Exception
      */
     public static function lookup($code)
     {
         if (isset(self::$map[$code])) {
-            return self::$map[$code];
+            return ExcelException::fromErrorName(self::$map[$code]);
         }
 
         return false;

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Reader;
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\Hyperlink;
 use PhpOffice\PhpSpreadsheet\DefinedName;
@@ -250,7 +251,7 @@ class Xlsx extends BaseReader
 
     private static function castToError($c)
     {
-        return isset($c->v) ? (string) $c->v : null;
+        return isset($c->v) ? ExcelException::fromErrorName((string) $c->v) : null;
     }
 
     private static function castToString($c)

--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheet\Shared;
 use DateTimeInterface;
 use DateTimeZone;
 use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Exception as PhpSpreadsheetException;
@@ -438,13 +439,13 @@ class Date
 
         $dateValueNew = DateTime::DATEVALUE($dateValue);
 
-        if ($dateValueNew === Functions::VALUE()) {
+        if ($dateValueNew instanceof ExcelException && $dateValueNew == Functions::VALUE()) {
             return false;
         }
 
         if (strpos($dateValue, ':') !== false) {
             $timeValue = DateTime::TIMEVALUE($dateValue);
-            if ($timeValue === Functions::VALUE()) {
+            if ($timeValue instanceof ExcelException && $timeValue == Functions::VALUE()) {
                 return false;
             }
             $dateValueNew += $timeValue;

--- a/src/PhpSpreadsheet/Shared/Trend/Trend.php
+++ b/src/PhpSpreadsheet/Shared/Trend/Trend.php
@@ -48,6 +48,9 @@ class Trend
      */
     private static $trendCache = [];
 
+    /*
+     * @return BestFit|false
+     */
     public static function calculate($trendType = self::TREND_BEST_FIT, $yValues = [], $xValues = [], $const = true)
     {
         //    Calculate number of points in each dataset

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -4,6 +4,7 @@ namespace PhpOffice\PhpSpreadsheet\Worksheet;
 
 use ArrayObject;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
@@ -2522,7 +2523,10 @@ class Worksheet implements IComparable
                             $returnValue[$rRef][$cRef] = $cell->getValue()->getPlainText();
                         } else {
                             if ($calculateFormulas) {
-                                $returnValue[$rRef][$cRef] = $cell->getCalculatedValue();
+                                $calculatedValue = $cell->getCalculatedValue();
+                                $returnValue[$rRef][$cRef] = $calculatedValue instanceof ExcelException
+                                    ? $calculatedValue->errorName()
+                                    : $calculatedValue;
                             } else {
                                 $returnValue[$rRef][$cRef] = $cell->getValue();
                             }

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheet\Writer;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Chart\Chart;
@@ -156,6 +157,10 @@ class Html extends BaseWriter
     {
         // Open file
         $this->openFileHandle($pFilename);
+
+        if ($this->preCalculateFormulas) {
+            $this->spreadsheet->getCalculationEngine()->clearCalculationCache();
+        }
 
         // Write html
         fwrite($this->fileHandle, $this->generateHTMLAll());
@@ -1316,6 +1321,9 @@ class Html extends BaseWriter
             $this->generateRowCellDataValueRich($cell, $cellData);
         } else {
             $origData = $this->preCalculateFormulas ? $cell->getCalculatedValue() : $cell->getValue();
+            if ($origData instanceof ExcelException) {
+                $origData = $origData->errorName();
+            }
             $cellData = NumberFormat::toFormattedString(
                 $origData,
                 $pSheet->getParent()->getCellXfByIndex($cell->getXfIndex())->getNumberFormat()->getFormatCode(),

--- a/src/PhpSpreadsheet/Writer/Ods/Content.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Content.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Writer\Ods;
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
@@ -215,7 +216,7 @@ class Content extends WriterPart
                         $objWriter->writeAttribute('office:value-type', 'string');
                     }
                     $objWriter->writeAttribute('office:value', $formulaValue);
-                    $objWriter->writeElement('text:p', $formulaValue);
+                    $objWriter->writeElement('text:p', $formulaValue instanceof ExcelException ? $formulaValue->errorName() :$formulaValue);
 
                     break;
                 case DataType::TYPE_INLINE:

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit\Framework\TestCase;
@@ -371,9 +372,11 @@ class CalculationTest extends TestCase
         $sheet->setCellValue('A2', '=mode.gzorg(1)');
         $sheet->setCellValue('A3', '=gzorg(1,2)');
         $sheet->setCellValue('A4', '=3+IF(gzorg(),1,2)');
-        self::assertEquals('#NAME?', $sheet->getCell('A1')->getCalculatedValue());
-        self::assertEquals('#NAME?', $sheet->getCell('A2')->getCalculatedValue());
-        self::assertEquals('#NAME?', $sheet->getCell('A3')->getCalculatedValue());
-        self::assertEquals('#NAME?', $sheet->getCell('A4')->getCalculatedValue());
+        $sheet->setCellValue('A5', '=3+IFERROR(gzorg(),2)');
+        self::assertEquals(ExcelException::NAME(), $sheet->getCell('A1')->getCalculatedValue());
+        self::assertEquals(ExcelException::NAME(), $sheet->getCell('A2')->getCalculatedValue());
+        self::assertEquals(ExcelException::NAME(), $sheet->getCell('A3')->getCalculatedValue());
+        self::assertEquals(ExcelException::NAME(), $sheet->getCell('A4')->getCalculatedValue());
+        self::assertEquals(5, $sheet->getCell('A5')->getCalculatedValue());
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Engine/RangeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Engine/RangeTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Engine;
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
@@ -37,7 +38,13 @@ class RangeTest extends TestCase
         $workSheet->setCellValue('E1', $formula);
 
         $actualRresult = $workSheet->getCell('E1')->getCalculatedValue();
-        self::assertSame($expectedResult, $actualRresult);
+
+        if ($expectedResult instanceof ExcelException) {
+            // We can't use assertSame when comparing objects, unless they're the same instance
+            self::assertEquals($expectedResult, $actualRresult);
+        } else {
+            self::assertSame($expectedResult, $actualRresult);
+        }
     }
 
     public function providerRangeEvaluation()

--- a/tests/PhpSpreadsheetTests/Calculation/ExcelExceptionTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/ExcelExceptionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Calculation;
+
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+use PhpOffice\PhpSpreadsheet\Exception as SpreadsheetException;
+use PHPUnit\Framework\TestCase;
+
+class ExcelExceptionTest extends TestCase
+{
+    /**
+     * @dataProvider providerExcelException
+     *
+     * @param string $name
+     * @param ExcelException $expectedResult
+     */
+    public function testFromErrorName($name, $expectedResult)
+    {
+        $result = ExcelException::fromErrorName($name);
+
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerExcelException()
+    {
+        return require 'tests/data/Calculation/ExcelException.php';
+    }
+
+    public function testFromInvalidErrorName()
+    {
+        self:$this->expectException(SpreadsheetException::class);
+        $result = ExcelException::fromErrorName('#MARK!');
+    }
+}

--- a/tests/PhpSpreadsheetTests/Calculation/FinancialTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/FinancialTest.php
@@ -21,7 +21,12 @@ class FinancialTest extends TestCase
     public function testAMORDEGRC($expectedResult, ...$args): void
     {
         $result = Financial::AMORDEGRC(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerAMORDEGRC()
@@ -37,7 +42,12 @@ class FinancialTest extends TestCase
     public function testAMORLINC($expectedResult, ...$args): void
     {
         $result = Financial::AMORLINC(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerAMORLINC()
@@ -53,7 +63,12 @@ class FinancialTest extends TestCase
     public function testCOUPDAYBS($expectedResult, ...$args): void
     {
         $result = Financial::COUPDAYBS(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerCOUPDAYBS()
@@ -69,7 +84,12 @@ class FinancialTest extends TestCase
     public function testCOUPDAYS($expectedResult, ...$args): void
     {
         $result = Financial::COUPDAYS(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerCOUPDAYS()
@@ -85,7 +105,12 @@ class FinancialTest extends TestCase
     public function testCOUPDAYSNC($expectedResult, ...$args): void
     {
         $result = Financial::COUPDAYSNC(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerCOUPDAYSNC()
@@ -101,7 +126,12 @@ class FinancialTest extends TestCase
     public function testCOUPNCD($expectedResult, ...$args): void
     {
         $result = Financial::COUPNCD(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerCOUPNCD()
@@ -117,7 +147,12 @@ class FinancialTest extends TestCase
     public function testCOUPNUM($expectedResult, ...$args): void
     {
         $result = Financial::COUPNUM(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerCOUPNUM()
@@ -133,7 +168,12 @@ class FinancialTest extends TestCase
     public function testCOUPPCD($expectedResult, ...$args): void
     {
         $result = Financial::COUPPCD(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerCOUPPCD()
@@ -149,7 +189,12 @@ class FinancialTest extends TestCase
     public function testCUMIPMT($expectedResult, ...$args): void
     {
         $result = Financial::CUMIPMT(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerCUMIPMT()
@@ -165,7 +210,12 @@ class FinancialTest extends TestCase
     public function testCUMPRINC($expectedResult, ...$args): void
     {
         $result = Financial::CUMPRINC(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerCUMPRINC()
@@ -181,7 +231,12 @@ class FinancialTest extends TestCase
     public function testDB($expectedResult, ...$args): void
     {
         $result = Financial::DB(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerDB()
@@ -197,7 +252,12 @@ class FinancialTest extends TestCase
     public function testDDB($expectedResult, ...$args): void
     {
         $result = Financial::DDB(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerDDB()
@@ -213,7 +273,12 @@ class FinancialTest extends TestCase
     public function testDISC($expectedResult, ...$args): void
     {
         $result = Financial::DISC(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerDISC()
@@ -229,7 +294,12 @@ class FinancialTest extends TestCase
     public function testDOLLARDE($expectedResult, ...$args): void
     {
         $result = Financial::DOLLARDE(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerDOLLARDE()
@@ -245,7 +315,12 @@ class FinancialTest extends TestCase
     public function testDOLLARFR($expectedResult, ...$args): void
     {
         $result = Financial::DOLLARFR(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerDOLLARFR()
@@ -261,7 +336,12 @@ class FinancialTest extends TestCase
     public function testEFFECT($expectedResult, ...$args): void
     {
         $result = Financial::EFFECT(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerEFFECT()
@@ -277,7 +357,12 @@ class FinancialTest extends TestCase
     public function testFV($expectedResult, ...$args): void
     {
         $result = Financial::FV(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerFV()
@@ -293,7 +378,12 @@ class FinancialTest extends TestCase
     public function testFVSCHEDULE($expectedResult, ...$args): void
     {
         $result = Financial::FVSCHEDULE(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerFVSCHEDULE()
@@ -309,7 +399,12 @@ class FinancialTest extends TestCase
     public function testINTRATE($expectedResult, ...$args): void
     {
         $result = Financial::INTRATE(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerINTRATE()
@@ -325,7 +420,12 @@ class FinancialTest extends TestCase
     public function testIPMT($expectedResult, ...$args): void
     {
         $result = Financial::IPMT(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerIPMT()
@@ -341,7 +441,12 @@ class FinancialTest extends TestCase
     public function testIRR($expectedResult, ...$args): void
     {
         $result = Financial::IRR(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerIRR()
@@ -357,7 +462,12 @@ class FinancialTest extends TestCase
     public function testISPMT($expectedResult, ...$args): void
     {
         $result = Financial::ISPMT(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerISPMT()
@@ -373,7 +483,12 @@ class FinancialTest extends TestCase
     public function testMIRR($expectedResult, ...$args): void
     {
         $result = Financial::MIRR(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerMIRR()
@@ -389,7 +504,12 @@ class FinancialTest extends TestCase
     public function testNOMINAL($expectedResult, ...$args): void
     {
         $result = Financial::NOMINAL(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerNOMINAL()
@@ -405,7 +525,12 @@ class FinancialTest extends TestCase
     public function testNPER($expectedResult, ...$args): void
     {
         $result = Financial::NPER(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerNPER()
@@ -421,12 +546,38 @@ class FinancialTest extends TestCase
     public function testNPV($expectedResult, ...$args): void
     {
         $result = Financial::NPV(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerNPV()
     {
         return require 'tests/data/Calculation/Financial/NPV.php';
+    }
+
+    /**
+     * @dataProvider providerPDURATION
+     *
+     * @param mixed $expectedResult
+     */
+    public function testPDURATION($expectedResult, array $args): void
+    {
+        $result = Financial::PDURATION(...$args);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
+    }
+
+    public function providerPDURATION()
+    {
+        return require 'tests/data/Calculation/Financial/PDURATION.php';
     }
 
     /**
@@ -437,7 +588,12 @@ class FinancialTest extends TestCase
     public function testPRICE($expectedResult, ...$args): void
     {
         $result = Financial::PRICE(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-7);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-7);
+        }
     }
 
     public function providerPRICE()
@@ -456,7 +612,12 @@ class FinancialTest extends TestCase
         // agree with published algorithm, LibreOffice, and Gnumeric.
         // They do not agree with Excel.
         $result = Financial::PRICE(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-7);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-7);
+        }
     }
 
     public function providerPRICE3()
@@ -472,7 +633,12 @@ class FinancialTest extends TestCase
     public function testPRICEDISC($expectedResult, array $args): void
     {
         $result = Financial::PRICEDISC(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerPRICEDISC()
@@ -488,7 +654,12 @@ class FinancialTest extends TestCase
     public function testPV($expectedResult, array $args): void
     {
         $result = Financial::PV(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerPV()
@@ -504,12 +675,80 @@ class FinancialTest extends TestCase
     public function testRATE($expectedResult, ...$args): void
     {
         $result = Financial::RATE(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerRATE()
     {
         return require 'tests/data/Calculation/Financial/RATE.php';
+    }
+
+    /**
+     * @dataProvider providerRRI
+     *
+     * @param mixed $expectedResult
+     */
+    public function testRRI($expectedResult, array $args): void
+    {
+        $result = Financial::RRI(...$args);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
+    }
+
+    public function providerRRI()
+    {
+        return require 'tests/data/Calculation/Financial/RRI.php';
+    }
+
+    /**
+     * @dataProvider providerSLN
+     *
+     * @param mixed $expectedResult
+     */
+    public function testSLN($expectedResult, array $args): void
+    {
+        $result = Financial::SLN(...$args);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
+    }
+
+    public function providerSLN()
+    {
+        return require 'tests/data/Calculation/Financial/SLN.php';
+    }
+
+    /**
+     * @dataProvider providerSYD
+     *
+     * @param mixed $expectedResult
+     */
+    public function testSYD($expectedResult, array $args): void
+    {
+        $result = Financial::SYD(...$args);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
+    }
+
+    public function providerSYD()
+    {
+        return require 'tests/data/Calculation/Financial/SYD.php';
     }
 
     /**
@@ -560,69 +799,5 @@ class FinancialTest extends TestCase
     public function providerXNPV()
     {
         return require 'tests/data/Calculation/Financial/XNPV.php';
-    }
-
-    /**
-     * @dataProvider providerPDURATION
-     *
-     * @param mixed $expectedResult
-     */
-    public function testPDURATION($expectedResult, array $args): void
-    {
-        $result = Financial::PDURATION(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
-    }
-
-    public function providerPDURATION()
-    {
-        return require 'tests/data/Calculation/Financial/PDURATION.php';
-    }
-
-    /**
-     * @dataProvider providerRRI
-     *
-     * @param mixed $expectedResult
-     */
-    public function testRRI($expectedResult, array $args): void
-    {
-        $result = Financial::RRI(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
-    }
-
-    public function providerRRI()
-    {
-        return require 'tests/data/Calculation/Financial/RRI.php';
-    }
-
-    /**
-     * @dataProvider providerSLN
-     *
-     * @param mixed $expectedResult
-     */
-    public function testSLN($expectedResult, array $args): void
-    {
-        $result = Financial::SLN(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
-    }
-
-    public function providerSLN()
-    {
-        return require 'tests/data/Calculation/Financial/SLN.php';
-    }
-
-    /**
-     * @dataProvider providerSYD
-     *
-     * @param mixed $expectedResult
-     */
-    public function testSYD($expectedResult, array $args): void
-    {
-        $result = Financial::SYD(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
-    }
-
-    public function providerSYD()
-    {
-        return require 'tests/data/Calculation/Financial/SYD.php';
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateDifTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateDifTest.php
@@ -27,7 +27,11 @@ class DateDifTest extends TestCase
     public function testDATEDIF($expectedResult, $startDate, $endDate, $unit): void
     {
         $result = DateTime::DATEDIF($startDate, $endDate, $unit);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerDATEDIF()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateTest.php
@@ -27,7 +27,12 @@ class DateTest extends TestCase
     public function testDATE($expectedResult, $year, $month, $day): void
     {
         $result = DateTime::DATE($year, $month, $day);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerDATE()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateValueTest.php
@@ -26,7 +26,11 @@ class DateValueTest extends TestCase
     public function testDATEVALUE($expectedResult, $dateValue): void
     {
         $result = DateTime::DATEVALUE($dateValue);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerDATEVALUE()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DayTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DayTest.php
@@ -42,12 +42,22 @@ class DayTest extends TestCase
     public function testDAY($expectedResultExcel, $expectedResultOpenOffice, $dateTimeValue): void
     {
         $resultExcel = DateTime::DAYOFMONTH($dateTimeValue);
-        self::assertEqualsWithDelta($expectedResultExcel, $resultExcel, 1E-8);
+
+        if (is_object($expectedResultExcel)) {
+            self::assertEquals($expectedResultExcel, $resultExcel);
+        } else {
+            self::assertEqualsWithDelta($expectedResultExcel, $resultExcel, 1E-8);
+        }
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
         $resultOpenOffice = DateTime::DAYOFMONTH($dateTimeValue);
-        self::assertEqualsWithDelta($expectedResultOpenOffice, $resultOpenOffice, 1E-8);
+
+        if (is_object($expectedResultOpenOffice)) {
+            self::assertEquals($expectedResultOpenOffice, $resultOpenOffice);
+        } else {
+            self::assertEqualsWithDelta($expectedResultOpenOffice, $resultOpenOffice, 1E-8);
+        }
     }
 
     public function providerDAY()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImDivTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImDivTest.php
@@ -35,10 +35,15 @@ class ImDivTest extends TestCase
     public function testIMDIV($expectedResult, ...$args): void
     {
         $result = Engineering::IMDIV(...$args);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertTrue(
+                $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
+                $this->complexAssert->getErrorMessage()
+            );
+        }
     }
 
     public function providerIMDIV()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLnTest.php
@@ -36,10 +36,15 @@ class ImLnTest extends TestCase
     public function testIMLN($expectedResult, $value): void
     {
         $result = Engineering::IMLN($value);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertTrue(
+                $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
+                $this->complexAssert->getErrorMessage()
+            );
+        }
     }
 
     public function providerIMLN()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog10Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog10Test.php
@@ -36,10 +36,15 @@ class ImLog10Test extends TestCase
     public function testIMLOG10($expectedResult, $value): void
     {
         $result = Engineering::IMLOG10($value);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertTrue(
+                $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
+                $this->complexAssert->getErrorMessage()
+            );
+        }
     }
 
     public function providerIMLOG10()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog2Test.php
@@ -36,10 +36,15 @@ class ImLog2Test extends TestCase
     public function testIMLOG2($expectedResult, $value): void
     {
         $result = Engineering::IMLOG2($value);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertTrue(
+                $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
+                $this->complexAssert->getErrorMessage()
+            );
+        }
     }
 
     public function providerIMLOG2()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImPowerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImPowerTest.php
@@ -35,10 +35,15 @@ class ImPowerTest extends TestCase
     public function testIMPOWER($expectedResult, ...$args): void
     {
         $result = Engineering::IMPOWER(...$args);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertTrue(
+                $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
+                $this->complexAssert->getErrorMessage()
+            );
+        }
     }
 
     public function providerIMPOWER()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImProductTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImProductTest.php
@@ -35,10 +35,15 @@ class ImProductTest extends TestCase
     public function testIMPRODUCT($expectedResult, ...$args): void
     {
         $result = Engineering::IMPRODUCT(...$args);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertTrue(
+                $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
+                $this->complexAssert->getErrorMessage()
+            );
+        }
     }
 
     public function providerIMPRODUCT()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSubTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSubTest.php
@@ -35,10 +35,15 @@ class ImSubTest extends TestCase
     public function testIMSUB($expectedResult, ...$args): void
     {
         $result = Engineering::IMSUB(...$args);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertTrue(
+                $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
+                $this->complexAssert->getErrorMessage()
+            );
+        }
     }
 
     public function providerIMSUB()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSumTest.php
@@ -35,10 +35,15 @@ class ImSumTest extends TestCase
     public function testIMSUM($expectedResult, ...$args): void
     {
         $result = Engineering::IMSUM(...$args);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertTrue(
+                $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
+                $this->complexAssert->getErrorMessage()
+            );
+        }
     }
 
     public function providerIMSUM()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AccrintMTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AccrintMTest.php
@@ -21,7 +21,12 @@ class AccrintMTest extends TestCase
     public function testACCRINTM($expectedResult, ...$args): void
     {
         $result = Financial::ACCRINTM(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerACCRINTM()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AccrintTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AccrintTest.php
@@ -21,7 +21,12 @@ class AccrintTest extends TestCase
     public function testACCRINT($expectedResult, ...$args): void
     {
         $result = Financial::ACCRINT(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerACCRINT()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/AndTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/AndTest.php
@@ -21,7 +21,12 @@ class AndTest extends TestCase
     public function testAND($expectedResult, ...$args): void
     {
         $result = Logical::logicalAnd(...$args);
-        self::assertEquals($expectedResult, $result);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEquals($expectedResult, $result);
+        }
     }
 
     public function providerAND()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfTest.php
@@ -21,7 +21,12 @@ class IfTest extends TestCase
     public function testIF($expectedResult, ...$args): void
     {
         $result = Logical::statementIf(...$args);
-        self::assertEquals($expectedResult, $result);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEquals($expectedResult, $result);
+        }
     }
 
     public function providerIF()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/OrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/OrTest.php
@@ -21,7 +21,12 @@ class OrTest extends TestCase
     public function testOR($expectedResult, ...$args): void
     {
         $result = Logical::logicalOr(...$args);
-        self::assertEquals($expectedResult, $result);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEquals($expectedResult, $result);
+        }
     }
 
     public function providerOR()

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AveDevTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AveDevTest.php
@@ -21,7 +21,12 @@ class AveDevTest extends TestCase
     public function testAVEDEV($expectedResult, ...$args): void
     {
         $result = Statistical::AVEDEV(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
+        }
     }
 
     public function providerAVEDEV()

--- a/tests/PhpSpreadsheetTests/Calculation/FunctionsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/FunctionsTest.php
@@ -168,7 +168,12 @@ class FunctionsTest extends TestCase
     public function testErrorType($expectedResult, ...$args): void
     {
         $result = Functions::errorType(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerErrorType()
@@ -264,7 +269,12 @@ class FunctionsTest extends TestCase
     public function testIsEven($expectedResult, ...$args): void
     {
         $result = Functions::isEven(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerIsEven()
@@ -280,7 +290,12 @@ class FunctionsTest extends TestCase
     public function testIsOdd($expectedResult, ...$args): void
     {
         $result = Functions::isOdd(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerIsOdd()
@@ -312,7 +327,12 @@ class FunctionsTest extends TestCase
     public function testN($expectedResult, ...$args): void
     {
         $result = Functions::n(...$args);
-        self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+
+        if (is_object($expectedResult)) {
+            self::assertEquals($expectedResult, $result);
+        } else {
+            self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
+        }
     }
 
     public function providerN()

--- a/tests/PhpSpreadsheetTests/Cell/CellTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CellTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Cell;
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
 use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit\Framework\TestCase;
@@ -20,7 +21,12 @@ class CellTest extends TestCase
         $cell = $spreadsheet->getActiveSheet()->getCell('A1');
         $cell->setValueExplicit($value, $dataType);
 
-        self::assertSame($expected, $cell->getValue());
+        if ($expected instanceof ExcelException) {
+            // We can't use assertSame when comparing objects, unless they're the same instance
+            self::assertEquals($expected, $cell->getValue());
+        } else {
+            self::assertSame($expected, $cell->getValue());
+        }
     }
 
     public function providerSetValueExplicit()

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/StartsWithHashTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/StartsWithHashTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx as Reader;
 use PhpOffice\PhpSpreadsheet\Settings;
@@ -31,9 +32,11 @@ class StartsWithHashTest extends TestCase
         unlink($outputFilename);
 
         self::assertSame('#define M', $sheet->getActiveSheet()->getCell('A1')->getValue());
+        self::assertSame('s', $sheet->getActiveSheet()->getCell('A1')->getDataType());
         self::assertSame('#define M', $sheet->getActiveSheet()->getCell('A2')->getCalculatedValue());
-        self::assertSame('f', $sheet->getActiveSheet()->getCell('A3')->getDataType());
-        self::assertSame('#NAME?', $sheet->getActiveSheet()->getCell('A3')->getCalculatedValue());
+        self::assertSame('f', $sheet->getActiveSheet()->getCell('A2')->getDataType());
+        self::assertInstanceOf(ExcelException::class, $sheet->getActiveSheet()->getCell('A3')->getCalculatedValue());
+        self::assertSame('#NAME?', $sheet->getActiveSheet()->getCell('A3')->getCalculatedValue()->errorName());
         self::assertSame('f', $sheet->getActiveSheet()->getCell('A3')->getDataType());
     }
 

--- a/tests/data/Calculation/DateTime/DATE.php
+++ b/tests/data/Calculation/DateTime/DATE.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     'Year without century specified' => [
         6890, // '11th November 1918'
@@ -222,15 +224,15 @@ return [
         null, 10, null,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         null, null, 10,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         -20, null, null,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         -20, 6, 15,
     ],
     'Excel Maximum Date' => [
@@ -238,7 +240,7 @@ return [
         9999, 12, 31,
     ],
     'Exceeded Excel Maximum Date' => [
-        '#NUM!',
+        ExcelException::NUM(),
         10000, 1, 1,
     ],
     [
@@ -305,15 +307,15 @@ return [
         2010, 'March', 21,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'ABC', 1, 21,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         2010, 'DEF', 21,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         2010, 3, 'GHI',
     ],
 ];

--- a/tests/data/Calculation/DateTime/DATEDIF.php
+++ b/tests/data/Calculation/DateTime/DATEDIF.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         365,
@@ -22,19 +24,19 @@ return [
         '2017-01-01', '2018-12-31', 'YD',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'ABC', '2007-1-10', 'Y',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '2007-1-1', 'DEF', 'Y',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '2007-1-1', '2007-1-10', 'XYZ',
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '2007-1-10', '2007-1-1', 'Y',
     ],
     [

--- a/tests/data/Calculation/DateTime/DATEVALUE.php
+++ b/tests/data/Calculation/DateTime/DATEVALUE.php
@@ -1,14 +1,16 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 //  Date String, Result
 
 return [
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '25-Dec-1899',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '31-Dec-1899',
     ],
     [
@@ -20,12 +22,12 @@ return [
         '1900/2/28',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '29-02-1900',
     ],
     // MS Excel will fail with a #VALUE return, but PhpSpreadsheet can parse this date
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '29th February 1900',
     ],
     [
@@ -135,7 +137,7 @@ return [
     ],
     // Should fail because it's an invalid date, but PhpSpreadsheet currently adjusts to 1-3-2007 - FIX NEEDED
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '29-2-2007',
     ],
     [
@@ -156,7 +158,7 @@ return [
         '1st March 2007',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'The 1st day of March 2007',
     ],
     // 01/01 of the current year
@@ -193,27 +195,27 @@ return [
         '10/32',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         11,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         true,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         false,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         1,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         12345,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         12,
     ],
     [
@@ -260,7 +262,7 @@ return [
         '1st-Feb-2010',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '1me Fev 2010',
     ],
     // MS Excel will fail with a #VALUE return, but PhpSpreadsheet can parse this date
@@ -274,11 +276,11 @@ return [
         '2nd Feb 2010',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'Second Feb 2010',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'First August 2010',
     ],
     // MS Excel will fail with a #VALUE return, but PhpSpreadsheet can parse this date
@@ -291,7 +293,7 @@ return [
         '15:30:25',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'ABCDEFGHIJKMNOPQRSTUVWXYZ',
     ],
 ];

--- a/tests/data/Calculation/DateTime/DAY.php
+++ b/tests/data/Calculation/DateTime/DAY.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 //  Date Value, Result
 
 return [
@@ -29,12 +31,12 @@ return [
         '28-Feb-1904',
     ],
     [
-        '#VALUE!', // Result for Excel
-        '#VALUE!', // Result for OpenOffice
+        ExcelException::VALUE(), // Result for Excel
+        ExcelException::VALUE(), // Result for OpenOffice
         'Invalid',
     ],
     [
-        '#NUM!', // Result for Excel
+        ExcelException::NUM(), // Result for Excel
         29, // Result for OpenOffice
         -1,
     ],

--- a/tests/data/Calculation/Engineering/IMDIV.php
+++ b/tests/data/Calculation/Engineering/IMDIV.php
@@ -1,8 +1,10 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '12.34+5.67j',
         '123.45+67.89i',
     ],

--- a/tests/data/Calculation/Engineering/IMLN.php
+++ b/tests/data/Calculation/Engineering/IMLN.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         '2.60862008281875+0.430710595550204j',
@@ -58,7 +60,7 @@ return [
         'i',
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '0',
     ],
     [

--- a/tests/data/Calculation/Engineering/IMLOG10.php
+++ b/tests/data/Calculation/Engineering/IMLOG10.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         '1.13290930735019+0.187055234944717j',
@@ -58,7 +60,7 @@ return [
         'i',
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '0',
     ],
     [

--- a/tests/data/Calculation/Engineering/IMLOG2.php
+++ b/tests/data/Calculation/Engineering/IMLOG2.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         '3.76344325733562+0.621384040306436j',
@@ -58,7 +60,7 @@ return [
         'i',
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '0',
     ],
     [

--- a/tests/data/Calculation/Engineering/IMPOWER.php
+++ b/tests/data/Calculation/Engineering/IMPOWER.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         '120.1267+139.9356j',
@@ -57,7 +59,7 @@ return [
         '2.5',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '2.5i',
         '2.5i',
     ],

--- a/tests/data/Calculation/Engineering/IMPRODUCT.php
+++ b/tests/data/Calculation/Engineering/IMPRODUCT.php
@@ -1,8 +1,10 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '12.34+5.67j',
         '123.45+67.89i',
     ],

--- a/tests/data/Calculation/Engineering/IMSUB.php
+++ b/tests/data/Calculation/Engineering/IMSUB.php
@@ -1,8 +1,10 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '12.34+5.67j',
         '123.45+67.89i',
     ],

--- a/tests/data/Calculation/Engineering/IMSUM.php
+++ b/tests/data/Calculation/Engineering/IMSUM.php
@@ -1,8 +1,10 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '12.34+5.67j',
         '123.45+67.89i',
     ],
@@ -33,7 +35,7 @@ return [
         '123.45+67.89i',
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '12.34+5.67i',
         '123.45+67.89i',
         '123.45+67.89j',

--- a/tests/data/Calculation/ExcelException.php
+++ b/tests/data/Calculation/ExcelException.php
@@ -1,0 +1,10 @@
+<?php
+
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
+return [
+    ['#NULL!', ExcelException::NULL()],
+    ['#DIV/0!', ExcelException::DIV0()],
+    ['#VALUE!', ExcelException::VALUE()],
+    ['#NUM!', ExcelException::NUM()],
+];

--- a/tests/data/Calculation/Financial/ACCRINT.php
+++ b/tests/data/Calculation/Financial/ACCRINT.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // Issue date, 1st Interest, Settlement, Rate, Par, Freq, Basis, Result
 
 return [
@@ -33,7 +35,7 @@ return [
         4,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '2008-03-05',
         '2008-08-31',
         '2008-05-01',
@@ -43,7 +45,7 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'Invalid Date',
         '2008-08-31',
         '2008-05-01',
@@ -53,7 +55,7 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '2008-03-01',
         '2008-08-31',
         '2008-05-01',
@@ -63,7 +65,7 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '2008-03-01',
         '2008-08-31',
         '2008-05-01',

--- a/tests/data/Calculation/Financial/ACCRINTM.php
+++ b/tests/data/Calculation/Financial/ACCRINTM.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // Issue date, Settlement, Rate, Par, Basis, Result
 
 return [
@@ -19,7 +21,7 @@ return [
         10000,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '2008-03-05',
         '2008-08-31',
         -0.10000000000000001,
@@ -27,7 +29,7 @@ return [
         2,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'Invalid Date',
         '2008-08-31',
         0.10000000000000001,
@@ -35,7 +37,7 @@ return [
         2,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '2008-03-01',
         '2008-08-31',
         'ABC',

--- a/tests/data/Calculation/Financial/COUPDAYBS.php
+++ b/tests/data/Calculation/Financial/COUPDAYBS.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // Settlement, Maturity, Frequency, Basis, Result
 
 return [
@@ -17,21 +19,21 @@ return [
         4,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'Invalid Date',
         '15-Nov-2008',
         2,
         1,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '25-Jan-2007',
         'Invalid Date',
         2,
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '25-Jan-2007',
         '15-Nov-2008',
         3,

--- a/tests/data/Calculation/Financial/COUPDAYS.php
+++ b/tests/data/Calculation/Financial/COUPDAYS.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // Settlement, Maturity, Frequency, Basis, Result
 
 return [
@@ -38,21 +40,21 @@ return [
         1,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'Invalid Date',
         '15-Nov-2008',
         2,
         1,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '25-Jan-2007',
         'Invalid Date',
         2,
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '25-Jan-2007',
         '15-Nov-2008',
         3,

--- a/tests/data/Calculation/Financial/COUPDAYSNC.php
+++ b/tests/data/Calculation/Financial/COUPDAYSNC.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // Settlement, Maturity, Frequency, Basis, Result
 
 return [
@@ -17,21 +19,21 @@ return [
         4,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'Invalid Date',
         '15-Nov-2008',
         2,
         1,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '25-Jan-2007',
         'Invalid Date',
         2,
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '25-Jan-2007',
         '15-Nov-2008',
         3,

--- a/tests/data/Calculation/Financial/COUPNCD.php
+++ b/tests/data/Calculation/Financial/COUPNCD.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // Settlement, Maturity, Frequency, Basis, Result
 
 return [
@@ -17,28 +19,28 @@ return [
         4,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'Invalid Date',
         '15-Nov-2008',
         2,
         1,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '25-Jan-2007',
         'Invalid Date',
         2,
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '25-Jan-2007',
         '15-Nov-2008',
         3,
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '24-Dec-2000',
         '24-Dec-2000',
         4,

--- a/tests/data/Calculation/Financial/COUPNUM.php
+++ b/tests/data/Calculation/Financial/COUPNUM.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // Settlement, Maturity, Frequency, Basis, Result
 
 return [
@@ -18,21 +20,21 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'Invalid Date',
         '15-Nov-2008',
         2,
         1,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '25-Jan-2007',
         'Invalid Date',
         2,
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '25-Jan-2007',
         '15-Nov-2008',
         3,
@@ -46,7 +48,7 @@ return [
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '24-Dec-2000',
         '24-Dec-2000',
         4,

--- a/tests/data/Calculation/Financial/COUPPCD.php
+++ b/tests/data/Calculation/Financial/COUPPCD.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // Settlement, Maturity, Frequency, Basis, Result
 
 return [
@@ -17,28 +19,28 @@ return [
         4,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'Invalid Date',
         '15-Nov-2008',
         2,
         1,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '25-Jan-2007',
         'Invalid Date',
         2,
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '25-Jan-2007',
         '15-Nov-2008',
         3,
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '24-Dec-2000',
         '24-Dec-2000',
         4,

--- a/tests/data/Calculation/Financial/CUMIPMT.php
+++ b/tests/data/Calculation/Financial/CUMIPMT.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // rate, nper, pv, start_period, end_period, type, result
 
 return [
@@ -67,7 +69,7 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         0.0074999999999999997,
         360,
         125000,
@@ -76,7 +78,7 @@ return [
         0,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         0.0074999999999999997,
         360,
         125000,

--- a/tests/data/Calculation/Financial/CUMPRINC.php
+++ b/tests/data/Calculation/Financial/CUMPRINC.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // rate, nper, pv, start_period, end_period, type, result
 
 return [
@@ -67,7 +69,7 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         0.0074999999999999997,
         360,
         125000,
@@ -76,7 +78,7 @@ return [
         0,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         0.0074999999999999997,
         360,
         125000,

--- a/tests/data/Calculation/Financial/DB.php
+++ b/tests/data/Calculation/Financial/DB.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // cost, salvage, life, period, month, result
 
 return [
@@ -116,7 +118,7 @@ return [
         6,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         -1000,
         100,
         5,
@@ -124,7 +126,7 @@ return [
         6,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'ABC',
         100,
         5,

--- a/tests/data/Calculation/Financial/DDB.php
+++ b/tests/data/Calculation/Financial/DDB.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // cost, salvage, life, period, month, result
 
 return [
@@ -99,14 +101,14 @@ return [
         5,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         -2400,
         300,
         36500,
         1,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'ABC',
         300,
         36500,

--- a/tests/data/Calculation/Financial/DISC.php
+++ b/tests/data/Calculation/Financial/DISC.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // settlement, maturity, price, redemption, basis, result
 
 return [
@@ -19,21 +21,21 @@ return [
         100,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '2010-04-01',
         '2015-03-31',
         0,
         100,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '2010-04-01',
         '2015-03-31',
         'ABC',
         100,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'Invalid Date',
         '2007-06-15',
         97.974999999999994,

--- a/tests/data/Calculation/Financial/DOLLARDE.php
+++ b/tests/data/Calculation/Financial/DOLLARDE.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // fractional_dollar, fraction, result
 
 return [
@@ -39,12 +41,12 @@ return [
         32,
     ],
     [
-        '#DIV/0!',
+        ExcelException::DIV0(),
         1.2344999999999999,
         0,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         1.2344999999999999,
         -2,
     ],

--- a/tests/data/Calculation/Financial/DOLLARFR.php
+++ b/tests/data/Calculation/Financial/DOLLARFR.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // decimal_dollar, fraction, result
 
 return [
@@ -39,12 +41,12 @@ return [
         32,
     ],
     [
-        '#DIV/0!',
+        ExcelException::DIV0(),
         1.2344999999999999,
         0,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         1.2344999999999999,
         -2,
     ],

--- a/tests/data/Calculation/Financial/EFFECT.php
+++ b/tests/data/Calculation/Financial/EFFECT.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // nominal_rate, npery, Result
 
 return [
@@ -24,7 +26,7 @@ return [
         2,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         1,
         0,
     ],

--- a/tests/data/Calculation/Financial/FV.php
+++ b/tests/data/Calculation/Financial/FV.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // rate, nper, pmt, pv, type, Result
 
 return [
@@ -48,7 +50,7 @@ return [
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         0.10000000000000001,
         12,
         -100,

--- a/tests/data/Calculation/Financial/INTRATE.php
+++ b/tests/data/Calculation/Financial/INTRATE.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // Settlement, Maturity, Investment, Redemption, Basis, Result
 
 return [
@@ -19,7 +21,7 @@ return [
         2125,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '2008-02-15',
         '2008-05-15',
         1000000,
@@ -27,7 +29,7 @@ return [
         'ABC',
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '2008-02-15',
         '2008-05-15',
         1000000,
@@ -35,7 +37,7 @@ return [
         2,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'Invalid Date',
         '2008-05-15',
         1000000,

--- a/tests/data/Calculation/Financial/IPMT.php
+++ b/tests/data/Calculation/Financial/IPMT.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // rate, per, nper, pv, fv, type, Result
 
 return [
@@ -50,7 +52,7 @@ return [
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         0.0050000000000000001,
         2,
         8,
@@ -59,7 +61,7 @@ return [
         6,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         0.0050000000000000001,
         8,
         2,

--- a/tests/data/Calculation/Financial/IRR.php
+++ b/tests/data/Calculation/Financial/IRR.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // values, guess, Result
 
 return [
@@ -56,6 +58,13 @@ return [
                 34.560000000000002,
                 41.469999999999999,
             ],
+        ],
+    ],
+    [
+        ExcelException::VALUE(),
+        [
+            -100,
+            20,
         ],
     ],
 ];

--- a/tests/data/Calculation/Financial/NOMINAL.php
+++ b/tests/data/Calculation/Financial/NOMINAL.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // effect_rate, npery, result
 
 return [
@@ -24,7 +26,7 @@ return [
         12,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         -0.025000000000000001,
         12,
     ],

--- a/tests/data/Calculation/Financial/NPER.php
+++ b/tests/data/Calculation/Financial/NPER.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // rate, pmt, pv, fv, type, result
 
 return [
@@ -39,7 +41,7 @@ return [
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         0.014999999999999999,
         -1200,
         9000,
@@ -47,7 +49,7 @@ return [
         2,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         0.014999999999999999,
         0.0,
         0.0,
@@ -55,7 +57,7 @@ return [
         1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         0.0,
         0.0,
         -500,

--- a/tests/data/Calculation/Financial/PDURATION.php
+++ b/tests/data/Calculation/Financial/PDURATION.php
@@ -1,16 +1,18 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         ['ABC', 'DEF', 'GHI'],
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         [0.0, 0.0, 0.0],
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         [0.05, 10.0, -2.0],
     ],
     [

--- a/tests/data/Calculation/Financial/PRICE.php
+++ b/tests/data/Calculation/Financial/PRICE.php
@@ -1,10 +1,12 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // Result, Settlement, Maturity, Rate, Yield, Redemption, Frequency, Basis
 
 return [
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'xyz',
         '15-Nov-2017',
         0.0575,
@@ -14,7 +16,7 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '15-Feb-2008',
         'xyz',
         0.0575,
@@ -24,7 +26,7 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '15-Feb-2008',
         '15-Nov-2017',
         'xyz',
@@ -34,7 +36,7 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '15-Feb-2008',
         '15-Nov-2017',
         0.0575,
@@ -44,7 +46,7 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '15-Feb-2008',
         '15-Nov-2017',
         0.0575,
@@ -54,7 +56,7 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '15-Feb-2008',
         '15-Nov-2017',
         0.0575,
@@ -64,7 +66,7 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '15-Feb-2008',
         '15-Nov-2017',
         0.0575,
@@ -74,7 +76,7 @@ return [
         'xyz',
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '15-Feb-2008',
         '15-Nov-2017',
         0.0575,
@@ -84,7 +86,7 @@ return [
         -1, // invalid basis
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '15-Feb-2008',
         '15-Nov-2017',
         0.0575,
@@ -94,7 +96,7 @@ return [
         5, // invalid basis
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '15-Nov-2017', // maturity before settlement
         '15-Feb-2008',
         0.0575,
@@ -104,7 +106,7 @@ return [
         0,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '15-Feb-2008',
         '15-Nov-2017',
         0.0575,
@@ -114,7 +116,7 @@ return [
         0,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '15-Feb-2008',
         '15-Nov-2017',
         0.0575,
@@ -124,7 +126,7 @@ return [
         0,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         '15-Feb-2008',
         '15-Nov-2017',
         0.0575,

--- a/tests/data/Calculation/Financial/PRICEDISC.php
+++ b/tests/data/Calculation/Financial/PRICEDISC.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         90.0,

--- a/tests/data/Calculation/Financial/RATE.php
+++ b/tests/data/Calculation/Financial/RATE.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // Periods, Payment, Present Value, Future Value, Type, Guess, Result
 
 return [
@@ -70,13 +72,13 @@ return [
         0,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         0,
         1,
         8000,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         208,
         -700,
         8000,

--- a/tests/data/Calculation/Financial/RRI.php
+++ b/tests/data/Calculation/Financial/RRI.php
@@ -1,16 +1,18 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         ['ABC', 'DEF', 'GHI'],
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         [0.0, 10.0, 20.0],
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         [0.05, 10.0, -2.0],
     ],
     [

--- a/tests/data/Calculation/Financial/SLN.php
+++ b/tests/data/Calculation/Financial/SLN.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         1800,
@@ -30,11 +32,11 @@ return [
         [45000, 7500, 10],
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         [10000, 1000, -1],
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         ['INVALID', 1000, -1],
     ],
 ];

--- a/tests/data/Calculation/Financial/SYD.php
+++ b/tests/data/Calculation/Financial/SYD.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         3000,
@@ -34,11 +36,11 @@ return [
         [30000, 7500, 10, 10],
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         [10000, 1000, 5, 10],
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         ['INVALID', 1000, 5, 1],
     ],
 ];

--- a/tests/data/Calculation/Financial/XIRR.php
+++ b/tests/data/Calculation/Financial/XIRR.php
@@ -1,59 +1,61 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // result, message, values, dates, guess
 
 return [
     [
-        '#NUM!',
+        ExcelException::NUM(),
         'If values and dates contain a different number of values, returns the #NUM! error value',
         [4000, -46000],
         ['2015-01-04'],
         0.1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         'Expects at least one positive cash flow and one negative cash flow; otherwise returns the #NUM! error value',
         [-4000, -46000],
         ['2015-01-04', '2019-06-27'],
         0.1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         'Expects at least one positive cash flow and one negative cash flow; otherwise returns the #NUM! error value',
         [4000, 46000],
         ['2015-01-04', '2019-06-27'],
         0.1,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'If any number in dates is not a valid date, returns the #VALUE! error value',
         [4000, -46000],
         ['2015-01-04', '2019X06-27'],
         0.1,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'If any entry in values is not numeric, returns the #VALUE! error value',
         ['y', -46000],
         ['2015-01-04', '2019-06-27'],
         0.1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         'If values is not an array, returns the #NUM! error value',
         -46000,
         ['2015-01-04', '2019-06-27'],
         0.1,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         'If dates is not an array but values is, returns the #NUM! error value',
         [4000, -46000],
         '2015-01-04',
         0.1,
     ],
     [
-        '#N/A',
+        ExcelException::NA(),
         'If neither dates nor values is an array, returns the #N/A error value',
         4000,
         '2015-01-04',
@@ -119,7 +121,7 @@ return [
         0.00000,
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         'Can\'t find a result2 that works after FINANCIAL_MAX_ITERATIONS tries, the #NUM! error value is returned',
         [-10000, 10000, -10000, 5],
         ['2010-01-15', '2010-04-16', '2010-07-16', '2010-10-15'],

--- a/tests/data/Calculation/Financial/XNPV.php
+++ b/tests/data/Calculation/Financial/XNPV.php
@@ -1,10 +1,12 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 // result, message, rate, values, dates
 
 return [
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'If rate is not numeric, returns the #VALUE! error value',
         'xyz',
         [0, 120000, 120000, 120000, 120000, 120000, 120000, 120000, 120000, 120000, 120000],
@@ -18,49 +20,49 @@ return [
         '2018-06-30',
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         'If different number of elements in values and dates, return NUM',
         0.10,
         [1000.0, 1000.1],
         '2018-06-30',
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         'If minimum value > 0, return NUM',
         0.10,
         [1000.0, 1000.1],
         ['2018-06-30', '2018-07-30'],
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         'If maximum value < 0, return NUM',
         0.10,
         [-1000.0, -1000.1],
         ['2018-06-30', '2018-07-30'],
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'If any value is non-numeric, return VALUE',
         0.10,
         [-1000.0, 1000.1, 'x'],
         ['2018-06-30', '2018-07-30', '2018-08-30'],
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'If first date is non-numeric, return VALUE',
         0.10,
         [-1000.0, 1000.1, 1000.2],
         ['2018-06x30', '2018-07-30', '2018-08-30'],
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'If any other date is non-numeric, return VALUE',
         0.10,
         [-1000.0, 1000.1, 1000.2],
         ['2018-06-30', '2018-07-30', '2018-08z30'],
     ],
     [
-        '#NUM!',
+        ExcelException::NUM(),
         'If any date is before first date, return NUM',
         0.10,
         [-1000.0, 1000.1, 1000.2],

--- a/tests/data/Calculation/Functions/ERROR_TYPE.php
+++ b/tests/data/Calculation/Functions/ERROR_TYPE.php
@@ -1,59 +1,61 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
-        '#N/A',
+        ExcelException::NA(),
     ],
     [
-        '#N/A',
+        ExcelException::NA(),
         null,
     ],
     [
-        '#N/A',
+        ExcelException::NA(),
         -1,
     ],
     [
-        '#N/A',
+        ExcelException::NA(),
         1.25,
     ],
     [
-        '#N/A',
+        ExcelException::NA(),
         '',
     ],
     [
-        '#N/A',
+        ExcelException::NA(),
         '2.5',
     ],
     [
-        '#N/A',
+        ExcelException::NA(),
         true,
     ],
     [
         1,
-        '#NULL!',
+        ExcelException::NULL(),
     ],
     [
         2,
-        '#DIV/0!',
+        ExcelException::DIV0(),
     ],
     [
         3,
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     [
         4,
-        '#REF!',
+        ExcelException::REF(),
     ],
     [
         5,
-        '#NAME?',
+        ExcelException::NAME(),
     ],
     [
         6,
-        '#NUM!',
+        ExcelException::NUM(),
     ],
     [
         7,
-        '#N/A',
+        ExcelException::NA(),
     ],
 ];

--- a/tests/data/Calculation/Functions/ISFORMULA.php
+++ b/tests/data/Calculation/Functions/ISFORMULA.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         false,
@@ -34,12 +36,12 @@ return [
     [
         false,
         'A7',
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     [
         false,
         'A8',
-        '#N/A',
+        ExcelException::NA(),
     ],
     [
         false,

--- a/tests/data/Calculation/Functions/IS_BLANK.php
+++ b/tests/data/Calculation/Functions/IS_BLANK.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         true,
@@ -46,11 +48,11 @@ return [
     ],
     [
         false,
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     [
         false,
-        '#N/A',
+        ExcelException::NA(),
     ],
     [
         false,

--- a/tests/data/Calculation/Functions/IS_ERR.php
+++ b/tests/data/Calculation/Functions/IS_ERR.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         false,
@@ -46,11 +48,11 @@ return [
     ],
     [
         true,
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     [
         false,
-        '#N/A',
+        ExcelException::NA(),
     ],
     [
         false,

--- a/tests/data/Calculation/Functions/IS_ERROR.php
+++ b/tests/data/Calculation/Functions/IS_ERROR.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         false,
@@ -46,11 +48,11 @@ return [
     ],
     [
         true,
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     [
         true,
-        '#N/A',
+        ExcelException::NA(),
     ],
     [
         false,

--- a/tests/data/Calculation/Functions/IS_EVEN.php
+++ b/tests/data/Calculation/Functions/IS_EVEN.php
@@ -1,83 +1,85 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
-    [
-        '#NAME?',
+    'Empty Value' => [
+        ExcelException::NAME(),
     ],
-    [
-        '#NAME?',
+    'Null Value' => [
+        ExcelException::NAME(),
         null,
     ],
-    [
+    'Negative Integer' => [
         false,
         -1,
     ],
-    [
+    'Zero Value' => [
         true,
         0,
     ],
-    [
+    'Positive Integer' => [
         false,
         9,
     ],
-    [
+    'Odd Float #1' => [
         false,
         1.25,
     ],
-    [
+    'Odd Float #2' => [
         false,
         1.5,
     ],
-    [
+    'Even Float #1' => [
         true,
         2.25,
     ],
-    [
+    'Even Float #2' => [
         true,
         2.5,
     ],
-    [
-        '#VALUE!',
+    'Empty String' => [
+        ExcelException::VALUE(),
         '',
     ],
-    [
+    'String containing Negative Odd Integer' => [
         false,
         '-1',
     ],
-    [
+    'String containing Positive Even Integer' => [
         true,
         '2',
     ],
-    [
+    'String containing Negative Odd Float' => [
         false,
         '-1.5',
     ],
-    [
+    'String containing Positive Even Float' => [
         true,
         '2.5',
     ],
-    [
-        '#VALUE!',
+    'Non-numeric String' => [
+        ExcelException::VALUE(),
         'ABC',
     ],
-    [
-        '#VALUE!',
-        '#VALUE!',
+    'VALUE Exception' => [
+        ExcelException::VALUE(),
+        ExcelException::VALUE(),
     ],
-    [
-        '#VALUE!',
-        '#N/A',
+    'NA Exception' => [
+        ExcelException::NA(),
+        ExcelException::NA(),
     ],
-    [
-        '#VALUE!',
+    'String containing TRUE text' => [
+        ExcelException::VALUE(),
         'TRUE',
     ],
-    [
-        '#VALUE!',
+    'Boolean True' => [
+        ExcelException::VALUE(),
         true,
     ],
-    [
-        '#VALUE!',
+    'Boolean False' => [
+        ExcelException::VALUE(),
         false,
     ],
 ];

--- a/tests/data/Calculation/Functions/IS_LOGICAL.php
+++ b/tests/data/Calculation/Functions/IS_LOGICAL.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         false,
@@ -46,7 +48,7 @@ return [
     ],
     [
         false,
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     [
         false,

--- a/tests/data/Calculation/Functions/IS_NA.php
+++ b/tests/data/Calculation/Functions/IS_NA.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         false,
@@ -46,11 +48,11 @@ return [
     ],
     [
         false,
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     [
         true,
-        '#N/A',
+        ExcelException::NA(),
     ],
     [
         false,

--- a/tests/data/Calculation/Functions/IS_NONTEXT.php
+++ b/tests/data/Calculation/Functions/IS_NONTEXT.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         true,
@@ -46,11 +48,11 @@ return [
     ],
     [
         true,
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     [
         true,
-        '#N/A',
+        ExcelException::NUM(),
     ],
     [
         false,

--- a/tests/data/Calculation/Functions/IS_NUMBER.php
+++ b/tests/data/Calculation/Functions/IS_NUMBER.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         false,
@@ -46,11 +48,11 @@ return [
     ],
     [
         false,
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     [
         false,
-        '#N/A',
+        ExcelException::NA(),
     ],
     [
         false,

--- a/tests/data/Calculation/Functions/IS_ODD.php
+++ b/tests/data/Calculation/Functions/IS_ODD.php
@@ -1,11 +1,13 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
-        '#NAME?',
+        ExcelException::NAME(),
     ],
     [
-        '#NAME?',
+        ExcelException::NAME(),
         null,
     ],
     [
@@ -37,7 +39,7 @@ return [
         2.5,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '',
     ],
     [
@@ -57,27 +59,27 @@ return [
         '2.5',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'ABC',
     ],
     [
-        '#VALUE!',
-        '#VALUE!',
+        ExcelException::VALUE(),
+        ExcelException::VALUE(),
     ],
     [
-        '#VALUE!',
-        '#N/A',
+        ExcelException::NA(),
+        ExcelException::NA(),
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'TRUE',
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         true,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         false,
     ],
 ];

--- a/tests/data/Calculation/Functions/IS_TEXT.php
+++ b/tests/data/Calculation/Functions/IS_TEXT.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         false,
@@ -46,11 +48,11 @@ return [
     ],
     [
         false,
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     [
         false,
-        '#N/A',
+        ExcelException::NA(),
     ],
     [
         true,

--- a/tests/data/Calculation/Functions/N.php
+++ b/tests/data/Calculation/Functions/N.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         0,
@@ -37,12 +39,12 @@ return [
         true,
     ],
     [
-        '#DIV/0!',
-        '#DIV/0!',
+        ExcelException::DIV0(),
+        ExcelException::DIV0(),
     ],
     [
-        '#NUM!',
-        '#NUM!',
+        ExcelException::NUM(),
+        ExcelException::NUM(),
     ],
     [
         0,

--- a/tests/data/Calculation/Functions/TYPE.php
+++ b/tests/data/Calculation/Functions/TYPE.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         1,
@@ -38,11 +40,11 @@ return [
     ],
     [
         16,
-        '#DIV/0!',
+        ExcelException::DIV0(),
     ],
     [
         16,
-        '#NUM!',
+        ExcelException::NUM(),
     ],
     [
         1,

--- a/tests/data/Calculation/Logical/AND.php
+++ b/tests/data/Calculation/Logical/AND.php
@@ -1,9 +1,11 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     // No arguments
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     // NULL
     [
@@ -89,7 +91,7 @@ return [
         1,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         '1',
         1,
     ],
@@ -107,7 +109,7 @@ return [
     ],
     // Non-numeric String
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'ABCD',
         1,
     ],

--- a/tests/data/Calculation/Logical/IF.php
+++ b/tests/data/Calculation/Logical/IF.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         0,
@@ -35,8 +37,8 @@ return [
         'XYZ',
     ],
     [
-        '#N/A',
-        '#N/A',
+        ExcelException::NA(),
+        ExcelException::NA(),
         'ABC',
         'XYZ',
     ],

--- a/tests/data/Calculation/Logical/IFERROR.php
+++ b/tests/data/Calculation/Logical/IFERROR.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         null,
@@ -28,17 +30,17 @@ return [
     ],
     [
         'Error',
-        '#VALUE!',
+        ExcelException::VALUE(),
         'Error',
     ],
     [
         'Error',
-        '#NAME?',
+        ExcelException::NAME(),
         'Error',
     ],
     [
         'Error',
-        '#N/A',
+        ExcelException::NA(),
         'Error',
     ],
 ];

--- a/tests/data/Calculation/Logical/IFNA.php
+++ b/tests/data/Calculation/Logical/IFNA.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         55,
@@ -7,6 +9,6 @@ return [
     ],
     [
         'not found',
-        '#N/A', 'not found',
+        ExcelException::NA(), 'not found',
     ],
 ];

--- a/tests/data/Calculation/Logical/OR.php
+++ b/tests/data/Calculation/Logical/OR.php
@@ -1,9 +1,11 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     // No arguments
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     // NULL
     [
@@ -102,7 +104,7 @@ return [
     ],
     // Non-numeric String
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'ABCD',
         1,
     ],

--- a/tests/data/Calculation/Logical/XOR.php
+++ b/tests/data/Calculation/Logical/XOR.php
@@ -1,9 +1,11 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     // No arguments
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
     ],
     [
         false,
@@ -46,7 +48,7 @@ return [
         0,
     ],
     [
-        '#VALUE!',
+        ExcelException::VALUE(),
         'HELLO WORLD',
     ],
 ];

--- a/tests/data/Calculation/Statistical/AVEDEV.php
+++ b/tests/data/Calculation/Statistical/AVEDEV.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
+
 return [
     [
         1.020408163265,
@@ -39,7 +41,11 @@ return [
     ],
     [
         // When non-numeric strings are passed directly, then a #VALUE! error is raised
-        '#VALUE!',
+        ExcelException::VALUE(),
         [1, '2', 3.4, true, 5, null, 6.7, 'STRING', ''],
+    ],
+    [
+        ExcelException::DIV0(),
+        [1, '2', 3.4, true, 5, null, 6.7, ExcelException::DIV0(), ''],
     ],
 ];

--- a/tests/data/Cell/SetValueExplicit.php
+++ b/tests/data/Cell/SetValueExplicit.php
@@ -1,5 +1,6 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Calculation\ExcelException;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 
 return [
@@ -39,12 +40,12 @@ return [
         DataType::TYPE_NUMERIC,
     ],
     [
-        '#DIV/0!',
-        '#DIV/0!',
+        ExcelException::DIV0(),
+        ExcelException::DIV0(),
         DataType::TYPE_ERROR,
     ],
     [
-        '#NULL!',
+        ExcelException::NULL(),
         'NOT A VALID ERROR TYPE VALUE',
         DataType::TYPE_ERROR,
     ],


### PR DESCRIPTION
Return an ExcelException object rather than a string to represent MS Excel formula errors, so that formulae that return string values that do begin with a '#' can be distinguished from actual formula errors

This is:

```
- [X] a bugfix
- [X] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [ X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
