### PR TITLE
Avoid the performance/memory overheads of "clone on modify" of $args

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Statistical/Conditional.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Conditional.php
@@ -123,13 +123,19 @@ class Conditional
         }
 
         $conditions = $database = [];
+        $argumentCount = count($args);
         $pairCount = 1;
-        while (count($args) > 0) {
-            $conditions[] = array_merge([sprintf(self::CONDITIONAL_COLUMN_NAME, $pairCount)], [array_pop($args)]);
+        for ($argument = 0; $argument < $argumentCount; $argument += 2) {
             $database[] = array_merge(
                 [sprintf(self::CONDITIONAL_COLUMN_NAME, $pairCount)],
-                Functions::flattenArray(array_pop($args))
+                Functions::flattenArray($args[$argument])
             );
+            ++$pairCount;
+        }
+
+        $pairCount = 1;
+        for ($argument = 1; $argument < $argumentCount; $argument += 2) {
+            $conditions[] = array_merge([sprintf(self::CONDITIONAL_COLUMN_NAME, $pairCount)], [$args[$argument]]);
             ++$pairCount;
         }
 

--- a/src/PhpSpreadsheet/Calculation/Statistical/Conditional.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Conditional.php
@@ -189,13 +189,11 @@ class Conditional
 
     private static function buildConditionSet(...$args): array
     {
-        array_shift($args);
-
         $conditions = [];
         $pairCount = 1;
-        while (count($args) > 0) {
-            $conditions[] = array_merge([sprintf(self::CONDITIONAL_COLUMN_NAME, $pairCount)], [array_pop($args)]);
-            array_pop($args);
+        $argumentCount = count($args);
+        for ($argument = 2; $argument < $argumentCount; $argument += 2) {
+            $conditions[] = array_merge([sprintf(self::CONDITIONAL_COLUMN_NAME, $pairCount)], [$args[$argument]]);
             ++$pairCount;
         }
 
@@ -216,15 +214,15 @@ class Conditional
         $database = [];
         $database[] = array_merge(
             [self::VALUE_COLUMN_NAME],
-            Functions::flattenArray(array_shift($args))
+            Functions::flattenArray($args[0])
         );
 
         $pairCount = 1;
-        while (count($args) > 0) {
-            array_pop($args);
+        $argumentCount = count($args);
+        for ($argument = 1; $argument < $argumentCount; $argument += 2) {
             $database[] = array_merge(
                 [sprintf(self::CONDITIONAL_COLUMN_NAME, $pairCount)],
-                Functions::flattenArray(array_pop($args))
+                Functions::flattenArray($args[$argument])
             );
             ++$pairCount;
         }


### PR DESCRIPTION
Avoid the performance/memory overheads of "clone on modify" of $args when building the condition set/database for AVERAGEIFS(), COUNTIFS(), MAXIFS() and MINIFS()

This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
