### PR TITLE
Update RowCellIterator.php

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/RowCellIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/RowCellIterator.php
@@ -173,6 +173,21 @@ class RowCellIterator extends CellIterator
     {
         return $this->currentColumnIndex;
     }
+    
+     /**
+     * Return the current Cell by Column position.
+     * Row Iterator already knows the current $rowIndex
+     * @param string $column The column address for the cell
+     * Edited Shahroz BUTT
+     * Email : shahroz.butt@yahoo.com
+     *
+     * @return Cell
+     */
+    public function getCellByColumn($column)
+    {
+        $column = Coordinate::columnIndexFromString($column);
+        return $this->worksheet->getCellByColumnAndRow($column, $this->rowIndex);
+    }
 
     /**
      * Validate start/end values for "IterateOnlyExistingCells" mode, and adjust if necessary.


### PR DESCRIPTION
There is no specific way to get a cell through the RowCellIterator. I have seen many posts where developers are getting the rowIndex through row and then putting in the column index that they have to get to a specific cell. Where I think as the Row (RowCellIterator knows current $rowIndex ) knows what it's index is, we should only have to provide the Column (in String) to get to the cell. Similar function should be added for ColumnCellIterator where Column knows its index a row index is to be provided for the cell.

This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
