### PR TITLE
Additional argument validation for LEFT(), MID() and RIGHT() text functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Fixed
 
 - Fixed issue with Xlsx@listWorksheetInfo not returning any data
+- Fixed invalid arguments triggering mb_substr() error in LEFT(), MID() and RIGHT() text functions. [Issue #640](https://github.com/PHPOffice/PhpSpreadsheet/issues/640)
 
 ## 1.17.1 - 2021-03-01
 

--- a/src/PhpSpreadsheet/Calculation/TextData.php
+++ b/src/PhpSpreadsheet/Calculation/TextData.php
@@ -333,10 +333,6 @@ class TextData
             $value = ($value) ? Calculation::getTRUE() : Calculation::getFALSE();
         }
 
-        if (empty($chars)) {
-            return '';
-        }
-
         return mb_substr($value, --$start, $chars, 'UTF-8');
     }
 

--- a/src/PhpSpreadsheet/Calculation/TextData.php
+++ b/src/PhpSpreadsheet/Calculation/TextData.php
@@ -299,7 +299,7 @@ class TextData
         $value = Functions::flattenSingleValue($value);
         $chars = Functions::flattenSingleValue($chars);
 
-        if ($chars < 0) {
+        if (!is_numeric($chars) || $chars < 0) {
             return Functions::VALUE();
         }
 
@@ -325,7 +325,7 @@ class TextData
         $start = Functions::flattenSingleValue($start);
         $chars = Functions::flattenSingleValue($chars);
 
-        if (($start < 1) || ($chars < 0)) {
+        if (!is_numeric($start) || $start < 1 || !is_numeric($chars) || $chars < 0) {
             return Functions::VALUE();
         }
 
@@ -353,7 +353,7 @@ class TextData
         $value = Functions::flattenSingleValue($value);
         $chars = Functions::flattenSingleValue($chars);
 
-        if ($chars < 0) {
+        if (!is_numeric($chars) || $chars < 0) {
             return Functions::VALUE();
         }
 

--- a/tests/data/Calculation/TextData/LEFT.php
+++ b/tests/data/Calculation/TextData/LEFT.php
@@ -17,6 +17,16 @@ return [
         -1,
     ],
     [
+        '#VALUE!',
+        'QWERTYUIOP',
+        'NaN',
+    ],
+    [
+        '#VALUE!',
+        'QWERTYUIOP',
+        null,
+    ],
+    [
         'ABC',
         'ABCDEFGHI',
         3,

--- a/tests/data/Calculation/TextData/MID.php
+++ b/tests/data/Calculation/TextData/MID.php
@@ -26,7 +26,19 @@ return [
         -1,
     ],
     [
-        '',
+        '#VALUE!',
+        'QWERTYUIOP',
+        'NaN',
+        1,
+    ],
+    [
+        '#VALUE!',
+        'QWERTYUIOP',
+        2,
+        'NaN',
+    ],
+    [
+        '#VALUE!',
         'QWERTYUIOP',
         5,
     ],

--- a/tests/data/Calculation/TextData/RIGHT.php
+++ b/tests/data/Calculation/TextData/RIGHT.php
@@ -17,6 +17,16 @@ return [
         -1,
     ],
     [
+        '#VALUE!',
+        'QWERTYUIOP',
+        'NaN',
+    ],
+    [
+        '#VALUE!',
+        'QWERTYUIOP',
+        null,
+    ],
+    [
         'GHI',
         'ABCDEFGHI',
         3,


### PR DESCRIPTION
Additional argument validation for LEFT(), MID() and RIGHT() text functions

This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

When non-numeric `start` and `char` arguments are passed to the LEFT(), MID() and RIGHT() text functions, these are not valiated, resulting in a PHP error when executing the `mb_substr()` function