### PR TITLE
Fixed reading XSLS style alignments from XML

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -143,21 +143,21 @@ class Styles extends BaseParserClass
 
     private static function readAlignmentStyle(Alignment $alignment, SimpleXMLElement $alignmentXml): void
     {
-        $alignment->setHorizontal((string) $alignmentXml->alignment['horizontal']);
-        $alignment->setVertical((string) $alignmentXml->alignment['vertical']);
+        $alignment->setHorizontal((string) $alignmentXml['horizontal']);
+        $alignment->setVertical((string) $alignmentXml['vertical']);
 
         $textRotation = 0;
-        if ((int) $alignmentXml->alignment['textRotation'] <= 90) {
-            $textRotation = (int) $alignmentXml->alignment['textRotation'];
-        } elseif ((int) $alignmentXml->alignment['textRotation'] > 90) {
-            $textRotation = 90 - (int) $alignmentXml->alignment['textRotation'];
+        if ((int) $alignmentXml['textRotation'] <= 90) {
+            $textRotation = (int) $alignmentXml['textRotation'];
+        } elseif ((int) $alignmentXml['textRotation'] > 90) {
+            $textRotation = 90 - (int) $alignmentXml['textRotation'];
         }
 
         $alignment->setTextRotation((int) $textRotation);
-        $alignment->setWrapText(self::boolean((string) $alignmentXml->alignment['wrapText']));
-        $alignment->setShrinkToFit(self::boolean((string) $alignmentXml->alignment['shrinkToFit']));
-        $alignment->setIndent((int) ((string) $alignmentXml->alignment['indent']) > 0 ? (int) ((string) $alignmentXml->alignment['indent']) : 0);
-        $alignment->setReadOrder((int) ((string) $alignmentXml->alignment['readingOrder']) > 0 ? (int) ((string) $alignmentXml->alignment['readingOrder']) : 0);
+        $alignment->setWrapText(self::boolean((string) $alignmentXml['wrapText']));
+        $alignment->setShrinkToFit(self::boolean((string) $alignmentXml['shrinkToFit']));
+        $alignment->setIndent((int) ((string) $alignmentXml['indent']) > 0 ? (int) ((string) $alignmentXml['indent']) : 0);
+        $alignment->setReadOrder((int) ((string) $alignmentXml['readingOrder']) > 0 ? (int) ((string) $alignmentXml['readingOrder']) : 0);
     }
 
     private function readStyle(Style $docStyle, $style): void


### PR DESCRIPTION
These changes remove the redundant child-node access in the method `readAlignmentStyle` which would otherwise lead to errors.

This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

The attribute `$alignmentXml` given to the private method `readAlignmentStyle` is the alignment XML tag that contains the alignment data itself. But inside that method all data are read from another `alignment` XML tag within that given tag. This redundant child-node access resulted in the following error- / notice-message: `PHP Notice:  Trying to access array offset on value of type null in /foo/bar/baz/vendor/phpoffice/phpspreadsheet/src/PhpSpreadsheet/Reader/Xlsx/Styles.php on line 146`.
