### PR TITLE
Update remaining references in the Financial Functions code to avoid calling deprecated methods

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Financial.php
+++ b/src/PhpSpreadsheet/Calculation/Financial.php
@@ -1781,6 +1781,7 @@ class Financial
         $values = Functions::flattenArray($values);
         $dates = Functions::flattenArray($dates);
         $valCount = count($values);
+
         try {
             $date0 = DateTimeExcel\Helpers::getDateValue($dates[0]);
         } catch (Exception $e) {
@@ -1795,6 +1796,7 @@ class Financial
             if (!is_numeric($values[$i])) {
                 return Functions::VALUE();
             }
+
             try {
                 $datei = DateTimeExcel\Helpers::getDateValue($dates[$i]);
             } catch (Exception $e) {

--- a/src/PhpSpreadsheet/Calculation/Financial.php
+++ b/src/PhpSpreadsheet/Calculation/Financial.php
@@ -620,7 +620,7 @@ class Financial
             if (($price <= 0) || ($redemption <= 0)) {
                 return Functions::NAN();
             }
-            $daysBetweenSettlementAndMaturity = DateTime::YEARFRAC($settlement, $maturity, $basis);
+            $daysBetweenSettlementAndMaturity = DateTimeExcel\YearFrac::funcYearFrac($settlement, $maturity, $basis);
             if (!is_numeric($daysBetweenSettlementAndMaturity)) {
                 //    return date error
                 return $daysBetweenSettlementAndMaturity;
@@ -810,7 +810,7 @@ class Financial
             if (($investment <= 0) || ($redemption <= 0)) {
                 return Functions::NAN();
             }
-            $daysBetweenSettlementAndMaturity = DateTime::YEARFRAC($settlement, $maturity, $basis);
+            $daysBetweenSettlementAndMaturity = DateTimeExcel\YearFrac::funcYearFrac($settlement, $maturity, $basis);
             if (!is_numeric($daysBetweenSettlementAndMaturity)) {
                 //    return date error
                 return $daysBetweenSettlementAndMaturity;
@@ -1451,7 +1451,7 @@ class Financial
             if (($investment <= 0) || ($discount <= 0)) {
                 return Functions::NAN();
             }
-            $daysBetweenSettlementAndMaturity = DateTime::YEARFRAC($settlement, $maturity, $basis);
+            $daysBetweenSettlementAndMaturity = DateTimeExcel\YearFrac::funcYearFrac($settlement, $maturity, $basis);
             if (!is_numeric($daysBetweenSettlementAndMaturity)) {
                 //    return date error
                 return $daysBetweenSettlementAndMaturity;
@@ -1639,7 +1639,7 @@ class Financial
 
         $datesCount = count($dates);
         for ($i = 0; $i < $datesCount; ++$i) {
-            $dates[$i] = DateTime::getDateValue($dates[$i]);
+            $dates[$i] = DateTimeExcel\Helpers::getDateValue($dates[$i]);
             if (!is_numeric($dates[$i])) {
                 return Functions::VALUE();
             }
@@ -1766,7 +1766,7 @@ class Financial
         if ($valCount > 1 && ((min($values) > 0) || (max($values) < 0))) {
             return Functions::NAN();
         }
-        $date0 = DateTime::getDateValue($dates[0]);
+        $date0 = DateTimeExcel\Helpers::getDateValue($dates[0]);
         if (is_string($date0)) {
             return Functions::VALUE();
         }
@@ -1780,7 +1780,7 @@ class Financial
         $values = Functions::flattenArray($values);
         $dates = Functions::flattenArray($dates);
         $valCount = count($values);
-        $date0 = DateTime::getDateValue($dates[0]);
+        $date0 = DateTimeExcel\Helpers::getDateValue($dates[0]);
         $rslt = self::validateXnpv($rate, $values, $dates);
         if ($rslt) {
             return $rslt;
@@ -1790,14 +1790,14 @@ class Financial
             if (!is_numeric($values[$i])) {
                 return Functions::VALUE();
             }
-            $datei = DateTime::getDateValue($dates[$i]);
+            $datei = DateTimeExcel\Helpers::getDateValue($dates[$i]);
             if (is_string($datei)) {
                 return Functions::VALUE();
             }
             if ($date0 > $datei) {
-                $dif = $ordered ? Functions::NAN() : -DateTime::DATEDIF($datei, $date0, 'd');
+                $dif = $ordered ? Functions::NAN() : -DateTimeExcel\DateDif::funcDateDif($datei, $date0, 'd');
             } else {
-                $dif = DateTime::DATEDIF($date0, $datei, 'd');
+                $dif = DateTimeExcel\DateDif::funcDateDif($date0, $datei, 'd');
             }
             if (!is_numeric($dif)) {
                 return $dif;

--- a/src/PhpSpreadsheet/Calculation/Financial.php
+++ b/src/PhpSpreadsheet/Calculation/Financial.php
@@ -1639,9 +1639,10 @@ class Financial
 
         $datesCount = count($dates);
         for ($i = 0; $i < $datesCount; ++$i) {
-            $dates[$i] = DateTimeExcel\Helpers::getDateValue($dates[$i]);
-            if (!is_numeric($dates[$i])) {
-                return Functions::VALUE();
+            try {
+                $dates[$i] = DateTimeExcel\Helpers::getDateValue($dates[$i]);
+            } catch (Exception $e) {
+                return $e->getMessage();
             }
         }
 
@@ -1780,7 +1781,11 @@ class Financial
         $values = Functions::flattenArray($values);
         $dates = Functions::flattenArray($dates);
         $valCount = count($values);
-        $date0 = DateTimeExcel\Helpers::getDateValue($dates[0]);
+        try {
+            $date0 = DateTimeExcel\Helpers::getDateValue($dates[0]);
+        } catch (Exception $e) {
+            return $e->getMessage();
+        }
         $rslt = self::validateXnpv($rate, $values, $dates);
         if ($rslt) {
             return $rslt;
@@ -1790,9 +1795,10 @@ class Financial
             if (!is_numeric($values[$i])) {
                 return Functions::VALUE();
             }
-            $datei = DateTimeExcel\Helpers::getDateValue($dates[$i]);
-            if (is_string($datei)) {
-                return Functions::VALUE();
+            try {
+                $datei = DateTimeExcel\Helpers::getDateValue($dates[$i]);
+            } catch (Exception $e) {
+                return $e->getMessage();
             }
             if ($date0 > $datei) {
                 $dif = $ordered ? Functions::NAN() : -DateTimeExcel\DateDif::funcDateDif($datei, $date0, 'd');

--- a/src/PhpSpreadsheet/Calculation/Financial/Securities/AccruedInterest.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Securities/AccruedInterest.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheet\Calculation\Financial\Securities;
 
 use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
+use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel\YearFrac;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 
@@ -76,12 +77,12 @@ class AccruedInterest
             return $e->getMessage();
         }
 
-        $daysBetweenIssueAndSettlement = DateTime::YEARFRAC($issue, $settlement, $basis);
+        $daysBetweenIssueAndSettlement = YearFrac::funcYearFrac($issue, $settlement, $basis);
         if (!is_numeric($daysBetweenIssueAndSettlement)) {
             //    return date error
             return $daysBetweenIssueAndSettlement;
         }
-        $daysBetweenFirstInterestAndSettlement = DateTime::YEARFRAC($firstinterest, $settlement, $basis);
+        $daysBetweenFirstInterestAndSettlement = YearFrac::funcYearFrac($firstinterest, $settlement, $basis);
         if (!is_numeric($daysBetweenFirstInterestAndSettlement)) {
             //    return date error
             return $daysBetweenFirstInterestAndSettlement;
@@ -132,7 +133,7 @@ class AccruedInterest
             return $e->getMessage();
         }
 
-        $daysBetweenIssueAndSettlement = DateTime::YEARFRAC($issue, $settlement, $basis);
+        $daysBetweenIssueAndSettlement = YearFrac::funcYearFrac($issue, $settlement, $basis);
         if (!is_numeric($daysBetweenIssueAndSettlement)) {
             //    return date error
             return $daysBetweenIssueAndSettlement;

--- a/src/PhpSpreadsheet/Calculation/Financial/Securities/AccruedInterest.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Securities/AccruedInterest.php
@@ -2,7 +2,6 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\Financial\Securities;
 
-use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
 use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel\YearFrac;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] refactoring
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Update remaining references in the Financial Functions code to bypass the newly deprecated date methods and use the new date function methods directly
