### PR TITLE
jpgraph seems to be finally dying with PHP.

### DIFF
--- a/samples/Chart/35_Chart_render.php
+++ b/samples/Chart/35_Chart_render.php
@@ -5,6 +5,11 @@ use PhpOffice\PhpSpreadsheet\Settings;
 
 require __DIR__ . '/../Header.php';
 
+if (PHP_VERSION_ID >= 80000) {
+    $helper->log('Jpgraph no longer runs against PHP8');
+    exit;
+}
+
 // Change these values to select the Rendering library that you wish to use
 Settings::setChartRenderer(\PhpOffice\PhpSpreadsheet\Chart\Renderer\JpGraph::class);
 

--- a/tests/PhpSpreadsheetTests/Helper/SampleTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/SampleTest.php
@@ -30,6 +30,7 @@ class SampleTest extends TestCase
         $skipped = [
             'Chart/32_Chart_read_write_PDF.php', // Unfortunately JpGraph is not up to date for latest PHP and raise many warnings
             'Chart/32_Chart_read_write_HTML.php', // idem
+            'Chart/35_Chart_render.php', // idem
         ];
         // TCPDF and DomPDF libraries don't support PHP8 yet
         if (\PHP_VERSION_ID >= 80000) {


### PR DESCRIPTION
jpgraph seems to be finally dying with PHP. Until we have a valid alternative, disabling this run for PHP because it errors

This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
