### PR TITLE
Reverted Scrutinzer fix in Xslx Reader listWorksheetInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- Nothing.
+- Fixed issue with Xlsx@listWorksheetInfo not returning any data
 
 ## 1.17.1 - 2021-03-01
 

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -187,7 +187,8 @@ class Xlsx extends BaseReader
                 );
                 if ($xmlWorkbook->sheets) {
                     $dir = dirname($rel['Target']);
-                    foreach ($xmlWorkbook->sheets->sheet->children() as $eleSheet) {
+                    /** @var SimpleXMLElement $eleSheet */
+                    foreach ($xmlWorkbook->sheets->sheet as $eleSheet) {
                         $tmpInfo = [
                             'worksheetName' => (string) $eleSheet['name'],
                             'lastColumnLetter' => 'A',

--- a/tests/PhpSpreadsheetTests/Reader/XlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/XlsxTest.php
@@ -55,6 +55,25 @@ class XlsxTest extends TestCase
         }
     }
 
+    public function testListWorksheetInfo(): void
+    {
+        $filename = 'tests/data/Reader/XLSX/rowColumnAttributeTest.xlsx';
+        $reader = new Xlsx();
+        $actual = $reader->listWorksheetInfo($filename);
+
+        $expected = [
+            [
+                'worksheetName' => 'Sheet1',
+                'lastColumnLetter' => 'F',
+                'lastColumnIndex' => 5,
+                'totalRows' => '6',
+                'totalColumns' => 6,
+            ],
+        ];
+
+        self::assertEquals($expected, $actual);
+    }
+
     public function testLoadXlsxRowColumnAttributes(): void
     {
         $filename = 'tests/data/Reader/XLSX/rowColumnAttributeTest.xlsx';


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```
Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
#1806 introduced a bug in the listWorksheetInfo method of Xlsx. When calling this method it would now always return an empty array, by reverting the Scrutinizer change, the behaviour is back. I've added a regression test which will fail without this fix. 

Reported by CI of Laravel Excel: https://github.com/Maatwebsite/Laravel-Excel/runs/2018138488?check_suite_focus=true
And in issue: https://github.com/Maatwebsite/Laravel-Excel/issues/3048#issuecomment-789749616