### PR TITLE
ReverseSort bug, exposed but not caused by PHP8

### DIFF
--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -68,7 +68,7 @@ class ReferenceHelper
      */
     public static function columnReverseSort($a, $b)
     {
-        return 1 - strcasecmp(strlen($a) . $a, strlen($b) . $b);
+        return -strcasecmp(strlen($a) . $a, strlen($b) . $b);
     }
 
     /**
@@ -107,7 +107,7 @@ class ReferenceHelper
         [$bc, $br] = sscanf($b, '%[A-Z]%d');
 
         if ($ar === $br) {
-            return 1 - strcasecmp(strlen($ac) . $ac, strlen($bc) . $bc);
+            return -strcasecmp(strlen($ac) . $ac, strlen($bc) . $bc);
         }
 
         return ($ar < $br) ? 1 : -1;


### PR DESCRIPTION
Some tests of ReferenceHelper functions columnReverseSort and
cellReverseSort which passed with PHP7 fail with PHP8.
Both functions use the following construction:
  return 1 - strcasecmp(whatever);
The "1" seems very mysterious. I believe that the correct code should be:
  return -strcasecmp(whatever);
It appears in particular that PHP7 strcasecmp was never returning a
value of 1 for the tests in question, but PHP8 strcasecmp does so.
With the corrected code, the tests pass in both PHP7 and PHP8.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Bugfix in ReferenceHelper reverseColumnSort and reverseCellSort
