### PR TITLE
Switch calls to deprecated function methods to the equivalent new methods

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Database/DProduct.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DProduct.php
@@ -38,7 +38,7 @@ class DProduct extends DatabaseAbstract
             return null;
         }
 
-        return MathTrig::PRODUCT(
+        return MathTrig\Product::funcProduct(
             self::getFilteredColumn($database, $field, $criteria)
         );
     }

--- a/src/PhpSpreadsheet/Calculation/Database/DSum.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DSum.php
@@ -38,7 +38,7 @@ class DSum extends DatabaseAbstract
             return null;
         }
 
-        return MathTrig::SUM(
+        return MathTrig\Sum::funcSum(
             self::getFilteredColumn($database, $field, $criteria)
         );
     }

--- a/src/PhpSpreadsheet/Calculation/Financial/Amortization.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Amortization.php
@@ -2,7 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\Financial;
 
-use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
+use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 
 class Amortization
@@ -47,7 +47,7 @@ class Amortization
         $rate = Functions::flattenSingleValue($rate);
         $basis = ($basis === null) ? 0 : (int) Functions::flattenSingleValue($basis);
 
-        $yearFrac = DateTime::YEARFRAC($purchased, $firstPeriod, $basis);
+        $yearFrac = DateTimeExcel\YearFrac::funcYearFrac($purchased, $firstPeriod, $basis);
         if (is_string($yearFrac)) {
             return $yearFrac;
         }
@@ -116,13 +116,13 @@ class Amortization
         $fOneRate = $cost * $rate;
         $fCostDelta = $cost - $salvage;
         //    Note, quirky variation for leap years on the YEARFRAC for this function
-        $purchasedYear = DateTime::YEAR($purchased);
-        $yearFrac = DateTime::YEARFRAC($purchased, $firstPeriod, $basis);
+        $purchasedYear = DateTimeExcel\Year::funcYear($purchased);
+        $yearFrac = DateTimeExcel\YearFrac::funcYearFrac($purchased, $firstPeriod, $basis);
         if (is_string($yearFrac)) {
             return $yearFrac;
         }
 
-        if (($basis == 1) && ($yearFrac < 1) && (DateTime::isLeapYear($purchasedYear))) {
+        if (($basis == 1) && ($yearFrac < 1) && (DateTimeExcel\Helpers::isLeapYear($purchasedYear))) {
             $yearFrac *= 365 / 366;
         }
 

--- a/src/PhpSpreadsheet/Calculation/Financial/Coupons.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Coupons.php
@@ -2,7 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\Financial;
 
-use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
+use DateTime;
+use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
@@ -60,14 +61,14 @@ class Coupons
             return $e->getMessage();
         }
 
-        $daysPerYear = Helpers::daysPerYear(DateTime::YEAR($settlement), $basis);
+        $daysPerYear = Helpers::daysPerYear(DateTimeExcel\Year::funcYear($settlement), $basis);
         $prev = self::couponFirstPeriodDate($settlement, $maturity, $frequency, self::PERIOD_DATE_PREVIOUS);
 
         if ($basis === Helpers::DAYS_PER_YEAR_ACTUAL) {
-            return abs(DateTime::DAYS($prev, $settlement));
+            return abs(DateTimeExcel\Days::funcDays($prev, $settlement));
         }
 
