### PR TITLE
Enable support for dates and percentages in Excel Database functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
+- Support for date values and percentages in query parameters for Database functions, and the IF expressions in functions like COUNTIF() and AVERAGEIF(). [#1875](https://github.com/PHPOffice/PhpSpreadsheet/pull/1875)
 - Implemented DataBar for conditional formatting in Xlsx, providing read/write and creation of (type, value, direction, fills, border, axis position, color settings) as DataBar options in Excel. [#1754](https://github.com/PHPOffice/PhpSpreadsheet/pull/1754)
 - Alignment for ODS Writer [#1796](https://github.com/PHPOffice/PhpSpreadsheet/issues/1796)
 - Basic implementation of the PERMUTATIONA() Statistical Function

--- a/src/PhpSpreadsheet/Calculation/Database/DatabaseAbstract.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DatabaseAbstract.php
@@ -83,7 +83,6 @@ abstract class DatabaseAbstract
     }
 
     /**
-     * @TODO Suport for booleans
      * @TODO Suport for wildcard ? and * in strings (includng escaping)
      */
     private static function buildQuery(array $criteriaNames, array $criteria): string
@@ -93,10 +92,8 @@ abstract class DatabaseAbstract
             foreach ($criterion as $field => $value) {
                 $criterionName = $criteriaNames[$field];
                 if ($value !== null && $value !== '') {
-//                    var_dump($value);
                     $condition = '[:' . $criterionName . ']' . Functions::ifCondition($value);
                     $baseQuery[$key][] = $condition;
-//                    var_dump($condition);
                 }
             }
         }
@@ -122,7 +119,9 @@ abstract class DatabaseAbstract
             $testConditionList = $query;
             foreach ($criteriaNames as $key => $criteriaName) {
                 $key = array_search($criteriaName, $fieldNames, true);
-                if (isset($dataValues[$key])) {
+                if (is_bool($dataValues[$key])) {
+                    $dataValue = ($dataValues[$key]) ? 'TRUE' : 'FALSE';
+                } elseif ($dataValues[$key] !== null) {
                     $dataValue = $dataValues[$key];
                     $dataValue = (is_string($dataValue)) ? Calculation::wrapResult(strtoupper($dataValue)) : $dataValue;
                 } else {
@@ -130,7 +129,6 @@ abstract class DatabaseAbstract
                 }
                 $testConditionList = str_replace('[:' . $criteriaName . ']', $dataValue, $testConditionList);
             }
-
             //    evaluate the criteria against the row data
             $result = Calculation::getInstance()->_calculateFormulaValue('=' . $testConditionList);
             //    If the row failed to meet the criteria, remove it from the database

--- a/src/PhpSpreadsheet/Calculation/Database/DatabaseAbstract.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DatabaseAbstract.php
@@ -83,8 +83,7 @@ abstract class DatabaseAbstract
     }
 
     /**
-     * @TODO Support for Dates (including handling for >, <=, etc)
-     * @TODO Suport for formatted numerics (e.g. '>12.5%' => '>0.125')
+     * @TODO Suport for booleans
      * @TODO Suport for wildcard ? and * in strings (includng escaping)
      */
     private static function buildQuery(array $criteriaNames, array $criteria): string
@@ -94,8 +93,10 @@ abstract class DatabaseAbstract
             foreach ($criterion as $field => $value) {
                 $criterionName = $criteriaNames[$field];
                 if ($value !== null && $value !== '') {
+//                    var_dump($value);
                     $condition = '[:' . $criterionName . ']' . Functions::ifCondition($value);
                     $baseQuery[$key][] = $condition;
+//                    var_dump($condition);
                 }
             }
         }

