### PR TITLE
Resolution for [#Issue 1972](https://github.com/PHPOffice/PhpSpreadsheet/issues/1972)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Fixed issue with quoted strings in number format mask rendered with toFormattedString() [Issue 1972#](https://github.com/PHPOffice/PhpSpreadsheet/issues/1972) [PR #1978](https://github.com/PHPOffice/PhpSpreadsheet/pull/1978)
 - Fixed issue with percentage formats in number format mask rendered with toFormattedString() [Issue 1929#](https://github.com/PHPOffice/PhpSpreadsheet/issues/1929) [PR #1928](https://github.com/PHPOffice/PhpSpreadsheet/pull/1928)
 - Fixed issue with _ spacing character in number format mask corrupting output from toFormattedString() [Issue 1924#](https://github.com/PHPOffice/PhpSpreadsheet/issues/1924) [PR #1927](https://github.com/PHPOffice/PhpSpreadsheet/pull/1927)
 - Fix for [Issue #1887](https://github.com/PHPOffice/PhpSpreadsheet/issues/1887) - Lose Track of Selected Cells After Save

--- a/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
@@ -43,7 +43,7 @@ class Formatter
         //   3 sections:  [POSITIVE/TEXT] [NEGATIVE] [ZERO]
         //   4 sections:  [POSITIVE] [NEGATIVE] [ZERO] [TEXT]
         $cnt = count($sections);
-        $color_regex = '/\\[(' . implode('|', Color::NAMED_COLORS) . ')\\]/';
+        $color_regex = '/\\[(' . implode('|', Color::NAMED_COLORS) . ')\\]/mui';
         $cond_regex = '/\\[(>|>=|<|<=|=|<>)([+-]?\\d+([.]\\d+)?)\\]/';
         $colors = ['', '', '', '', ''];
         $condops = ['', '', '', '', ''];
@@ -139,7 +139,7 @@ class Formatter
             // datetime format
             $value = DateFormatter::format($value, $format);
         } else {
-            if (substr($format, 0, 1) === '"' && substr($format, -1, 1) === '"') {
+            if (substr($format, 0, 1) === '"' && substr($format, -1, 1) === '"' && substr_count($format, '"') === 2) {
                 $value = substr($format, 1, -1);
             } elseif (preg_match('/[0#, ]%/', $format)) {
                 // % number format

--- a/tests/data/Style/NumberFormat.php
+++ b/tests/data/Style/NumberFormat.php
@@ -391,6 +391,11 @@ return [
         '[Green]General',
     ],
     [
+        '12345',
+        12345,
+        '[GrEeN]General',
+    ],
+    [
         '-70',
         -70,
         '#,##0;[Red]-#,##0',
@@ -404,14 +409,24 @@ return [
     [
         '12345',
         12345,
-        '[Blue]0;[Red]0',
+        '[Blue]0;[Red]0-',
     ],
+    [
+        '12345-',
+        -12345,
+        '[BLUE]0;[red]0-',
+    ],
+    [
+        '12345-',
+        -12345,
+        '[blue]0;[RED]0-',
+    ],
+    // Multiple colors with text substitution
     [
         'Positive',
         12,
         '[Green]"Positive";[Red]"Negative";[Blue]"Zero"',
     ],
-    // Multiple colors with text substitution
     [
         'Zero',
         0,
@@ -422,6 +437,7 @@ return [
         -2,
         '[Green]"Positive";[Red]"Negative";[Blue]"Zero"',
     ],
+    // Value break points
     [
         '<=3500 red',
         3500,
@@ -441,6 +457,17 @@ return [
         'else red',
         25,
         '[Green][<>25]"<>25 green";[Red]"else red"',
+    ],
+    // Leading/trailing quotes in mask
+    [
+        '$12.34 ',
+        12.34,
+        '$#,##0.00_;[RED]"($"#,##0.00")"',
+    ],
+    [
+        '($12.34)',
+        -12.34,
+        '$#,##0.00_;[RED]"($"#,##0.00")"',
     ],
     [
         'pfx. 25.00',


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Resolution for [#Issue 1972](https://github.com/PHPOffice/PhpSpreadsheet/issues/1972) where format masks with a leading and trailing quote were always treated as literal strings, even when they masks containing quoted characters.

Also resolves issue with colour name case-sensitivity
