### PR TITLE
Two Problems with Sample19

### DIFF
--- a/samples/Basic/19_Namedrange.php
+++ b/samples/Basic/19_Namedrange.php
@@ -31,8 +31,8 @@ $spreadsheet->getActiveSheet()->setCellValue('A1', 'Firstname:')
 
 // Define named ranges
 $helper->log('Define named ranges');
-$spreadsheet->addNamedRange(new NamedRange('PersonName', $spreadsheet->getActiveSheet(), 'B1'));
-$spreadsheet->addNamedRange(new NamedRange('PersonLN', $spreadsheet->getActiveSheet(), 'B2'));
+$spreadsheet->addNamedRange(new NamedRange('PersonName', $spreadsheet->getActiveSheet(), '$B$1'));
+$spreadsheet->addNamedRange(new NamedRange('PersonLN', $spreadsheet->getActiveSheet(), '$B$2'));
 
 // Rename named ranges
 $helper->log('Rename named ranges');

--- a/src/PhpSpreadsheet/Writer/Xls/Parser.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Parser.php
@@ -1149,8 +1149,9 @@ class Parser
             $result2 = $this->expression();
             $result = $this->createTree('ptgNE', $result, $result2);
         } elseif ($this->currentToken == '&') {
+            $result = $this->term();
             $this->advance();
-            $result2 = $this->expression();
+            $result2 = $this->term();
             $result = $this->createTree('ptgConcat', $result, $result2);
         }
 

--- a/tests/PhpSpreadsheetTests/Writer/Xls/Sample19Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/Sample19Test.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xls;
+
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class Sample19Test extends AbstractFunctional
+{
+    public function testSample19Xls(): void
+    {
+        $spreadsheet = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
+        $spreadsheet->setActiveSheetIndex(0);
+        $spreadsheet->getActiveSheet()->setCellValue('A1', 'Firstname:')
+            ->setCellValue('A2', 'Lastname:')
+            ->setCellValue('A3', 'Fullname:')
+            ->setCellValue('B1', 'Maarten')
+            ->setCellValue('B2', 'Balliauw')
+            ->setCellValue('B3', '=B1 & " " & B2');
+
+        $robj = $this->writeAndReload($spreadsheet, 'Xls');
+        $sheet0 = $robj->setActiveSheetIndex(0);
+        //self::assertEquals('=B1 & " " & B2', $sheet0->getCell('B3')->getValue());
+        self::assertEquals('Maarten Balliauw', $sheet0->getCell('B3')->getCalculatedValue());
+    }
+}


### PR DESCRIPTION
19_NamedRange.php was not changed to use absolute addressing when that was introduced to Named Ranges. Consequently, the output from this sample has been wrong ever since, for both Xls and Xlsx.

There was an additional problem with Xls. It appears that the Xls Writer Parser does not parse multiple concatenations using the ampersand operator correctly. So, `=B1+" "+B2` was parsed as `=B1+" "`. I believe that this is due to ampersand being treated as a condition rather than an operator. I attempted to resolve this, but my attempt is only partially successful. I tried to parse it as other operators by treating the left side as a 'term' rather than an 'expression'. In the resulting spreadsheet, the cell contains the correct calculated value, but it does not contain the actual formula. This is better than it had been, so I have left that change intact while I continue to research.

There are already more than ample tests for Named Ranges, so I did not add a new one for that purpose. However, I did add a new test for the Xls parser problem.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
