### PR TITLE
Change PhpOffice\PhpSpreadsheet\Reader\Html.php methods visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Ensure that the list of shared formulae is maintained when an xlsx file is chunked with readFilter[Issue #169](https://github.com/PHPOffice/PhpSpreadsheet/issues/1669).
 - Fix for notice during accessing "cached magnification factor" offset [#1354](https://github.com/PHPOffice/PhpSpreadsheet/pull/1354)
 
+## 1.15.1 - 2020-10-15
+
+### Added
+
+- Missing PHPDoc comments to PhpOffice\PhpSpreadsheet\Reader\Html.php
+
+### Changed
+
+- Change methods ([insertImage](https://github.com/PHPOffice/PhpSpreadsheet/blob/master/src/PhpSpreadsheet/Reader/Html.php#L930), [setBorderStyle](https://github.com/PHPOffice/PhpSpreadsheet/blob/master/src/PhpSpreadsheet/Reader/Html.php#L1008), [applyInlineStyle](https://github.com/PHPOffice/PhpSpreadsheet/blob/master/src/PhpSpreadsheet/Reader/Html.php#L743)) visibility in [PhpOffice\PhpSpreadsheet\Reader\Html.php](https://github.com/PHPOffice/PhpSpreadsheet/blob/master/src/PhpSpreadsheet/Reader/Html.php) from private to protected. [Issue #1654](https://github.com/PHPOffice/PhpSpreadsheet/issues/1654)
+
+
 ## 1.15.0 - 2020-10-11
 
 ### Added

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -207,6 +207,7 @@ class Html extends BaseReader
      * @param string $pFilename
      *
      * @return Spreadsheet
+     * @throws Exception
      */
     public function load($pFilename)
     {
@@ -632,7 +633,9 @@ class Html extends BaseReader
      *
      * @param string $pFilename
      *
+     * @param Spreadsheet $spreadsheet
      * @return Spreadsheet
+     * @throws Exception
      */
     public function loadIntoExisting($pFilename, Spreadsheet $spreadsheet)
     {
@@ -660,6 +663,9 @@ class Html extends BaseReader
      * Spreadsheet from content.
      *
      * @param string $content
+     * @param Spreadsheet|null $spreadsheet
+     * @return Spreadsheet
+     * @throws Exception
      */
     public function loadFromString($content, ?Spreadsheet $spreadsheet = null): Spreadsheet
     {
@@ -924,8 +930,11 @@ class Html extends BaseReader
     }
 
     /**
-     * @param string    $column
-     * @param int       $row
+     * @param Worksheet $sheet
+     * @param string $column
+     * @param int $row
+     * @param array $attributes
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
      */
     private function insertImage(Worksheet $sheet, $column, $row, array $attributes): void
     {

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -632,7 +632,6 @@ class Html extends BaseReader
      *
      * @param string $pFilename
      *
-     * @param Spreadsheet $spreadsheet
      * @return Spreadsheet
      */
     public function loadIntoExisting($pFilename, Spreadsheet $spreadsheet)
@@ -661,8 +660,6 @@ class Html extends BaseReader
      * Spreadsheet from content.
      *
      * @param string $content
-     * @param Spreadsheet|null $spreadsheet
-     * @return Spreadsheet
      */
     public function loadFromString($content, ?Spreadsheet $spreadsheet = null): Spreadsheet
     {
@@ -927,10 +924,8 @@ class Html extends BaseReader
     }
 
     /**
-     * @param Worksheet $sheet
      * @param string $column
      * @param int $row
-     * @param array $attributes
      */
     protected function insertImage(Worksheet $sheet, $column, $row, array $attributes): void
     {

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -746,7 +746,7 @@ class Html extends BaseReader
      * @param string $column
      * @param array $attributeArray
      */
-    private function applyInlineStyle(&$sheet, $row, $column, $attributeArray): void
+    protected function applyInlineStyle(&$sheet, $row, $column, $attributeArray): void
     {
         if (!isset($attributeArray['style'])) {
             return;
@@ -936,7 +936,7 @@ class Html extends BaseReader
      * @param array $attributes
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      */
-    private function insertImage(Worksheet $sheet, $column, $row, array $attributes): void
+    protected function insertImage(Worksheet $sheet, $column, $row, array $attributes): void
     {
         if (!isset($attributes['src'])) {
             return;
@@ -1014,7 +1014,7 @@ class Html extends BaseReader
      * @param string $styleValue
      * @param string $type
      */
-    private function setBorderStyle(Style $cellStyle, $styleValue, $type): void
+    protected function setBorderStyle(Style $cellStyle, $styleValue, $type): void
     {
         if (trim($styleValue) === Border::BORDER_NONE) {
             $borderStyle = Border::BORDER_NONE;

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -207,7 +207,6 @@ class Html extends BaseReader
      * @param string $pFilename
      *
      * @return Spreadsheet
-     * @throws Exception
      */
     public function load($pFilename)
     {
@@ -635,7 +634,6 @@ class Html extends BaseReader
      *
      * @param Spreadsheet $spreadsheet
      * @return Spreadsheet
-     * @throws Exception
      */
     public function loadIntoExisting($pFilename, Spreadsheet $spreadsheet)
     {
@@ -665,7 +663,6 @@ class Html extends BaseReader
      * @param string $content
      * @param Spreadsheet|null $spreadsheet
      * @return Spreadsheet
-     * @throws Exception
      */
     public function loadFromString($content, ?Spreadsheet $spreadsheet = null): Spreadsheet
     {
@@ -934,7 +931,6 @@ class Html extends BaseReader
      * @param string $column
      * @param int $row
      * @param array $attributes
-     * @throws \PhpOffice\PhpSpreadsheet\Exception
      */
     protected function insertImage(Worksheet $sheet, $column, $row, array $attributes): void
     {


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
I made this changes for issue [1654](https://github.com/PHPOffice/PhpSpreadsheet/issues/1654)
