### PR TITLE
Enable support for wildcard text searches in Excel Database functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Added
 
 - Support for date values and percentages in query parameters for Database functions, and the IF expressions in functions like COUNTIF() and AVERAGEIF(). [#1875](https://github.com/PHPOffice/PhpSpreadsheet/pull/1875)
+- Support for booleans, and for wildcard text search in query parameters for Database functions. [#1876](https://github.com/PHPOffice/PhpSpreadsheet/pull/1876)
 - Implemented DataBar for conditional formatting in Xlsx, providing read/write and creation of (type, value, direction, fills, border, axis position, color settings) as DataBar options in Excel. [#1754](https://github.com/PHPOffice/PhpSpreadsheet/pull/1754)
 - Alignment for ODS Writer [#1796](https://github.com/PHPOffice/PhpSpreadsheet/issues/1796)
 - Basic implementation of the PERMUTATIONA() Statistical Function

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -2663,11 +2663,15 @@ class Calculation
     private static $controlFunctions = [
         'MKMATRIX' => [
             'argumentCount' => '*',
-            'functionCall' => [__CLASS__, 'mkMatrix'],
+            'functionCall' => [Internal\MakeMatrix::class, 'make'],
         ],
         'NAME.ERROR' => [
             'argumentCount' => '*',
             'functionCall' => [Functions::class, 'NAME'],
+        ],
+        'WILDCARDMATCH' => [
+            'argumentCount' => '2',
+            'functionCall' => [Internal\WildcardMatch::class, 'compare'],
         ],
     ];
 
@@ -3740,11 +3744,6 @@ class Calculation
         }
 
         return $formula;
-    }
-
-    private static function mkMatrix(...$args)
-    {
-        return $args;
     }
 
     //    Binary Operators

--- a/src/PhpSpreadsheet/Calculation/Internal/MakeMatrix.php
+++ b/src/PhpSpreadsheet/Calculation/Internal/MakeMatrix.php
@@ -4,7 +4,7 @@ namespace PhpOffice\PhpSpreadsheet\Calculation\Internal;
 
 class MakeMatrix
 {
-    private static function make(...$args)
+    public static function make(...$args)
     {
         return $args;
     }

--- a/src/PhpSpreadsheet/Calculation/Internal/MakeMatrix.php
+++ b/src/PhpSpreadsheet/Calculation/Internal/MakeMatrix.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Calculation\Internal;
+
+class MakeMatrix
+{
+    private static function make(...$args)
+    {
+        return $args;
+    }
+}

--- a/src/PhpSpreadsheet/Calculation/Internal/MakeMatrix.php
+++ b/src/PhpSpreadsheet/Calculation/Internal/MakeMatrix.php
@@ -4,7 +4,7 @@ namespace PhpOffice\PhpSpreadsheet\Calculation\Internal;
 
 class MakeMatrix
 {
-    public static function make(...$args)
+    public static function make(...$args): array
     {
         return $args;
     }

--- a/src/PhpSpreadsheet/Calculation/Internal/WildcardMatch.php
+++ b/src/PhpSpreadsheet/Calculation/Internal/WildcardMatch.php
@@ -18,17 +18,17 @@ class WildcardMatch
         '\?',
     ];
 
-    public static function wildcard($wildcard)
+    public static function wildcard(string $wildcard): string
     {
         return preg_replace(self::SEARCH_SET, self::REPLACEMENT_SET, $wildcard);
     }
 
-    public static function compare($value, $wildcard)
+    public static function compare($value, string $wildcard): bool
     {
         if ($value === '') {
             return true;
         }
 
-        return preg_match("/{$wildcard}/ui", $value);
+        return (bool) preg_match("/{$wildcard}/ui", $value);
     }
 }

--- a/src/PhpSpreadsheet/Calculation/Internal/WildcardMatch.php
+++ b/src/PhpSpreadsheet/Calculation/Internal/WildcardMatch.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Calculation\Internal;
+
+class WildcardMatch
+{
+    private const SEARCH_SET = [
+        '/([^~])(\*)/ui',
+        '/~\*/ui',
+        '/([^~])(\?)/ui',
+        '/~\?/ui',
+    ];
+
+    private const REPLACEMENT_SET = [
+        '${1}.*',
+        '\*',
+        '${1}.',
+        '\?',
+    ];
+
+    public static function wildcard($wildcard)
+    {
+        return preg_replace(self::SEARCH_SET, self::REPLACEMENT_SET, $wildcard);
+    }
+
+    public static function compare($value, $wildcard)
+    {
+        if ($value === '') {
+            return true;
+        }
+
+        return preg_match("/{$wildcard}/ui", $value);
+    }
+}

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Database/DSumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Database/DSumTest.php
@@ -94,8 +94,6 @@ class DSumTest extends TestCase
                     ['>2', 'North'],
                 ],
             ],
-            /*
-             * We don't yet support wildcards in text search fields
             [
                 710000,
                 $this->database2(),
@@ -105,7 +103,6 @@ class DSumTest extends TestCase
                     ['3', 'C*'],
                 ],
             ],
-             */
             [
                 null,
                 $this->database1(),


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

This provides the final extra level of functionality in MS Excel Database functions, the ability to use wildcard values in text searches (e.g. `="C*es"`, or `<>"a?c"`)

With some additional refactoring, it should also be fairly strightforward to rework the Statistical <x>IF() functions like AVERAGEIF() and COUNTIF() to use the same additional logic so they too will support booleans and wildcard text searches