### PR TITLE
WIP: Skip adding a defined name if the sheet isn't found

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1398,6 +1398,11 @@ class Xlsx extends BaseReader
                                         $locatedSheet = $excel->getSheetByName($extractedSheetName);
                                     }
 
+                                    // skip if the sheet isn't located
+                                    if ($locatedSheet) {
+                                        break 2;
+                                    }
+
                                     $excel->addDefinedName(DefinedName::createInstance((string) $definedName['name'], $locatedSheet, $definedRange, false));
                                 }
                             }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

in case when in the xlsx file has unused range name and the library will throw a exception with the following message as below, every time when we try to read the file
> You must specify a worksheet or a scope for a Named Range