### PR TITLE
Fix pixelsToPoints conversion ratio (for HTML/CSS & PDF col width)

### DIFF
--- a/src/PhpSpreadsheet/Shared/Drawing.php
+++ b/src/PhpSpreadsheet/Shared/Drawing.php
@@ -98,7 +98,7 @@ class Drawing
      */
     public static function pixelsToPoints($pValue)
     {
-        return $pValue * 0.67777777;
+        return $pValue * 0.75;
     }
 
     /**
@@ -111,7 +111,7 @@ class Drawing
     public static function pointsToPixels($pValue)
     {
         if ($pValue != 0) {
-            return (int) ceil($pValue * 1.333333333);
+            return (int) ceil($pValue / 0.75);
         }
 
         return 0;


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

When converting an XLSX to PDF, the resulting columns widths are smaller.

"0.67777777" is wrong, the correct pt/px ratio is 72/96 = 3/4 = 0.75

Refs https://github.com/PHPOffice/PHPWord/pull/234
Replaces https://github.com/PHPOffice/PHPExcel/pull/497

Additionally, I updated `* 1.333333333` to `/ 0.75` in `pointsToPixels` (rather than updating `* 0.75` to `/ 1.333333333` in `pixelsToPoints`) for symmetry/consistency (and because 3/4 has an exact representation in both decimal and binary, while 4/3 hasn't)