--- a/src/PhpSpreadsheet/Calculation/Functions.php
+++ b/src/PhpSpreadsheet/Calculation/Functions.php
@@ -255,7 +255,9 @@ class Functions
         }
         if (!is_string($condition) || !in_array($condition[0], ['>', '<', '='])) {
             $condition = self::operandSpecialHandling($condition);
-            if (!is_numeric($condition)) {
+            if (is_bool($condition)) {
+                return '=' . ($condition ? 'TRUE' : 'FALSE');
+            } elseif (!is_numeric($condition)) {
                 $condition = Calculation::wrapResult(strtoupper($condition));
             }
 
@@ -265,10 +267,9 @@ class Functions
         [, $operator, $operand] = $matches;
 
         $operand = self::operandSpecialHandling($operand);
-
         if (is_numeric(trim($operand, '"'))) {
             $operand = trim($operand, '"');
-        } elseif (!is_numeric($operand)) {
+        } elseif (!is_numeric($operand) && $operand !== 'FALSE' && $operand !== 'TRUE') {
             $operand = str_replace('"', '""', $operand);
             $operand = Calculation::wrapResult(strtoupper($operand));
         }
@@ -276,10 +277,12 @@ class Functions
         return str_replace('""""', '""', $operator . $operand);
     }
 
-    private static function operandSpecialHandling(string $operand)
+    private static function operandSpecialHandling($operand)
     {
-        if (is_numeric($operand)) {
+        if (is_numeric($operand) || is_bool($operand)) {
             return $operand;
+        } elseif (strtoupper($operand) === Calculation::getTRUE() || strtoupper($operand) === Calculation::getFALSE()) {
+            return strtoupper($operand);
         }
 
         // Check for percentage

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Database/DCountATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Database/DCountATest.php
@@ -100,7 +100,7 @@ class DCountATest extends TestCase
                 'Score',
                 [
                     ['Subject', 'Score'],
-                    ['English', '>0.60'],
+                    ['English', '>60%'],
                 ],
             ],
         ];

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Database/DCountTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Database/DCountTest.php
@@ -95,7 +95,7 @@ class DCountTest extends TestCase
                 null,
                 [
                     ['Subject', 'Score'],
-                    ['English', '>0.63'],
+                    ['English', '>63%'],
                 ],
             ],
         ];

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Database/DCountTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Database/DCountTest.php
@@ -59,6 +59,21 @@ class DCountTest extends TestCase
         ];
     }
 
+    protected function database3()
+    {
+        return [
+            ['Status', 'Value'],
+            [false, 1],
+            [true, 2],
+            [true, 4],
+            [false, 8],
+            [true, 16],
+            [false, 32],
+            [false, 64],
+            [false, 128],
+        ];
+    }
+
     public function providerDCount()
     {
         return [
@@ -96,6 +111,24 @@ class DCountTest extends TestCase
                 [
                     ['Subject', 'Score'],
                     ['English', '>63%'],
+                ],
+            ],
+            [
+                3,
+                $this->database3(),
+                'Value',
+                [
+                    ['Status'],
+                    [true],
+                ],
+            ],
+            [
+                5,
+                $this->database3(),
+                'Value',
+                [
+                    ['Status'],
+                    ['<>true'],
                 ],
             ],
         ];

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Database/DProductTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Database/DProductTest.php
@@ -73,8 +73,6 @@ class DProductTest extends TestCase
                     ['=Pear', null, null],
                 ],
             ],
-            /*
-             * We don't yet support date handling in the search query
             [
                 36,
                 $this->database2(),
@@ -93,7 +91,6 @@ class DProductTest extends TestCase
                     ['Test1', '<05-Jan-2017'],
                 ],
             ],
-             */
             [
                 null,
                 $this->database1(),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Database/DSumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Database/DSumTest.php
@@ -95,7 +95,7 @@ class DSumTest extends TestCase
                 ],
             ],
             /*
-             * We don't yet support woldcards in text search fields
+             * We don't yet support wildcards in text search fields
             [
                 710000,
                 $this->database2(),


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

The Excel Database functions don't just support basic numeric and string queries, but also allow formatted values like percentages (e.g. "<62%") and dates (e.g. ">=22-Feb-2021"). These structures are also permitted in functions like CountIf() and AverageIf().

This PR provides support for that functionality.

Still outstanding
 - Support for Boolean expressions
 - Support for wildcards in strings (e.g. ? and *)