-        return DateTime::YEARFRAC($prev, $settlement, $basis) * $daysPerYear;
+        return DateTimeExcel\YearFrac::funcYearFrac($prev, $settlement, $basis) * $daysPerYear;
     }
 
     /**
@@ -121,7 +122,7 @@ class Coupons
             case Helpers::DAYS_PER_YEAR_ACTUAL:
                 // Actual/actual
                 if ($frequency == self::FREQUENCY_ANNUAL) {
-                    $daysPerYear = Helpers::daysPerYear(DateTime::YEAR($settlement), $basis);
+                    $daysPerYear = Helpers::daysPerYear(DateTimeExcel\Year::funcYear($settlement), $basis);
 
                     return $daysPerYear / $frequency;
                 }
@@ -179,7 +180,7 @@ class Coupons
             return $e->getMessage();
         }
 
-        $daysPerYear = Helpers::daysPerYear(DateTime::YEAR($settlement), $basis);
+        $daysPerYear = Helpers::daysPerYear(DateTimeExcel\Year::funcYear($settlement), $basis);
         $next = self::couponFirstPeriodDate($settlement, $maturity, $frequency, self::PERIOD_DATE_NEXT);
 
         if ($basis === Helpers::DAYS_PER_YEAR_NASD) {
@@ -190,7 +191,7 @@ class Coupons
             }
         }
 
-        return DateTime::YEARFRAC($settlement, $next, $basis) * $daysPerYear;
+        return DateTimeExcel\YearFrac::funcYearFrac($settlement, $next, $basis) * $daysPerYear;
     }
 
     /**
@@ -286,7 +287,7 @@ class Coupons
             return $e->getMessage();
         }
 
-        $yearsBetweenSettlementAndMaturity = DateTime::YEARFRAC($settlement, $maturity, 0);
+        $yearsBetweenSettlementAndMaturity = DateTimeExcel\YearFrac::funcYearFrac($settlement, $maturity, 0);
 
         return ceil($yearsBetweenSettlementAndMaturity * $frequency);
     }
@@ -344,11 +345,11 @@ class Coupons
      *
      * Returns a boolean TRUE/FALSE indicating if this date is the last date of the month
      *
-     * @param \DateTime $testDate The date for testing
+     * @param DateTime $testDate The date for testing
      *
      * @return bool
      */
-    private static function isLastDayOfMonth(\DateTime $testDate)
+    private static function isLastDayOfMonth(DateTime $testDate)
     {
         return $testDate->format('d') === $testDate->format('t');
     }
@@ -376,7 +377,7 @@ class Coupons
 
     private static function validateInputDate($date)
     {
-        $date = DateTime::getDateValue($date);
+        $date = DateTimeExcel\Helpers::getDateValue($date);
         if (is_string($date)) {
             throw new Exception(Functions::VALUE());
         }

--- a/src/PhpSpreadsheet/Calculation/Financial/Helpers.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Helpers.php
@@ -2,7 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\Financial;
 
-use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
+use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 
 class Helpers
@@ -42,7 +42,7 @@ class Helpers
             case self::DAYS_PER_YEAR_365:
                 return 365;
             case self::DAYS_PER_YEAR_ACTUAL:
-                return (DateTime::isLeapYear($year)) ? 366 : 365;
+                return (DateTimeExcel\Helpers::isLeapYear($year)) ? 366 : 365;
         }
 
         return Functions::NAN();

--- a/src/PhpSpreadsheet/Calculation/Financial/Securities/BaseValidations.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Securities/BaseValidations.php
@@ -2,7 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\Financial\Securities;
 
