### PR TITLE
Coverage for Helper/Samples

### DIFF
--- a/src/PhpSpreadsheet/Helper/Sample.php
+++ b/src/PhpSpreadsheet/Helper/Sample.php
@@ -71,7 +71,7 @@ class Sample
     /**
      * Returns an array of all known samples.
      *
-     * @return string[] [$name => $path]
+     * @return string[][] [$name => $path]
      */
     public function getSamples()
     {

--- a/src/PhpSpreadsheet/Helper/Sample.php
+++ b/src/PhpSpreadsheet/Helper/Sample.php
@@ -132,6 +132,11 @@ class Sample
         $this->logEndingNotes();
     }
 
+    protected function isDirOrMkdir(string $folder): bool
+    {
+        return \is_dir($folder) || \mkdir($folder);
+    }
+
     /**
      * Returns the temporary directory and make sure it exists.
      *
@@ -140,10 +145,8 @@ class Sample
     private function getTemporaryFolder()
     {
         $tempFolder = sys_get_temp_dir() . '/phpspreadsheet';
-        if (!is_dir($tempFolder)) {
-            if (!mkdir($tempFolder) && !is_dir($tempFolder)) {
-                throw new RuntimeException(sprintf('Directory "%s" was not created', $tempFolder));
-            }
+        if (!$this->isDirOrMkdir($tempFolder)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $tempFolder));
         }
 
         return $tempFolder;

--- a/tests/PhpSpreadsheetTests/Helper/SampleCoverageTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/SampleCoverageTest.php
@@ -6,6 +6,9 @@ use PhpOffice\PhpSpreadsheet\Helper\Sample;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
+/**
+ * @covers \PhpOffice\PhpSpreadsheet\Helper\Sample
+ */
 class SampleCoverageTest extends TestCase
 {
     public function testSample(): void
@@ -15,9 +18,9 @@ class SampleCoverageTest extends TestCase
         self::assertArrayHasKey('Basic', $samples);
         $basic = $samples['Basic'];
         self::assertArrayHasKey('02 Types', $basic);
-        self::assertEquals('Basic/02_Types.php', $basic['02 Types']);
-        self::assertEquals('phpunit', $helper->getPageTitle());
-        self::assertEquals('<h1>phpunit</h1>', $helper->getPageHeading());
+        self::assertSame('Basic/02_Types.php', $basic['02 Types']);
+        self::assertSame('phpunit', $helper->getPageTitle());
+        self::assertSame('<h1>phpunit</h1>', $helper->getPageHeading());
     }
 
     public function testDirectoryFail(): void
@@ -27,7 +30,10 @@ class SampleCoverageTest extends TestCase
         $helper = $this->getMockBuilder(Sample::class)
             ->onlyMethods(['isDirOrMkdir'])
             ->getMock();
-        $helper->expects(self::atMost(1))->method('isDirOrMkdir')->willReturn(false);
-        self::assertEquals('', $helper->getFilename('a.xlsx'));
+        $helper->expects(self::once())
+            ->method('isDirOrMkdir')
+            ->with(self::isType('string'))
+            ->willReturn(false);
+        self::assertSame('', $helper->getFilename('a.xlsx'));
     }
 }

--- a/tests/PhpSpreadsheetTests/Helper/SampleCoverageTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/SampleCoverageTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Helper;
+
+use PhpOffice\PhpSpreadsheet\Helper\Sample;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class SampleCoverageTest extends TestCase
+{
+    public function testSample(): void
+    {
+        $helper = new Sample();
+        $samples = $helper->getSamples();
+        self::assertArrayHasKey('Basic', $samples);
+        $basic = $samples['Basic'];
+        self::assertArrayHasKey('02 Types', $basic);
+        self::assertEquals('Basic/02_Types.php', $basic['02 Types']);
+        self::assertEquals('phpunit', $helper->getPageTitle());
+        self::assertEquals('<h1>phpunit</h1>', $helper->getPageHeading());
+    }
+
+    public function testDirectoryFail(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $helper = $this->getMockBuilder(Sample::class)
+            ->setMethods(['isDirOrMkdir'])
+            ->getMock();
+        $helper->expects(self::atMost(1))->method('isDirOrMkdir')->willReturn(false);
+        self::assertEquals('', $helper->getFilename('a.xlsx'));
+    }
+}

--- a/tests/PhpSpreadsheetTests/Helper/SampleCoverageTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/SampleCoverageTest.php
@@ -25,7 +25,7 @@ class SampleCoverageTest extends TestCase
         $this->expectException(RuntimeException::class);
 
         $helper = $this->getMockBuilder(Sample::class)
-            ->setMethods(['isDirOrMkdir'])
+            ->onlyMethods(['isDirOrMkdir'])
             ->getMock();
         $helper->expects(self::atMost(1))->method('isDirOrMkdir')->willReturn(false);
         self::assertEquals('', $helper->getFilename('a.xlsx'));


### PR DESCRIPTION
I was perplexed by the fact that Helper/Samples seemed to be entirely uncovered when running the test suite, since I know all the samples are run as part of the test. I think that what must be happening is that the Helper code is invoked mostly as part of a Data Provider (and therefore not counted), not as part of the test proper (which would count). So, this change adds a small number of tests which result in Samples being 100% covered.

Covering one statement was tricky - simulating the inability to create a test directory. Mocking, a technique I have not used before, solves this problem admirably.

This is:

```
- [ ] a bugfix
- [ ] a new feature
- [x] code coverage
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Code coverage.