### PR TITLE
Fix compatibility with ext-gd on php 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Fix for issue [#1735](https://github.com/PHPOffice/PhpSpreadsheet/issues/1735) Incorrect activeSheetIndex after RemoveSheetByIndex - [PR #1743](https://github.com/PHPOffice/PhpSpreadsheet/pull/1743) 
 - Ensure that the list of shared formulae is maintained when an xlsx file is chunked with readFilter[Issue #169](https://github.com/PHPOffice/PhpSpreadsheet/issues/1669).
 - Fix for notice during accessing "cached magnification factor" offset [#1354](https://github.com/PHPOffice/PhpSpreadsheet/pull/1354)
+- Fix compatibility with ext-gd on php 8
 
 ### Security Fix (CVE-2020-7776)
 

--- a/src/PhpSpreadsheet/Shared/Drawing.php
+++ b/src/PhpSpreadsheet/Shared/Drawing.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheet\Shared;
 
+use GdImage;
+
 class Drawing
 {
     /**
@@ -152,7 +154,7 @@ class Drawing
      *
      * @param string $p_sFile Path to Windows DIB (BMP) image
      *
-     * @return resource
+     * @return GdImage|resource
      */
     public static function imagecreatefrombmp($p_sFile)
     {

--- a/src/PhpSpreadsheet/Worksheet/MemoryDrawing.php
+++ b/src/PhpSpreadsheet/Worksheet/MemoryDrawing.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheet\Worksheet;
 
+use GdImage;
+
 class MemoryDrawing extends BaseDrawing
 {
     // Rendering functions
@@ -19,7 +21,7 @@ class MemoryDrawing extends BaseDrawing
     /**
      * Image resource.
      *
-     * @var resource
+     * @var GdImage|resource
      */
     private $imageResource;
 
@@ -62,7 +64,7 @@ class MemoryDrawing extends BaseDrawing
     /**
      * Get image resource.
      *
-     * @return resource
+     * @return GdImage|resource
      */
     public function getImageResource()
     {
@@ -72,7 +74,7 @@ class MemoryDrawing extends BaseDrawing
     /**
      * Set image resource.
      *
-     * @param resource $value
+     * @param GdImage|resource $value
      *
      * @return $this
      */

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Writer\Xls;
 
+use GdImage;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Cell\DataValidation;
@@ -2254,7 +2255,7 @@ class Worksheet extends BIFFwriter
      */
     public function insertBitmap($row, $col, $bitmap, $x = 0, $y = 0, $scale_x = 1, $scale_y = 1): void
     {
-        $bitmap_array = (is_resource($bitmap) ? $this->processBitmapGd($bitmap) : $this->processBitmap($bitmap));
+        $bitmap_array = (is_resource($bitmap) || $bitmap instanceof GdImage ? $this->processBitmapGd($bitmap) : $this->processBitmap($bitmap));
         [$width, $height, $size, $data] = $bitmap_array;
 
         // Scale the frame of the image.
@@ -2460,7 +2461,7 @@ class Worksheet extends BIFFwriter
     /**
      * Convert a GD-image into the internal format.
      *
-     * @param resource $image The image to process
+     * @param GdImage|resource $image The image to process
      *
      * @return array Array with data and properties of the bitmap
      */


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

On PHP 8, the GD extension migrated away from the `resource` type and uses objects instead. This PR makes the necessary adjustments.