### PR TITLE
Fix XLSX reader when having a corrupt numeric cell data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Improve Coverage for ODS Reader [#1545](https://github.com/phpoffice/phpspreadsheet/pull/1545)
 - Named formula implementation, and improved handling of Defined Names generally [#1535](https://github.com/PHPOffice/PhpSpreadsheet/pull/1535)
-  - fix resolution of relative named range values in the calculation engine; previously all named range values had been treated as absolute.
+- fix resolution of relative named range values in the calculation engine; previously all named range values had been treated as absolute.
+- Drop $this->spreadSheet null check from Xlsx Writer [#1646](https://github.com/phpoffice/phpspreadsheet/pull/1646)
 
 ### Deprecated
 
@@ -49,6 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Fixed
 
 - PrintArea causes exception [#1544](https://github.com/phpoffice/phpspreadsheet/pull/1544) 
+- Calculation/DateTime Failure With PHP8 [#1661](https://github.com/phpoffice/phpspreadsheet/pull/1661)
+- Reader/Gnumeric Failure with PHP8 [#1662](https://github.com/phpoffice/phpspreadsheet/pull/1662)
+- ReverseSort bug, exposed but not caused by PHP8 [#1660](https://github.com/phpoffice/phpspreadsheet/pull/1660)
+- Bug setting Superscript/Subscript to false [#1567](https://github.com/phpoffice/phpspreadsheet/pull/1567)
 - Fix XLSX reader when having a corrupt numeric cell data type [#1664](https://github.com/phpoffice/phpspreadsheet/pull/1664) 
 
 ## 1.14.1 - 2020-07-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Fixed
 
 - PrintArea causes exception [#1544](https://github.com/phpoffice/phpspreadsheet/pull/1544) 
+- Fix XLSX reader when having a corrupt numeric cell data type [#1664](https://github.com/phpoffice/phpspreadsheet/pull/1664) 
 
 ## 1.14.1 - 2020-07-19
 

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Reader;
 
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\Hyperlink;
 use PhpOffice\PhpSpreadsheet\DefinedName;
@@ -732,6 +733,10 @@ class Xlsx extends BaseReader
                                             $cell = $docSheet->getCell($r);
                                             // Assign value
                                             if ($cellDataType != '') {
+                                                // it is possible, that datatype is numeric but with an empty string, which result in an error
+                                                if ($cellDataType === DataType::TYPE_NUMERIC && $value === "") {
+                                                    $cellDataType = DataType::TYPE_STRING;
+                                                }
                                                 $cell->setValueExplicit($value, $cellDataType);
                                             } else {
                                                 $cell->setValue($value);

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2,8 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheet\Reader;
 
-use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Cell\Hyperlink;
 use PhpOffice\PhpSpreadsheet\DefinedName;
 use PhpOffice\PhpSpreadsheet\Reader\Security\XmlScanner;
@@ -734,7 +734,7 @@ class Xlsx extends BaseReader
                                             // Assign value
                                             if ($cellDataType != '') {
                                                 // it is possible, that datatype is numeric but with an empty string, which result in an error
-                                                if ($cellDataType === DataType::TYPE_NUMERIC && $value === "") {
+                                                if ($cellDataType === DataType::TYPE_NUMERIC && $value === '') {
                                                     $cellDataType = DataType::TYPE_STRING;
                                                 }
                                                 $cell->setValueExplicit($value, $cellDataType);


### PR DESCRIPTION
This is:

```
- [x] a bugfix
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

In some rare cases, when reading an XLSX file that may contain invalid cell type values, the reader throw an error. It happens when the found data type in a table cell is numeric, but the actual value is an empty string. This will throw a exception and the result is the file cannot be read.

You can open those files in any reader (LibreOffice, MS Office) without problems but PhpSpreadsheet struggles with it.

Unfortunetely i cannot add tests or a demonstration file because our files that cause this error contains sensible data. If we try to remove the sensible data, the file is automatically fixed by our Office Suite. The file we use is generated from a third party company, so we have no chance to generate files with those errors.

Hopefully this PR will be merged even if no test scenario is provided.