### PR TITLE
Add null typehint to Worksheet::getColumnDimension() since it returns null

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1337,7 +1337,7 @@ class Worksheet implements IComparable
      * @param int $pRow Numeric index of the row
      * @param bool $create
      *
-     * @return RowDimension
+     * @return null|RowDimension
      */
     public function getRowDimension($pRow, $create = true)
     {
@@ -1390,7 +1390,7 @@ class Worksheet implements IComparable
      *
      * @param int $columnIndex Numeric column coordinate of the cell
      *
-     * @return ColumnDimension
+     * @return null|ColumnDimension
      */
     public function getColumnDimensionByColumn($columnIndex)
     {

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1363,7 +1363,7 @@ class Worksheet implements IComparable
      * @param string $pColumn String index of the column eg: 'A'
      * @param bool $create
      *
-     * @return ColumnDimension
+     * @return ColumnDimension|null
      */
     public function getColumnDimension($pColumn, $create = true)
     {

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1363,7 +1363,7 @@ class Worksheet implements IComparable
      * @param string $pColumn String index of the column eg: 'A'
      * @param bool $create
      *
-     * @return ColumnDimension|null
+     * @return null|ColumnDimension
      */
     public function getColumnDimension($pColumn, $create = true)
     {


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Should this be somehow more documented? It has always returned null.

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
