### PR TITLE
Unhappy path tests for FORMULATEXT() Function

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/LookupRefTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/LookupRefTest.php
@@ -73,4 +73,10 @@ class LookupRefTest extends TestCase
     {
         return require 'tests/data/Calculation/LookupRef/FORMULATEXT.php';
     }
+
+    public function testFormulaTextWithoutCell()
+    {
+        $result = LookupRef::FORMULATEXT('A1');
+        self::assertEquals(Functions::REF(), $result);
+    }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/LookupRefTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/LookupRefTest.php
@@ -74,7 +74,7 @@ class LookupRefTest extends TestCase
         return require 'tests/data/Calculation/LookupRef/FORMULATEXT.php';
     }
 
-    public function testFormulaTextWithoutCell()
+    public function testFormulaTextWithoutCell(): void
     {
         $result = LookupRef::FORMULATEXT('A1');
         self::assertEquals(Functions::REF(), $result);


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [ ] unit tests
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Unit tests for unhappy path