### PR TITLE
Fix SpreadsheetML (xml) detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Fix for [Issue #1887](https://github.com/PHPOffice/PhpSpreadsheet/issues/1887) - Lose Track of Selected Cells After Save
 - Fixed issue with Xlsx@listWorksheetInfo not returning any data
 - Fixed invalid arguments triggering mb_substr() error in LEFT(), MID() and RIGHT() text functions. [Issue #640](https://github.com/PHPOffice/PhpSpreadsheet/issues/640)
+- Fix for [Issue #1916](https://github.com/PHPOffice/PhpSpreadsheet/issues/1916) - Invalid signature check for XML files
 
 ## 1.17.1 - 2021-03-01
 

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -116,7 +116,7 @@ class Xml extends BaseReader
 
         $signature = [
             '<?xml version="1.0"',
-            '<?mso-application progid="Excel.Sheet"?>',
+            'xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet',
         ];
 
         // Open file


### PR DESCRIPTION
Replace the unrequired product signature by the
required namespace definition for XML Spreadsheet.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

Fixes the issue #1917  and allows processing of exported SpreadsheetML files from other sources than MS Excel itself.
