### PR TITLE
Fix Xlsx reader overriding manually set number format with builtin number format

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -488,7 +488,7 @@ class Xlsx extends BaseReader
                     }
                     if (!$this->readDataOnly && $xmlStyles) {
                         foreach ($xmlStyles->cellXfs->xf as $xf) {
-                            $numFmt = NumberFormat::FORMAT_GENERAL;
+                            $numFmt = null;
 
                             if ($xf['numFmtId']) {
                                 if (isset($numFmts)) {
@@ -503,6 +503,7 @@ class Xlsx extends BaseReader
                                 //  But there's a lot of naughty homebrew xlsx writers that do use "reserved" id values that aren't actually used
                                 //  So we make allowance for them rather than lose formatting masks
                                 if (
+                                    $numFmt === null &&
                                     (int) $xf['numFmtId'] < 164 &&
                                     NumberFormat::builtInFormatCode((int) $xf['numFmtId']) !== ''
                                 ) {
@@ -515,7 +516,7 @@ class Xlsx extends BaseReader
                             }
 
                             $style = (object) [
-                                'numFmt' => $numFmt,
+                                'numFmt' => $numFmt === null ? NumberFormat::FORMAT_GENERAL : $numFmt,
                                 'font' => $xmlStyles->fonts->font[(int) ($xf['fontId'])],
                                 'fill' => $xmlStyles->fills->fill[(int) ($xf['fillId'])],
                                 'border' => $xmlStyles->borders->border[(int) ($xf['borderId'])],


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Relevant spreadsheet: https://circabc.europa.eu/ui/group/0e5f18c2-4b2f-42e9-aed4-dfe50ae1263b/library/3bbc2ffd-d4c1-4cbd-b8e5-71aa44f6ed3c/details

This spreadsheet overrides codes 50 and 51, but the reader ignores that and uses the built-in formats instead.

Verified by running:

```
var_dump($worksheet->getCell('E2')->getFormattedValue());
```

... which should output `2`, not some garbled mess

(I was unable to quickly produce a reduced payload - the original file is ~1.5MB which isn't suitable to include here)