### PR TITLE
improved performance of column width calculation for spreadsheets wit…

### DIFF
--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -496,7 +496,7 @@ class Cell
     public function isMergeRangeValueCell()
     {
         if ($mergeRange = $this->getMergeRange()) {
-			return $this->isMergeRangeValueCell2($mergeRange);
+            return $this->isMergeRangeValueCell2($mergeRange);
         }
         return false;
     }
@@ -509,9 +509,9 @@ class Cell
      */
     public function isMergeRangeValueCell2($mergeRange)
     {
-		$splittedRanges = Coordinate::splitRange($mergeRange);
-		[$startCell] = $splittedRanges[0];
-		return $this->getCoordinate() === $startCell;
+        $splittedRanges = Coordinate::splitRange($mergeRange);
+        [$startCell] = $splittedRanges[0];
+        return $this->getCoordinate() === $startCell;
     }
 
     /**
@@ -564,12 +564,12 @@ class Cell
         [$rangeStart, $rangeEnd] = Coordinate::rangeBoundaries($pRange);
 
         // Verify if cell is in range
-		$myRow = $this->getRow();
-        if( $rangeStart[1] <= $myRow && $rangeEnd[1] >= $myRow ) {
-			$myColumn = Coordinate::columnIndexFromString($this->getColumn());
-			return ($rangeStart[0] <= $myColumn) && ($rangeEnd[0] >= $myColumn);
-		}
-		return false;
+        $myRow = $this->getRow();
+        if ($rangeStart[1] <= $myRow && $rangeEnd[1] >= $myRow) {
+            $myColumn = Coordinate::columnIndexFromString($this->getColumn());
+            return ($rangeStart[0] <= $myColumn) && ($rangeEnd[0] >= $myColumn);
+        }
+        return false;
     }
 
     /**

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -501,10 +501,10 @@ class Cell
         return false;
     }
 
-	/**
+    /**
      * Is this cell the master (top left cell) in a merge range (that holds the actual data value).
      *
-	 * @param string $mergeRange
+     * @param string $mergeRange
      * @return bool
      */
     public function isMergeRangeValueCell2($mergeRange)

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -498,13 +498,14 @@ class Cell
         if ($mergeRange = $this->getMergeRange()) {
             return $this->isMergeRangeValueCell2($mergeRange);
         }
+
         return false;
     }
 
     /**
      * Is this cell the master (top left cell) in a merge range (that holds the actual data value).
      *
-     * @param string $mergeRange Merge range from getMergeRange().
+     * @param string $mergeRange merge range from getMergeRange()
      *
      * @return bool
      */
@@ -512,6 +513,7 @@ class Cell
     {
         $splittedRanges = Coordinate::splitRange($mergeRange);
         [$startCell] = $splittedRanges[0];
+
         return $this->getCoordinate() === $startCell;
     }
 
@@ -568,8 +570,10 @@ class Cell
         $myRow = $this->getRow();
         if ($rangeStart[1] <= $myRow && $rangeEnd[1] >= $myRow) {
             $myColumn = Coordinate::columnIndexFromString($this->getColumn());
+
             return ($rangeStart[0] <= $myColumn) && ($rangeEnd[0] >= $myColumn);
         }
