### PR TITLE
Improved Support for INDIRECT, ROW, and COLUMN Functions

### DIFF
--- a/src/PhpSpreadsheet/Calculation/LookupRef.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef.php
@@ -188,7 +188,7 @@ class LookupRef
      *
      * NOTE - INDIRECT() does not yet support the optional a1 parameter introduced in Excel 2010
      *
-     * @param null|array|string $cellAddress $cellAddress The cell address of the current cell (containing this formula)
+     * @param array|string $cellAddress $cellAddress The cell address of the current cell (containing this formula)
      * @param Cell $pCell The current cell (containing this formula)
      *
      * @return array|string An array containing a cell or range of cells, or a string on error

--- a/src/PhpSpreadsheet/Calculation/LookupRef.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef.php
@@ -195,7 +195,7 @@ class LookupRef
      *
      * @TODO    Support for the optional a1 parameter introduced in Excel 2010
      */
-    public static function INDIRECT($cellAddress = null, ?Cell $pCell = null)
+    public static function INDIRECT($cellAddress, Cell $pCell)
     {
         return Indirect::INDIRECT($cellAddress, true, $pCell);
     }

--- a/src/PhpSpreadsheet/Calculation/LookupRef.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef.php
@@ -197,7 +197,7 @@ class LookupRef
      */
     public static function INDIRECT($cellAddress = null, ?Cell $pCell = null)
     {
-        return Indirect::INDIRECT($cellAddress, $pCell);
+        return Indirect::INDIRECT($cellAddress, true, $pCell);
     }
 
     /**

--- a/src/PhpSpreadsheet/Calculation/LookupRef/Helpers.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Helpers.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Calculation\LookupRef;
+
+use PhpOffice\PhpSpreadsheet\Cell\AddressHelper;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+class Helpers
+{
+    private static function convertR1C1(string &$cellAddress1, ?string &$cellAddress2, bool $a1): string
+    {
+        if (!$a1) {
+            $cellAddress1 = AddressHelper::convertToA1($cellAddress1);
+            if ($cellAddress2) {
+                $cellAddress2 = AddressHelper::convertToA1($cellAddress2);
+            }
+        }
+
+        return $cellAddress1 . ($cellAddress2 ? ":$cellAddress2" : '');
+    }
+
+    public static function extractCellAddresses(string $cellAddress, bool $a1, Spreadsheet $spreadsheet, Worksheet $sheet): array
+    {
+        $cellAddress1 = $cellAddress;
+        $cellAddress2 = null;
+        $namedRanges = $spreadsheet->getNamedRanges();
+        foreach ($namedRanges as $namedRange) {
+            $scope = $namedRange->getScope();
+            if ($cellAddress1 === $namedRange->getName() && ($scope === null || $scope === $sheet)) {
+                $sheet = $namedRange->getWorkSheet()->getTitle() . '!';
+                $cellAddress1 = $sheet . $namedRange->getValue();
+                $cellAddress = $cellAddress1;
+                $a1 = true;
+
+                break;
+            }
+        }
+        if (strpos($cellAddress, ':') !== false) {
+            [$cellAddress1, $cellAddress2] = explode(':', $cellAddress);
+        }
+        $cellAddress = self::convertR1C1($cellAddress1, $cellAddress2, $a1);
+
+        return [$cellAddress1, $cellAddress2, $cellAddress];
+    }
+}

--- a/src/PhpSpreadsheet/Calculation/LookupRef/Helpers.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Helpers.php
@@ -28,7 +28,7 @@ class Helpers
         foreach ($namedRanges as $namedRange) {
             $scope = $namedRange->getScope();
             if ($cellAddress1 === $namedRange->getName() && ($scope === null || $scope === $sheet)) {
-                $sheet = $namedRange->getWorkSheet()->getTitle() . '!';
+                $sheet = $namedRange->getWorkSheet() ? ($namedRange->getWorkSheet()->getTitle() . '!') : '';
                 $cellAddress1 = $sheet . $namedRange->getValue();
                 $cellAddress = $cellAddress1;
                 $a1 = true;

--- a/src/PhpSpreadsheet/Calculation/LookupRef/Helpers.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Helpers.php
@@ -32,7 +32,8 @@ class Helpers
                 if ($namedRange->getWorkSheet() !== null) {
                     $sheet = $namedRange->getWorkSheet()->getTitle() . '!';
                 }
-                $cellAddress1 = $sheet . $namedRange->getValue();
+                $value = preg_replace('/^=/', '', $namedRange->getValue());
+                $cellAddress1 = $sheet . $value;
                 $cellAddress = $cellAddress1;
                 $a1 = true;
 

--- a/src/PhpSpreadsheet/Calculation/LookupRef/Helpers.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Helpers.php
@@ -28,7 +28,10 @@ class Helpers
         foreach ($namedRanges as $namedRange) {
             $scope = $namedRange->getScope();
             if ($cellAddress1 === $namedRange->getName() && ($scope === null || $scope === $sheet)) {
-                $sheet = $namedRange->getWorkSheet() ? ($namedRange->getWorkSheet()->getTitle() . '!') : '';
+                $sheet = '';
+                if ($namedRange->getWorkSheet() !== null) {
+                    $sheet = $namedRange->getWorkSheet()->getTitle() . '!';
+                }
                 $cellAddress1 = $sheet . $namedRange->getValue();
                 $cellAddress = $cellAddress1;
                 $a1 = true;

--- a/src/PhpSpreadsheet/Calculation/LookupRef/Indirect.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Indirect.php
@@ -38,7 +38,7 @@ class Indirect
     private static function validateAddress($cellAddress): string
     {
         $cellAddress = Functions::flattenSingleValue($cellAddress);
-        if (!$cellAddress) {
+        if (!is_string($cellAddress) || !$cellAddress) {
             throw new Exception(Functions::REF());
         }
 

--- a/src/PhpSpreadsheet/Calculation/LookupRef/Indirect.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Indirect.php
@@ -5,9 +5,7 @@ namespace PhpOffice\PhpSpreadsheet\Calculation\LookupRef;
 use Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
-use PhpOffice\PhpSpreadsheet\Cell\AddressHelper;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class Indirect
@@ -45,42 +43,6 @@ class Indirect
         return $cellAddress;
     }
 
-    private static function convertR1C1(string &$cellAddress1, ?string &$cellAddress2, bool $a1): string
-    {
-        if (!$a1) {
-            $cellAddress1 = AddressHelper::convertToA1($cellAddress1);
-            if ($cellAddress2) {
-                $cellAddress2 = AddressHelper::convertToA1($cellAddress2);
-            }
-        }
-
-        return $cellAddress1 . ($cellAddress2 ? ":$cellAddress2" : '');
-    }
-
-    private static function extractCellAddresses(string $cellAddress, bool $a1, Spreadsheet $spreadsheet, Worksheet $sheet): array
-    {
-        $cellAddress1 = $cellAddress;
-        $cellAddress2 = null;
-        $namedRanges = $spreadsheet->getNamedRanges();
-        foreach ($namedRanges as $namedRange) {
-            $scope = $namedRange->getScope();
-            if ($cellAddress1 === $namedRange->getName() && ($scope === null || $scope === $sheet)) {
-                $sheet = $namedRange->getWorkSheet()->getTitle() . '!';
-                $cellAddress1 = $sheet . $namedRange->getValue();
-                $cellAddress = $cellAddress1;
-                $a1 = true;
-
-                break;
-            }
-        }
-        if (strpos($cellAddress, ':') !== false) {
-            [$cellAddress1, $cellAddress2] = explode(':', $cellAddress);
-        }
-        $cellAddress = self::convertR1C1($cellAddress1, $cellAddress2, $a1);
-
-        return [$cellAddress1, $cellAddress2, $cellAddress];
-    }
-
     /**
      * INDIRECT.
      *
@@ -108,7 +70,7 @@ class Indirect
 
         [$cellAddress, $pSheet] = self::extractWorksheet($cellAddress, $pCell);
 
-        [$cellAddress1, $cellAddress2, $cellAddress] = self::extractCellAddresses($cellAddress, $a1, $spreadsheet, $pCell->getWorkSheet());
+        [$cellAddress1, $cellAddress2, $cellAddress] = Helpers::extractCellAddresses($cellAddress, $a1, $spreadsheet, $pCell->getWorkSheet());
 
         if (
             (!preg_match('/^' . Calculation::CALCULATION_REGEXP_CELLREF . '$/i', $cellAddress1, $matches)) ||

--- a/src/PhpSpreadsheet/Calculation/LookupRef/Indirect.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Indirect.php
@@ -2,13 +2,85 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\LookupRef;
 
+use Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
+use PhpOffice\PhpSpreadsheet\Cell\AddressHelper;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class Indirect
 {
+    /**
+     * Determine whether cell address is in A1 (true) or R1C1 (false) format.
+     *
+     * @param null|bool|float|int|string $a1fmt
+     */
+    private static function a1Format($a1fmt): bool
+    {
+        $a1fmt = Functions::flattenSingleValue($a1fmt);
+        if ($a1fmt === null) {
+            return true;
+        }
+        if (is_string($a1fmt)) {
+            throw new Exception(Functions::VALUE());
+        }
+
+        return (bool) $a1fmt;
+    }
+
+    /**
+     * Convert cellAddress to string, verify not null string.
+     *
+     * @param array|string $cellAddress
+     */
+    private static function validateAddress($cellAddress): string
+    {
+        $cellAddress = Functions::flattenSingleValue($cellAddress);
+        if (!$cellAddress) {
+            throw new Exception(Functions::REF());
+        }
+
+        return $cellAddress;
+    }
+
+    private static function convertR1C1(string &$cellAddress1, ?string &$cellAddress2, bool $a1): string
+    {
+        if (!$a1) {
+            $cellAddress1 = AddressHelper::convertToA1($cellAddress1);
+            if ($cellAddress2) {
+                $cellAddress2 = AddressHelper::convertToA1($cellAddress2);
+            }
+        }
+
+        return $cellAddress1 . ($cellAddress2 ? ":$cellAddress2" : '');
+    }
+
+    private static function extractCellAddresses(string $cellAddress, bool $a1, Spreadsheet $spreadsheet, Worksheet $sheet): array
+    {
+        $cellAddress1 = $cellAddress;
+        $cellAddress2 = null;
+        $namedRanges = $spreadsheet->getNamedRanges();
+        foreach ($namedRanges as $namedRange) {
+            $scope = $namedRange->getScope();
+            if ($cellAddress1 === $namedRange->getName() && ($scope === null || $scope === $sheet)) {
+                $sheet = $namedRange->getWorkSheet()->getTitle() . '!';
+                $cellAddress1 = $sheet . $namedRange->getValue();
+                $cellAddress = $cellAddress1;
+                $a1 = true;
+
+                break;
+            }
+        }
+        if (strpos($cellAddress, ':') !== false) {
+            [$cellAddress1, $cellAddress2] = explode(':', $cellAddress);
+        }
+        $cellAddress = self::convertR1C1($cellAddress1, $cellAddress2, $a1);
+
+        return [$cellAddress1, $cellAddress2, $cellAddress];
+    }
+
     /**
      * INDIRECT.
      *
@@ -16,31 +88,27 @@ class Indirect
      * References are immediately evaluated to display their contents.
      *
      * Excel Function:
-     *        =INDIRECT(cellAddress)
+     *        =INDIRECT(cellAddress, bool) where the bool argument is optional
      *
-     * NOTE - INDIRECT() does not yet support the optional a1 parameter introduced in Excel 2010
-     *
-     * @param null|array|string $cellAddress $cellAddress The cell address of the current cell (containing this formula)
+     * @param array|string $cellAddress $cellAddress The cell address of the current cell (containing this formula)
+     * @param null|bool|float|int|string $a1fmt
      * @param null|Cell $pCell The current cell (containing this formula)
      *
      * @return array|string An array containing a cell or range of cells, or a string on error
-     *
-     * @TODO    Support for the optional a1 parameter introduced in Excel 2010
      */
