### PR TITLE
Refactoring and Clean-up of Xlsx/Xls Writer Defined Names quick-fix

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/DefinedNames.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/DefinedNames.php
@@ -72,55 +72,7 @@ class DefinedNames
             $this->objWriter->writeAttribute('localSheetId', $pDefinedName->getScope()->getParent()->getIndex($pDefinedName->getScope()));
         }
 
-        $definedRange = $pDefinedName->getValue();
-        $splitCount = preg_match_all(
-            '/' . Calculation::CALCULATION_REGEXP_CELLREF_RELATIVE . '/mui',
-            $definedRange,
-            $splitRanges,
-            PREG_OFFSET_CAPTURE
-        );
-
-        $lengths = array_map('strlen', array_column($splitRanges[0], 0));
-        $offsets = array_column($splitRanges[0], 1);
-
-        $worksheets = $splitRanges[2];
-        $columns = $splitRanges[6];
-        $rows = $splitRanges[7];
-
-        while ($splitCount > 0) {
-            --$splitCount;
-            $length = $lengths[$splitCount];
-            $offset = $offsets[$splitCount];
-            $worksheet = $worksheets[$splitCount][0];
-            $column = $columns[$splitCount][0];
-            $row = $rows[$splitCount][0];
-
-            $newRange = '';
-            if (empty($worksheet)) {
-                if (($offset === 0) || ($definedRange[$offset - 1] !== ':')) {
-                    // We should have a worksheet
-                    $worksheet = $pDefinedName->getWorksheet() ? $pDefinedName->getWorksheet()->getTitle() : null;
-                }
-            } else {
-                $worksheet = str_replace("''", "'", trim($worksheet, "'"));
-            }
-            if (!empty($worksheet)) {
-                $newRange = "'" . str_replace("'", "''", $worksheet) . "'!";
-            }
-
-            if (!empty($column)) {
-                $newRange .= $column;
-            }
-            if (!empty($row)) {
-                $newRange .= $row;
-            }
-
-            $definedRange = substr($definedRange, 0, $offset) . $newRange . substr($definedRange, $offset + $length);
-        }
-
-        if (substr($definedRange, 0, 1) === '=') {
-            $definedRange = substr($definedRange, 1);
-        }
+        $definedRange = $this->getDefinedRange($pDefinedName);
 
         $this->objWriter->writeRawData($definedRange);
 
@@ -144,7 +96,7 @@ class DefinedNames
             $range = Coordinate::splitRange($autoFilterRange);
             $range = $range[0];
             //    Strip any worksheet ref so we can make the cell ref absolute
-            [$ws, $range[0]] = Worksheet::extractSheetTitle($range[0], true);
+            [, $range[0]] = Worksheet::extractSheetTitle($range[0], true);
 
             $range[0] = Coordinate::absoluteCoordinate($range[0]);
             $range[1] = Coordinate::absoluteCoordinate($range[1]);
@@ -219,5 +171,60 @@ class DefinedNames
 
             $this->objWriter->endElement();
         }
+    }
+
+    private function getDefinedRange(DefinedName $pDefinedName): string
+    {
+        $definedRange = $pDefinedName->getValue();
+        $splitCount = preg_match_all(
+            '/' . Calculation::CALCULATION_REGEXP_CELLREF_RELATIVE . '/mui',
+            $definedRange,
+            $splitRanges,
+            PREG_OFFSET_CAPTURE
+        );
+
+        $lengths = array_map('strlen', array_column($splitRanges[0], 0));
+        $offsets = array_column($splitRanges[0], 1);
+
+        $worksheets = $splitRanges[2];
+        $columns = $splitRanges[6];
+        $rows = $splitRanges[7];
+
+        while ($splitCount > 0) {
+            --$splitCount;
+            $length = $lengths[$splitCount];
+            $offset = $offsets[$splitCount];
+            $worksheet = $worksheets[$splitCount][0];
+            $column = $columns[$splitCount][0];
+            $row = $rows[$splitCount][0];
+
+            $newRange = '';
+            if (empty($worksheet)) {
+                if (($offset === 0) || ($definedRange[$offset - 1] !== ':')) {
+                    // We should have a worksheet
+                    $worksheet = $pDefinedName->getWorksheet() ? $pDefinedName->getWorksheet()->getTitle() : null;
+                }
+            } else {
+                $worksheet = str_replace("''", "'", trim($worksheet, "'"));
+            }
+            if (!empty($worksheet)) {
+                $newRange = "'" . str_replace("'", "''", $worksheet) . "'!";
+            }
+
+            if (!empty($column)) {
+                $newRange .= $column;
+            }
+            if (!empty($row)) {
+                $newRange .= $row;
+            }
+
+            $definedRange = substr($definedRange, 0, $offset) . $newRange . substr($definedRange, $offset + $length);
+        }
+
+        if (substr($definedRange, 0, 1) === '=') {
+            $definedRange = substr($definedRange, 1);
+        }
+
+        return $definedRange;
     }
 }

--- a/src/PhpSpreadsheet/Writer/Xlsx/DefinedNames.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/DefinedNames.php
@@ -69,7 +69,10 @@ class DefinedNames
         $this->objWriter->startElement('definedName');
         $this->objWriter->writeAttribute('name', $pDefinedName->getName());
         if ($pDefinedName->getLocalOnly() && $pDefinedName->getScope() !== null) {
-            $this->objWriter->writeAttribute('localSheetId', $pDefinedName->getScope()->getParent()->getIndex($pDefinedName->getScope()));
+            $this->objWriter->writeAttribute(
+                'localSheetId',
+                $pDefinedName->getScope()->getParent()->getIndex($pDefinedName->getScope())
+            );
         }
 
         $definedRange = $this->getDefinedRange($pDefinedName);
@@ -207,16 +210,11 @@ class DefinedNames
             } else {
                 $worksheet = str_replace("''", "'", trim($worksheet, "'"));
             }
+
             if (!empty($worksheet)) {
                 $newRange = "'" . str_replace("'", "''", $worksheet) . "'!";
             }
-
-            if (!empty($column)) {
-                $newRange .= $column;
-            }
-            if (!empty($row)) {
-                $newRange .= $row;
-            }
+            $newRange = "{$newRange}{$column}{$row}";
 
             $definedRange = substr($definedRange, 0, $offset) . $newRange . substr($definedRange, $offset + $length);
         }


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

This is a small clean-up hack for code already merged into master to resolve an issue with Defined Names in the Xls and Xlsx Writers with a request for users to test. Once the fix has been confirmed, then this refactoring cleans up the code for the fix