+
         return false;
     }
 

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -504,8 +504,8 @@ class Cell
     /**
      * Is this cell the master (top left cell) in a merge range (that holds the actual data value).
      *
-     * @param string $mergeRange
-	 * 
+     * @param string $mergeRange Merge range from getMergeRange().
+     *
      * @return bool
      */
     public function isMergeRangeValueCell2($mergeRange)

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -496,14 +496,22 @@ class Cell
     public function isMergeRangeValueCell()
     {
         if ($mergeRange = $this->getMergeRange()) {
-            $mergeRange = Coordinate::splitRange($mergeRange);
-            [$startCell] = $mergeRange[0];
-            if ($this->getCoordinate() === $startCell) {
-                return true;
-            }
+			return $this->isMergeRangeValueCell2($mergeRange);
         }
-
         return false;
+    }
+
+	/**
+     * Is this cell the master (top left cell) in a merge range (that holds the actual data value).
+     *
+	 * @param string $mergeRange
+     * @return bool
+     */
+    public function isMergeRangeValueCell2($mergeRange)
+    {
+		$splittedRanges = Coordinate::splitRange($mergeRange);
+		[$startCell] = $splittedRanges[0];
+		return $this->getCoordinate() === $startCell;
     }
 
     /**
@@ -555,13 +563,13 @@ class Cell
     {
         [$rangeStart, $rangeEnd] = Coordinate::rangeBoundaries($pRange);
 
-        // Translate properties
-        $myColumn = Coordinate::columnIndexFromString($this->getColumn());
-        $myRow = $this->getRow();
-
         // Verify if cell is in range
-        return ($rangeStart[0] <= $myColumn) && ($rangeEnd[0] >= $myColumn) &&
-                ($rangeStart[1] <= $myRow) && ($rangeEnd[1] >= $myRow);
+		$myRow = $this->getRow();
+        if( $rangeStart[1] <= $myRow && $rangeEnd[1] >= $myRow ) {
+			$myColumn = Coordinate::columnIndexFromString($this->getColumn());
+			return ($rangeStart[0] <= $myColumn) && ($rangeEnd[0] >= $myColumn);
+		}
+		return false;
     }
 
     /**

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -505,6 +505,7 @@ class Cell
      * Is this cell the master (top left cell) in a merge range (that holds the actual data value).
      *
      * @param string $mergeRange
+	 * 
      * @return bool
      */
     public function isMergeRangeValueCell2($mergeRange)

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -157,6 +157,8 @@ abstract class Coordinate
         return implode(',', $pRange);
     }
 