-use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
+use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Financial\Securities\Constants as SecuritiesConstants;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
@@ -11,7 +11,7 @@ abstract class BaseValidations
 {
     protected static function validateInputDate($date)
     {
-        $date = DateTime::getDateValue($date);
+        $date = DateTimeExcel\Helpers::getDateValue($date);
         if (is_string($date)) {
             throw new Exception(Functions::VALUE());
         }

--- a/src/PhpSpreadsheet/Calculation/Financial/Securities/Price.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Securities/Price.php
@@ -2,7 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\Financial\Securities;
 
-use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
+use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Financial\Coupons;
 use PhpOffice\PhpSpreadsheet\Calculation\Financial\Helpers;
@@ -117,7 +117,7 @@ class Price extends BaseValidations
             return $e->getMessage();
         }
 
-        $daysBetweenSettlementAndMaturity = DateTime::YEARFRAC($settlement, $maturity, $basis);
+        $daysBetweenSettlementAndMaturity = DateTimeExcel\YearFrac::funcYearFrac($settlement, $maturity, $basis);
         if (!is_numeric($daysBetweenSettlementAndMaturity)) {
             //    return date error
             return $daysBetweenSettlementAndMaturity;
@@ -169,23 +169,23 @@ class Price extends BaseValidations
             return $e->getMessage();
         }
 
-        $daysPerYear = Helpers::daysPerYear(DateTime::YEAR($settlement), $basis);
+        $daysPerYear = Helpers::daysPerYear(DateTimeExcel\Year::funcYear($settlement), $basis);
         if (!is_numeric($daysPerYear)) {
             return $daysPerYear;
         }
-        $daysBetweenIssueAndSettlement = DateTime::YEARFRAC($issue, $settlement, $basis);
+        $daysBetweenIssueAndSettlement = DateTimeExcel\YearFrac::funcYearFrac($issue, $settlement, $basis);
         if (!is_numeric($daysBetweenIssueAndSettlement)) {
             //    return date error
             return $daysBetweenIssueAndSettlement;
         }
         $daysBetweenIssueAndSettlement *= $daysPerYear;
-        $daysBetweenIssueAndMaturity = DateTime::YEARFRAC($issue, $maturity, $basis);
+        $daysBetweenIssueAndMaturity = DateTimeExcel\YearFrac::funcYearFrac($issue, $maturity, $basis);
         if (!is_numeric($daysBetweenIssueAndMaturity)) {
             //    return date error
             return $daysBetweenIssueAndMaturity;
         }
         $daysBetweenIssueAndMaturity *= $daysPerYear;
-        $daysBetweenSettlementAndMaturity = DateTime::YEARFRAC($settlement, $maturity, $basis);
+        $daysBetweenSettlementAndMaturity = DateTimeExcel\YearFrac::funcYearFrac($settlement, $maturity, $basis);
         if (!is_numeric($daysBetweenSettlementAndMaturity)) {
             //    return date error
             return $daysBetweenSettlementAndMaturity;

--- a/src/PhpSpreadsheet/Calculation/Financial/Securities/Yields.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Securities/Yields.php
@@ -2,7 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\Financial\Securities;
 
-use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
+use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Financial\Helpers;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
@@ -49,11 +49,11 @@ class Yields extends BaseValidations
             return $e->getMessage();
         }
 
-        $daysPerYear = Helpers::daysPerYear(DateTime::YEAR($settlement), $basis);
+        $daysPerYear = Helpers::daysPerYear(DateTimeExcel\Year::funcYear($settlement), $basis);
         if (!is_numeric($daysPerYear)) {
             return $daysPerYear;
         }
-        $daysBetweenSettlementAndMaturity = DateTime::YEARFRAC($settlement, $maturity, $basis);
+        $daysBetweenSettlementAndMaturity = DateTimeExcel\YearFrac::funcYearFrac($settlement, $maturity, $basis);
         if (!is_numeric($daysBetweenSettlementAndMaturity)) {
             //    return date error
             return $daysBetweenSettlementAndMaturity;
@@ -106,23 +106,23 @@ class Yields extends BaseValidations
             return $e->getMessage();
         }
 
-        $daysPerYear = Helpers::daysPerYear(DateTime::YEAR($settlement), $basis);
+        $daysPerYear = Helpers::daysPerYear(DateTimeExcel\Year::funcYear($settlement), $basis);
         if (!is_numeric($daysPerYear)) {
             return $daysPerYear;
         }
-        $daysBetweenIssueAndSettlement = DateTime::YEARFRAC($issue, $settlement, $basis);
+        $daysBetweenIssueAndSettlement = DateTimeExcel\YearFrac::funcYearFrac($issue, $settlement, $basis);
         if (!is_numeric($daysBetweenIssueAndSettlement)) {
             //    return date error
             return $daysBetweenIssueAndSettlement;
         }
         $daysBetweenIssueAndSettlement *= $daysPerYear;
-        $daysBetweenIssueAndMaturity = DateTime::YEARFRAC($issue, $maturity, $basis);
+        $daysBetweenIssueAndMaturity = DateTimeExcel\YearFrac::funcYearFrac($issue, $maturity, $basis);
         if (!is_numeric($daysBetweenIssueAndMaturity)) {
             //    return date error
             return $daysBetweenIssueAndMaturity;
         }
         $daysBetweenIssueAndMaturity *= $daysPerYear;
-        $daysBetweenSettlementAndMaturity = DateTime::YEARFRAC($settlement, $maturity, $basis);
+        $daysBetweenSettlementAndMaturity = DateTimeExcel\YearFrac::funcYearFrac($settlement, $maturity, $basis);
         if (!is_numeric($daysBetweenSettlementAndMaturity)) {
             //    return date error
             return $daysBetweenSettlementAndMaturity;

--- a/src/PhpSpreadsheet/Calculation/Financial/TreasuryBill.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/TreasuryBill.php
@@ -2,7 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\Financial;
 
-use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
+use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel;
+use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 
 class TreasuryBill
@@ -27,11 +28,11 @@ class TreasuryBill
         $maturity = Functions::flattenSingleValue($maturity);
         $discount = Functions::flattenSingleValue($discount);
 
-        if (
-            is_string($maturity = DateTime::getDateValue($maturity)) ||
-            is_string($settlement = DateTime::getDateValue($settlement))
-        ) {
-            return Functions::VALUE();
+        try {
+            $maturity = DateTimeExcel\Helpers::getDateValue($maturity);
+            $settlement = DateTimeExcel\Helpers::getDateValue($settlement);
+        } catch (Exception $e) {
+            return $e->getMessage();
         }
 
         //    Validate
@@ -41,11 +42,9 @@ class TreasuryBill
             }
 
             $daysBetweenSettlementAndMaturity = $maturity - $settlement;
+            $daysPerYear = Helpers::daysPerYear(DateTimeExcel\Year::funcYear($maturity), Helpers::DAYS_PER_YEAR_ACTUAL);
 
-            if (
-                $daysBetweenSettlementAndMaturity > Helpers::daysPerYear(DateTime::YEAR($maturity), Helpers::DAYS_PER_YEAR_ACTUAL) ||
-                $daysBetweenSettlementAndMaturity < 0
-            ) {
+            if ($daysBetweenSettlementAndMaturity > $daysPerYear || $daysBetweenSettlementAndMaturity < 0) {
                 return Functions::NAN();
             }
 
@@ -75,11 +74,11 @@ class TreasuryBill
         $maturity = Functions::flattenSingleValue($maturity);
         $discount = Functions::flattenSingleValue($discount);
 
-        if (
-            is_string($maturity = DateTime::getDateValue($maturity)) ||
-            is_string($settlement = DateTime::getDateValue($settlement))
-        ) {
-            return Functions::VALUE();
+        try {
+            $maturity = DateTimeExcel\Helpers::getDateValue($maturity);
+            $settlement = DateTimeExcel\Helpers::getDateValue($settlement);
+        } catch (Exception $e) {
+            return $e->getMessage();
         }
 
         //    Validate
@@ -89,13 +88,12 @@ class TreasuryBill
             }
 
             $daysBetweenSettlementAndMaturity = $maturity - $settlement;
+            $daysPerYear = Helpers::daysPerYear(DateTimeExcel\Year::funcYear($maturity), Helpers::DAYS_PER_YEAR_ACTUAL);
 
-            if (
-                $daysBetweenSettlementAndMaturity > Helpers::daysPerYear(DateTime::YEAR($maturity), Helpers::DAYS_PER_YEAR_ACTUAL) ||
-                $daysBetweenSettlementAndMaturity < 0
-            ) {
+            if ($daysBetweenSettlementAndMaturity > $daysPerYear || $daysBetweenSettlementAndMaturity < 0) {
                 return Functions::NAN();
             }
+
             $price = 100 * (1 - (($discount * $daysBetweenSettlementAndMaturity) / 360));
             if ($price < 0.0) {
                 return Functions::NAN();
@@ -127,11 +125,11 @@ class TreasuryBill
         $maturity = Functions::flattenSingleValue($maturity);
         $price = Functions::flattenSingleValue($price);
 
-        if (
-            is_string($maturity = DateTime::getDateValue($maturity)) ||
-            is_string($settlement = DateTime::getDateValue($settlement))
-        ) {
-            return Functions::VALUE();
+        try {
+            $maturity = DateTimeExcel\Helpers::getDateValue($maturity);
+            $settlement = DateTimeExcel\Helpers::getDateValue($settlement);
+        } catch (Exception $e) {
+            return $e->getMessage();
         }
 
         //    Validate
@@ -141,8 +139,9 @@ class TreasuryBill
             }
 
             $daysBetweenSettlementAndMaturity = $maturity - $settlement;
+            $daysPerYear = Helpers::daysPerYear(DateTimeExcel\Year::funcYear($maturity), Helpers::DAYS_PER_YEAR_ACTUAL);
 
-            if ($daysBetweenSettlementAndMaturity > 360 || $daysBetweenSettlementAndMaturity < 0) {
+            if ($daysBetweenSettlementAndMaturity > $daysPerYear || $daysBetweenSettlementAndMaturity < 0) {
                 return Functions::NAN();
             }
 

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Fact.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Fact.php
@@ -33,7 +33,7 @@ class Fact
         $factLoop = floor($factVal);
         if ($factVal > $factLoop) {
             if (Functions::getCompatibilityMode() == Functions::COMPATIBILITY_GNUMERIC) {
-                return Statistical::GAMMAFunction($factVal + 1);
+                return Statistical\Distributions\Gamma::gammaValue($factVal + 1);
             }
         }
 

--- a/src/PhpSpreadsheet/Calculation/Statistical.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical.php
@@ -946,7 +946,7 @@ class Statistical
     {
         $aArgs = Functions::flattenArray($args);
 
-        $aMean = MathTrig::PRODUCT($aArgs);
+        $aMean = MathTrig\Product::funcProduct($aArgs);
         if (is_numeric($aMean) && ($aMean > 0)) {
             $aCount = Counts::COUNT($aArgs);
             if (Minimum::MIN($aArgs) > 0) {

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Poisson.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Poisson.php
@@ -44,12 +44,12 @@ class Poisson
             $summer = 0;
             $floor = floor($value);
             for ($i = 0; $i <= $floor; ++$i) {
-                $summer += $mean ** $i / MathTrig::FACT($i);
+                $summer += $mean ** $i / MathTrig\Fact::funcFact($i);
             }
 
             return exp(0 - $mean) * $summer;
         }
 
-        return (exp(0 - $mean) * $mean ** $value) / MathTrig::FACT($value);
+        return (exp(0 - $mean) * $mean ** $value) / MathTrig\Fact::funcFact($value);
     }
 }

--- a/src/PhpSpreadsheet/Calculation/Statistical/Permutations.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Permutations.php
@@ -32,7 +32,7 @@ class Permutations
                 return Functions::NAN();
             }
 
-            return round(MathTrig::FACT($numObjs) / MathTrig::FACT($numObjs - $numInSet));
+            return round(MathTrig\Fact::funcFact($numObjs) / MathTrig\Fact::funcFact($numObjs - $numInSet));
         }
 
         return Functions::VALUE();

--- a/src/PhpSpreadsheet/Calculation/TextData/Format.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Format.php
@@ -3,7 +3,7 @@
 namespace PhpOffice\PhpSpreadsheet\Calculation\TextData;
 
 use DateTimeInterface;
-use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
+use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\MathTrig;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
@@ -96,7 +96,7 @@ class Format
         $format = Functions::flattenSingleValue($format);
 
         if ((is_string($value)) && (!is_numeric($value)) && Date::isDateTimeFormatCode($format)) {
-            $value = DateTime::DATEVALUE($value);
+            $value = DateTimeExcel\DateValue::funcDateValue($value);
         }
 
         return (string) NumberFormat::toFormattedString($value, $format);
@@ -127,14 +127,14 @@ class Format
             Functions::setReturnDateType(Functions::RETURNDATE_EXCEL);
 
             if (strpos($value, ':') !== false) {
-                $timeValue = DateTime::TIMEVALUE($value);
+                $timeValue = DateTimeExcel\TimeValue::funcTimeValue($value);
                 if ($timeValue !== Functions::VALUE()) {
                     Functions::setReturnDateType($dateSetting);
 
                     return $timeValue;
                 }
             }
-            $dateValue = DateTime::DATEVALUE($value);
+            $dateValue = DateTimeExcel\DateValue::funcDateValue($value);
             if ($dateValue !== Functions::VALUE()) {
                 Functions::setReturnDateType($dateSetting);
 

--- a/src/PhpSpreadsheet/Calculation/TextData/Replace.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Replace.php
@@ -3,7 +3,6 @@
 namespace PhpOffice\PhpSpreadsheet\Calculation\TextData;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
-use PhpOffice\PhpSpreadsheet\Calculation\TextData;
 
 class Replace
 {
@@ -23,7 +22,7 @@ class Replace
         $newText = Functions::flattenSingleValue($newText);
 
         $left = Extract::left($oldText, $start - 1);
-        $right = Extract::right($oldText, TextData::STRINGLENGTH($oldText) - ($start + $chars) + 1);
+        $right = Extract::right($oldText, Text::length($oldText) - ($start + $chars) + 1);
 
         return $left . $newText . $right;
     }

--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -2,9 +2,10 @@
 
 namespace PhpOffice\PhpSpreadsheet\Shared;
 
+use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
-use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
+use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Exception as PhpSpreadsheetException;
@@ -154,7 +155,7 @@ class Date
      *                                                                        if you don't want to treat it as a UTC value
      *                                                                    Use the default (UST) unless you absolutely need a conversion
      *
-     * @return \DateTime PHP date/time object
+     * @return DateTime PHP date/time object
      */
     public static function excelToDateTimeObject($excelTimestamp, $timeZone = null)
     {
@@ -162,18 +163,18 @@ class Date
         if (Functions::getCompatibilityMode() == Functions::COMPATIBILITY_EXCEL) {
             if ($excelTimestamp < 1 && self::$excelCalendar === self::CALENDAR_WINDOWS_1900) {
                 // Unix timestamp base date
-                $baseDate = new \DateTime('1970-01-01', $timeZone);
+                $baseDate = new DateTime('1970-01-01', $timeZone);
             } else {
                 // MS Excel calendar base dates
                 if (self::$excelCalendar == self::CALENDAR_WINDOWS_1900) {
                     // Allow adjustment for 1900 Leap Year in MS Excel
-                    $baseDate = ($excelTimestamp < 60) ? new \DateTime('1899-12-31', $timeZone) : new \DateTime('1899-12-30', $timeZone);
+                    $baseDate = ($excelTimestamp < 60) ? new DateTime('1899-12-31', $timeZone) : new DateTime('1899-12-30', $timeZone);
                 } else {
-                    $baseDate = new \DateTime('1904-01-01', $timeZone);
+                    $baseDate = new DateTime('1904-01-01', $timeZone);
                 }
             }
         } else {
-            $baseDate = new \DateTime('1899-12-30', $timeZone);
+            $baseDate = new DateTime('1899-12-30', $timeZone);
         }
 
         $days = floor($excelTimestamp);
@@ -262,7 +263,7 @@ class Date
             return false;
         }
 
-        return self::dateTimeToExcel(new \DateTime('@' . $dateValue));
+        return self::dateTimeToExcel(new DateTime('@' . $dateValue));
     }
 
     /**
@@ -436,14 +437,14 @@ class Date
             return false;
         }
 
-        $dateValueNew = DateTime::DATEVALUE($dateValue);
+        $dateValueNew = DateTimeExcel\DateValue::funcDateValue($dateValue);
 
         if ($dateValueNew === Functions::VALUE()) {
             return false;
         }
 
         if (strpos($dateValue, ':') !== false) {
-            $timeValue = DateTime::TIMEVALUE($dateValue);
+            $timeValue = DateTimeExcel\TimeValue::funcTimeValue($dateValue);
             if ($timeValue === Functions::VALUE()) {
                 return false;
             }

--- a/src/PhpSpreadsheet/Worksheet/AutoFilter.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter.php
@@ -3,7 +3,7 @@
 namespace PhpOffice\PhpSpreadsheet\Worksheet;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
-use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
+use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Exception as PhpSpreadsheetException;
@@ -472,7 +472,7 @@ class AutoFilter
         $val = $maxVal = null;
 
         $ruleValues = [];
-        $baseDate = DateTime::DATENOW();
+        $baseDate = DateTimeExcel\Now::funcNow();
         //    Calculate start/end dates for the required date range based on current date
         switch ($dynamicRuleType) {
             case AutoFilter\Column\Rule::AUTOFILTER_RULETYPE_DYNAMIC_LASTWEEK:


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] refactoring
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Check for calls to the older deprecated Excel function methods, and instead call the new refactored code