### PR TITLE
Avoid Duplicate Titles When Reading Multiple HTML Files

### DIFF
--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -320,7 +320,7 @@ class Html extends BaseReader
     {
         if ($child->nodeName === 'title') {
             $this->processDomElement($child, $sheet, $row, $column, $cellContent);
-            $sheet->setTitle($cellContent, true, false);
+            $sheet->setTitle($cellContent, true, true);
             $cellContent = '';
         } else {
             $this->processDomElementSpanEtc($sheet, $row, $column, $cellContent, $child, $attributeArray);

--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlLoadStringTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlLoadStringTest.php
@@ -89,4 +89,33 @@ class HtmlLoadStringTest extends TestCase
         $spreadsheet = $reader->loadFromString($html, $spreadsheet);
         self::assertEquals(2, $spreadsheet->getSheetCount());
     }
+
+    public function testCanLoadDuplicateTitle(): void
+    {
+        $html = <<<'EOF'
+<html>
+<head>
+<title>Sheet</title>
+</head>
+<body>
+<table><tr><td>1</td></tr></table>
+</body>
+</html>
+EOF;
+        $reader = new \PhpOffice\PhpSpreadsheet\Reader\Html();
+        $spreadsheet = $reader->loadFromString($html);
+        $reader->setSheetIndex(1);
+        $reader->loadFromString($html, $spreadsheet);
+        $reader->setSheetIndex(2);
+        $reader->loadFromString($html, $spreadsheet);
+        $sheet = $spreadsheet->getSheet(0);
+        self::assertEquals(1, $sheet->getCell('A1')->getValue());
+        self::assertEquals('Sheet', $sheet->getTitle());
+        $sheet = $spreadsheet->getSheet(1);
+        self::assertEquals(1, $sheet->getCell('A1')->getValue());
+        self::assertEquals('Sheet 1', $sheet->getTitle());
+        $sheet = $spreadsheet->getSheet(2);
+        self::assertEquals(1, $sheet->getCell('A1')->getValue());
+        self::assertEquals('Sheet 2', $sheet->getTitle());
+    }
 }


### PR DESCRIPTION
This issue arose while researching issue #1823. The issue was not a bug;
it just required clarification to the author of how to use the software.
But, while researching, I discovered that loading html into 2
sheets of a spreadsheet has a problem if the html title tag is the same
for the 2 sheets. PhpSpreadsheet would be able to save the resulting file,
but Excel would not be able to read it properly because of the duplicate title.
The worksheet setTitle method allows for disambiguation is such a circumstance.
The html reader passed a parameter indicating "don't disambiguate", but I can't
see any harm in changing that to "disambiguate". An extremely simple fix,
with tests to back it up.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Avoid bug where PhpSpreadsheet can save a file which Excel cannot read.
