### PR TITLE
Do not swallow previous exception when loading content as DOM Document fails

### DIFF
--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -650,7 +650,7 @@ class Html extends BaseReader
             $loaded = false;
         }
         if ($loaded === false) {
-            throw new Exception('Failed to load ' . $pFilename . ' as a DOM Document');
+            throw new Exception('Failed to load ' . $pFilename . ' as a DOM Document', 0, $e ?? null);
         }
 
         return $this->loadDocument($dom, $spreadsheet);
@@ -672,7 +672,7 @@ class Html extends BaseReader
             $loaded = false;
         }
         if ($loaded === false) {
-            throw new Exception('Failed to load content as a DOM Document');
+            throw new Exception('Failed to load content as a DOM Document', 0, $e ?? null);
         }
 
         return $this->loadDocument($dom, $spreadsheet ?? new Spreadsheet());


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

I didn't add tests to cover this change as there isn't something like `expectPreviousException` in PHPUnit. However, I'm open for suggestions to cover this with tests!

### Why this change is needed?

The previous exception will be included when loading the content as DOM Document fails. This makes debugging the reason behind the failure much easier.

N.B. I'm using this library with Laravel which converts all warnings/errors to an ErrorException so the error isn't reported but thrown.