+	private static $_rangeBoundariesCache = [];
+
     /**
      * Calculate range boundaries.
      *
@@ -167,7 +169,9 @@ abstract class Coordinate
      */
     public static function rangeBoundaries($pRange)
     {
-        // Ensure $pRange is a valid range
+		if( isset(self::$_rangeBoundariesCache[$pRange]) ) return self::$_rangeBoundariesCache[$pRange];
+
+		// Ensure $pRange is a valid range
         if (empty($pRange)) {
             $pRange = self::DEFAULT_RANGE;
         }
@@ -184,12 +188,13 @@ abstract class Coordinate
 
         // Calculate range outer borders
         $rangeStart = self::coordinateFromString($rangeA);
-        $rangeEnd = self::coordinateFromString($rangeB);
+        $rangeEnd = $rangeA===$rangeB ? $rangeStart : self::coordinateFromString($rangeB);
 
         // Translate column into index
         $rangeStart[0] = self::columnIndexFromString($rangeStart[0]);
         $rangeEnd[0] = self::columnIndexFromString($rangeEnd[0]);
 
+		self::$_rangeBoundariesCache[$pRange] = [$rangeStart, $rangeEnd];
         return [$rangeStart, $rangeEnd];
     }
 

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -170,7 +170,9 @@ abstract class Coordinate
      */
     public static function rangeBoundaries($pRange)
     {
-        if (isset(self::$_rangeBoundariesCache[$pRange])) return self::$_rangeBoundariesCache[$pRange];
+        if (isset(self::$_rangeBoundariesCache[$pRange])) {
+            return self::$_rangeBoundariesCache[$pRange];
+        }
 
         // Ensure $pRange is a valid range
         if (empty($pRange)) {
@@ -189,7 +191,7 @@ abstract class Coordinate
 
         // Calculate range outer borders
         $rangeStart = self::coordinateFromString($rangeA);
-        $rangeEnd = $rangeA===$rangeB ? $rangeStart : self::coordinateFromString($rangeB);
+        $rangeEnd = $rangeA === $rangeB ? $rangeStart : self::coordinateFromString($rangeB);
 
         // Translate column into index
         $rangeStart[0] = self::columnIndexFromString($rangeStart[0]);

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -19,7 +19,7 @@ abstract class Coordinate
      *
      * @var array
      */
-	private static $_rangeBoundariesCache = [];
+    private static $_rangeBoundariesCache = [];
 
     /**
      * Default range variable constant.

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -13,7 +13,6 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
  */
 abstract class Coordinate
 {
-
     /**
      * Cache for rangeBoundaries.
      *
@@ -165,7 +164,6 @@ abstract class Coordinate
         return implode(',', $pRange);
     }
 
-
     /**
      * Calculate range boundaries.
      *
@@ -204,6 +202,7 @@ abstract class Coordinate
         $rangeEnd[0] = self::columnIndexFromString($rangeEnd[0]);
 
         self::$_rangeBoundariesCache[$pRange] = [$rangeStart, $rangeEnd];
+
         return [$rangeStart, $rangeEnd];
     }
 

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -13,7 +13,13 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
  */
 abstract class Coordinate
 {
-    private static $_rangeBoundariesCache = [];
+
+    /**
+     * Cache for rangeBoundaries.
+     *
+     * @var array
+     */
+	private static $_rangeBoundariesCache = [];
 
     /**
      * Default range variable constant.

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -13,6 +13,8 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
  */
 abstract class Coordinate
 {
+    private static $_rangeBoundariesCache = [];
+
     /**
      * Default range variable constant.
      *
@@ -157,7 +159,6 @@ abstract class Coordinate
         return implode(',', $pRange);
     }
 
-	private static $_rangeBoundariesCache = [];
 
     /**
      * Calculate range boundaries.
@@ -169,9 +170,9 @@ abstract class Coordinate
      */
     public static function rangeBoundaries($pRange)
     {
-		if( isset(self::$_rangeBoundariesCache[$pRange]) ) return self::$_rangeBoundariesCache[$pRange];
+        if (isset(self::$_rangeBoundariesCache[$pRange])) return self::$_rangeBoundariesCache[$pRange];
 
-		// Ensure $pRange is a valid range
+        // Ensure $pRange is a valid range
         if (empty($pRange)) {
             $pRange = self::DEFAULT_RANGE;
         }
@@ -194,7 +195,7 @@ abstract class Coordinate
         $rangeStart[0] = self::columnIndexFromString($rangeStart[0]);
         $rangeEnd[0] = self::columnIndexFromString($rangeEnd[0]);
 
-		self::$_rangeBoundariesCache[$pRange] = [$rangeStart, $rangeEnd];
+        self::$_rangeBoundariesCache[$pRange] = [$rangeStart, $rangeEnd];
         return [$rangeStart, $rangeEnd];
     }
 

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -738,13 +738,13 @@ class Worksheet implements IComparable
 
                     //The only exception is if it's a merge range value cell of a 'vertical' randge (1 column wide)
                     if ($isMerged) {
-						$range = $cell->getMergeRange();
-						if ($cell->isMergeRangeValueCell2($range)) {
-							$rangeBoundaries = Coordinate::rangeDimension($range);
-							if ($rangeBoundaries[0] == 1) {
-								$isMergedButProceed = true;
-							}
-						}
+                        $range = $cell->getMergeRange();
+                        if ($cell->isMergeRangeValueCell2($range)) {
+                            $rangeBoundaries = Coordinate::rangeDimension($range);
+                            if ($rangeBoundaries[0] == 1) {
+                                $isMergedButProceed = true;
+                            }
+                       }
                     }
 
                     // Determine width if cell does not participate in a merge or does and is a value cell of 1-column wide range

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -737,12 +737,14 @@ class Worksheet implements IComparable
                     $isMergedButProceed = false;
 
                     //The only exception is if it's a merge range value cell of a 'vertical' randge (1 column wide)
-                    if ($isMerged && $cell->isMergeRangeValueCell()) {
-                        $range = $cell->getMergeRange();
-                        $rangeBoundaries = Coordinate::rangeDimension($range);
-                        if ($rangeBoundaries[0] == 1) {
-                            $isMergedButProceed = true;
-                        }
+                    if ($isMerged) {
+						$range = $cell->getMergeRange();
+						if ($cell->isMergeRangeValueCell2($range)) {
+							$rangeBoundaries = Coordinate::rangeDimension($range);
+							if ($rangeBoundaries[0] == 1) {
+								$isMergedButProceed = true;
+							}
+						}
                     }
 
                     // Determine width if cell does not participate in a merge or does and is a value cell of 1-column wide range

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -744,7 +744,7 @@ class Worksheet implements IComparable
                             if ($rangeBoundaries[0] == 1) {
                                 $isMergedButProceed = true;
                             }
-                       }
+                        }
                     }
 
                     // Determine width if cell does not participate in a merge or does and is a value cell of 1-column wide range


### PR DESCRIPTION
improved performance of column width calculation for spreadsheets with many merged cells

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Creating Spreadsheets with many merged cells was very slow.

This was (to some degree) because of a many (unnecesserily) repeated calls to Coordinate::rangeBoundaries(), Cell::isInRange() and Cell::getMergeRange().


