### PR TITLE
Fix for Issue #1887 - Lose Track of Selected Cells After Save

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -3389,9 +3389,17 @@ class Calculation
     {
         $cellValue = null;
 
+        $pCellParent = ($pCell !== null) ? $pCell->getWorksheet() : null;
         //  Quote-Prefixed cell values cannot be formulae, but are treated as strings
-        if ($pCell !== null && $pCell->getStyle()->getQuotePrefix() === true) {
-            return self::wrapResult((string) $formula);
+        if ($pCell !== null) {
+            $selected = isset($pCellParent) ? $pCellParent->getSelectedCells() : '';
+            $quoted = $pCell->getStyle()->getQuotePrefix();
+            if ($pCellParent !== null) {
+                $pCellParent->setSelectedCells($selected);
+            }
+            if ($quoted === true) {
+                return self::wrapResult((string) $formula);
+            }
         }
 
         if (preg_match('/^=\s*cmd\s*\|/miu', $formula) !== 0) {
@@ -3409,7 +3417,6 @@ class Calculation
             return self::wrapResult($formula);
         }
 
-        $pCellParent = ($pCell !== null) ? $pCell->getWorksheet() : null;
         $wsTitle = ($pCellParent !== null) ? $pCellParent->getTitle() : "\x00Wrk";
         $wsCellReference = $wsTitle . '!' . $cellID;
 

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -3389,17 +3389,9 @@ class Calculation
     {
         $cellValue = null;
 
-        $pCellParent = ($pCell !== null) ? $pCell->getWorksheet() : null;
         //  Quote-Prefixed cell values cannot be formulae, but are treated as strings
-        if ($pCell !== null) {
-            $selected = isset($pCellParent) ? $pCellParent->getSelectedCells() : '';
-            $quoted = $pCell->getStyle()->getQuotePrefix();
-            if ($pCellParent !== null) {
-                $pCellParent->setSelectedCells($selected);
-            }
-            if ($quoted === true) {
-                return self::wrapResult((string) $formula);
-            }
+        if ($pCell !== null && $pCell->getStyle()->getQuotePrefix() === true) {
+            return self::wrapResult((string) $formula);
         }
 
         if (preg_match('/^=\s*cmd\s*\|/miu', $formula) !== 0) {
@@ -3417,6 +3409,7 @@ class Calculation
             return self::wrapResult($formula);
         }
 
+        $pCellParent = ($pCell !== null) ? $pCell->getWorksheet() : null;
         $wsTitle = ($pCellParent !== null) ? $pCellParent->getTitle() : "\x00Wrk";
         $wsCellReference = $wsTitle . '!' . $cellID;
 

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -252,9 +252,11 @@ class Cell
         if ($this->dataType == DataType::TYPE_FORMULA) {
             try {
                 $index = $this->getWorksheet()->getParent()->getActiveSheetIndex();
+                $selected = $this->getWorksheet()->getSelectedCells();
                 $result = Calculation::getInstance(
                     $this->getWorksheet()->getParent()
                 )->calculateCellValue($this, $resetLog);
+                $this->getWorksheet()->setSelectedCells($selected);
                 $this->getWorksheet()->getParent()->setActiveSheetIndex($index);
                 //    We don't yet handle array returns
                 if (is_array($result)) {

--- a/src/PhpSpreadsheet/Writer/Ods/Settings.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Settings.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Writer\Ods;
 
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Shared\XMLWriter;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
@@ -16,7 +17,6 @@ class Settings extends WriterPart
      */
     public function write(?Spreadsheet $spreadsheet = null)
     {
-        $objWriter = null;
         if ($this->getParentWriter()->getUseDiskCaching()) {
             $objWriter = new XMLWriter(XMLWriter::STORAGE_DISK, $this->getParentWriter()->getDiskCachingDirectory());
         } else {
@@ -39,13 +39,52 @@ class Settings extends WriterPart
         $objWriter->writeAttribute('config:name', 'ooo:view-settings');
         $objWriter->startElement('config:config-item-map-indexed');
         $objWriter->writeAttribute('config:name', 'Views');
-        $objWriter->endElement();
-        $objWriter->endElement();
+        $objWriter->startElement('config:config-item-map-entry');
+        $spreadsheet = $spreadsheet ?? $this->getParentWriter()->getSpreadsheet();
+
+        $objWriter->startElement('config:config-item');
+        $objWriter->writeAttribute('config:name', 'ViewId');
+        $objWriter->writeAttribute('config:type', 'string');
+        $objWriter->text('view1');
+        $objWriter->endElement(); // ViewId
+        $objWriter->startElement('config:config-item-map-named');
+        $objWriter->writeAttribute('config:name', 'Tables');
+        foreach ($spreadsheet->getWorksheetIterator() as $ws) {
+            $objWriter->startElement('config:config-item-map-entry');
+            $objWriter->writeAttribute('config:name', $ws->getTitle());
+            $selected = $ws->getSelectedCells();
+            if (preg_match('/^([a-z]+)([0-9]+)/i', $selected, $matches) === 1) {
+                $colSel = Coordinate::columnIndexFromString($matches[1]) - 1;
+                $rowSel = (int) $matches[2] - 1;
+                $objWriter->startElement('config:config-item');
+                $objWriter->writeAttribute('config:name', 'CursorPositionX');
+                $objWriter->writeAttribute('config:type', 'int');
+                $objWriter->text($colSel);
+                $objWriter->endElement();
+                $objWriter->startElement('config:config-item');
+                $objWriter->writeAttribute('config:name', 'CursorPositionY');
+                $objWriter->writeAttribute('config:type', 'int');
+                $objWriter->text($rowSel);
+                $objWriter->endElement();
+            }
+            $objWriter->endElement(); // config:config-item-map-entry
+        }
+        $objWriter->endElement(); // config:config-item-map-named
+        $wstitle = $spreadsheet->getActiveSheet()->getTitle();
+        $objWriter->startElement('config:config-item');
+        $objWriter->writeAttribute('config:name', 'ActiveTable');
+        $objWriter->writeAttribute('config:type', 'string');
+        $objWriter->text($wstitle);
+        $objWriter->endElement(); // config:config-item ActiveTable
+
+        $objWriter->endElement(); // config:config-item-map-entry
+        $objWriter->endElement(); // config:config-item-map-indexed Views
+        $objWriter->endElement(); // config:config-item-set ooo:view-settings
         $objWriter->startElement('config:config-item-set');
         $objWriter->writeAttribute('config:name', 'ooo:configuration-settings');
-        $objWriter->endElement();
-        $objWriter->endElement();
-        $objWriter->endElement();
+        $objWriter->endElement(); // config:config-item-set ooo:configuration-settings
+        $objWriter->endElement(); // office:settings
+        $objWriter->endElement(); // office:document-settings
 
         return $objWriter->getData();
     }

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -4,6 +4,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit\Framework\TestCase;
 
@@ -159,6 +160,14 @@ class CalculationTest extends TestCase
         $cell->getStyle()->setQuotePrefix(true);
 
         self::assertEquals("=cmd|'/C calc'!A0", $cell->getCalculatedValue());
+
+        $cell2 = $workSheet->getCell('A2');
+        $cell2->setValueExplicit('ABC', DataType::TYPE_FORMULA);
+        self::assertEquals('ABC', $cell2->getCalculatedValue());
+
+        $cell3 = $workSheet->getCell('A3');
+        $cell3->setValueExplicit('=', DataType::TYPE_FORMULA);
+        self::assertEquals('', $cell3->getCalculatedValue());
     }
 
     public function testCellWithDdeExpresion(): void

--- a/tests/PhpSpreadsheetTests/Reader/Ods/OdsTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Ods/OdsTest.php
@@ -101,6 +101,20 @@ class OdsTest extends TestCase
         self::assertEquals('Sheet1', $spreadsheet->getSheet(0)->getTitle());
     }
 
+    public function testLoadOneWorksheetNotActive(): void
+    {
+        $filename = 'tests/data/Reader/Ods/data.ods';
+
+        // Load into this instance
+        $reader = new Ods();
+        $reader->setLoadSheetsOnly(['Second Sheet']);
+        $spreadsheet = $reader->load($filename);
+
+        self::assertEquals(1, $spreadsheet->getSheetCount());
+
+        self::assertEquals('Second Sheet', $spreadsheet->getSheet(0)->getTitle());
+    }
+
     public function testLoadBadFile(): void
     {
         $this->expectException(ReaderException::class);

--- a/tests/PhpSpreadsheetTests/Writer/RetainSelectedCellsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/RetainSelectedCellsTest.php
@@ -67,8 +67,7 @@ class RetainSelectedCellsTest extends AbstractFunctional
         self::assertEquals('C2', $spreadsheet->getSheet(2)->getSelectedCells());
         self::assertEquals(1, $spreadsheet->getActiveSheetIndex());
         // SelectedCells and ActiveSheet don't make sense for Html, Csv.
-        // They make sense for Ods, but are not yet implemented in Reader/Writer.
-        if ($format === 'Xlsx' || $format === 'Xls') {
+        if ($format === 'Xlsx' || $format === 'Xls' || $format === 'Ods') {
             self::assertEquals('A3', $reloaded->getSheet(0)->getSelectedCells());
             self::assertEquals('B1', $reloaded->getSheet(1)->getSelectedCells());
             self::assertEquals('C2', $reloaded->getSheet(2)->getSelectedCells());

--- a/tests/PhpSpreadsheetTests/Writer/RetainSelectedCellsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/RetainSelectedCellsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class RetainSelectedCellsTest extends AbstractFunctional
+{
+    public function providerFormats()
+    {
+        return [
+            ['Xls'],
+            ['Xlsx'],
+            ['Ods'],
+            ['Csv'],
+            ['Html'],
+        ];
+    }
+
+    /**
+     * Test selected cell is retained in memory and in file written to disk.
+     *
+     * @dataProvider providerFormats
+     */
+    public function testRetainSelectedCells(string $format): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', '=SIN(1)')
+            ->setCellValue('A2', '=SIN(2)')
+            ->setCellValue('A3', '=SIN(3)')
+            ->setCellValue('B1', '=SIN(4)')
+            ->setCellValue('B2', '=SIN(5)')
+            ->setCellValue('B3', '=SIN(6)')
+            ->setCellValue('C1', '=SIN(7)')
+            ->setCellValue('C2', '=SIN(8)')
+            ->setCellValue('C3', '=SIN(9)');
+        $sheet->setSelectedCell('A3');
+        $sheet = $spreadsheet->createSheet();
+        $sheet->setCellValue('A1', '=SIN(1)')
+            ->setCellValue('A2', '=SIN(2)')
+            ->setCellValue('A3', '=SIN(3)')
+            ->setCellValue('B1', '=SIN(4)')
+            ->setCellValue('B2', '=SIN(5)')
+            ->setCellValue('B3', '=SIN(6)')
+            ->setCellValue('C1', '=SIN(7)')
+            ->setCellValue('C2', '=SIN(8)')
+            ->setCellValue('C3', '=SIN(9)');
+        $sheet->setSelectedCell('B1');
+        $sheet = $spreadsheet->createSheet();
+        $sheet->setCellValue('A1', '=SIN(1)')
+            ->setCellValue('A2', '=SIN(2)')
+            ->setCellValue('A3', '=SIN(3)')
+            ->setCellValue('B1', '=SIN(4)')
+            ->setCellValue('B2', '=SIN(5)')
+            ->setCellValue('B3', '=SIN(6)')
+            ->setCellValue('C1', '=SIN(7)')
+            ->setCellValue('C2', '=SIN(8)')
+            ->setCellValue('C3', '=SIN(9)');
+        $sheet->setSelectedCell('C2');
+        $spreadsheet->setActiveSheetIndex(1);
+
+        $reloaded = $this->writeAndReload($spreadsheet, $format);
+        self::assertEquals('A3', $spreadsheet->getSheet(0)->getSelectedCells());
+        self::assertEquals('B1', $spreadsheet->getSheet(1)->getSelectedCells());
+        self::assertEquals('C2', $spreadsheet->getSheet(2)->getSelectedCells());
+        self::assertEquals(1, $spreadsheet->getActiveSheetIndex());
+        // SelectedCells and ActiveSheet don't make sense for Html, Csv.
+        // They make sense for Ods, but are not yet implemented in Reader/Writer.
+        if ($format === 'Xlsx' || $format === 'Xls') {
+            self::assertEquals('A3', $reloaded->getSheet(0)->getSelectedCells());
+            self::assertEquals('B1', $reloaded->getSheet(1)->getSelectedCells());
+            self::assertEquals('C2', $reloaded->getSheet(2)->getSelectedCells());
+            self::assertEquals(1, $reloaded->getActiveSheetIndex());
+        }
+    }
+}


### PR DESCRIPTION
Issue #1887 reports that selected cells are lost after saving Xlsx. Testing indicates that this applies to the object in memory, though not to the saved spreadsheet.

Xlsx writer tries to save calculated values for cells which contain formulas. Calculation::_calculateFormulaValue issues a getStyle call merely to retrieve the quotePrefix property, which, if set, indicates that the cell does not contain a formula even though it looks like one. A side-effect of calls to getStyle is that selectedCell is updated. That is clearly accidental, and highly undesirable, in this case. Code is changed to save selectedCell before getStyle call and restore it afterwards.

The problem was reported only for Xlsx save. To be on the safe side, test is made for output formats of Xlsx, Xls, Ods, Html (which basically includes Pdf), and Csv. For all of those, the object in memory is tested after the save. For Xlsx and Xls, the saved file is also tested. It does not make sense to test the saved file for Csv and Html. It does make sense to test it for Ods, but the necessary support is not yet present in either the Ods Reader or Ods Writer - a project for another day.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Bug fix - see details above.