### PR TITLE
Resolve Deprecated setMethods() call when Mocking for tests

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnTest.php
@@ -34,7 +34,7 @@ class ColumnTest extends TestCase
     public function testCOLUMNwithNull(): void
     {
         $cell = $this->getMockBuilder(Cell::class)
-            ->setMethods(['getColumn'])
+            ->onlyMethods(['getColumn'])
             ->disableOriginalConstructor()
             ->getMock();
         $cell->method('getColumn')

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowTest.php
@@ -34,7 +34,7 @@ class RowTest extends TestCase
     public function testROWwithNull(): void
     {
         $cell = $this->getMockBuilder(Cell::class)
-            ->setMethods(['getRow'])
+            ->onlyMethods(['getRow'])
             ->disableOriginalConstructor()
             ->getMock();
         $cell->method('getRow')

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SubTotalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SubTotalTest.php
@@ -25,7 +25,7 @@ class SubTotalTest extends TestCase
     public function testSUBTOTAL($expectedResult, ...$args): void
     {
         $cell = $this->getMockBuilder(Cell::class)
-            ->setMethods(['getValue', 'isFormula'])
+            ->onlyMethods(['getValue', 'isFormula'])
             ->disableOriginalConstructor()
             ->getMock();
         $cell->method('getValue')
@@ -33,7 +33,7 @@ class SubTotalTest extends TestCase
         $cell->method('getValue')
             ->willReturn(false);
         $worksheet = $this->getMockBuilder(Worksheet::class)
-            ->setMethods(['cellExists', 'getCell'])
+            ->onlyMethods(['cellExists', 'getCell'])
             ->disableOriginalConstructor()
             ->getMock();
         $worksheet->method('cellExists')
@@ -41,7 +41,7 @@ class SubTotalTest extends TestCase
         $worksheet->method('getCell')
             ->willReturn($cell);
         $cellReference = $this->getMockBuilder(Cell::class)
-            ->setMethods(['getWorksheet'])
+            ->onlyMethods(['getWorksheet'])
             ->disableOriginalConstructor()
             ->getMock();
         $cellReference->method('getWorksheet')
@@ -75,7 +75,7 @@ class SubTotalTest extends TestCase
         $visibilityGenerator = $this->rowVisibility($hiddenRows);
 
         $rowDimension = $this->getMockBuilder(RowDimension::class)
-            ->setMethods(['getVisible'])
+            ->onlyMethods(['getVisible'])
             ->disableOriginalConstructor()
             ->getMock();
         $rowDimension->method('getVisible')
@@ -86,13 +86,13 @@ class SubTotalTest extends TestCase
                 return $result;
             });
         $columnDimension = $this->getMockBuilder(ColumnDimension::class)
-            ->setMethods(['getVisible'])
+            ->onlyMethods(['getVisible'])
             ->disableOriginalConstructor()
             ->getMock();
         $columnDimension->method('getVisible')
             ->willReturn(true);
         $cell = $this->getMockBuilder(Cell::class)
-            ->setMethods(['getValue', 'isFormula'])
+            ->onlyMethods(['getValue', 'isFormula'])
             ->disableOriginalConstructor()
             ->getMock();
         $cell->method('getValue')
@@ -100,7 +100,7 @@ class SubTotalTest extends TestCase
         $cell->method('getValue')
             ->willReturn(false);
         $worksheet = $this->getMockBuilder(Worksheet::class)
-            ->setMethods(['cellExists', 'getCell', 'getRowDimension', 'getColumnDimension'])
+            ->onlyMethods(['cellExists', 'getCell', 'getRowDimension', 'getColumnDimension'])
             ->disableOriginalConstructor()
             ->getMock();
         $worksheet->method('cellExists')
@@ -112,7 +112,7 @@ class SubTotalTest extends TestCase
         $worksheet->method('getColumnDimension')
             ->willReturn($columnDimension);
         $cellReference = $this->getMockBuilder(Cell::class)
-            ->setMethods(['getWorksheet'])
+            ->onlyMethods(['getWorksheet'])
             ->disableOriginalConstructor()
             ->getMock();
         $cellReference->method('getWorksheet')
@@ -153,7 +153,7 @@ class SubTotalTest extends TestCase
         $cellIsFormulaGenerator = $this->cellIsFormula(Functions::flattenArray(array_slice($args, 1)));
 
         $cell = $this->getMockBuilder(Cell::class)
-            ->setMethods(['getValue', 'isFormula'])
+            ->onlyMethods(['getValue', 'isFormula'])
             ->disableOriginalConstructor()
             ->getMock();
         $cell->method('getValue')
@@ -171,7 +171,7 @@ class SubTotalTest extends TestCase
                 return $result;
             });
         $worksheet = $this->getMockBuilder(Worksheet::class)
-            ->setMethods(['cellExists', 'getCell'])
+            ->onlyMethods(['cellExists', 'getCell'])
             ->disableOriginalConstructor()
             ->getMock();
         $worksheet->method('cellExists')
