### PR TITLE
PHP8 nightly build included in test run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - nightly
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 
 before_script:
   # Deactivate xdebug
-  - if [[ $TRAVIS_PHP_VERSION <> nightly ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != nightly ]]; then phpenv config-rm xdebug.ini; fi
   - composer install --ignore-platform-reqs
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,14 @@ cache:
 
 before_script:
   # Deactivate xdebug
-  - phpenv config-rm xdebug.ini
+  - if [[ $TRAVIS_PHP_VERSION <> nightly ]]; then phpenv config-rm xdebug.ini; fi
   - composer install --ignore-platform-reqs
 
 script:
   - ./vendor/bin/phpunit --color=always --coverage-text
+
+allow_failures:
+  - php: nightly
 
 jobs:
   include:

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "jpgraph/jpgraph": "^4.0",
         "mpdf/mpdf": "^8.0",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^8.5|^9.3",
         "squizlabs/php_codesniffer": "^3.5",
         "tecnickcom/tcpdf": "^6.3"
     },


### PR DESCRIPTION
PHP8 nightly build included in test run and it should pick up PHPUnit >= 9.3

This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
