### PR TITLE
fixed php8 deprecation warning for libxml_disable_entity_loader()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Fixed
 
 - PrintArea causes exception [#1544](https://github.com/phpoffice/phpspreadsheet/pull/1544) 
+- Fixed PHP8 deprecation warning for libxml_disable_entity_loader() [#1625](https://github.com/phpoffice/phpspreadsheet/pull/1625) 
 
 ## 1.14.1 - 2020-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Improve Coverage for ODS Reader [#1545](https://github.com/phpoffice/phpspreadsheet/pull/1545)
 - Named formula implementation, and improved handling of Defined Names generally [#1535](https://github.com/PHPOffice/PhpSpreadsheet/pull/1535)
-  - fix resolution of relative named range values in the calculation engine; previously all named range values had been treated as absolute.
+- fix resolution of relative named range values in the calculation engine; previously all named range values had been treated as absolute.
+- Drop $this->spreadSheet null check from Xlsx Writer [#1646](https://github.com/phpoffice/phpspreadsheet/pull/1646)
 
 ### Deprecated
 
@@ -49,7 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Fixed
 
 - PrintArea causes exception [#1544](https://github.com/phpoffice/phpspreadsheet/pull/1544) 
-- Fixed PHP8 deprecation warning for libxml_disable_entity_loader() [#1625](https://github.com/phpoffice/phpspreadsheet/pull/1625) 
+- Calculation/DateTime Failure With PHP8 [#1661](https://github.com/phpoffice/phpspreadsheet/pull/1661)
+- Reader/Gnumeric Failure with PHP8 [#1662](https://github.com/phpoffice/phpspreadsheet/pull/1662)
+- ReverseSort bug, exposed but not caused by PHP8 [#1660](https://github.com/phpoffice/phpspreadsheet/pull/1660)
+- Bug setting Superscript/Subscript to false [#1567](https://github.com/phpoffice/phpspreadsheet/pull/1567)
 
 ## 1.14.1 - 2020-07-19
 
@@ -556,6 +560,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Ignore inlineStr type if formula element exists - @ncrypthic [#570](https://github.com/PHPOffice/PHPExcel/issues/570)
 - Excel 2007 Reader freezes because of conditional formatting - @rentalhost [#575](https://github.com/PHPOffice/PHPExcel/issues/575)
 - Readers will now parse files containing worksheet titles over 31 characters [#176](https://github.com/PHPOffice/PhpSpreadsheet/pull/176)
+- Fixed PHP8 deprecation warning for libxml_disable_entity_loader() [#1625](https://github.com/phpoffice/phpspreadsheet/pull/1625) 
 
 ### General
 

--- a/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
+++ b/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
@@ -63,7 +63,7 @@ class XmlScanner
 
     private function disableEntityLoaderCheck(): void
     {
-        if (Settings::getLibXmlDisableEntityLoader()) {
+        if (Settings::getLibXmlDisableEntityLoader() && \PHP_VERSION_ID < 80000) {
             $libxmlDisableEntityLoaderValue = libxml_disable_entity_loader(true);
 
             if (self::$libxmlDisableEntityLoaderValue === null) {
@@ -74,7 +74,7 @@ class XmlScanner
 
     public static function shutdown(): void
     {
-        if (self::$libxmlDisableEntityLoaderValue !== null) {
+        if (self::$libxmlDisableEntityLoaderValue !== null && \PHP_VERSION_ID < 80000) {
             libxml_disable_entity_loader(self::$libxmlDisableEntityLoaderValue);
             self::$libxmlDisableEntityLoaderValue = null;
         }

--- a/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
@@ -12,7 +12,10 @@ class XmlScannerTest extends TestCase
 {
     protected function setUp(): void
     {
-        libxml_disable_entity_loader(false);
+        // php 8.+ deprecated libxml_disable_entity_loader() - It's on by default
+        if (\PHP_VERSION_ID < 80000) {
+            libxml_disable_entity_loader(false);
+        }
     }
 
     /**
@@ -24,13 +27,19 @@ class XmlScannerTest extends TestCase
      */
     public function testValidXML($filename, $expectedResult, $libxmlDisableEntityLoader): void
     {
-        $oldDisableEntityLoaderState = libxml_disable_entity_loader($libxmlDisableEntityLoader);
+        // php 8.+ deprecated libxml_disable_entity_loader() - It's on by default
+        if (\PHP_VERSION_ID < 80000) {
+            $oldDisableEntityLoaderState = libxml_disable_entity_loader($libxmlDisableEntityLoader);
+        }
 
         $reader = XmlScanner::getInstance(new \PhpOffice\PhpSpreadsheet\Reader\Xml());
         $result = $reader->scanFile($filename);
         self::assertEquals($expectedResult, $result);
 
-        libxml_disable_entity_loader($oldDisableEntityLoaderState);
+        // php 8.+ deprecated libxml_disable_entity_loader() - It's on by default
+        if (\PHP_VERSION_ID < 80000) {
+            libxml_disable_entity_loader($oldDisableEntityLoaderState);
+        }
     }
 
     public function providerValidXML()
@@ -56,13 +65,19 @@ class XmlScannerTest extends TestCase
     {
         $this->expectException(\PhpOffice\PhpSpreadsheet\Reader\Exception::class);
 
-        libxml_disable_entity_loader($libxmlDisableEntityLoader);
+        // php 8.+ deprecated libxml_disable_entity_loader() - It's on by default
+        if (\PHP_VERSION_ID < 80000) {
+            libxml_disable_entity_loader($libxmlDisableEntityLoader);
+        }
 
         $reader = XmlScanner::getInstance(new \PhpOffice\PhpSpreadsheet\Reader\Xml());
         $expectedResult = 'FAILURE: Should throw an Exception rather than return a value';
         $result = $reader->scanFile($filename);
         self::assertEquals($expectedResult, $result);
-        self::assertEquals($libxmlDisableEntityLoader, libxml_disable_entity_loader());
+        // php 8.+ deprecated libxml_disable_entity_loader() - It's on by default
+        if (\PHP_VERSION_ID < 80000) {
+            self::assertEquals($libxmlDisableEntityLoader, libxml_disable_entity_loader());
+        }
     }
 
     public function providerInvalidXML()

--- a/tests/PhpSpreadsheetTests/SettingsTest.php
+++ b/tests/PhpSpreadsheetTests/SettingsTest.php
@@ -14,27 +14,39 @@ class SettingsTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->prevValue = libxml_disable_entity_loader();
-        libxml_disable_entity_loader(false); // Enable entity loader
+        // php 8.+ deprecated libxml_disable_entity_loader() - It's on by default
+        if (\PHP_VERSION_ID < 80000) {
+            $this->prevValue = libxml_disable_entity_loader();
+            libxml_disable_entity_loader(false); // Enable entity loader
+        }
     }
 
     protected function tearDown(): void
     {
-        libxml_disable_entity_loader($this->prevValue);
+        // php 8.+ deprecated libxml_disable_entity_loader() - It's on by default
+        if (\PHP_VERSION_ID < 80000) {
+            libxml_disable_entity_loader($this->prevValue);
+        }
     }
 
     public function testGetXMLSettings(): void
     {
         $result = Settings::getLibXmlLoaderOptions();
-        self::assertTrue((bool) ((LIBXML_DTDLOAD | LIBXML_DTDATTR) & $result));
-        self::assertFalse(libxml_disable_entity_loader());
+        self::assertTrue((bool)((LIBXML_DTDLOAD | LIBXML_DTDATTR) & $result));
+        // php 8.+ deprecated libxml_disable_entity_loader() - It's on by default
+        if (\PHP_VERSION_ID < 80000) {
+            self::assertFalse(libxml_disable_entity_loader());
+        }
     }
 
     public function testSetXMLSettings(): void
     {
         Settings::setLibXmlLoaderOptions(LIBXML_DTDLOAD | LIBXML_DTDATTR | LIBXML_DTDVALID);
         $result = Settings::getLibXmlLoaderOptions();
-        self::assertTrue((bool) ((LIBXML_DTDLOAD | LIBXML_DTDATTR | LIBXML_DTDVALID) & $result));
-        self::assertFalse(libxml_disable_entity_loader());
+        self::assertTrue((bool)((LIBXML_DTDLOAD | LIBXML_DTDATTR | LIBXML_DTDVALID) & $result));
+        // php 8.+ deprecated libxml_disable_entity_loader() - It's on by default
+        if (\PHP_VERSION_ID < 80000) {
+            self::assertFalse(libxml_disable_entity_loader());
+        }
     }
 }

--- a/tests/PhpSpreadsheetTests/SettingsTest.php
+++ b/tests/PhpSpreadsheetTests/SettingsTest.php
@@ -32,7 +32,7 @@ class SettingsTest extends TestCase
     public function testGetXMLSettings(): void
     {
         $result = Settings::getLibXmlLoaderOptions();
-        self::assertTrue((bool)((LIBXML_DTDLOAD | LIBXML_DTDATTR) & $result));
+        self::assertTrue((bool) ((LIBXML_DTDLOAD | LIBXML_DTDATTR) & $result));
         // php 8.+ deprecated libxml_disable_entity_loader() - It's on by default
         if (\PHP_VERSION_ID < 80000) {
             self::assertFalse(libxml_disable_entity_loader());
@@ -43,7 +43,7 @@ class SettingsTest extends TestCase
     {
         Settings::setLibXmlLoaderOptions(LIBXML_DTDLOAD | LIBXML_DTDATTR | LIBXML_DTDVALID);
         $result = Settings::getLibXmlLoaderOptions();
-        self::assertTrue((bool)((LIBXML_DTDLOAD | LIBXML_DTDATTR | LIBXML_DTDVALID) & $result));
+        self::assertTrue((bool) ((LIBXML_DTDLOAD | LIBXML_DTDATTR | LIBXML_DTDVALID) & $result));
         // php 8.+ deprecated libxml_disable_entity_loader() - It's on by default
         if (\PHP_VERSION_ID < 80000) {
             self::assertFalse(libxml_disable_entity_loader());


### PR DESCRIPTION
This is:

```
- [x] a bugfix
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

PHP8 has deprecated the function `libxml_disable_entity_loader`. Simple fix is to check php version. More info here: https://php.watch/versions/8.0/libxml_disable_entity_loader-deprecation