@@ -179,7 +179,7 @@ class SubTotalTest extends TestCase
         $worksheet->method('getCell')
             ->willReturn($cell);
         $cellReference = $this->getMockBuilder(Cell::class)
-            ->setMethods(['getWorksheet'])
+            ->onlyMethods(['getWorksheet'])
             ->disableOriginalConstructor()
             ->getMock();
         $cellReference->method('getWorksheet')

--- a/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
@@ -46,7 +46,8 @@ class AdvancedValueBinderTest extends TestCase
     public function testCurrency($value, $valueBinded, $format, $thousandsSeparator, $decimalSeparator, $currencyCode): void
     {
         $sheet = $this->getMockBuilder(Worksheet::class)
-            ->setMethods(['getStyle', 'getNumberFormat', 'setFormatCode', 'getCellCollection'])
+            ->onlyMethods(['getStyle', 'getCellCollection'])
+            ->addMethods(['getNumberFormat', 'setFormatCode'])
             ->getMock();
         $cellCollection = $this->getMockBuilder(Cells::class)
             ->disableOriginalConstructor()
@@ -106,7 +107,8 @@ class AdvancedValueBinderTest extends TestCase
     public function testFractions($value, $valueBinded, $format): void
     {
         $sheet = $this->getMockBuilder(Worksheet::class)
-            ->setMethods(['getStyle', 'getNumberFormat', 'setFormatCode', 'getCellCollection'])
+            ->onlyMethods(['getStyle', 'getCellCollection'])
+            ->addMethods(['getNumberFormat', 'setFormatCode'])
             ->getMock();
 
         $cellCollection = $this->getMockBuilder(Cells::class)
@@ -164,7 +166,8 @@ class AdvancedValueBinderTest extends TestCase
     public function testPercentages($value, $valueBinded, $format): void
     {
         $sheet = $this->getMockBuilder(Worksheet::class)
-            ->setMethods(['getStyle', 'getNumberFormat', 'setFormatCode', 'getCellCollection'])
+            ->onlyMethods(['getStyle', 'getCellCollection'])
+            ->addMethods(['getNumberFormat', 'setFormatCode'])
             ->getMock();
         $cellCollection = $this->getMockBuilder(Cells::class)
             ->disableOriginalConstructor()
@@ -214,7 +217,8 @@ class AdvancedValueBinderTest extends TestCase
     public function testTimes($value, $valueBinded, $format): void
     {
         $sheet = $this->getMockBuilder(Worksheet::class)
-            ->setMethods(['getStyle', 'getNumberFormat', 'setFormatCode', 'getCellCollection'])
+            ->onlyMethods(['getStyle', 'getCellCollection'])
+            ->addMethods(['getNumberFormat', 'setFormatCode'])
             ->getMock();
 
         $cellCollection = $this->getMockBuilder(Cells::class)
@@ -265,7 +269,8 @@ class AdvancedValueBinderTest extends TestCase
     public function testStringWrapping(string $value, bool $wrapped): void
     {
         $sheet = $this->getMockBuilder(Worksheet::class)
-            ->setMethods(['getStyle', 'getAlignment', 'setWrapText', 'getCellCollection'])
+            ->onlyMethods(['getStyle', 'getCellCollection'])
+            ->addMethods(['getAlignment', 'setWrapText'])
             ->getMock();
         $cellCollection = $this->getMockBuilder(Cells::class)
             ->disableOriginalConstructor()

--- a/tests/PhpSpreadsheetTests/Collection/CellsTest.php
+++ b/tests/PhpSpreadsheetTests/Collection/CellsTest.php
@@ -91,7 +91,7 @@ class CellsTest extends TestCase
 
         $collection = $this->getMockBuilder(Cells::class)
             ->setConstructorArgs([new Worksheet(), new Memory()])
-            ->setMethods(['has'])
+            ->onlyMethods(['has'])
             ->getMock();
 
         $collection->method('has')

--- a/tests/PhpSpreadsheetTests/Helper/SampleTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/SampleTest.php
@@ -30,7 +30,6 @@ class SampleTest extends TestCase
         $skipped = [
             'Chart/32_Chart_read_write_PDF.php', // Unfortunately JpGraph is not up to date for latest PHP and raise many warnings
             'Chart/32_Chart_read_write_HTML.php', // idem
-            'Chart/35_Chart_render.php', // idem
         ];
         // TCPDF and DomPDF libraries don't support PHP8 yet
         if (\PHP_VERSION_ID >= 80000) {
@@ -39,6 +38,7 @@ class SampleTest extends TestCase
                 [
                     'Pdf/21_Pdf_Domdf.php',
                     'Pdf/21_Pdf_TCPDF.php',
+                    'Chart/35_Chart_render.php', // idem
                 ]
             );
         }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Resolve Deprecated setMethods() call when Mocking for tests