### PR TITLE
Fix reference to deprecated transpose in lookup

### DIFF
--- a/src/PhpSpreadsheet/Calculation/LookupRef/Lookup.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Lookup.php
@@ -29,7 +29,7 @@ class Lookup
         $lookupColumns = self::columnCount($lookupVector);
         // we correctly orient our results
         if (($lookupRows === 1 && $lookupColumns > 1) || (!$hasResultVector && $lookupRows === 2 && $lookupColumns !== 2)) {
-            $lookupVector = LookupRef\Matrix::TRANSPOSE($lookupVector);
+            $lookupVector = LookupRef\Matrix::transpose($lookupVector);
             $lookupRows = self::rowCount($lookupVector);
             $lookupColumns = self::columnCount($lookupVector);
         }
@@ -84,7 +84,7 @@ class Lookup
 
         // we correctly orient our results
         if ($resultRows === 1 && $resultColumns > 1) {
-            $resultVector = LookupRef\Matrix::TRANSPOSE($resultVector);
+            $resultVector = LookupRef\Matrix::transpose($resultVector);
         }
 
         return $resultVector;

--- a/src/PhpSpreadsheet/Calculation/LookupRef/Lookup.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Lookup.php
@@ -29,7 +29,7 @@ class Lookup
         $lookupColumns = self::columnCount($lookupVector);
         // we correctly orient our results
         if (($lookupRows === 1 && $lookupColumns > 1) || (!$hasResultVector && $lookupRows === 2 && $lookupColumns !== 2)) {
-            $lookupVector = LookupRef::TRANSPOSE($lookupVector);
+            $lookupVector = LookupRef\Matrix::TRANSPOSE($lookupVector);
             $lookupRows = self::rowCount($lookupVector);
             $lookupColumns = self::columnCount($lookupVector);
         }
@@ -84,7 +84,7 @@ class Lookup
 
         // we correctly orient our results
         if ($resultRows === 1 && $resultColumns > 1) {
-            $resultVector = LookupRef::TRANSPOSE($resultVector);
+            $resultVector = LookupRef\Matrix::TRANSPOSE($resultVector);
         }
 
         return $resultVector;


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

@MarkBaker
Fix reference to the deprecated `TRANSPOSE()` function in `LOOKUP()`, pointing to the new `transpose()` method in the `LookupRef\Matrix` class instead