### PR TITLE
Let's start with some appeasements to phpstan, just to reduce the baseline

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Database/DMax.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DMax.php
@@ -30,7 +30,7 @@ class DMax extends DatabaseAbstract
      *                                        the column label in which you specify a condition for the
      *                                        column.
      *
-     * @return float
+     * @return null|float|string
      */
     public static function evaluate($database, $field, $criteria)
     {

--- a/src/PhpSpreadsheet/Calculation/Database/DMin.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DMin.php
@@ -30,7 +30,7 @@ class DMin extends DatabaseAbstract
      *                                        the column label in which you specify a condition for the
      *                                        column.
      *
-     * @return float
+     * @return null|float|string
      */
     public static function evaluate($database, $field, $criteria)
     {

--- a/src/PhpSpreadsheet/Calculation/Database/DProduct.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DProduct.php
@@ -29,7 +29,7 @@ class DProduct extends DatabaseAbstract
      *                                        the column label in which you specify a condition for the
      *                                        column.
      *
-     * @return float|string
+     * @return null|float|string
      */
     public static function evaluate($database, $field, $criteria)
     {

--- a/src/PhpSpreadsheet/Calculation/Database/DStDev.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DStDev.php
@@ -30,7 +30,7 @@ class DStDev extends DatabaseAbstract
      *                                        the column label in which you specify a condition for the
      *                                        column.
      *
-     * @return float|string
+     * @return null|float|string
      */
     public static function evaluate($database, $field, $criteria)
     {

--- a/src/PhpSpreadsheet/Calculation/Database/DStDevP.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DStDevP.php
@@ -30,7 +30,7 @@ class DStDevP extends DatabaseAbstract
      *                                        the column label in which you specify a condition for the
      *                                        column.
      *
-     * @return float|string
+     * @return null|float|string
      */
     public static function evaluate($database, $field, $criteria)
     {

--- a/src/PhpSpreadsheet/Calculation/Database/DSum.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DSum.php
@@ -29,7 +29,7 @@ class DSum extends DatabaseAbstract
      *                                        the column label in which you specify a condition for the
      *                                        column.
      *
-     * @return float|string
+     * @return null|float|string
      */
     public static function evaluate($database, $field, $criteria)
     {

--- a/src/PhpSpreadsheet/Calculation/Database/DVar.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DVar.php
@@ -30,7 +30,7 @@ class DVar extends DatabaseAbstract
      *                                        the column label in which you specify a condition for the
      *                                        column.
      *
-     * @return float|string (string if result is an error)
+     * @return null|float|string (string if result is an error)
      */
     public static function evaluate($database, $field, $criteria)
     {

--- a/src/PhpSpreadsheet/Calculation/Database/DVarP.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DVarP.php
@@ -30,7 +30,7 @@ class DVarP extends DatabaseAbstract
      *                                        the column label in which you specify a condition for the
      *                                        column.
      *
-     * @return float|string (string if result is an error)
+     * @return null|float|string (string if result is an error)
      */
     public static function evaluate($database, $field, $criteria)
     {

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/Days360.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/Days360.php
@@ -19,20 +19,20 @@ class Days360
      *        DAYS360(startDate,endDate[,method])
      *
      * @param mixed $startDate Excel date serial value (float), PHP date timestamp (integer),
-     *                                        PHP DateTime object, or a standard date string
+     *                               PHP DateTime object, or a standard date string
      * @param mixed $endDate Excel date serial value (float), PHP date timestamp (integer),
-     *                                        PHP DateTime object, or a standard date string
-     * @param mixed (bool) $method US or European Method
-     *                                        FALSE or omitted: U.S. (NASD) method. If the starting date is
-     *                                        the last day of a month, it becomes equal to the 30th of the
-     *                                        same month. If the ending date is the last day of a month and
-     *                                        the starting date is earlier than the 30th of a month, the
-     *                                        ending date becomes equal to the 1st of the next month;
-     *                                        otherwise the ending date becomes equal to the 30th of the
-     *                                        same month.
-     *                                        TRUE: European method. Starting dates and ending dates that
-     *                                        occur on the 31st of a month become equal to the 30th of the
-     *                                        same month.
+     *                             PHP DateTime object, or a standard date string
+     * @param mixed $method US or European Method as a bool
+     *                         FALSE or omitted: U.S. (NASD) method. If the starting date is
+     *                               the last day of a month, it becomes equal to the 30th of the
+     *                               same month. If the ending date is the last day of a month and
+     *                               the starting date is earlier than the 30th of a month, the
+     *                               ending date becomes equal to the 1st of the next month;
+     *                               otherwise the ending date becomes equal to the 30th of the
+     *                               same month.
+     *                         TRUE: European method. Starting dates and ending dates that
+     *                               occur on the 31st of a month become equal to the 30th of the
+     *                               same month.
      *
      * @return int|string Number of days between start date and end date
      */

--- a/src/PhpSpreadsheet/Calculation/Engineering.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering.php
@@ -156,7 +156,7 @@ class Engineering
      *
      * @see Use the toDecimal() method in the Engineering\ConvertBinary class instead
      *
-     * @param string $x The binary number (as a string) that you want to convert. The number
+     * @param mixed $x The binary number (as a string) that you want to convert. The number
      *                                cannot contain more than 10 characters (10 bits). The most significant
      *                                bit of number is the sign bit. The remaining 9 bits are magnitude bits.
      *                                Negative numbers are represented using two's-complement notation.
@@ -182,13 +182,13 @@ class Engineering
      *
      * @see Use the toHex() method in the Engineering\ConvertBinary class instead
      *
-     * @param string $x The binary number (as a string) that you want to convert. The number
+     * @param mixed $x The binary number (as a string) that you want to convert. The number
      *                                cannot contain more than 10 characters (10 bits). The most significant
      *                                bit of number is the sign bit. The remaining 9 bits are magnitude bits.
      *                                Negative numbers are represented using two's-complement notation.
      *                                If number is not a valid binary number, or if number contains more than
      *                                10 characters (10 bits), BIN2HEX returns the #NUM! error value.
-     * @param int $places The number of characters to use. If places is omitted, BIN2HEX uses the
+     * @param mixed $places The number of characters to use. If places is omitted, BIN2HEX uses the
      *                                minimum number of characters necessary. Places is useful for padding the
      *                                return value with leading 0s (zeros).
      *                                If places is not an integer, it is truncated.
@@ -214,13 +214,13 @@ class Engineering
      *
      * @see Use the toOctal() method in the Engineering\ConvertBinary class instead
      *
-     * @param string $x The binary number (as a string) that you want to convert. The number
+     * @param mixed $x The binary number (as a string) that you want to convert. The number
      *                                cannot contain more than 10 characters (10 bits). The most significant
      *                                bit of number is the sign bit. The remaining 9 bits are magnitude bits.
      *                                Negative numbers are represented using two's-complement notation.
      *                                If number is not a valid binary number, or if number contains more than
      *                                10 characters (10 bits), BIN2OCT returns the #NUM! error value.
-     * @param int $places The number of characters to use. If places is omitted, BIN2OCT uses the
+     * @param mixed $places The number of characters to use. If places is omitted, BIN2OCT uses the
      *                                minimum number of characters necessary. Places is useful for padding the
      *                                return value with leading 0s (zeros).
      *                                If places is not an integer, it is truncated.
@@ -246,7 +246,7 @@ class Engineering
      *
      * @see Use the toBinary() method in the Engineering\ConvertDecimal class instead
      *
-     * @param string $x The decimal integer you want to convert. If number is negative,
+     * @param mixed $x The decimal integer you want to convert. If number is negative,
      *                                valid place values are ignored and DEC2BIN returns a 10-character
      *                                (10-bit) binary number in which the most significant bit is the sign
      *                                bit. The remaining 9 bits are magnitude bits. Negative numbers are
@@ -256,7 +256,7 @@ class Engineering
      *                                If number is nonnumeric, DEC2BIN returns the #VALUE! error value.
      *                                If DEC2BIN requires more than places characters, it returns the #NUM!
      *                                error value.
-     * @param int $places The number of characters to use. If places is omitted, DEC2BIN uses
+     * @param mixed $places The number of characters to use. If places is omitted, DEC2BIN uses
      *                                the minimum number of characters necessary. Places is useful for
      *                                padding the return value with leading 0s (zeros).
      *                                If places is not an integer, it is truncated.
@@ -282,7 +282,7 @@ class Engineering
      *
      * @see Use the toHex() method in the Engineering\ConvertDecimal class instead
      *
-     * @param string $x The decimal integer you want to convert. If number is negative,
+     * @param mixed $x The decimal integer you want to convert. If number is negative,
      *                                places is ignored and DEC2HEX returns a 10-character (40-bit)
      *                                hexadecimal number in which the most significant bit is the sign
      *                                bit. The remaining 39 bits are magnitude bits. Negative numbers
@@ -292,7 +292,7 @@ class Engineering
      *                                If number is nonnumeric, DEC2HEX returns the #VALUE! error value.
      *                                If DEC2HEX requires more than places characters, it returns the
      *                                #NUM! error value.
-     * @param int $places The number of characters to use. If places is omitted, DEC2HEX uses
+     * @param mixed $places The number of characters to use. If places is omitted, DEC2HEX uses
      *                                the minimum number of characters necessary. Places is useful for
      *                                padding the return value with leading 0s (zeros).
      *                                If places is not an integer, it is truncated.
@@ -318,7 +318,7 @@ class Engineering
      *
      * @see Use the toOctal() method in the Engineering\ConvertDecimal class instead
      *
-     * @param string $x The decimal integer you want to convert. If number is negative,
+     * @param mixed $x The decimal integer you want to convert. If number is negative,
      *                                places is ignored and DEC2OCT returns a 10-character (30-bit)
      *                                octal number in which the most significant bit is the sign bit.
      *                                The remaining 29 bits are magnitude bits. Negative numbers are
@@ -328,7 +328,7 @@ class Engineering
      *                                If number is nonnumeric, DEC2OCT returns the #VALUE! error value.
      *                                If DEC2OCT requires more than places characters, it returns the
      *                                #NUM! error value.
-     * @param int $places The number of characters to use. If places is omitted, DEC2OCT uses
+     * @param mixed $places The number of characters to use. If places is omitted, DEC2OCT uses
      *                                the minimum number of characters necessary. Places is useful for
      *                                padding the return value with leading 0s (zeros).
      *                                If places is not an integer, it is truncated.
@@ -354,7 +354,7 @@ class Engineering
      *
      * @see Use the toBinary() method in the Engineering\ConvertHex class instead
      *
-     * @param string $x the hexadecimal number you want to convert.
+     * @param mixed $x the hexadecimal number (as a string) that you want to convert.
      *                  Number cannot contain more than 10 characters.
      *                  The most significant bit of number is the sign bit (40th bit from the right).
      *                  The remaining 9 bits are magnitude bits.
@@ -364,7 +364,7 @@ class Engineering
      *                      and if number is positive, it cannot be greater than 1FF.
      *                  If number is not a valid hexadecimal number, HEX2BIN returns the #NUM! error value.
      *                  If HEX2BIN requires more than places characters, it returns the #NUM! error value.
-     * @param int $places The number of characters to use. If places is omitted,
+     * @param mixed $places The number of characters to use. If places is omitted,
      *                                    HEX2BIN uses the minimum number of characters necessary. Places
      *                                    is useful for padding the return value with leading 0s (zeros).
      *                                    If places is not an integer, it is truncated.
@@ -390,7 +390,7 @@ class Engineering
      *
      * @see Use the toDecimal() method in the Engineering\ConvertHex class instead
      *
-     * @param string $x The hexadecimal number you want to convert. This number cannot
+     * @param mixed $x The hexadecimal number (as a string) that you want to convert. This number cannot
      *                                contain more than 10 characters (40 bits). The most significant
      *                                bit of number is the sign bit. The remaining 39 bits are magnitude
      *                                bits. Negative numbers are represented using two's-complement
@@ -417,7 +417,7 @@ class Engineering
      *
      * @see Use the toOctal() method in the Engineering\ConvertHex class instead
      *
-     * @param string $x The hexadecimal number you want to convert. Number cannot
+     * @param mixed $x The hexadecimal number (as a string) that you want to convert. Number cannot
      *                                    contain more than 10 characters. The most significant bit of
      *                                    number is the sign bit. The remaining 39 bits are magnitude
      *                                    bits. Negative numbers are represented using two's-complement
@@ -430,7 +430,7 @@ class Engineering
      *                                    the #NUM! error value.
      *                                    If HEX2OCT requires more than places characters, it returns
      *                                    the #NUM! error value.
-     * @param int $places The number of characters to use. If places is omitted, HEX2OCT
+     * @param mixed $places The number of characters to use. If places is omitted, HEX2OCT
      *                                    uses the minimum number of characters necessary. Places is
      *                                    useful for padding the return value with leading 0s (zeros).
      *                                    If places is not an integer, it is truncated.
@@ -457,7 +457,7 @@ class Engineering
      *
      * @see Use the toBinary() method in the Engineering\ConvertOctal class instead
      *
-     * @param string $x The octal number you want to convert. Number may not
+     * @param mixed $x The octal number you want to convert. Number may not
      *                                    contain more than 10 characters. The most significant
      *                                    bit of number is the sign bit. The remaining 29 bits
      *                                    are magnitude bits. Negative numbers are represented
@@ -470,7 +470,7 @@ class Engineering
      *                                    the #NUM! error value.
      *                                    If OCT2BIN requires more than places characters, it
      *                                    returns the #NUM! error value.
-     * @param int $places The number of characters to use. If places is omitted,
+     * @param mixed $places The number of characters to use. If places is omitted,
      *                                    OCT2BIN uses the minimum number of characters necessary.
      *                                    Places is useful for padding the return value with
      *                                    leading 0s (zeros).
@@ -499,7 +499,7 @@ class Engineering
      *
      * @see Use the toDecimal() method in the Engineering\ConvertOctal class instead
      *
-     * @param string $x The octal number you want to convert. Number may not contain
+     * @param mixed $x The octal number you want to convert. Number may not contain
      *                                more than 10 octal characters (30 bits). The most significant
      *                                bit of number is the sign bit. The remaining 29 bits are
      *                                magnitude bits. Negative numbers are represented using
@@ -526,7 +526,7 @@ class Engineering
      *
      * @see Use the toHex() method in the Engineering\ConvertOctal class instead
      *
-     * @param string $x The octal number you want to convert. Number may not contain
+     * @param mixed $x The octal number you want to convert. Number may not contain
      *                                    more than 10 octal characters (30 bits). The most significant
      *                                    bit of number is the sign bit. The remaining 29 bits are
      *                                    magnitude bits. Negative numbers are represented using
@@ -537,7 +537,7 @@ class Engineering
      *                                    #NUM! error value.
      *                                    If OCT2HEX requires more than places characters, it returns
      *                                    the #NUM! error value.
-     * @param int $places The number of characters to use. If places is omitted, OCT2HEX
+     * @param mixed $places The number of characters to use. If places is omitted, OCT2HEX
      *                                    uses the minimum number of characters necessary. Places is useful
      *                                    for padding the return value with leading 0s (zeros).
      *                                    If places is not an integer, it is truncated.

--- a/src/PhpSpreadsheet/Calculation/Engineering/BesselI.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/BesselI.php
@@ -21,12 +21,12 @@ class BesselI
      * NOTE: The MS Excel implementation of the BESSELI function is still not accurate.
      *       This code provides a more accurate calculation
      *
-     * @param mixed (float) $x The value at which to evaluate the function.
-     *                                If x is nonnumeric, BESSELI returns the #VALUE! error value.
-     * @param mixed (int) $ord The order of the Bessel function.
-     *                                If ord is not an integer, it is truncated.
-     *                                If $ord is nonnumeric, BESSELI returns the #VALUE! error value.
-     *                                If $ord < 0, BESSELI returns the #NUM! error value.
+     * @param mixed $x A float value at which to evaluate the function.
+     *                   If x is nonnumeric, BESSELI returns the #VALUE! error value.
+     * @param mixed $ord The integer order of the Bessel function.
+     *                       If ord is not an integer, it is truncated.
+     *                       If $ord is nonnumeric, BESSELI returns the #VALUE! error value.
+     *                       If $ord < 0, BESSELI returns the #NUM! error value.
      *
      * @return float|string Result, or a string containing an error
      */

--- a/src/PhpSpreadsheet/Calculation/Engineering/BesselJ.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/BesselJ.php
@@ -20,11 +20,12 @@ class BesselJ
      * NOTE: The MS Excel implementation of the BESSELJ function is still not accurate, particularly for higher order
      *       values with x < -8 and x > 8. This code provides a more accurate calculation
      *
-     * @param mixed (float) $x The value at which to evaluate the function.
-     *                                If x is nonnumeric, BESSELJ returns the #VALUE! error value.
-     * @param mixed (int) $ord The order of the Bessel function. If n is not an integer, it is truncated.
-     *                                If $ord is nonnumeric, BESSELJ returns the #VALUE! error value.
-     *                                If $ord < 0, BESSELJ returns the #NUM! error value.
+     * @param mixed $x A float value at which to evaluate the function.
+     *                   If x is nonnumeric, BESSELJ returns the #VALUE! error value.
+     * @param mixed $ord The integer order of the Bessel function.
+     *                       If ord is not an integer, it is truncated.
+     *                       If $ord is nonnumeric, BESSELJ returns the #VALUE! error value.
+     *                       If $ord < 0, BESSELJ returns the #NUM! error value.
      *
      * @return float|string Result, or a string containing an error
      */

--- a/src/PhpSpreadsheet/Calculation/Engineering/BesselK.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/BesselK.php
@@ -18,11 +18,12 @@ class BesselK
      *    Excel Function:
      *        BESSELK(x,ord)
      *
-     * @param mixed (float) $x The value at which to evaluate the function.
-     *                                If x is nonnumeric, BESSELK returns the #VALUE! error value.
-     * @param mixed (int) $ord The order of the Bessel function. If n is not an integer, it is truncated.
-     *                                If $ord is nonnumeric, BESSELK returns the #VALUE! error value.
-     *                                If $ord < 0, BESSELK returns the #NUM! error value.
+     * @param mixed $x A float value at which to evaluate the function.
+     *                   If x is nonnumeric, BESSELK returns the #VALUE! error value.
+     * @param mixed $ord The integer order of the Bessel function.
+     *                       If ord is not an integer, it is truncated.
+     *                       If $ord is nonnumeric, BESSELK returns the #VALUE! error value.
+     *                       If $ord < 0, BESSELKI returns the #NUM! error value.
      *
      * @return float|string Result, or a string containing an error
      */

--- a/src/PhpSpreadsheet/Calculation/Engineering/BesselY.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/BesselY.php
@@ -17,11 +17,12 @@ class BesselY
      *    Excel Function:
      *        BESSELY(x,ord)
      *
-     * @param mixed (float) $x The value at which to evaluate the function.
-     *                             If x is nonnumeric, BESSELY returns the #VALUE! error value.
-     * @param mixed (int) $ord The order of the Bessel function. If n is not an integer, it is truncated.
-     *                             If $ord is nonnumeric, BESSELY returns the #VALUE! error value.
-     *                             If $ord < 0, BESSELY returns the #NUM! error value.
+     * @param mixed $x A float value at which to evaluate the function.
+     *                   If x is nonnumeric, BESSELY returns the #VALUE! error value.
+     * @param mixed $ord The integer order of the Bessel function.
+     *                       If ord is not an integer, it is truncated.
+     *                       If $ord is nonnumeric, BESSELY returns the #VALUE! error value.
+     *                       If $ord < 0, BESSELY returns the #NUM! error value.
      *
      * @return float|string Result, or a string containing an error
      */

--- a/src/PhpSpreadsheet/Calculation/Engineering/Complex.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/Complex.php
@@ -19,10 +19,10 @@ class Complex
      * Excel Function:
      *        COMPLEX(realNumber,imaginary[,suffix])
      *
-     * @param mixed (float) $realNumber the real coefficient of the complex number
-     * @param mixed (float) $imaginary the imaginary coefficient of the complex number
-     * @param mixed (string) $suffix The suffix for the imaginary component of the complex number.
-     *                                        If omitted, the suffix is assumed to be "i".
+     * @param mixed $realNumber the real float coefficient of the complex number
+     * @param mixed $imaginary the imaginary float coefficient of the complex number
+     * @param mixed $suffix The character suffix for the imaginary component of the complex number.
+     *                          If omitted, the suffix is assumed to be "i".
      *
      * @return string
      */

--- a/src/PhpSpreadsheet/Calculation/Engineering/Erf.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/Erf.php
@@ -21,9 +21,9 @@ class Erf
      *    Excel Function:
      *        ERF(lower[,upper])
      *
-     * @param mixed (float) $lower lower bound for integrating ERF
-     * @param mixed (float) $upper upper bound for integrating ERF.
-     *                                If omitted, ERF integrates between zero and lower_limit
+     * @param mixed $lower lower bound float for integrating ERF
+     * @param mixed $upper upper bound float for integrating ERF.
+     *                           If omitted, ERF integrates between zero and lower_limit
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/Engineering/Erf.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/Erf.php
@@ -21,8 +21,8 @@ class Erf
      *    Excel Function:
      *        ERF(lower[,upper])
      *
-     * @param mixed $lower lower bound float for integrating ERF
-     * @param mixed $upper upper bound float for integrating ERF.
+     * @param mixed $lower Lower bound float for integrating ERF
+     * @param mixed $upper Upper bound float for integrating ERF.
      *                           If omitted, ERF integrates between zero and lower_limit
      *
      * @return float|string
@@ -52,7 +52,7 @@ class Erf
      *    Excel Function:
      *        ERF.PRECISE(limit)
      *
-     * @param mixed (float) $limit bound for integrating ERF
+     * @param mixed $limit Float bound for integrating ERF, other bound is zero
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/Engineering/ErfC.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/ErfC.php
@@ -19,7 +19,7 @@ class ErfC
      *    Excel Function:
      *        ERFC(x)
      *
-     * @param float $value The lower bound for integrating ERFC
+     * @param mixed $value The float lower bound for integrating ERFC
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/Financial.php
+++ b/src/PhpSpreadsheet/Calculation/Financial.php
@@ -49,21 +49,21 @@ class Financial
      * @param mixed $settlement The security's settlement date.
      *                              The security settlement date is the date after the issue date
      *                                  when the security is traded to the buyer.
-     * @param mixed (float) $rate the security's annual coupon rate
-     * @param mixed (float) $par The security's par value.
+     * @param mixed $rate the security's annual coupon rate
+     * @param mixed $par The security's par value.
      *                               If you omit par, ACCRINT uses $1,000.
-     * @param mixed (int) $frequency The number of coupon payments per year.
+     * @param mixed $frequency The number of coupon payments per year.
      *                                    Valid frequency values are:
      *                                        1    Annual
      *                                        2    Semi-Annual
      *                                        4    Quarterly
-     * @param mixed (int) $basis The type of day count to use.
+     * @param mixed $basis The type of day count to use.
      *                               0 or omitted    US (NASD) 30/360
      *                               1                Actual/actual
      *                               2                Actual/360
      *                               3                Actual/365
      *                               4                European 30/360
-     * @param mixed (bool) $calcMethod
+     * @param mixed $calcMethod
      *                          If true, use Issue to Settlement
      *                          If false, use FirstInterest to Settlement
      *
@@ -106,10 +106,10 @@ class Financial
      *
      * @param mixed $issue The security's issue date
      * @param mixed $settlement The security's settlement (or maturity) date
-     * @param mixed (float) $rate The security's annual coupon rate
-     * @param mixed (float) $par The security's par value.
+     * @param mixed $rate The security's annual coupon rate
+     * @param mixed $par The security's par value.
      *                               If you omit par, ACCRINT uses $1,000.
-     * @param mixed (int) $basis The type of day count to use.
+     * @param mixed $basis The type of day count to use.
      *                               0 or omitted    US (NASD) 30/360
      *                               1                Actual/actual
      *                               2                Actual/360
@@ -876,11 +876,11 @@ class Financial
      * Excel Function:
      *        IRR(values[,guess])
      *
-     * @param mixed (float[]) $values An array or a reference to cells that contain numbers for which you want
+     * @param mixed $values An array or a reference to cells that contain numbers for which you want
      *                                    to calculate the internal rate of return.
      *                                Values must contain at least one positive value and one negative value to
      *                                    calculate the internal rate of return.
-     * @param mixed (float) $guess A number that you guess is close to the result of IRR
+     * @param mixed $guess A number that you guess is close to the result of IRR
      *
      * @return float|string
      */
@@ -986,11 +986,11 @@ class Financial
      * Excel Function:
      *        MIRR(values,finance_rate, reinvestment_rate)
      *
-     * @param mixed (float[]) $values An array or a reference to cells that contain a series of payments and
-     *                                            income occurring at regular intervals.
-     *                                        Payments are negative value, income is positive values.
-     * @param mixed (float) $finance_rate The interest rate you pay on the money used in the cash flows
-     * @param mixed (float) $reinvestment_rate The interest rate you receive on the cash flows as you reinvest them
+     * @param mixed $values An array or a reference to cells that contain a series of payments and
+     *                         income occurring at regular intervals.
+     *                      Payments are negative value, income is positive values.
+     * @param mixed $finance_rate The interest rate you pay on the money used in the cash flows
+     * @param mixed $reinvestment_rate The interest rate you receive on the cash flows as you reinvest them
      *
      * @return float|string Result, or a string containing an error
      */
@@ -1357,20 +1357,20 @@ class Financial
      * Excel Function:
      *        RATE(nper,pmt,pv[,fv[,type[,guess]]])
      *
-     * @param mixed (float) $nper The total number of payment periods in an annuity
-     * @param mixed (float) $pmt The payment made each period and cannot change over the life
+     * @param mixed $nper The total number of payment periods in an annuity
+     * @param mixed $pmt The payment made each period and cannot change over the life
      *                                    of the annuity.
      *                                Typically, pmt includes principal and interest but no other
      *                                    fees or taxes.
-     * @param mixed (float) $pv The present value - the total amount that a series of future
+     * @param mixed $pv The present value - the total amount that a series of future
      *                                    payments is worth now
-     * @param mixed (float) $fv The future value, or a cash balance you want to attain after
+     * @param mixed $fv The future value, or a cash balance you want to attain after
      *                                    the last payment is made. If fv is omitted, it is assumed
      *                                    to be 0 (the future value of a loan, for example, is 0).
-     * @param mixed (int) $type A number 0 or 1 and indicates when payments are due:
+     * @param mixed $type A number 0 or 1 and indicates when payments are due:
      *                                        0 or omitted    At the end of the period.
      *                                        1                At the beginning of the period.
-     * @param mixed (float) $guess Your guess for what the rate will be.
+     * @param mixed $guess Your guess for what the rate will be.
      *                                    If you omit guess, it is assumed to be 10 percent.
      *
      * @return float|string
@@ -1429,9 +1429,9 @@ class Financial
      *                                The security settlement date is the date after the issue date when the security is traded to the buyer.
      * @param mixed $maturity The security's maturity date.
      *                                The maturity date is the date when the security expires.
-     * @param mixed (int) $investment The amount invested in the security
-     * @param mixed (int) $discount The security's discount rate
-     * @param mixed (int) $basis The type of day count to use.
+     * @param mixed $investment The amount invested in the security
+     * @param mixed $discount The security's discount rate
+     * @param mixed $basis The type of day count to use.
      *                                        0 or omitted    US (NASD) 30/360
      *                                        1                Actual/actual
      *                                        2                Actual/360

--- a/src/PhpSpreadsheet/Calculation/Financial/Amortization.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Amortization.php
@@ -103,18 +103,18 @@ class Amortization
      * Excel Function:
      *        AMORLINC(cost,purchased,firstPeriod,salvage,period,rate[,basis])
      *
-     * @param mixed (float) $cost The cost of the asset
+     * @param mixed $cost The cost of the asset as a float
      * @param mixed $purchased Date of the purchase of the asset
      * @param mixed $firstPeriod Date of the end of the first period
      * @param mixed $salvage The salvage value at the end of the life of the asset
-     * @param mixed (float) $period The period
-     * @param mixed (float) $rate Rate of depreciation
-     * @param mixed (int) $basis The type of day count to use.
-     *                                        0 or omitted    US (NASD) 30/360
-     *                                        1                Actual/actual
-     *                                        2                Actual/360
-     *                                        3                Actual/365
-     *                                        4                European 30/360
+     * @param mixed $period The period as a float
+     * @param mixed $rate Rate of depreciation as  float
+     * @param mixed $basis Integer indicating the type of day count to use.
+     *                             0 or omitted    US (NASD) 30/360
+     *                             1               Actual/actual
+     *                             2               Actual/360
+     *                             3               Actual/365
+     *                             4               European 30/360
      *
      * @return float|string (string containing the error type if there is an error)
      */

--- a/src/PhpSpreadsheet/Calculation/Financial/Amortization.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Amortization.php
@@ -25,18 +25,18 @@ class Amortization
      * Excel Function:
      *        AMORDEGRC(cost,purchased,firstPeriod,salvage,period,rate[,basis])
      *
-     * @param mixed (float) $cost The cost of the asset
+     * @param mixed $cost The float cost of the asset
      * @param mixed $purchased Date of the purchase of the asset
      * @param mixed $firstPeriod Date of the end of the first period
      * @param mixed $salvage The salvage value at the end of the life of the asset
-     * @param mixed (float) $period The period
-     * @param mixed (float) $rate Rate of depreciation
-     * @param mixed (int) $basis The type of day count to use.
-     *                                        0 or omitted    US (NASD) 30/360
-     *                                        1                Actual/actual
-     *                                        2                Actual/360
-     *                                        3                Actual/365
-     *                                        4                European 30/360
+     * @param mixed $period The period (float).
+     * @param mixed $rate Rate of depreciation (float).
+     * @param mixed $basis The type of day count to use (int).
+     *                         0 or omitted    US (NASD) 30/360
+     *                         1               Actual/actual
+     *                         2               Actual/360
+     *                         3               Actual/365
+     *                         4               European 30/360
      *
      * @return float|string (string containing the error type if there is an error)
      */

--- a/src/PhpSpreadsheet/Calculation/Financial/Amortization.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Amortization.php
@@ -29,8 +29,8 @@ class Amortization
      * @param mixed $purchased Date of the purchase of the asset
      * @param mixed $firstPeriod Date of the end of the first period
      * @param mixed $salvage The salvage value at the end of the life of the asset
-     * @param mixed $period The period (float).
-     * @param mixed $rate Rate of depreciation (float).
+     * @param mixed $period the period (float)
+     * @param mixed $rate rate of depreciation (float)
      * @param mixed $basis The type of day count to use (int).
      *                         0 or omitted    US (NASD) 30/360
      *                         1               Actual/actual

--- a/src/PhpSpreadsheet/Calculation/Financial/Coupons.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Coupons.php
@@ -293,7 +293,7 @@ class Coupons
 
         $yearsBetweenSettlementAndMaturity = DateTimeExcel\YearFrac::funcYearFrac($settlement, $maturity, 0);
 
-        return ceil($yearsBetweenSettlementAndMaturity * $frequency);
+        return (int) ceil($yearsBetweenSettlementAndMaturity * $frequency);
     }
 
     /**

--- a/src/PhpSpreadsheet/Calculation/Financial/Coupons.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Coupons.php
@@ -27,21 +27,21 @@ class Coupons
      *        COUPDAYBS(settlement,maturity,frequency[,basis])
      *
      * @param mixed $settlement The security's settlement date.
-     *                                The security settlement date is the date after the issue
-     *                                date when the security is traded to the buyer.
+     *                              The security settlement date is the date after the issue
+     *                                  date when the security is traded to the buyer.
      * @param mixed $maturity The security's maturity date.
-     *                                The maturity date is the date when the security expires.
-     * @param mixed (int) $frequency the number of coupon payments per year.
-     *                                    Valid frequency values are:
-     *                                        1    Annual
-     *                                        2    Semi-Annual
-     *                                        4    Quarterly
-     * @param mixed (int) $basis The type of day count to use.
-     *                                        0 or omitted    US (NASD) 30/360
-     *                                        1                Actual/actual
-     *                                        2                Actual/360
-     *                                        3                Actual/365
-     *                                        4                European 30/360
+     *                            The maturity date is the date when the security expires.
+     * @param mixed $frequency The number of coupon payments per year (int).
+     *                             Valid frequency values are:
+     *                               1    Annual
+     *                               2    Semi-Annual
+     *                               4    Quarterly
+     * @param mixed $basis The type of day count to use (int).
+     *                         0 or omitted    US (NASD) 30/360
+     *                         1               Actual/actual
+     *                         2               Actual/360
+     *                         3               Actual/365
+     *                         4               European 30/360
      *
      * @return float|string
      */
@@ -84,21 +84,21 @@ class Coupons
      *        COUPDAYS(settlement,maturity,frequency[,basis])
      *
      * @param mixed $settlement The security's settlement date.
-     *                                The security settlement date is the date after the issue
-     *                                date when the security is traded to the buyer.
+     *                              The security settlement date is the date after the issue
+     *                                  date when the security is traded to the buyer.
      * @param mixed $maturity The security's maturity date.
-     *                                The maturity date is the date when the security expires.
-     * @param mixed $frequency the number of coupon payments per year.
-     *                                    Valid frequency values are:
-     *                                        1    Annual
-     *                                        2    Semi-Annual
-     *                                        4    Quarterly
-     * @param mixed (int) $basis The type of day count to use.
-     *                                        0 or omitted    US (NASD) 30/360
-     *                                        1                Actual/actual
-     *                                        2                Actual/360
-     *                                        3                Actual/365
-     *                                        4                European 30/360
+     *                            The maturity date is the date when the security expires.
+     * @param mixed $frequency The number of coupon payments per year.
+     *                             Valid frequency values are:
+     *                               1    Annual
+     *                               2    Semi-Annual
+     *                               4    Quarterly
+     * @param mixed $basis The type of day count to use (int).
+     *                         0 or omitted    US (NASD) 30/360
+     *                         1               Actual/actual
+     *                         2               Actual/360
+     *                         3               Actual/365
+     *                         4               European 30/360
      *
      * @return float|string
      */
@@ -149,21 +149,21 @@ class Coupons
      *        COUPDAYSNC(settlement,maturity,frequency[,basis])
      *
      * @param mixed $settlement The security's settlement date.
-     *                                The security settlement date is the date after the issue
-     *                                date when the security is traded to the buyer.
+     *                              The security settlement date is the date after the issue
+     *                                  date when the security is traded to the buyer.
      * @param mixed $maturity The security's maturity date.
-     *                                The maturity date is the date when the security expires.
-     * @param mixed $frequency the number of coupon payments per year.
-     *                                    Valid frequency values are:
-     *                                        1    Annual
-     *                                        2    Semi-Annual
-     *                                        4    Quarterly
-     * @param mixed (int) $basis The type of day count to use.
-     *                                        0 or omitted    US (NASD) 30/360
-     *                                        1                Actual/actual
-     *                                        2                Actual/360
-     *                                        3                Actual/365
-     *                                        4                European 30/360
+     *                            The maturity date is the date when the security expires.
+     * @param mixed $frequency The number of coupon payments per year.
+     *                             Valid frequency values are:
+     *                               1    Annual
+     *                               2    Semi-Annual
+     *                               4    Quarterly
+     * @param mixed $basis The type of day count to use (int) .
+     *                         0 or omitted    US (NASD) 30/360
+     *                         1               Actual/actual
+     *                         2               Actual/360
+     *                         3               Actual/365
+     *                         4               European 30/360
      *
      * @return float|string
      */
@@ -207,24 +207,24 @@ class Coupons
      *        COUPNCD(settlement,maturity,frequency[,basis])
      *
      * @param mixed $settlement The security's settlement date.
-     *                                The security settlement date is the date after the issue
-     *                                date when the security is traded to the buyer.
+     *                              The security settlement date is the date after the issue
+     *                                  date when the security is traded to the buyer.
      * @param mixed $maturity The security's maturity date.
-     *                                The maturity date is the date when the security expires.
-     * @param mixed $frequency the number of coupon payments per year.
-     *                                    Valid frequency values are:
-     *                                        1    Annual
-     *                                        2    Semi-Annual
-     *                                        4    Quarterly
-     * @param mixed (int) $basis The type of day count to use.
-     *                                        0 or omitted    US (NASD) 30/360
-     *                                        1                Actual/actual
-     *                                        2                Actual/360
-     *                                        3                Actual/365
-     *                                        4                European 30/360
+     *                            The maturity date is the date when the security expires.
+     * @param mixed $frequency The number of coupon payments per year.
+     *                             Valid frequency values are:
+     *                               1    Annual
+     *                               2    Semi-Annual
+     *                               4    Quarterly
+     * @param mixed $basis The type of day count to use (int).
+     *                         0 or omitted    US (NASD) 30/360
+     *                         1               Actual/actual
+     *                         2               Actual/360
+     *                         3               Actual/365
+     *                         4               European 30/360
      *
      * @return mixed Excel date/time serial value, PHP date/time serial value or PHP date/time object,
-     *                        depending on the value of the ReturnDateType flag
+     *                     depending on the value of the ReturnDateType flag
      */
     public static function COUPNCD($settlement, $maturity, $frequency, $basis = Helpers::DAYS_PER_YEAR_NASD)
     {
@@ -256,21 +256,21 @@ class Coupons
      *        COUPNUM(settlement,maturity,frequency[,basis])
      *
      * @param mixed $settlement The security's settlement date.
-     *                                The security settlement date is the date after the issue
-     *                                date when the security is traded to the buyer.
+     *                              The security settlement date is the date after the issue
+     *                                  date when the security is traded to the buyer.
      * @param mixed $maturity The security's maturity date.
-     *                                The maturity date is the date when the security expires.
-     * @param mixed $frequency the number of coupon payments per year.
-     *                                    Valid frequency values are:
-     *                                        1    Annual
-     *                                        2    Semi-Annual
-     *                                        4    Quarterly
-     * @param mixed (int) $basis The type of day count to use.
-     *                                        0 or omitted    US (NASD) 30/360
-     *                                        1                Actual/actual
-     *                                        2                Actual/360
-     *                                        3                Actual/365
-     *                                        4                European 30/360
+     *                            The maturity date is the date when the security expires.
+     * @param mixed $frequency The number of coupon payments per year.
+     *                             Valid frequency values are:
+     *                               1    Annual
+     *                               2    Semi-Annual
+     *                               4    Quarterly
+     * @param mixed $basis The type of day count to use (int).
+     *                         0 or omitted    US (NASD) 30/360
+     *                         1               Actual/actual
+     *                         2               Actual/360
+     *                         3               Actual/365
+     *                         4               European 30/360
      *
      * @return int|string
      */
@@ -305,24 +305,24 @@ class Coupons
      *        COUPPCD(settlement,maturity,frequency[,basis])
      *
      * @param mixed $settlement The security's settlement date.
-     *                                The security settlement date is the date after the issue
-     *                                date when the security is traded to the buyer.
+     *                              The security settlement date is the date after the issue
+     *                              date when the security is traded to the buyer.
      * @param mixed $maturity The security's maturity date.
-     *                                The maturity date is the date when the security expires.
-     * @param mixed $frequency the number of coupon payments per year.
-     *                                    Valid frequency values are:
-     *                                        1    Annual
-     *                                        2    Semi-Annual
-     *                                        4    Quarterly
-     * @param mixed (int) $basis The type of day count to use.
-     *                                        0 or omitted    US (NASD) 30/360
-     *                                        1                Actual/actual
-     *                                        2                Actual/360
-     *                                        3                Actual/365
-     *                                        4                European 30/360
+     *                            The maturity date is the date when the security expires.
+     * @param mixed $frequency The number of coupon payments per year.
+     *                             Valid frequency values are:
+     *                               1    Annual
+     *                               2    Semi-Annual
+     *                               4    Quarterly
+     * @param mixed $basis The type of day count to use (int).
+     *                         0 or omitted    US (NASD) 30/360
+     *                         1               Actual/actual
+     *                         2               Actual/360
+     *                         3               Actual/365
+     *                         4               European 30/360
      *
      * @return mixed Excel date/time serial value, PHP date/time serial value or PHP date/time object,
-     *                        depending on the value of the ReturnDateType flag
+     *                     depending on the value of the ReturnDateType flag
      */
     public static function COUPPCD($settlement, $maturity, $frequency, $basis = Helpers::DAYS_PER_YEAR_NASD)
     {

--- a/src/PhpSpreadsheet/Calculation/Financial/Depreciation.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Depreciation.php
@@ -22,15 +22,15 @@ class Depreciation
      * Excel Function:
      *        DB(cost,salvage,life,period[,month])
      *
-     * @param mixed (float) $cost Initial cost of the asset
-     * @param mixed (float) $salvage Value at the end of the depreciation.
-     *                                (Sometimes called the salvage value of the asset)
-     * @param mixed (int) $life Number of periods over which the asset is depreciated.
-     *                                (Sometimes called the useful life of the asset)
-     * @param mixed (int) $period The period for which you want to calculate the
-     *                                depreciation. Period must use the same units as life.
-     * @param mixed (int) $month Number of months in the first year. If month is omitted,
-     *                                it defaults to 12.
+     * @param mixed $cost Initial cost of the asset
+     * @param mixed $salvage Value at the end of the depreciation.
+     *                             (Sometimes called the salvage value of the asset)
+     * @param mixed $life Number of periods over which the asset is depreciated.
+     *                           (Sometimes called the useful life of the asset)
+     * @param mixed $period The period for which you want to calculate the
+     *                          depreciation. Period must use the same units as life.
+     * @param mixed $month Number of months in the first year. If month is omitted,
+     *                         it defaults to 12.
      *
      * @return float|string
      */
@@ -87,14 +87,14 @@ class Depreciation
      * Excel Function:
      *        DDB(cost,salvage,life,period[,factor])
      *
-     * @param mixed (float) $cost Initial cost of the asset
-     * @param mixed (float) $salvage Value at the end of the depreciation.
+     * @param mixed $cost Initial cost of the asset
+     * @param mixed $salvage Value at the end of the depreciation.
      *                                (Sometimes called the salvage value of the asset)
-     * @param mixed (int) $life Number of periods over which the asset is depreciated.
+     * @param mixed $life Number of periods over which the asset is depreciated.
      *                                (Sometimes called the useful life of the asset)
-     * @param mixed (int) $period The period for which you want to calculate the
+     * @param mixed $period The period for which you want to calculate the
      *                                depreciation. Period must use the same units as life.
-     * @param mixed (float) $factor The rate at which the balance declines.
+     * @param mixed $factor The rate at which the balance declines.
      *                                If factor is omitted, it is assumed to be 2 (the
      *                                double-declining balance method).
      *
@@ -139,9 +139,9 @@ class Depreciation
      *
      * Returns the straight-line depreciation of an asset for one period
      *
-     * @param mixed (float) $cost Initial cost of the asset
-     * @param mixed (float) $salvage Value at the end of the depreciation
-     * @param mixed (float) $life Number of periods over which the asset is depreciated
+     * @param mixed $cost Initial cost of the asset
+     * @param mixed $salvage Value at the end of the depreciation
+     * @param mixed $life Number of periods over which the asset is depreciated
      *
      * @return float|string Result, or a string containing an error
      */
@@ -171,10 +171,10 @@ class Depreciation
      *
      * Returns the sum-of-years' digits depreciation of an asset for a specified period.
      *
-     * @param mixed (float) $cost Initial cost of the asset
-     * @param mixed (float) $salvage Value at the end of the depreciation
-     * @param mixed (float) $life Number of periods over which the asset is depreciated
-     * @param mixed (float) $period Period
+     * @param mixed $cost Initial cost of the asset
+     * @param mixed $salvage Value at the end of the depreciation
+     * @param mixed $life Number of periods over which the asset is depreciated
+     * @param mixed $period Period
      *
      * @return float|string Result, or a string containing an error
      */

--- a/src/PhpSpreadsheet/Calculation/Financial/Dollar.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Dollar.php
@@ -16,8 +16,8 @@ class Dollar
      * Excel Function:
      *        DOLLARDE(fractional_dollar,fraction)
      *
-     * @param mixed (float) $fractionalDollar Fractional Dollar
-     * @param mixed (int) $fraction Fraction
+     * @param mixed $fractionalDollar Fractional Dollar
+     * @param mixed $fraction Fraction
      *
      * @return float|string
      */
@@ -52,8 +52,8 @@ class Dollar
      * Excel Function:
      *        DOLLARFR(decimal_dollar,fraction)
      *
-     * @param mixed (float) $decimalDollar Decimal Dollar
-     * @param mixed (int) $fraction Fraction
+     * @param mixed $decimalDollar Decimal Dollar
+     * @param mixed $fraction Fraction
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/Financial/InterestRate.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/InterestRate.php
@@ -18,8 +18,8 @@ class InterestRate
      * Excel Function:
      *        EFFECT(nominal_rate,npery)
      *
-     * @param mixed (float) $nominalRate Nominal interest rate
-     * @param mixed (int) $periodsPerYear Number of compounding payments per year
+     * @param mixed $nominalRate Nominal interest rate as a float
+     * @param mixed $periodsPerYear Integer number of compounding payments per year
      *
      * @return float|string
      */
@@ -47,8 +47,8 @@ class InterestRate
      *
      * Returns the nominal interest rate given the effective rate and the number of compounding payments per year.
      *
-     * @param mixed (float) $effectiveRate Effective interest rate
-     * @param mixed (int) $periodsPerYear Number of compounding payments per year
+     * @param mixed $effectiveRate Effective interest rate as a float
+     * @param mixed $periodsPerYear Integer number of compounding payments per year
      *
      * @return float|string Result, or a string containing an error
      */

--- a/src/PhpSpreadsheet/Calculation/Financial/Securities/AccruedInterest.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Securities/AccruedInterest.php
@@ -27,21 +27,20 @@ class AccruedInterest
      * @param mixed $settlement The security's settlement date.
      *                              The security settlement date is the date after the issue date
      *                                  when the security is traded to the buyer.
-     * @param mixed (float) $rate The security's annual coupon rate
-     * @param mixed (float) $par The security's par value.
-     *                               If you omit par, ACCRINT uses $1,000.
-     * @param mixed (int) $frequency The number of coupon payments per year.
-     *                                    Valid frequency values are:
-     *                                        1    Annual
-     *                                        2    Semi-Annual
-     *                                        4    Quarterly
-     * @param mixed (int) $basis The type of day count to use.
-     *                               0 or omitted    US (NASD) 30/360
-     *                               1                Actual/actual
-     *                               2                Actual/360
-     *                               3                Actual/365
-     *                               4                European 30/360
-     * @param mixed $parValue
+     * @param mixed $rate The security's annual coupon rate
+     * @param mixed $parValue The security's par value.
+     *                            If you omit par, ACCRINT uses $1,000.
+     * @param mixed $frequency The number of coupon payments per year.
+     *                             Valid frequency values are:
+     *                               1    Annual
+     *                               2    Semi-Annual
+     *                               4    Quarterly
+     * @param mixed $basis The type of day count to use.
+     *                         0 or omitted    US (NASD) 30/360
+     *                         1               Actual/actual
+     *                         2               Actual/360
+     *                         3               Actual/365
+     *                         4               European 30/360
      * @param mixed $calcMethod
      *
      * @return float|string Result, or a string containing an error
@@ -100,16 +99,15 @@ class AccruedInterest
      *
      * @param mixed $issue The security's issue date
      * @param mixed $settlement The security's settlement (or maturity) date
-     * @param mixed (float) $rate The security's annual coupon rate
-     * @param mixed (float) $par The security's par value.
-     *                               If you omit par, ACCRINT uses $1,000.
-     * @param mixed (int) $basis The type of day count to use.
-     *                               0 or omitted    US (NASD) 30/360
-     *                               1                Actual/actual
-     *                               2                Actual/360
-     *                               3                Actual/365
-     *                               4                European 30/360
-     * @param mixed $parValue
+     * @param mixed $rate The security's annual coupon rate
+     * @param mixed $parValue The security's par value.
+     *                            If you omit par, ACCRINT uses $1,000.
+     * @param mixed $basis The type of day count to use.
+     *                         0 or omitted    US (NASD) 30/360
+     *                         1               Actual/actual
+     *                         2               Actual/360
+     *                         3               Actual/365
+     *                         4               European 30/360
      *
      * @return float|string Result, or a string containing an error
      */

--- a/src/PhpSpreadsheet/Calculation/Financial/Securities/Price.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Securities/Price.php
@@ -22,19 +22,19 @@ class Price
      *                              is traded to the buyer.
      * @param mixed $maturity The security's maturity date.
      *                                The maturity date is the date when the security expires.
-     * @param mixed (float) $rate the security's annual coupon rate
-     * @param mixed (float) $yield the security's annual yield
-     * @param mixed (float) $redemption The number of coupon payments per year.
+     * @param mixed $rate the security's annual coupon rate
+     * @param mixed $yield the security's annual yield
+     * @param mixed $redemption The number of coupon payments per year.
      *                              For annual payments, frequency = 1;
      *                              for semiannual, frequency = 2;
      *                              for quarterly, frequency = 4.
-     * @param mixed (int) $frequency
-     * @param mixed (int) $basis The type of day count to use.
-     *                       0 or omitted    US (NASD) 30/360
-     *                       1                Actual/actual
-     *                       2                Actual/360
-     *                       3                Actual/365
-     *                       4                European 30/360
+     * @param mixed $frequency
+     * @param mixed $basis The type of day count to use.
+     *                         0 or omitted    US (NASD) 30/360
+     *                         1               Actual/actual
+     *                         2               Actual/360
+     *                         3               Actual/365
+     *                         4               European 30/360
      *
      * @return float|string Result, or a string containing an error
      */
@@ -89,14 +89,14 @@ class Price
      *                              is traded to the buyer.
      * @param mixed $maturity The security's maturity date.
      *                                The maturity date is the date when the security expires.
-     * @param mixed (float) $discount The security's discount rate
-     * @param mixed (float) $redemption The security's redemption value per $100 face value
-     * @param mixed (int) $basis The type of day count to use.
-     *                                        0 or omitted    US (NASD) 30/360
-     *                                        1                Actual/actual
-     *                                        2                Actual/360
-     *                                        3                Actual/365
-     *                                        4                European 30/360
+     * @param mixed $discount The security's discount rate
+     * @param mixed $redemption The security's redemption value per $100 face value
+     * @param mixed $basis The type of day count to use.
+     *                         0 or omitted    US (NASD) 30/360
+     *                         1               Actual/actual
+     *                         2               Actual/360
+     *                         3               Actual/365
+     *                         4               European 30/360
      *
      * @return float|string Result, or a string containing an error
      */
@@ -139,14 +139,14 @@ class Price
      * @param mixed $maturity The security's maturity date.
      *                                The maturity date is the date when the security expires.
      * @param mixed $issue The security's issue date
-     * @param mixed (float) $rate The security's interest rate at date of issue
-     * @param mixed (float) $yield The security's annual yield
-     * @param mixed (int) $basis The type of day count to use.
-     *                                        0 or omitted    US (NASD) 30/360
-     *                                        1                Actual/actual
-     *                                        2                Actual/360
-     *                                        3                Actual/365
-     *                                        4                European 30/360
+     * @param mixed $rate The security's interest rate at date of issue
+     * @param mixed $yield The security's annual yield
+     * @param mixed $basis The type of day count to use.
+     *                         0 or omitted    US (NASD) 30/360
+     *                         1               Actual/actual
+     *                         2               Actual/360
+     *                         3               Actual/365
+     *                         4               European 30/360
      *
      * @return float|string Result, or a string containing an error
      */

--- a/src/PhpSpreadsheet/Calculation/Financial/TreasuryBill.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/TreasuryBill.php
@@ -20,7 +20,7 @@ class TreasuryBill
      *                                    when the Treasury bill is traded to the buyer.
      * @param mixed $maturity The Treasury bill's maturity date.
      *                                The maturity date is the date when the Treasury bill expires.
-     * @param mixed (int) $discount The Treasury bill's discount rate
+     * @param mixed $discount The Treasury bill's discount rate
      *
      * @return float|string Result, or a string containing an error
      */
@@ -66,7 +66,7 @@ class TreasuryBill
      *                                    when the Treasury bill is traded to the buyer.
      * @param mixed $maturity The Treasury bill's maturity date.
      *                                The maturity date is the date when the Treasury bill expires.
-     * @param mixed (int) $discount The Treasury bill's discount rate
+     * @param mixed $discount The Treasury bill's discount rate
      *
      * @return float|string Result, or a string containing an error
      */
@@ -117,7 +117,7 @@ class TreasuryBill
      *                                    the Treasury bill is traded to the buyer.
      * @param mixed $maturity The Treasury bill's maturity date.
      *                                The maturity date is the date when the Treasury bill expires.
-     * @param mixed (int) $price The Treasury bill's price per $100 face value
+     * @param mixed $price The Treasury bill's price per $100 face value
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/LookupRef.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef.php
@@ -148,8 +148,8 @@ class LookupRef
      * Excel Function:
      *        =HYPERLINK(linkURL,displayName)
      *
-     * @param mixed (string) $linkURL Value to check, is also the value returned when no error
-     * @param mixed (string) $displayName Value to return when testValue is an error condition
+     * @param mixed $linkURL URL Value to check, is also the value returned when no error
+     * @param mixed $displayName String Value to return when testValue is an error condition
      * @param Cell $pCell The cell to set the hyperlink in
      *
      * @return mixed The value of $displayName (or $linkURL if $displayName was blank)

--- a/src/PhpSpreadsheet/Calculation/LookupRef/Address.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Address.php
@@ -23,17 +23,17 @@ class Address
      * Excel Function:
      *        =ADDRESS(row, column, [relativity], [referenceStyle], [sheetText])
      *
-     * @param mixed $row Row number to use in the cell reference
-     * @param mixed $column Column number to use in the cell reference
-     * @param mixed (int) $relativity Flag indicating the type of reference to return
-     *                                1 or omitted     Absolute
-     *                                2                Absolute row; relative column
-     *                                3                Relative row; absolute column
-     *                                4                Relative
-     * @param mixed (bool) $referenceStyle A logical value that specifies the A1 or R1C1 reference style.
-     *                                TRUE or omitted      ADDRESS returns an A1-style reference
-     *                                FALSE                ADDRESS returns an R1C1-style reference
-     * @param mixed (string) $sheetName Optional Name of worksheet to use
+     * @param mixed $row Row number (integer) to use in the cell reference
+     * @param mixed $column Column number (integer) to use in the cell reference
+     * @param mixed $relativity Integer flag indicating the type of reference to return
+     *                             1 or omitted    Absolute
+     *                             2               Absolute row; relative column
+     *                             3               Relative row; absolute column
+     *                             4               Relative
+     * @param mixed $referenceStyle A logical (boolean) value that specifies the A1 or R1C1 reference style.
+     *                                TRUE or omitted    ADDRESS returns an A1-style reference
+     *                                FALSE              ADDRESS returns an R1C1-style reference
+     * @param mixed $sheetName Optional Name of worksheet to use
      *
      * @return string
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical.php
@@ -172,10 +172,10 @@ class Statistical
      * @see Statistical\Distributions\Binomial::distribution()
      *      Use the distribution() method in the Statistical\Distributions\Binomial class instead
      *
-     * @param mixed (float) $value Number of successes in trials
-     * @param mixed (float) $trials Number of trials
-     * @param mixed (float) $probability Probability of success on each trial
-     * @param mixed (bool) $cumulative
+     * @param mixed $value Number of successes in trials
+     * @param mixed $trials Number of trials
+     * @param mixed $probability Probability of success on each trial
+     * @param mixed $cumulative
      *
      * @return float|string
      */
@@ -790,10 +790,10 @@ class Statistical
      * @see Statistical\Distributions\HyperGeometric::distribution()
      *      Use the distribution() method in the Statistical\Distributions\HyperGeometric class instead
      *
-     * @param mixed (int) $sampleSuccesses Number of successes in the sample
-     * @param mixed (int) $sampleNumber Size of the sample
-     * @param mixed (int) $populationSuccesses Number of successes in the population
-     * @param mixed (int) $populationNumber Population size
+     * @param mixed $sampleSuccesses Number of successes in the sample
+     * @param mixed $sampleNumber Size of the sample
+     * @param mixed $populationSuccesses Number of successes in the population
+     * @param mixed $populationNumber Population size
      *
      * @return float|string
      */
@@ -1221,9 +1221,9 @@ class Statistical
      * @see Statistical\Distributions\Binomial::negative()
      *      Use the negative() method in the Statistical\Distributions\Binomial class instead
      *
-     * @param mixed (float) $failures Number of Failures
-     * @param mixed (float) $successes Threshold number of Successes
-     * @param mixed (float) $probability Probability of success on each trial
+     * @param mixed $failures Number of Failures
+     * @param mixed $successes Threshold number of Successes
+     * @param mixed $probability Probability of success on each trial
      *
      * @return float|string The result, or a string containing an error
      */
@@ -1244,10 +1244,10 @@ class Statistical
      * @see Statistical\Distributions\Normal::distribution()
      *      Use the distribution() method in the Statistical\Distributions\Normal class instead
      *
-     * @param mixed (float) $value
-     * @param mixed (float) $mean Mean Value
-     * @param mixed (float) $stdDev Standard Deviation
-     * @param mixed (bool) $cumulative
+     * @param mixed $value
+     * @param mixed $mean Mean Value
+     * @param mixed $stdDev Standard Deviation
+     * @param mixed $cumulative
      *
      * @return float|string The result, or a string containing an error
      */
@@ -1266,9 +1266,9 @@ class Statistical
      * @see Statistical\Distributions\Normal::inverse()
      *      Use the inverse() method in the Statistical\Distributions\Normal class instead
      *
-     * @param mixed (float) $probability
-     * @param mixed (float) $mean Mean Value
-     * @param mixed (float) $stdDev Standard Deviation
+     * @param mixed $probability
+     * @param mixed $mean Mean Value
+     * @param mixed $stdDev Standard Deviation
      *
      * @return float|string The result, or a string containing an error
      */
@@ -1289,7 +1289,7 @@ class Statistical
      * @see Statistical\Distributions\StandardNormal::cumulative()
      *      Use the cumulative() method in the Statistical\Distributions\StandardNormal class instead
      *
-     * @param mixed (float) $value
+     * @param mixed $value
      *
      * @return float|string The result, or a string containing an error
      */
@@ -1310,8 +1310,8 @@ class Statistical
      * @see Statistical\Distributions\StandardNormal::distribution()
      *      Use the distribution() method in the Statistical\Distributions\StandardNormal class instead
      *
-     * @param mixed (float) $value
-     * @param mixed (bool) $cumulative
+     * @param mixed $value
+     * @param mixed $cumulative
      *
      * @return float|string The result, or a string containing an error
      */
@@ -1330,7 +1330,7 @@ class Statistical
      * @see Statistical\Distributions\StandardNormal::inverse()
      *      Use the inverse() method in the Statistical\Distributions\StandardNormal class instead
      *
-     * @param mixed (float) $value
+     * @param mixed $value
      *
      * @return float|string The result, or a string containing an error
      */
@@ -1374,9 +1374,9 @@ class Statistical
      * @see Statistical\Percentiles::PERCENTRANK()
      * Use the PERCENTRANK() method in the Statistical\Percentiles class instead
      *
-     * @param mixed (float[]) $valueSet An array of, or a reference to, a list of numbers
-     * @param mixed (int) $value the number whose rank you want to find
-     * @param mixed (int) $significance the number of significant digits for the returned percentage value
+     * @param mixed $valueSet An array of, or a reference to, a list of numbers
+     * @param mixed $value the number whose rank you want to find
+     * @param mixed $significance the number of significant digits for the returned percentage value
      *
      * @return float|string (string if result is an error)
      */
@@ -1421,9 +1421,9 @@ class Statistical
      * @see Statistical\Distributions\Poisson::distribution()
      * Use the distribution() method in the Statistical\Distributions\Poisson class instead
      *
-     * @param mixed (float) $value
-     * @param mixed (float) $mean Mean Value
-     * @param mixed (bool) $cumulative
+     * @param mixed $value
+     * @param mixed $mean Mean Value
+     * @param mixed $cumulative
      *
      * @return float|string The result, or a string containing an error
      */
@@ -1464,9 +1464,9 @@ class Statistical
      * @see Statistical\Percentiles::RANK()
      * Use the RANK() method in the Statistical\Percentiles class instead
      *
-     * @param mixed (float) $value the number whose rank you want to find
-     * @param mixed (float[]) $valueSet An array of, or a reference to, a list of numbers
-     * @param mixed (int) $order Order to sort the values in the value set
+     * @param mixed $value the number whose rank you want to find
+     * @param mixed $valueSet An array of, or a reference to, a list of numbers
+     * @param mixed $order Order to sort the values in the value set
      *
      * @return float|string The result, or a string containing an error
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Confidence.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Confidence.php
@@ -14,9 +14,9 @@ class Confidence
      *
      * Returns the confidence interval for a population mean
      *
-     * @param mixed (float) $alpha
-     * @param mixed (float) $stdDev Standard Deviation
-     * @param mixed (float) $size
+     * @param mixed $alpha As a float
+     * @param mixed $stdDev Standard Deviation as a float
+     * @param mixed $size As an integer
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Beta.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Beta.php
@@ -20,11 +20,11 @@ class Beta
      *
      * Returns the beta distribution.
      *
-     * @param mixed (float) $value Value at which you want to evaluate the distribution
-     * @param mixed (float) $alpha Parameter to the distribution
-     * @param mixed (float) $beta Parameter to the distribution
-     * @param mixed (float) $rMin
-     * @param mixed (float) $rMax
+     * @param mixed $value Float value at which you want to evaluate the distribution
+     * @param mixed $alpha Parameter to the distribution as a float
+     * @param mixed $beta Parameter to the distribution as a float
+     * @param mixed $rMin as an float
+     * @param mixed $rMax as an float
      *
      * @return float|string
      */
@@ -66,11 +66,11 @@ class Beta
      *
      * Returns the inverse of the Beta distribution.
      *
-     * @param mixed (float) $probability Probability at which you want to evaluate the distribution
-     * @param mixed (float) $alpha Parameter to the distribution
-     * @param mixed (float) $beta Parameter to the distribution
-     * @param mixed (float) $rMin Minimum value
-     * @param mixed (float) $rMax Maximum value
+     * @param mixed $probability Float probability at which you want to evaluate the distribution
+     * @param mixed $alpha Parameter to the distribution as a float
+     * @param mixed $beta Parameter to the distribution as a float
+     * @param mixed $rMin Minimum value as a float
+     * @param mixed $rMax Maximum value as a float
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Beta.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Beta.php
@@ -137,9 +137,9 @@ class Beta
      *
      * The computation is based on formulas from Numerical Recipes, Chapter 6.4 (W.H. Press et al, 1992).
      *
-     * @param mixed $x require 0<=x<=1
-     * @param mixed $p require p>0
-     * @param mixed $q require q>0
+     * @param float $x require 0<=x<=1
+     * @param float $p require p>0
+     * @param float $q require q>0
      *
      * @return float 0 if x<0, p<=0, q<=0 or p+q>2.55E305 and 1 if x>1 to avoid errors and over/underflow
      */
@@ -171,8 +171,8 @@ class Beta
     /**
      * The natural logarithm of the beta function.
      *
-     * @param mixed $p require p>0
-     * @param mixed $q require q>0
+     * @param float $p require p>0
+     * @param float $q require q>0
      *
      * @return float 0 if p<=0, q<=0 or p+q>2.55E305 to avoid errors and over/underflow
      *
@@ -199,9 +199,9 @@ class Beta
      *
      * @author Jaco van Kooten
      *
-     * @param mixed $x
-     * @param mixed $p
-     * @param mixed $q
+     * @param float $x
+     * @param float $p
+     * @param float $q
      */
     private static function betaFraction(float $x, float $p, float $q): float
     {

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Beta.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Beta.php
@@ -198,10 +198,6 @@ class Beta
      * Based on an idea from Numerical Recipes (W.H. Press et al, 1992).
      *
      * @author Jaco van Kooten
-     *
-     * @param float $x
-     * @param float $p
-     * @param float $q
      */
     private static function betaFraction(float $x, float $p, float $q): float
     {

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Binomial.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Binomial.php
@@ -19,10 +19,10 @@ class Binomial
      *        experiment. For example, BINOMDIST can calculate the probability that two of the next three
      *        babies born are male.
      *
-     * @param mixed (int) $value Number of successes in trials
-     * @param mixed (int) $trials Number of trials
-     * @param mixed (float) $probability Probability of success on each trial
-     * @param mixed (bool) $cumulative
+     * @param mixed $value Integer number of successes in trials
+     * @param mixed $trials Integer umber of trials
+     * @param mixed $probability Probability of success on each trial as a float
+     * @param mixed $cumulative Boolean value indicating if we want the cdf (true) or the pdf (false)
      *
      * @return float|string
      */
@@ -58,10 +58,11 @@ class Binomial
      * Returns returns the Binomial Distribution probability for the number of successes from a specified number
      *     of trials falling into a specified range.
      *
-     * @param mixed (int) $trials Number of trials
-     * @param mixed (float) $probability Probability of success on each trial
-     * @param mixed (int) $successes The number of successes in trials
-     * @param mixed (int) $limit Upper limit for successes in trials
+     * @param mixed $trials Integer number of trials
+     * @param mixed $probability Probability of success on each trial as a float
+     * @param mixed $successes The integer number of successes in trials
+     * @param mixed $limit Upper limit for successes in trials as null, or an integer
+     *                           If null, then this will indicate the same as the number of Successes
      *
      * @return float|string
      */
@@ -105,9 +106,9 @@ class Binomial
      *        distribution, except that the number of successes is fixed, and the number of trials is
      *        variable. Like the binomial, trials are assumed to be independent.
      *
-     * @param mixed (float) $failures Number of Failures
-     * @param mixed (float) $successes Threshold number of Successes
-     * @param mixed (float) $probability Probability of success on each trial
+     * @param mixed $failures Number of Failures as an integer
+     * @param mixed $successes Threshold number of Successes as an integer
+     * @param mixed $probability Probability of success on each trial as a float
      *
      * @return float|string The result, or a string containing an error
      *
@@ -147,9 +148,9 @@ class Binomial
      * Returns the smallest value for which the cumulative binomial distribution is greater
      *        than or equal to a criterion value
      *
-     * @param float $trials number of Bernoulli trials
-     * @param float $probability probability of a success on each trial
-     * @param float $alpha criterion value
+     * @param mixed $trials number of Bernoulli trials as an integer
+     * @param mixed $probability probability of a success on each trial as a float
+     * @param mixed $alpha criterion value as a float
      *
      * @return int|string
      */
@@ -174,7 +175,7 @@ class Binomial
         }
 
         $successes = 0;
-        while (true && $successes <= $trials) {
+        while ($successes <= $trials) {
             $result = self::calculateCumulativeBinomial($successes, $trials, $probability);
             if ($result >= $alpha) {
                 break;

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/ChiSquared.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/ChiSquared.php
@@ -18,8 +18,8 @@ class ChiSquared
      *
      * Returns the one-tailed probability of the chi-squared distribution.
      *
-     * @param mixed (float) $value Value for the function
-     * @param mixed (int) $degrees degrees of freedom
+     * @param mixed $value Float value for which we want the probability
+     * @param mixed $degrees Integer degrees of freedom
      *
      * @return float|string
      */
@@ -54,9 +54,9 @@ class ChiSquared
      *
      * Returns the one-tailed probability of the chi-squared distribution.
      *
-     * @param mixed (float) $value Value for the function
-     * @param mixed (int) $degrees degrees of freedom
-     * @param mixed $cumulative
+     * @param mixed $value Float value for which we want the probability
+     * @param mixed $degrees Integer degrees of freedom
+     * @param mixed $cumulative Boolean value indicating if we want the cdf (true) or the pdf (false)
      *
      * @return float|string
      */
@@ -98,8 +98,8 @@ class ChiSquared
      *
      * Returns the inverse of the right-tailed probability of the chi-squared distribution.
      *
-     * @param mixed (float) $probability Probability for the function
-     * @param mixed (int) $degrees degrees of freedom
+     * @param mixed $probability Float probability at which you want to evaluate the distribution
+     * @param mixed $degrees Integer degrees of freedom
      *
      * @return float|string
      */
@@ -134,8 +134,8 @@ class ChiSquared
      *
      * Returns the inverse of the left-tailed probability of the chi-squared distribution.
      *
-     * @param mixed (float) $probability Probability for the function
-     * @param mixed (int) $degrees degrees of freedom
+     * @param mixed $probability Float probability at which you want to evaluate the distribution
+     * @param mixed $degrees Integer degrees of freedom
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Exponential.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Exponential.php
@@ -16,9 +16,9 @@ class Exponential
      *        such as how long an automated bank teller takes to deliver cash. For example, you can
      *        use EXPONDIST to determine the probability that the process takes at most 1 minute.
      *
-     * @param mixed (float) $value Value of the function
-     * @param mixed (float) $lambda The parameter value
-     * @param mixed (bool) $cumulative
+     * @param mixed $value Float value for which we want the probability
+     * @param mixed $lambda The parameter value as a float
+     * @param mixed $cumulative Boolean value indicating if we want the cdf (true) or the pdf (false)
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/F.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/F.php
@@ -17,11 +17,10 @@ class F
      *    For example, you can examine the test scores of men and women entering high school, and determine
      *        if the variability in the females is different from that found in the males.
      *
-     * @param mixed(float) $value Value of the function
-     * @param mixed(int) $u The numerator degrees of freedom
-     * @param mixed(int) $v The denominator degrees of freedom
-     * @param mixed(bool) $cumulative If cumulative is TRUE, F.DIST returns the cumulative distribution function;
-     *                         if FALSE, it returns the probability density function.
+     * @param mixed $value Float value for which we want the probability
+     * @param mixed $u The numerator degrees of freedom as an integer
+     * @param mixed $v The denominator degrees of freedom as an integer
+     * @param mixed $cumulative Boolean value indicating if we want the cdf (true) or the pdf (false)
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Fisher.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Fisher.php
@@ -16,7 +16,7 @@ class Fisher
      *        is normally distributed rather than skewed. Use this function to perform hypothesis
      *        testing on the correlation coefficient.
      *
-     * @param mixed (float) $value
+     * @param mixed $value Float value for which we want the probability
      *
      * @return float|string
      */
@@ -44,20 +44,20 @@ class Fisher
      *        analyzing correlations between ranges or arrays of data. If y = FISHER(x), then
      *        FISHERINV(y) = x.
      *
-     * @param mixed (float) $value
+     * @param mixed $probability Float probability at which you want to evaluate the distribution
      *
      * @return float|string
      */
-    public static function inverse($value)
+    public static function inverse($probability)
     {
-        $value = Functions::flattenSingleValue($value);
+        $probability = Functions::flattenSingleValue($probability);
 
         try {
-            self::validateFloat($value);
+            self::validateFloat($probability);
         } catch (Exception $e) {
             return $e->getMessage();
         }
 
-        return (exp(2 * $value) - 1) / (exp(2 * $value) + 1);
+        return (exp(2 * $probability) - 1) / (exp(2 * $probability) + 1);
     }
 }

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Gamma.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Gamma.php
@@ -14,7 +14,7 @@ class Gamma extends GammaBase
      *
      * Return the gamma function value.
      *
-     * @param mixed (float) $value
+     * @param mixed $value Float value for which we want the probability
      *
      * @return float|string The result, or a string containing an error
      */
@@ -40,10 +40,10 @@ class Gamma extends GammaBase
      *
      * Returns the gamma distribution.
      *
-     * @param mixed (float) $value Value at which you want to evaluate the distribution
-     * @param mixed (float) $a Parameter to the distribution
-     * @param mixed (float) $b Parameter to the distribution
-     * @param mixed (bool) $cumulative
+     * @param mixed $value Float Value at which you want to evaluate the distribution
+     * @param mixed $a Parameter to the distribution as a float
+     * @param mixed $b Parameter to the distribution as a float
+     * @param mixed $cumulative Boolean value indicating if we want the cdf (true) or the pdf (false)
      *
      * @return float|string
      */
@@ -74,9 +74,9 @@ class Gamma extends GammaBase
      *
      * Returns the inverse of the Gamma distribution.
      *
-     * @param mixed (float) $probability Probability at which you want to evaluate the distribution
-     * @param mixed (float) $alpha Parameter to the distribution
-     * @param mixed (float) $beta Parameter to the distribution
+     * @param mixed $probability Float probability at which you want to evaluate the distribution
+     * @param mixed $alpha Parameter to the distribution as a float
+     * @param mixed $beta Parameter to the distribution as a float
      *
      * @return float|string
      */
@@ -106,7 +106,7 @@ class Gamma extends GammaBase
      *
      * Returns the natural logarithm of the gamma function.
      *
-     * @param mixed (float) $value
+     * @param mixed $value Float Value at which you want to evaluate the distribution
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/HyperGeometric.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/HyperGeometric.php
@@ -16,10 +16,10 @@ class HyperGeometric
      * Returns the hypergeometric distribution. HYPGEOMDIST returns the probability of a given number of
      * sample successes, given the sample size, population successes, and population size.
      *
-     * @param mixed (int) $sampleSuccesses Number of successes in the sample
-     * @param mixed (int) $sampleNumber Size of the sample
-     * @param mixed (int) $populationSuccesses Number of successes in the population
-     * @param mixed (int) $populationNumber Population size
+     * @param mixed $sampleSuccesses Integer number of successes in the sample
+     * @param mixed $sampleNumber Integer size of the sample
+     * @param mixed $populationSuccesses Integer number of successes in the population
+     * @param mixed $populationNumber Integer population size
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/LogNormal.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/LogNormal.php
@@ -15,9 +15,9 @@ class LogNormal
      * Returns the cumulative lognormal distribution of x, where ln(x) is normally distributed
      * with parameters mean and standard_dev.
      *
-     * @param mixed (float) $value
-     * @param mixed (float) $mean
-     * @param mixed (float) $stdDev
+     * @param mixed $value Float value for which we want the probability
+     * @param mixed $mean Mean value as a float
+     * @param mixed $stdDev Standard Deviation as a float
      *
      * @return float|string The result, or a string containing an error
      */
@@ -48,10 +48,10 @@ class LogNormal
      * Returns the lognormal distribution of x, where ln(x) is normally distributed
      * with parameters mean and standard_dev.
      *
-     * @param mixed (float) $value
-     * @param mixed (float) $mean
-     * @param mixed (float) $stdDev
-     * @param mixed (bool) $cumulative
+     * @param mixed $value Float value for which we want the probability
+     * @param mixed $mean Mean value as a float
+     * @param mixed $stdDev Standard Deviation as a float
+     * @param mixed $cumulative Boolean value indicating if we want the cdf (true) or the pdf (false)
      *
      * @return float|string The result, or a string containing an error
      */
@@ -86,11 +86,11 @@ class LogNormal
     /**
      * LOGINV.
      *
-     * Returns the inverse of the normal cumulative distribution
+     * Returns the inverse of the lognormal cumulative distribution
      *
-     * @param mixed (float) $probability
-     * @param mixed (float) $mean
-     * @param mixed (float) $stdDev
+     * @param mixed $probability Float probability for which we want the value
+     * @param mixed $mean Mean Value as a float
+     * @param mixed $stdDev Standard Deviation as a float
      *
      * @return float|string The result, or a string containing an error
      *

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Normal.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Normal.php
@@ -19,10 +19,10 @@ class Normal
      * function has a very wide range of applications in statistics, including hypothesis
      * testing.
      *
-     * @param mixed (float) $value
-     * @param mixed (float) $mean Mean Value
-     * @param mixed (float) $stdDev Standard Deviation
-     * @param mixed (bool) $cumulative
+     * @param mixed $value Float value for which we want the probability
+     * @param mixed $mean Mean value as a float
+     * @param mixed $stdDev Standard Deviation as a float
+     * @param mixed $cumulative Boolean value indicating if we want the cdf (true) or the pdf (false)
      *
      * @return float|string The result, or a string containing an error
      */
@@ -57,9 +57,9 @@ class Normal
      *
      * Returns the inverse of the normal cumulative distribution for the specified mean and standard deviation.
      *
-     * @param mixed (float) $probability
-     * @param mixed (float) $mean Mean Value
-     * @param mixed (float) $stdDev Standard Deviation
+     * @param mixed $probability Float probability for which we want the value
+     * @param mixed $mean Mean Value as a float
+     * @param mixed $stdDev Standard Deviation as a float
      *
      * @return float|string The result, or a string containing an error
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Poisson.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Poisson.php
@@ -17,9 +17,9 @@ class Poisson
      * is predicting the number of events over a specific time, such as the number of
      * cars arriving at a toll plaza in 1 minute.
      *
-     * @param mixed (float) $value
-     * @param mixed (float) $mean Mean Value
-     * @param mixed (bool) $cumulative
+     * @param mixed $value Float value for which we want the probability
+     * @param mixed $mean Mean value as a float
+     * @param mixed $cumulative Boolean value indicating if we want the cdf (true) or the pdf (false)
      *
      * @return float|string The result, or a string containing an error
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/StandardNormal.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/StandardNormal.php
@@ -15,7 +15,7 @@ class StandardNormal
      * a mean of 0 (zero) and a standard deviation of one. Use this function in place of a
      * table of standard normal curve areas.
      *
-     * @param mixed (float) $value
+     * @param mixed $value Float value for which we want the probability
      *
      * @return float|string The result, or a string containing an error
      */
@@ -31,8 +31,8 @@ class StandardNormal
      * a mean of 0 (zero) and a standard deviation of one. Use this function in place of a
      * table of standard normal curve areas.
      *
-     * @param mixed (float) $value
-     * @param mixed (bool) $cumulative
+     * @param mixed $value Float value for which we want the probability
+     * @param mixed $cumulative Boolean value indicating if we want the cdf (true) or the pdf (false)
      *
      * @return float|string The result, or a string containing an error
      */
@@ -46,7 +46,7 @@ class StandardNormal
      *
      * Returns the inverse of the standard normal cumulative distribution
      *
-     * @param mixed (float) $value
+     * @param mixed $value Float probability for which we want the value
      *
      * @return float|string The result, or a string containing an error
      */
@@ -63,9 +63,10 @@ class StandardNormal
      * For a given hypothesized population mean, x, Z.TEST returns the probability that the sample mean would be
      *     greater than the average of observations in the data set (array) — that is, the observed sample mean.
      *
-     * @param mixed (float) $dataSet
-     * @param mixed (float) $m0 Alpha Parameter
-     * @param mixed (null|float) $sigma Beta Parameter
+     * @param mixed $dataSet The dataset should be an array of float values for the observations
+     * @param mixed $m0 Alpha Parameter
+     * @param mixed $sigma A null or float value for the Beta (Standard Deviation) Parameter;
+     *                       if null, we use the standard deviation of the dataset
      *
      * @return float|string (string if result is an error)
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/StudentT.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/StudentT.php
@@ -16,9 +16,9 @@ class StudentT
      *
      * Returns the probability of Student's T distribution.
      *
-     * @param mixed (float) $value Value for the function
-     * @param mixed (float) $degrees degrees of freedom
-     * @param mixed (int) $tails number of tails (1 or 2)
+     * @param mixed $value Float value for the distribution
+     * @param mixed $degrees Integer value for degrees of freedom
+     * @param mixed $tails Integer value for the number of tails (1 or 2)
      *
      * @return float|string The result, or a string containing an error
      */
@@ -48,8 +48,8 @@ class StudentT
      *
      * Returns the one-tailed probability of the chi-squared distribution.
      *
-     * @param mixed (float) $probability Probability for the function
-     * @param mixed (float) $degrees degrees of freedom
+     * @param mixed $probability Float probability for the function
+     * @param mixed $degrees Integer value for degrees of freedom
      *
      * @return float|string The result, or a string containing an error
      */
@@ -79,7 +79,7 @@ class StudentT
     }
 
     /**
-     * @return float|int
+     * @return float
      */
     private static function calculateDistribution(float $value, int $degrees, int $tails)
     {

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Weibull.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Weibull.php
@@ -15,10 +15,10 @@ class Weibull
      * Returns the Weibull distribution. Use this distribution in reliability
      * analysis, such as calculating a device's mean time to failure.
      *
-     * @param mixed (float) $value
-     * @param mixed (float) $alpha Alpha Parameter
-     * @param mixed (float) $beta Beta Parameter
-     * @param mixed (bool) $cumulative
+     * @param mixed $value Float value for the distribution
+     * @param mixed $alpha Float alpha Parameter
+     * @param mixed $beta Float beta Parameter
+     * @param mixed $cumulative Boolean value indicating if we want the cdf (true) or the pdf (false)
      *
      * @return float|string (string if result is an error)
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Percentiles.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Percentiles.php
@@ -69,9 +69,9 @@ class Percentiles
      *      rather than floored (as MS Excel), so value 3 for a value set of  1, 2, 3, 4 will return
      *      0.667 rather than 0.666
      *
-     * @param mixed (float[]) $valueSet An array of, or a reference to, a list of numbers
-     * @param mixed (int) $value the number whose rank you want to find
-     * @param mixed (int) $significance the number of significant digits for the returned percentage value
+     * @param mixed $valueSet An array of (float) values, or a reference to, a list of numbers
+     * @param mixed $value The number whose rank you want to find
+     * @param mixed $significance The (integer) number of significant digits for the returned percentage value
      *
      * @return float|string (string if result is an error)
      */
@@ -151,11 +151,11 @@ class Percentiles
      *
      * Returns the rank of a number in a list of numbers.
      *
-     * @param mixed (float) $value the number whose rank you want to find
-     * @param mixed (float[]) $valueSet An array of, or a reference to, a list of numbers
-     * @param mixed (int) $order Order to sort the values in the value set
+     * @param mixed $value The number whose rank you want to find
+     * @param mixed $valueSet An array of float values, or a reference to, a list of numbers
+     * @param mixed $order Order to sort the values in the value set
      *
-     * @return float|string The result, or a string containing an error
+     * @return float|string The result, or a string containing an error (0 = Descending, 1 = Ascending)
      */
     public static function RANK($value, $valueSet, $order = self::RANK_SORT_DESCENDING)
     {

--- a/src/PhpSpreadsheet/Calculation/Statistical/Permutations.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Permutations.php
@@ -40,7 +40,7 @@ class Permutations
             return Functions::NAN();
         }
 
-        return round(MathTrig\Fact::funcFact($numObjs) / MathTrig\Fact::funcFact($numObjs - $numInSet));
+        return (int) round(MathTrig\Fact::funcFact($numObjs) / MathTrig\Fact::funcFact($numObjs - $numInSet));
     }
 
     /**
@@ -70,6 +70,6 @@ class Permutations
             return Functions::NAN();
         }
 
-        return $numObjs ** $numInSet;
+        return (int) ($numObjs ** $numInSet);
     }
 }

--- a/src/PhpSpreadsheet/Calculation/Statistical/Permutations.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Permutations.php
@@ -19,8 +19,8 @@ class Permutations
      *        combinations, for which the internal order is not significant. Use this function
      *        for lottery-style probability calculations.
      *
-     * @param mixed (int) $numObjs Number of different objects
-     * @param mixed (int) $numInSet Number of objects in each permutation
+     * @param mixed $numObjs Integer number of different objects
+     * @param mixed $numInSet Integer number of objects in each permutation
      *
      * @return int|string Number of permutations, or a string containing an error
      */
@@ -49,8 +49,8 @@ class Permutations
      * Returns the number of permutations for a given number of objects (with repetitions)
      *     that can be selected from the total objects.
      *
-     * @param int $numObjs Number of different objects
-     * @param int $numInSet Number of objects in each permutation
+     * @param mixed $numObjs Integer number of different objects
+     * @param mixed $numInSet Integer number of objects in each permutation
      *
      * @return int|string Number of permutations, or a string containing an error
      */

--- a/src/PhpSpreadsheet/Calculation/Statistical/Trends.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Trends.php
@@ -109,7 +109,7 @@ class Trends
      * Calculates, or predicts, a future value by using existing values.
      * The predicted value is a y-value for a given x-value.
      *
-     * @param mixed (float) $xValue Value of X for which we want to find Y
+     * @param mixed $xValue Float value of X for which we want to find Y
      * @param mixed $yValues array of mixed Data Series Y
      * @param mixed $xValues of mixed Data Series X
      *
@@ -140,7 +140,7 @@ class Trends
      * @param mixed[] $yValues Data Series Y
      * @param mixed[] $xValues Data Series X
      * @param mixed[] $newValues Values of X for which we want to find Y
-     * @param mixed (bool) $const a logical value specifying whether to force the intersect to equal 0
+     * @param mixed $const A logical (boolean) value specifying whether to force the intersect to equal 0 or not
      *
      * @return array of float
      */
@@ -196,8 +196,8 @@ class Trends
      *
      * @param mixed[] $yValues Data Series Y
      * @param null|mixed[] $xValues Data Series X
-     * @param mixed (bool) $const a logical value specifying whether to force the intersect to equal 0
-     * @param mixed (bool) $stats a logical value specifying whether to return additional regression statistics
+     * @param mixed $const A logical (boolean) value specifying whether to force the intersect to equal 0 or not
+     * @param mixed $stats A logical (boolean) value specifying whether to return additional regression statistics
      *
      * @return array|int|string The result, or a string containing an error
      */
@@ -257,8 +257,8 @@ class Trends
      *
      * @param mixed[] $yValues Data Series Y
      * @param null|mixed[] $xValues Data Series X
-     * @param mixed (bool) $const a logical value specifying whether to force the intersect to equal 0
-     * @param mixed (bool) $stats a logical value specifying whether to return additional regression statistics
+     * @param mixed $const A logical (boolean) value specifying whether to force the intersect to equal 0 or not
+     * @param mixed $stats A logical (boolean) value specifying whether to return additional regression statistics
      *
      * @return array|int|string The result, or a string containing an error
      */
@@ -397,7 +397,7 @@ class Trends
      * @param mixed[] $yValues Data Series Y
      * @param mixed[] $xValues Data Series X
      * @param mixed[] $newValues Values of X for which we want to find Y
-     * @param mixed (bool) $const a logical value specifying whether to force the intersect to equal 0
+     * @param mixed $const A logical (boolean) value specifying whether to force the intersect to equal 0 or not
      *
      * @return array of float
      */

--- a/src/PhpSpreadsheet/Calculation/TextData.php
+++ b/src/PhpSpreadsheet/Calculation/TextData.php
@@ -399,8 +399,8 @@ class TextData
      *
      * @see Use the exact() method in the TextData\Text class instead
      *
-     * @param $value1
-     * @param $value2
+     * @param mixed $value1
+     * @param mixed $value2
      *
      * @return bool
      */

--- a/src/PhpSpreadsheet/Calculation/TextData/CaseConvert.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/CaseConvert.php
@@ -13,7 +13,7 @@ class CaseConvert
      *
      * Converts a string value to upper case.
      *
-     * @param mixed (string) $mixedCaseValue
+     * @param mixed $mixedCaseValue The string value to convert to lower case
      */
     public static function lower($mixedCaseValue): string
     {
@@ -31,7 +31,7 @@ class CaseConvert
      *
      * Converts a string value to upper case.
      *
-     * @param mixed (string) $mixedCaseValue
+     * @param mixed $mixedCaseValue The string value to convert to upper case
      */
     public static function upper($mixedCaseValue): string
     {
@@ -47,9 +47,9 @@ class CaseConvert
     /**
      * PROPERCASE.
      *
-     * Converts a string value to upper case.
+     * Converts a string value to proper or title case.
      *
-     * @param mixed (string) $mixedCaseValue
+     * @param mixed $mixedCaseValue The string value to convert to title case
      */
     public static function proper($mixedCaseValue): string
     {

--- a/src/PhpSpreadsheet/Calculation/TextData/CharacterConvert.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/CharacterConvert.php
@@ -10,7 +10,7 @@ class CharacterConvert
     /**
      * CHARACTER.
      *
-     * @param mixed (int) $character Value
+     * @param mixed $character Integer Value to convert to its character representation
      */
     public static function character($character): string
     {
@@ -31,7 +31,7 @@ class CharacterConvert
     /**
      * ASCIICODE.
      *
-     * @param mixed (string) $characters Value
+     * @param mixed $characters String character to convert to its ASCII value
      *
      * @return int|string A string if arguments are invalid
      */

--- a/src/PhpSpreadsheet/Calculation/TextData/Extract.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Extract.php
@@ -10,8 +10,8 @@ class Extract
     /**
      * LEFT.
      *
-     * @param mixed (string) $value Value
-     * @param mixed (int) $chars Number of characters
+     * @param mixed $value String value from which to extract characters
+     * @param mixed $chars The number of characters to extract (as an integer)
      */
     public static function left($value = '', $chars = 1): string
     {
@@ -32,9 +32,9 @@ class Extract
     /**
      * MID.
      *
-     * @param mixed (string) $value Value
-     * @param mixed (int) $start Start character
-     * @param mixed (int) $chars Number of characters
+     * @param mixed $value String value from which to extract characters
+     * @param mixed $start Integer offset of the first character that we want to extract
+     * @param mixed $chars The number of characters to extract (as an integer)
      */
     public static function mid($value = '', $start = 1, $chars = null): string
     {
@@ -56,8 +56,8 @@ class Extract
     /**
      * RIGHT.
      *
-     * @param mixed (string) $value Value
-     * @param mixed (int) $chars Number of characters
+     * @param mixed $value String value from which to extract characters
+     * @param mixed $chars The number of characters to extract (as an integer)
      */
     public static function right($value = '', $chars = 1): string
     {

--- a/src/PhpSpreadsheet/Calculation/TextData/Format.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Format.php
@@ -18,10 +18,10 @@ class Format
      * This function converts a number to text using currency format, with the decimals rounded to the specified place.
      * The format used is $#,##0.00_);($#,##0.00)..
      *
-     * @param mixed (float) $value The value to format
-     * @param mixed (int) $decimals The number of digits to display to the right of the decimal point.
-     *                                    If decimals is negative, number is rounded to the left of the decimal point.
-     *                                    If you omit decimals, it is assumed to be 2
+     * @param mixed $value The value to format
+     * @param mixed $decimals The number of digits to display to the right of the decimal point (as an integer).
+     *                            If decimals is negative, number is rounded to the left of the decimal point.
+     *                            If you omit decimals, it is assumed to be 2
      */
     public static function DOLLAR($value = 0, $decimals = 2): string
     {
@@ -52,9 +52,9 @@ class Format
     /**
      * FIXEDFORMAT.
      *
-     * @param mixed $value Value to check
-     * @param mixed $decimals
-     * @param mixed (bool) $noCommas
+     * @param mixed $value The value to format
+     * @param mixed $decimals Integer value for the number of decimal places that should be formatted
+     * @param mixed $noCommas Boolean value indicating whether the value should have thousands separators or not
      */
     public static function FIXEDFORMAT($value, $decimals = 2, $noCommas = false): string
     {
@@ -87,8 +87,8 @@ class Format
     /**
      * TEXTFORMAT.
      *
-     * @param mixed $value Value to check
-     * @param mixed (string) $format Format mask to use
+     * @param mixed $value The value to format
+     * @param mixed $format A string with the Format mask that should be used
      */
     public static function TEXTFORMAT($value, $format): string
     {
@@ -151,9 +151,9 @@ class Format
     /**
      * NUMBERVALUE.
      *
-     * @param mixed $value Value to check
-     * @param mixed (string) $decimalSeparator decimal separator, defaults to locale defined value
-     * @param mixed (string) $groupSeparator group/thosands separator, defaults to locale defined value
+     * @param mixed $value The value to format
+     * @param mixed $decimalSeparator A string with the decimal separator to use, defaults to locale defined value
+     * @param mixed $groupSeparator A string with the group/thousands separator to use, defaults to locale defined value
      *
      * @return float|string
      */

--- a/src/PhpSpreadsheet/Calculation/TextData/Replace.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Replace.php
@@ -9,10 +9,10 @@ class Replace
     /**
      * REPLACE.
      *
-     * @param mixed (string) $oldText String to modify
-     * @param mixed (int) $start Start character
-     * @param mixed (int) $chars Number of characters
-     * @param mixed (string) $newText String to replace in defined position
+     * @param mixed $oldText The text string value to modify
+     * @param mixed $start Integer offset for start character of the replacement
+     * @param mixed $chars Integer number of characters to replace from the start offset
+     * @param mixed $newText String to replace in the defined position
      */
     public static function replace($oldText, $start, $chars, $newText): string
     {
@@ -30,10 +30,10 @@ class Replace
     /**
      * SUBSTITUTE.
      *
-     * @param mixed (string) $text Value
-     * @param mixed (string) $fromText From Value
-     * @param mixed (string) $toText To Value
-     * @param mixed (int) $instance Instance Number
+     * @param mixed $text The text string value to modify
+     * @param mixed $fromText The string value that we want to replace in $text
+     * @param mixed $toText The string value that we want to replace with in $text
+     * @param mixed $instance Integer instance Number for the occurrence of frmText to change
      */
     public static function substitute($text = '', $fromText = '', $toText = '', $instance = 0): string
     {

--- a/src/PhpSpreadsheet/Calculation/TextData/Search.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Search.php
@@ -11,9 +11,9 @@ class Search
     /**
      * SEARCHSENSITIVE.
      *
-     * @param mixed (string) $needle The string to look for
-     * @param mixed (string) $haystack The string in which to look
-     * @param mixed (int) $offset Offset within $haystack
+     * @param mixed $needle The string to look for
+     * @param mixed $haystack The string in which to look
+     * @param mixed $offset Integer offset within $haystack to start searching from
      *
      * @return int|string
      */
@@ -46,9 +46,9 @@ class Search
     /**
      * SEARCHINSENSITIVE.
      *
-     * @param mixed (string) $needle The string to look for
-     * @param mixed (string) $haystack The string in which to look
-     * @param mixed (int) $offset Offset within $haystack
+     * @param mixed $needle The string to look for
+     * @param mixed $haystack The string in which to look
+     * @param mixed $offset Integer offset within $haystack to start searching from
      *
      * @return int|string
      */

--- a/src/PhpSpreadsheet/Calculation/TextData/Text.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Text.php
@@ -10,7 +10,7 @@ class Text
     /**
      * STRINGLENGTH.
      *
-     * @param mixed (string) $value Value
+     * @param mixed $value String Value
      */
     public static function length($value = ''): int
     {
@@ -28,8 +28,8 @@ class Text
      * EXACT is case-sensitive but ignores formatting differences.
      * Use EXACT to test text being entered into a document.
      *
-     * @param mixed (string) $value1
-     * @param mixed (string) $value2
+     * @param mixed $value1 String Value
+     * @param mixed $value2 String Value
      */
     public static function exact($value1, $value2): bool
     {

--- a/src/PhpSpreadsheet/Calculation/TextData/Trim.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Trim.php
@@ -12,7 +12,7 @@ class Trim
     /**
      * TRIMNONPRINTABLE.
      *
-     * @param mixed (string) $stringValue Value to check
+     * @param mixed $stringValue String Value to check
      *
      * @return null|string
      */
@@ -38,7 +38,7 @@ class Trim
     /**
      * TRIMSPACES.
      *
-     * @param mixed (string) $stringValue Value to check
+     * @param mixed $stringValue String Value to check
      *
      * @return null|string
      */

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -319,8 +319,8 @@ class CalculationTest extends TestCase
     }
 
     /**
-     * @param $expectedResult
-     * @param $dataArray
+     * @param mixed $expectedResult
+     * @param mixed $dataArray
      * @param string $formula
      * @param string $cellCoordinates where to put the formula
      * @param string[] $shouldBeSetInCacheCells coordinates of cells that must

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeValueTest.php
@@ -10,7 +10,7 @@ class TimeValueTest extends AllSetupTeardown
      * @dataProvider providerTIMEVALUE
      *
      * @param mixed $expectedResult
-     * @param $timeValue
+     * @param mixed $timeValue
      */
     public function testTIMEVALUE($expectedResult, $timeValue): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfErrorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfErrorTest.php
@@ -17,8 +17,8 @@ class IfErrorTest extends TestCase
      * @dataProvider providerIFERROR
      *
      * @param mixed $expectedResult
-     * @param $value
-     * @param $return
+     * @param mixed $value
+     * @param mixed $return
      */
     public function testIFERROR($expectedResult, $value, $return): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfNaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfNaTest.php
@@ -17,8 +17,8 @@ class IfNaTest extends TestCase
      * @dataProvider providerIFNA
      *
      * @param mixed $expectedResult
-     * @param $value
-     * @param $return
+     * @param mixed $value
+     * @param mixed $return
      */
     public function testIFNA($expectedResult, $value, $return): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/EvenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/EvenTest.php
@@ -8,7 +8,7 @@ class EvenTest extends AllSetupTeardown
      * @dataProvider providerEVEN
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testEVEN($expectedResult, $value): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FactDoubleTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FactDoubleTest.php
@@ -8,7 +8,7 @@ class FactDoubleTest extends AllSetupTeardown
      * @dataProvider providerFACTDOUBLE
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testFACTDOUBLE($expectedResult, $value): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/OddTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/OddTest.php
@@ -8,7 +8,7 @@ class OddTest extends AllSetupTeardown
      * @dataProvider providerODD
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testODD($expectedResult, $value): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SignTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SignTest.php
@@ -8,7 +8,7 @@ class SignTest extends AllSetupTeardown
      * @dataProvider providerSIGN
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testSIGN($expectedResult, $value): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SqrtPiTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SqrtPiTest.php
@@ -17,7 +17,7 @@ class SqrtPiTest extends TestCase
      * @dataProvider providerSQRTPI
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testSQRTPI($expectedResult, $value): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FisherInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FisherInvTest.php
@@ -17,7 +17,7 @@ class FisherInvTest extends TestCase
      * @dataProvider providerFISHERINV
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testFISHERINV($expectedResult, $value): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FisherTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FisherTest.php
@@ -17,7 +17,7 @@ class FisherTest extends TestCase
      * @dataProvider providerFISHER
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testFISHER($expectedResult, $value): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaLnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaLnTest.php
@@ -17,7 +17,7 @@ class GammaLnTest extends TestCase
      * @dataProvider providerGAMMALN
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testGAMMALN($expectedResult, $value): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CharTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CharTest.php
@@ -11,7 +11,7 @@ class CharTest extends TestCase
      * @dataProvider providerCHAR
      *
      * @param mixed $expectedResult
-     * @param $character
+     * @param mixed $character
      */
     public function testCHAR($expectedResult, $character): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CleanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CleanTest.php
@@ -11,7 +11,7 @@ class CleanTest extends TestCase
      * @dataProvider providerCLEAN
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testCLEAN($expectedResult, $value): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CodeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CodeTest.php
@@ -11,7 +11,7 @@ class CodeTest extends TestCase
      * @dataProvider providerCODE
      *
      * @param mixed $expectedResult
-     * @param $character
+     * @param mixed $character
      */
     public function testCODE($expectedResult, $character): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LeftTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LeftTest.php
@@ -33,7 +33,7 @@ class LeftTest extends TestCase
      * @dataProvider providerLocaleLEFT
      *
      * @param string $expectedResult
-     * @param $value
+     * @param mixed $value
      * @param mixed $locale
      * @param mixed $characters
      */

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LenTest.php
@@ -11,7 +11,7 @@ class LenTest extends TestCase
      * @dataProvider providerLEN
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testLEN($expectedResult, $value): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LowerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LowerTest.php
@@ -17,7 +17,7 @@ class LowerTest extends TestCase
      * @dataProvider providerLOWER
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testLOWER($expectedResult, $value): void
     {
@@ -34,7 +34,7 @@ class LowerTest extends TestCase
      * @dataProvider providerLocaleLOWER
      *
      * @param string $expectedResult
-     * @param $value
+     * @param mixed $value
      * @param mixed $locale
      */
     public function testLowerWithLocaleBoolean($expectedResult, $locale, $value): void

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/MidTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/MidTest.php
@@ -33,7 +33,7 @@ class MidTest extends TestCase
      * @dataProvider providerLocaleMID
      *
      * @param string $expectedResult
-     * @param $value
+     * @param mixed $value
      * @param mixed $locale
      * @param mixed $offset
      * @param mixed $characters

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ProperTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ProperTest.php
@@ -17,7 +17,7 @@ class ProperTest extends TestCase
      * @dataProvider providerPROPER
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testPROPER($expectedResult, $value): void
     {
@@ -34,7 +34,7 @@ class ProperTest extends TestCase
      * @dataProvider providerLocaleLOWER
      *
      * @param string $expectedResult
-     * @param $value
+     * @param mixed $value
      * @param mixed $locale
      */
     public function testLowerWithLocaleBoolean($expectedResult, $locale, $value): void

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/RightTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/RightTest.php
@@ -33,7 +33,7 @@ class RightTest extends TestCase
      * @dataProvider providerLocaleRIGHT
      *
      * @param string $expectedResult
-     * @param $value
+     * @param mixed $value
      * @param mixed $locale
      * @param mixed $characters
      */

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TTest.php
@@ -11,7 +11,7 @@ class TTest extends TestCase
      * @dataProvider providerT
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testT($expectedResult, $value): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TrimTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TrimTest.php
@@ -11,7 +11,7 @@ class TrimTest extends TestCase
      * @dataProvider providerTRIM
      *
      * @param mixed $expectedResult
-     * @param $character
+     * @param mixed $character
      */
     public function testTRIM($expectedResult, $character): void
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/UpperTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/UpperTest.php
@@ -17,7 +17,7 @@ class UpperTest extends TestCase
      * @dataProvider providerUPPER
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testUPPER($expectedResult, $value): void
     {
@@ -34,7 +34,7 @@ class UpperTest extends TestCase
      * @dataProvider providerLocaleLOWER
      *
      * @param string $expectedResult
-     * @param $value
+     * @param mixed $value
      * @param mixed $locale
      */
     public function testLowerWithLocaleBoolean($expectedResult, $locale, $value): void

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ValueTest.php
@@ -32,7 +32,7 @@ class ValueTest extends TestCase
      * @dataProvider providerVALUE
      *
      * @param mixed $expectedResult
-     * @param $value
+     * @param mixed $value
      */
     public function testVALUE($expectedResult, $value): void
     {


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] Fixing docblock comments
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Reduce the phpstan baseline by fixing param datatypes in docblock comments
