### PR TITLE
Use DateTime Rather than gmmktime in Sample Template

### DIFF
--- a/samples/templates/sampleSpreadsheet.php
+++ b/samples/templates/sampleSpreadsheet.php
@@ -31,7 +31,9 @@ $spreadsheet->getProperties()->setCreator('Maarten Balliauw')
 $helper->log('Add some data');
 $spreadsheet->setActiveSheetIndex(0);
 $spreadsheet->getActiveSheet()->setCellValue('B1', 'Invoice');
-$spreadsheet->getActiveSheet()->setCellValue('D1', Date::PHPToExcel(gmmktime(0, 0, 0, date('m'), date('d'), date('Y'))));
+$date = new DateTime('now');
+$date->setTime(0, 0, 0);
+$spreadsheet->getActiveSheet()->setCellValue('D1', Date::PHPToExcel($date));
 $spreadsheet->getActiveSheet()->getStyle('D1')->getNumberFormat()->setFormatCode(NumberFormat::FORMAT_DATE_XLSX15);
 $spreadsheet->getActiveSheet()->setCellValue('E1', '#12566');
 


### PR DESCRIPTION
This avoids a potential Y2038 problem on 32-bit systems - see issue #1826.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
This avoids a potential Y2038 problem on 32-bit systems - see issue #1826.