-    public static function INDIRECT($cellAddress = null, ?Cell $pCell = null)
+    public static function INDIRECT($cellAddress, $a1fmt, Cell $pCell)
     {
-        $cellAddress = Functions::flattenSingleValue($cellAddress);
-        if ($cellAddress === null || $cellAddress === '' || !is_object($pCell)) {
-            return Functions::REF();
+        try {
+            $a1 = self::a1Format($a1fmt);
+            $spreadsheet = $pCell->getWorksheet()->getParent();
+            $cellAddress = self::validateAddress($cellAddress);
+        } catch (Exception $e) {
+            return $e->getMessage();
         }
 
         [$cellAddress, $pSheet] = self::extractWorksheet($cellAddress, $pCell);
 
-        $cellAddress1 = $cellAddress;
-        $cellAddress2 = null;
-        if (strpos($cellAddress, ':') !== false) {
-            [$cellAddress1, $cellAddress2] = explode(':', $cellAddress);
-        }
+        [$cellAddress1, $cellAddress2, $cellAddress] = self::extractCellAddresses($cellAddress, $a1, $spreadsheet, $pCell->getWorkSheet());
 
         if (
             (!preg_match('/^' . Calculation::CALCULATION_REGEXP_CELLREF . '$/i', $cellAddress1, $matches)) ||

--- a/src/PhpSpreadsheet/Calculation/LookupRef/Indirect.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Indirect.php
@@ -92,7 +92,7 @@ class Indirect
      *
      * @param array|string $cellAddress $cellAddress The cell address of the current cell (containing this formula)
      * @param null|bool|float|int|string $a1fmt
-     * @param null|Cell $pCell The current cell (containing this formula)
+     * @param Cell $pCell The current cell (containing this formula)
      *
      * @return array|string An array containing a cell or range of cells, or a string on error
      */

--- a/src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
@@ -11,6 +11,21 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 class RowColumnInformation
 {
     /**
+     * Test if cellAddress is null or whitespace string.
+     *
+     * @param null|array|string $cellAddress A reference to a range of cells
+     */
+    private static function cellAddressNullOrWhitespace($cellAddress): bool
+    {
+        return $cellAddress === null || (!is_array($cellAddress) && trim($cellAddress) === '');
+    }
+
+    private static function cellColumn(?Cell $pCell): int
+    {
+        return ($pCell !== null) ? (int) Coordinate::columnIndexFromString($pCell->getColumn()) : 1;
+    }
+
+    /**
      * COLUMN.
      *
      * Returns the column number of the given cell reference
@@ -27,10 +42,10 @@ class RowColumnInformation
      *
      * @return int|int[]
      */
-    public static function COLUMN($cellAddress = null, ?Cell $cell = null)
+    public static function COLUMN($cellAddress = null, ?Cell $pCell = null)
     {
-        if ($cellAddress === null || (!is_array($cellAddress) && trim($cellAddress) === '')) {
-            return ($cell !== null) ? (int) Coordinate::columnIndexFromString($cell->getColumn()) : 1;
+        if (self::cellAddressNullOrWhitespace($cellAddress)) {
+            return self::cellColumn($pCell);
         }
 
         if (is_array($cellAddress)) {
@@ -41,6 +56,9 @@ class RowColumnInformation
             }
         }
 
+        if ($pCell) {
+            [, , $cellAddress] = Helpers::extractCellAddresses((string) $cellAddress, true, $pCell->getWorksheet()->getParent(), $pCell->getWorksheet());
+        }
         [, $cellAddress] = Worksheet::extractSheetTitle((string) $cellAddress, true);
         if (strpos($cellAddress, ':') !== false) {
             [$startAddress, $endAddress] = explode(':', $cellAddress);
@@ -73,9 +91,10 @@ class RowColumnInformation
      */
     public static function COLUMNS($cellAddress = null)
     {
-        if ($cellAddress === null || (is_string($cellAddress) && trim($cellAddress) === '')) {
+        if (self::cellAddressNullOrWhitespace($cellAddress)) {
             return 1;
-        } elseif (!is_array($cellAddress)) {
+        }
+        if (!is_array($cellAddress)) {
             return Functions::VALUE();
         }
 
@@ -88,6 +107,11 @@ class RowColumnInformation
         }
 
         return $columns;
+    }
+
+    private static function cellRow(?Cell $pCell): int
+    {
+        return ($pCell !== null) ? $pCell->getRow() : 1;
     }
 
     /**
@@ -109,8 +133,8 @@ class RowColumnInformation
      */
     public static function ROW($cellAddress = null, ?Cell $pCell = null)
     {
-        if ($cellAddress === null || (!is_array($cellAddress) && trim($cellAddress) === '')) {
-            return ($pCell !== null) ? $pCell->getRow() : 1;
+        if (self::cellAddressNullOrWhitespace($cellAddress)) {
+            return self::cellRow($pCell);
         }
 
         if (is_array($cellAddress)) {
@@ -121,6 +145,9 @@ class RowColumnInformation
             }
         }
 
+        if ($pCell) {
+            [, , $cellAddress] = Helpers::extractCellAddresses((string) $cellAddress, true, $pCell->getWorksheet()->getParent(), $pCell->getWorksheet());
+        }
         [, $cellAddress] = Worksheet::extractSheetTitle((string) $cellAddress, true);
         if (strpos($cellAddress, ':') !== false) {
             [$startAddress, $endAddress] = explode(':', $cellAddress);
@@ -154,9 +181,10 @@ class RowColumnInformation
      */
     public static function ROWS($cellAddress = null)
     {
-        if ($cellAddress === null || (is_string($cellAddress) && trim($cellAddress) === '')) {
+        if (self::cellAddressNullOrWhitespace($cellAddress)) {
             return 1;
-        } elseif (!is_array($cellAddress)) {
+        }
+        if (!is_array($cellAddress)) {
             return Functions::VALUE();
         }
 

--- a/src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
@@ -56,10 +56,11 @@ class RowColumnInformation
             }
         }
 
-        if (is_string($cellAddress) && $pCell) {
+        $cellAddress = is_string($cellAddress) ? $cellAddress : '';
+        if ($pCell) {
             [, , $cellAddress] = Helpers::extractCellAddresses($cellAddress, true, $pCell->getWorksheet()->getParent(), $pCell->getWorksheet());
         }
-        [, $cellAddress] = Worksheet::extractSheetTitle((string) $cellAddress, true);
+        [, $cellAddress] = Worksheet::extractSheetTitle($cellAddress, true);
         if (strpos($cellAddress, ':') !== false) {
             [$startAddress, $endAddress] = explode(':', $cellAddress);
             $startAddress = preg_replace('/[^a-z]/i', '', $startAddress);
@@ -145,10 +146,11 @@ class RowColumnInformation
             }
         }
 
-        if (is_string($cellAddress) && $pCell) {
+        $cellAddress = is_string($cellAddress) ? $cellAddress : '';
+        if ($pCell) {
             [, , $cellAddress] = Helpers::extractCellAddresses($cellAddress, true, $pCell->getWorksheet()->getParent(), $pCell->getWorksheet());
         }
-        [, $cellAddress] = Worksheet::extractSheetTitle((string) $cellAddress, true);
+        [, $cellAddress] = Worksheet::extractSheetTitle($cellAddress, true);
         if (strpos($cellAddress, ':') !== false) {
             [$startAddress, $endAddress] = explode(':', $cellAddress);
             $startAddress = preg_replace('/\D/', '', $startAddress);

--- a/src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
@@ -56,8 +56,8 @@ class RowColumnInformation
             }
         }
 
-        if ($pCell) {
-            [, , $cellAddress] = Helpers::extractCellAddresses((string) $cellAddress, true, $pCell->getWorksheet()->getParent(), $pCell->getWorksheet());
+        if (is_string($cellAddress) && $pCell) {
+            [, , $cellAddress] = Helpers::extractCellAddresses($cellAddress, true, $pCell->getWorksheet()->getParent(), $pCell->getWorksheet());
         }
         [, $cellAddress] = Worksheet::extractSheetTitle((string) $cellAddress, true);
         if (strpos($cellAddress, ':') !== false) {
@@ -145,8 +145,8 @@ class RowColumnInformation
             }
         }
 
-        if ($pCell) {
-            [, , $cellAddress] = Helpers::extractCellAddresses((string) $cellAddress, true, $pCell->getWorksheet()->getParent(), $pCell->getWorksheet());
+        if (is_string($cellAddress) && $pCell) {
+            [, , $cellAddress] = Helpers::extractCellAddresses($cellAddress, true, $pCell->getWorksheet()->getParent(), $pCell->getWorksheet());
         }
         [, $cellAddress] = Worksheet::extractSheetTitle((string) $cellAddress, true);
         if (strpos($cellAddress, ':') !== false) {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AllSetupTeardown.php
@@ -17,12 +17,12 @@ class AllSetupTeardown extends TestCase
     protected $compatibilityMode;
 
     /**
-     * @var ?Spreadsheet
+     * @var Spreadsheet
      */
     protected $spreadsheet;
 
     /**
-     * @var ?Worksheet
+     * @var Worksheet
      */
     protected $sheet;
 
@@ -37,8 +37,6 @@ class AllSetupTeardown extends TestCase
     {
         Functions::setCompatibilityMode($this->compatibilityMode);
         $this->spreadsheet->disconnectWorksheets();
-        $this->spreadsheet = null;
-        $this->sheet = null;
     }
 
     protected static function setOpenOffice(): void

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AllSetupTeardown.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
+
+use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalcException;
+use PhpOffice\PhpSpreadsheet\Calculation\Functions;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+class AllSetupTeardown extends TestCase
+{
+    protected $compatibilityMode;
+
+    protected $spreadsheet;
+
+    protected $sheet;
+
+    protected function setUp(): void
+    {
+        $this->compatibilityMode = Functions::getCompatibilityMode();
+        $this->spreadsheet = new Spreadsheet();
+        $this->sheet = $this->spreadsheet->getActiveSheet();
+    }
+
+    protected function tearDown(): void
+    {
+        Functions::setCompatibilityMode($this->compatibilityMode);
+        $this->spreadsheet->disconnectWorksheets();
+        $this->spreadsheet = null;
+        $this->sheet = null;
+    }
+
+    protected static function setOpenOffice(): void
+    {
+        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+    }
+
+    protected static function setGnumeric(): void
+    {
+        Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+    }
+
+    /**
+     * @param mixed $expectedResult
+     */
+    protected function mightHaveException($expectedResult): void
+    {
+        if ($expectedResult === 'exception') {
+            $this->expectException(CalcException::class);
+        }
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected function setCell(string $cell, $value): void
+    {
+        if ($value !== null) {
+            if (is_string($value) && is_numeric($value)) {
+                $this->sheet->getCell($cell)->setValueExplicit($value, DataType::TYPE_STRING);
+            } else {
+                $this->sheet->getCell($cell)->setValue($value);
+            }
+        }
+    }
+}

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AllSetupTeardown.php
@@ -17,12 +17,12 @@ class AllSetupTeardown extends TestCase
     protected $compatibilityMode;
 
     /**
-     * @var Spreadsheet
+     * @var ?Spreadsheet
      */
     protected $spreadsheet;
 
     /**
-     * @var Worksheet
+     * @var ?Worksheet
      */
     protected $sheet;
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AllSetupTeardown.php
@@ -6,14 +6,24 @@ use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalcException;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PHPUnit\Framework\TestCase;
 
 class AllSetupTeardown extends TestCase
 {
+    /**
+     * @var string
+     */
     protected $compatibilityMode;
 
+    /**
+     * @var Spreadsheet
+     */
     protected $spreadsheet;
 
+    /**
+     * @var Worksheet
+     */
     protected $sheet;
 
     protected function setUp(): void

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnOnSpreadsheetTest.php
@@ -33,7 +33,7 @@ class ColumnOnSpreadsheetTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerCOLUMNonSpreadsheet()
+    public function providerCOLUMNonSpreadsheet(): array
     {
         return require 'tests/data/Calculation/LookupRef/COLUMNonSpreadsheet.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnOnSpreadsheetTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
+
+use PhpOffice\PhpSpreadsheet\NamedRange;
+
+class ColumnOnSpreadsheetTest extends AllSetupTeardown
+{
+    /**
+     * @dataProvider providerCOLUMNonSpreadsheet
+     *
+     * @param mixed $expectedResult
+     * @param string $cellReference
+     */
+    public function testColumnOnSpreadsheet($expectedResult, $cellReference = 'omitted'): void
+    {
+        $this->mightHaveException($expectedResult);
+        $sheet = $this->sheet;
+        $this->spreadsheet->addNamedRange(new NamedRange('namedrangex', $sheet, '$E$2:$E$6'));
+        $this->spreadsheet->addNamedRange(new NamedRange('namedrangey', $sheet, '$F$2:$H$2'));
+        $this->spreadsheet->addNamedRange(new NamedRange('namedrange3', $sheet, '$F$4:$H$4'));
+
+        $sheet1 = $this->spreadsheet->createSheet();
+        $sheet1->setTitle('OtherSheet');
+
+        if ($cellReference === 'omitted') {
+            $sheet->getCell('B3')->setValue('=COLUMN()');
+        } else {
+            $sheet->getCell('B3')->setValue("=COLUMN($cellReference)");
+        }
+
+        $result = $sheet->getCell('B3')->getCalculatedValue();
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function providerCOLUMNonSpreadsheet()
+    {
+        return require 'tests/data/Calculation/LookupRef/COLUMNonSpreadsheet.php';
+    }
+
+    public function testCOLUMNLocalDefinedName(): void
+    {
+        $sheet = $this->sheet;
+
+        $sheet1 = $this->spreadsheet->createSheet();
+        $sheet1->setTitle('OtherSheet');
+        $this->spreadsheet->addNamedRange(new NamedRange('newnr', $sheet1, '$F$5:$H$5', true)); // defined locally, only usable on sheet1
+
+        $sheet1->getCell('B3')->setValue('=COLUMN(newnr)');
+        $result = $sheet1->getCell('B3')->getCalculatedValue();
+        self::assertSame(6, $result);
+
+        $sheet->getCell('B3')->setValue('=COLUMN(newnr)');
+        $result = $sheet->getCell('B3')->getCalculatedValue();
+        self::assertSame('#NAME?', $result);
+    }
+}

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnsOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnsOnSpreadsheetTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
+
+use PhpOffice\PhpSpreadsheet\NamedRange;
+
+class ColumnsOnSpreadsheetTest extends AllSetupTeardown
+{
+    /**
+     * @dataProvider providerCOLUMNSonSpreadsheet
+     *
+     * @param mixed $expectedResult
+     * @param string $cellReference
+     */
+    public function testColumnsOnSpreadsheet($expectedResult, $cellReference = 'omitted'): void
+    {
+        $this->mightHaveException($expectedResult);
+        $sheet = $this->sheet;
+        $this->spreadsheet->addNamedRange(new NamedRange('namedrangex', $sheet, '$E$2:$E$6'));
+        $this->spreadsheet->addNamedRange(new NamedRange('namedrangey', $sheet, '$F$2:$H$2'));
+        $this->spreadsheet->addNamedRange(new NamedRange('namedrange3', $sheet, '$F$4:$H$4'));
+
+        $sheet1 = $this->spreadsheet->createSheet();
+        $sheet1->setTitle('OtherSheet');
+
+        if ($cellReference === 'omitted') {
+            $sheet->getCell('B3')->setValue('=COLUMNS()');
+        } else {
+            $sheet->getCell('B3')->setValue("=COLUMNS($cellReference)");
+        }
+
+        $result = $sheet->getCell('B3')->getCalculatedValue();
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function providerCOLUMNSonSpreadsheet()
+    {
+        return require 'tests/data/Calculation/LookupRef/COLUMNSonSpreadsheet.php';
+    }
+
+    public function testCOLUMNSLocalDefinedName(): void
+    {
+        $sheet = $this->sheet;
+
+        $sheet1 = $this->spreadsheet->createSheet();
+        $sheet1->setTitle('OtherSheet');
+        $this->spreadsheet->addNamedRange(new NamedRange('newnr', $sheet1, '$F$5:$H$5', true)); // defined locally, only usable on sheet1
+
+        $sheet1->getCell('B3')->setValue('=COLUMNS(newnr)');
+        $result = $sheet1->getCell('B3')->getCalculatedValue();
+        self::assertSame(3, $result);
+
+        $sheet->getCell('B3')->setValue('=COLUMNS(newnr)');
+        $result = $sheet->getCell('B3')->getCalculatedValue();
+        self::assertSame('#NAME?', $result);
+    }
+}

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnsOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnsOnSpreadsheetTest.php
@@ -33,7 +33,7 @@ class ColumnsOnSpreadsheetTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerCOLUMNSonSpreadsheet()
+    public function providerCOLUMNSonSpreadsheet(): array
     {
         return require 'tests/data/Calculation/LookupRef/COLUMNSonSpreadsheet.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndirectTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndirectTest.php
@@ -74,4 +74,21 @@ class IndirectTest extends AllSetupTeardown
         $result = $sheet->getCell('B3')->getCalculatedValue();
         self::assertSame('#REF!', $result);
     }
+
+    public function testINDIRECTEurUsd(): void
+    {
+        $sheet = $this->sheet;
+        $sheet->getCell('A1')->setValue('EUR');
+        $sheet->getCell('A2')->setValue('USD');
+        $sheet->getCell('B1')->setValue(360);
+        $sheet->getCell('B2')->setValue(300);
+
+        $this->spreadsheet->addNamedRange(new NamedRange('EUR', $sheet, '$B$1'));
+        $this->spreadsheet->addNamedRange(new NamedRange('USD', $sheet, '$B$2'));
+
+        $this->setCell('E1', '=INDIRECT("USD")');
+
+        $result = $sheet->getCell('E1')->getCalculatedValue();
+        self::assertSame(300, $result);
+    }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndirectTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndirectTest.php
@@ -2,54 +2,76 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
-use PhpOffice\PhpSpreadsheet\Calculation\LookupRef;
-use PhpOffice\PhpSpreadsheet\Cell\Cell;
-use PHPUnit\Framework\TestCase;
+use PhpOffice\PhpSpreadsheet\NamedRange;
 
-class IndirectTest extends TestCase
+class IndirectTest extends AllSetupTeardown
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-    }
-
     /**
      * @dataProvider providerINDIRECT
      *
      * @param mixed $expectedResult
-     * @param null|mixed $cellReference
+     * @param mixed $cellReference
+     * @param mixed $a1
      */
-    public function testINDIRECT($expectedResult, $cellReference = null): void
+    public function testINDIRECT($expectedResult, $cellReference = 'omitted', $a1 = 'omitted'): void
     {
-//        $calculation = $this->getMockBuilder(Calculation::class)
-//            ->setMethods(['getInstance', 'extractCellRange'])
-//            ->disableOriginalConstructor()
-//            ->getMock();
-//        $calculation->method('getInstance')
-//            ->willReturn($calculation);
-//        $calculation->method('extractCellRange')
-//            ->willReturn([]);
-//
-//        $worksheet = $this->getMockBuilder(Cell::class)
-//            ->setMethods(['getParent'])
-//            ->disableOriginalConstructor()
-//            ->getMock();
-//
-//        $cell = $this->getMockBuilder(Cell::class)
-//            ->setMethods(['getWorksheet'])
-//            ->disableOriginalConstructor()
-//            ->getMock();
-//        $cell->method('getWorksheet')
-//            ->willReturn($worksheet);
+        $this->mightHaveException($expectedResult);
+        $sheet = $this->sheet;
+        $sheet->getCell('A1')->setValue(100);
+        $sheet->getCell('A2')->setValue(200);
+        $sheet->getCell('A3')->setValue(300);
+        $sheet->getCell('A4')->setValue(400);
+        $sheet->getCell('A5')->setValue(500);
 
-        $result = LookupRef::INDIRECT($cellReference);
+        $sheet1 = $this->spreadsheet->createSheet();
+        $sheet1->getCell('A1')->setValue(10);
+        $sheet1->getCell('A2')->setValue(20);
+        $sheet1->getCell('A3')->setValue(30);
+        $sheet1->getCell('A4')->setValue(40);
+        $sheet1->getCell('A5')->setValue(50);
+        $sheet1->setTitle('OtherSheet');
+        $this->spreadsheet->addNamedRange(new NamedRange('newnr', $sheet1, '$A$2:$A$4'));
+
+        $this->setCell('B1', $cellReference);
+        $this->setCell('B2', $a1);
+        if ($cellReference === 'omitted') {
+            $sheet->getCell('B3')->setValue('=SUM(INDIRECT())');
+        } elseif ($a1 === 'omitted') {
+            $sheet->getCell('B3')->setValue('=SUM(INDIRECT(B1))');
+        } else {
+            $sheet->getCell('B3')->setValue('=SUM(INDIRECT(B1, B2))');
+        }
+
+        $result = $sheet->getCell('B3')->getCalculatedValue();
         self::assertSame($expectedResult, $result);
     }
 
     public function providerINDIRECT()
     {
         return require 'tests/data/Calculation/LookupRef/INDIRECT.php';
+    }
+
+    public function testINDIRECTLocalDefinedName(): void
+    {
+        $sheet = $this->sheet;
+
+        $sheet1 = $this->spreadsheet->createSheet();
+        $sheet1->getCell('A1')->setValue(10);
+        $sheet1->getCell('A2')->setValue(20);
+        $sheet1->getCell('A3')->setValue(30);
+        $sheet1->getCell('A4')->setValue(40);
+        $sheet1->getCell('A5')->setValue(50);
+        $sheet1->setTitle('OtherSheet');
+        $this->spreadsheet->addNamedRange(new NamedRange('newnr', $sheet1, '$A$2:$A$4', true)); // defined locally, only usable on sheet1
+
+        $sheet1->getCell('B1')->setValue('newnr');
+        $sheet1->getCell('B3')->setValue('=SUM(INDIRECT(B1))');
+        $result = $sheet1->getCell('B3')->getCalculatedValue();
+        self::assertSame(90, $result);
+
+        $sheet->getCell('B1')->setValue('newnr');
+        $sheet->getCell('B3')->setValue('=SUM(INDIRECT(B1))');
+        $result = $sheet->getCell('B3')->getCalculatedValue();
+        self::assertSame('#REF!', $result);
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowOnSpreadsheetTest.php
@@ -33,7 +33,7 @@ class RowOnSpreadsheetTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerROWOnSpreadsheet()
+    public function providerROWOnSpreadsheet(): array
     {
         return require 'tests/data/Calculation/LookupRef/ROWonSpreadsheet.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowOnSpreadsheetTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
+
+use PhpOffice\PhpSpreadsheet\NamedRange;
+
+class RowOnSpreadsheetTest extends AllSetupTeardown
+{
+    /**
+     * @dataProvider providerROWonSpreadsheet
+     *
+     * @param mixed $expectedResult
+     * @param string $cellReference
+     */
+    public function testRowOnSpreadsheet($expectedResult, $cellReference = 'omitted'): void
+    {
+        $this->mightHaveException($expectedResult);
+        $sheet = $this->sheet;
+        $this->spreadsheet->addNamedRange(new NamedRange('namedrangex', $sheet, '$E$2:$E$6'));
+        $this->spreadsheet->addNamedRange(new NamedRange('namedrangey', $sheet, '$F$2:$H$2'));
+        $this->spreadsheet->addNamedRange(new NamedRange('namedrange3', $sheet, '$F$4:$H$4'));
+
+        $sheet1 = $this->spreadsheet->createSheet();
+        $sheet1->setTitle('OtherSheet');
+
+        if ($cellReference === 'omitted') {
+            $sheet->getCell('B3')->setValue('=ROW()');
+        } else {
+            $sheet->getCell('B3')->setValue("=ROW($cellReference)");
+        }
+
+        $result = $sheet->getCell('B3')->getCalculatedValue();
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function providerROWOnSpreadsheet()
+    {
+        return require 'tests/data/Calculation/LookupRef/ROWonSpreadsheet.php';
+    }
+
+    public function testINDIRECTLocalDefinedName(): void
+    {
+        $sheet = $this->sheet;
+
+        $sheet1 = $this->spreadsheet->createSheet();
+        $sheet1->setTitle('OtherSheet');
+        $this->spreadsheet->addNamedRange(new NamedRange('newnr', $sheet1, '$F$5:$H$5', true)); // defined locally, only usable on sheet1
+
+        $sheet1->getCell('B3')->setValue('=ROW(newnr)');
+        $result = $sheet1->getCell('B3')->getCalculatedValue();
+        self::assertSame(5, $result);
+
+        $sheet->getCell('B3')->setValue('=ROW(newnr)');
+        $result = $sheet->getCell('B3')->getCalculatedValue();
+        self::assertSame('#NAME?', $result);
+    }
+}

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowsOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowsOnSpreadsheetTest.php
@@ -33,7 +33,7 @@ class RowsOnSpreadsheetTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerROWSOnSpreadsheet()
+    public function providerROWSOnSpreadsheet(): array
     {
         return require 'tests/data/Calculation/LookupRef/ROWSonSpreadsheet.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowsOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowsOnSpreadsheetTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
+
+use PhpOffice\PhpSpreadsheet\NamedRange;
+
+class RowsOnSpreadsheetTest extends AllSetupTeardown
+{
+    /**
+     * @dataProvider providerROWSonSpreadsheet
+     *
+     * @param mixed $expectedResult
+     * @param string $cellReference
+     */
+    public function testRowsOnSpreadsheet($expectedResult, $cellReference = 'omitted'): void
+    {
+        $this->mightHaveException($expectedResult);
+        $sheet = $this->sheet;
+        $this->spreadsheet->addNamedRange(new NamedRange('namedrangex', $sheet, '$E$2:$E$6'));
+        $this->spreadsheet->addNamedRange(new NamedRange('namedrangey', $sheet, '$F$2:$H$2'));
+        $this->spreadsheet->addNamedRange(new NamedRange('namedrange3', $sheet, '$F$4:$H$4'));
+
+        $sheet1 = $this->spreadsheet->createSheet();
+        $sheet1->setTitle('OtherSheet');
+
+        if ($cellReference === 'omitted') {
+            $sheet->getCell('B3')->setValue('=ROWS()');
+        } else {
+            $sheet->getCell('B3')->setValue("=ROWS($cellReference)");
+        }
+
+        $result = $sheet->getCell('B3')->getCalculatedValue();
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function providerROWSOnSpreadsheet()
+    {
+        return require 'tests/data/Calculation/LookupRef/ROWSonSpreadsheet.php';
+    }
+
+    public function testRowsLocalDefinedName(): void
+    {
+        $sheet = $this->sheet;
+
+        $sheet1 = $this->spreadsheet->createSheet();
+        $sheet1->setTitle('OtherSheet');
+        $this->spreadsheet->addNamedRange(new NamedRange('newnr', $sheet1, '$F$5:$H$10', true)); // defined locally, only usable on sheet1
+
+        $sheet1->getCell('B3')->setValue('=ROWS(newnr)');
+        $result = $sheet1->getCell('B3')->getCalculatedValue();
+        self::assertSame(6, $result);
+
+        $sheet->getCell('B3')->setValue('=ROWS(newnr)');
+        $result = $sheet->getCell('B3')->getCalculatedValue();
+        self::assertSame('#NAME?', $result);
+    }
+}

--- a/tests/data/Calculation/LookupRef/COLUMNSonSpreadsheet.php
+++ b/tests/data/Calculation/LookupRef/COLUMNSonSpreadsheet.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    ['exception', 'omitted'],
+    ['#NAME?', 'InvalidCellAddress'],
+    ['#NAME?', 'A2:InvalidCellAddress'],
+    [1, 'C7'],
+    [1, '$C$15'],
+    [1, 'namedrangex'],
+    [3, 'namedrangey'],
+    [3, 'namedrange3'],
+    ['#NAME?', 'namedrange2'],
+    [6, 'OtherSheet!B1:G1'],
+    [6, 'UnknownSheet!A1:F1'],
+];

--- a/tests/data/Calculation/LookupRef/COLUMNonSpreadsheet.php
+++ b/tests/data/Calculation/LookupRef/COLUMNonSpreadsheet.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    [2, 'omitted'],
+    ['#NAME?', 'InvalidCellAddress'],
+    ['#NAME?', 'A2:InvalidCellAddress'],
+    [3, 'C7'],
+    [3, '$C$15'],
+    [5, 'namedrangex'],
+    [6, 'namedrangey'],
+    [6, 'namedrange3'],
+    ['#NAME?', 'namedrange2'],
+    [1, 'OtherSheet!A1'],
+    [1, 'UnknownSheet!A1'],
+];

--- a/tests/data/Calculation/LookupRef/INDIRECT.php
+++ b/tests/data/Calculation/LookupRef/INDIRECT.php
@@ -1,16 +1,22 @@
 <?php
 
 return [
-    [
-        '#REF!',
-        null,
-    ],
-    [
-        '#REF!',
-        'InvalidCellAddress',
-    ],
-    [
-        '#REF!',
-        'C2:InvalidCellAddress',
-    ],
+    ['#REF!', null],
+    ['#REF!', 'InvalidCellAddress'],
+    ['#REF!', 'A2:InvalidCellAddress'],
+    [100, 'A1'],
+    [500, 'A2:A3'],
+    [600, '$A$1:$A$3'],
+    [900, 'A2:A4', true],
+    [200, 'R2C1', false],
+    [200, 'R2C1', 0],
+    ['#VALUE!', 'R2C1', '0'],
+    [600, 'R1C1:R3C1', false],
+    [10, 'OtherSheet!A1'],
+    [30, 'OtherSheet!A1:A2'],
+    [30, 'OtherSheet!$A$3'],
+    [40, 'OtherSheet!R4C1', false],
+    [90, 'OtherSheet!R4C1:R5C1', false],
+    [90, 'newnr'],
+    [90, 'newnr', false],
 ];

--- a/tests/data/Calculation/LookupRef/ROWSonSpreadsheet.php
+++ b/tests/data/Calculation/LookupRef/ROWSonSpreadsheet.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    ['exception', 'omitted'],
+    ['#NAME?', 'InvalidCellAddress'],
+    ['#NAME?', 'A2:InvalidCellAddress'],
+    [1, 'C7'],
+    [1, '$C$7'],
+    [5, 'namedrangex'],
+    [1, 'namedrangey'],
+    [1, 'namedrange3'],
+    ['#NAME?', 'namedrange2'],
+    [6, 'OtherSheet!A1:H6'],
+    [5, 'UnknownSheet!B2:K6'],
+];

--- a/tests/data/Calculation/LookupRef/ROWonSpreadsheet.php
+++ b/tests/data/Calculation/LookupRef/ROWonSpreadsheet.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    [3, 'omitted'],
+    ['#NAME?', 'InvalidCellAddress'],
+    ['#NAME?', 'A2:InvalidCellAddress'],
+    [7, 'C7'],
+    [7, '$C$7'],
+    [2, 'namedrangex'],
+    [2, 'namedrangey'],
+    [4, 'namedrange3'],
+    ['#NAME?', 'namedrange2'],
+    [1, 'OtherSheet!A1'],
+    [1, 'UnknownSheet!A1'],
+];


### PR DESCRIPTION
This should address issues #1913 and #1993. INDIRECT had heretofore not supported an optional parameter intended to support addresses in R1C1 format which was introduced with Excel 2010. It also had not supported the use of defined names as an argument.

The unit tests for INDIRECT had used mocking, and were sorely lacking (tested only error conditions). They have been replaced with normal, and hopefully adequate, tests. This includes testing globally defined names, as well as locally defined names, both in and out of scope.

The test case in 1913 was too complicated for me to add as a unit test. The main impediments to it are now removed, and its complex situation, will I hope, be corrected with this fix.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
