### PR TITLE
Calculation/DateTime Failure With PHP8

### DIFF
--- a/src/PhpSpreadsheet/Calculation/DateTime.php
+++ b/src/PhpSpreadsheet/Calculation/DateTime.php
@@ -487,7 +487,7 @@ class DateTime
             if ($yearFound) {
                 array_unshift($t1, 1);
             } else {
-                if ($t1[1] > 29) {
+                if (is_numeric($t1[1]) && $t1[1] > 29) {
                     $t1[1] += 1900;
                     array_unshift($t1, 1);
                 } else {


### PR DESCRIPTION
The following code generates an error with PHP8:
  if ($t1[1] > 29) {
    $t1[1] += 1900;

Under the "right" conditions, PHP8 evaluates the condition as true
when PHP8 is a non-numeric string and then generates an error trying
to perform += on that non-numeric string. Adding a numeric test
eliminates the problem. All unit tests involving this code now
succeed with both PHP7 and PHP8.

This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
