### PR TITLE
Update Coordinate::coordinateFromString

### DIFF
--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -25,12 +25,12 @@ abstract class Coordinate
      *
      * @param string $pCoordinateString eg: 'A1'
      *
-     * @return string[] Array containing column and row (indexes 0 and 1)
+     * @return array{0:string,1:int} Array containing column and row (indexes 0 and 1)
      */
     public static function coordinateFromString($pCoordinateString)
     {
         if (preg_match('/^([$]?[A-Z]{1,3})([$]?\\d{1,7})$/', $pCoordinateString, $matches)) {
-            return [$matches[1], $matches[2]];
+            return [$matches[1], (int) $matches[2]];
         } elseif (self::coordinateIsRange($pCoordinateString)) {
             throw new Exception('Cell coordinate string can not be a range of cells');
         } elseif ($pCoordinateString == '') {


### PR DESCRIPTION
Coordinate::coordinateFromString should return array [ string, int ] as row number is expected to be int in all other functions like Worksheet:getRowDimension(int $row)

This is:

```
- [*] a bugfix
- [ ] a new feature
```

Checklist:

- [?] Changes are covered by unit tests
- [*] Code style is respected
- [*] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
