### PR TITLE
MathTrig - Change Names of funcWhatever to evaluate

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1746,21 +1746,6 @@ parameters:
 			path: src/PhpSpreadsheet/Calculation/TextData/Extract.php
 
 		-
-			message: "#^Parameter \\#1 \\$number of static method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\MathTrig\\\\Mround\\:\\:funcMround\\(\\) expects float, float\\|int\\|string given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/TextData/Format.php
-
-		-
-			message: "#^Parameter \\#1 \\$number of function floor expects float, float\\|int\\|string given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/TextData/Format.php
-
-		-
-			message: "#^Parameter \\#1 \\$number of function round expects float, float\\|int\\|string given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/TextData/Format.php
-
-		-
 			message: "#^Cannot cast array\\|float\\|int\\|string to float\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Calculation/TextData/Format.php

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -243,22 +243,22 @@ class Calculation
         ],
         'ACOS' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Acos::class, 'funcAcos'],
+            'functionCall' => [MathTrig\Acos::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'ACOSH' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Acosh::class, 'funcAcosh'],
+            'functionCall' => [MathTrig\Acosh::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'ACOT' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Acot::class, 'funcAcot'],
+            'functionCall' => [MathTrig\Acot::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'ACOTH' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Acoth::class, 'funcAcoth'],
+            'functionCall' => [MathTrig\Acoth::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'ADDRESS' => [
@@ -303,27 +303,27 @@ class Calculation
         ],
         'ASIN' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Asin::class, 'funcAsin'],
+            'functionCall' => [MathTrig\Asin::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'ASINH' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Asinh::class, 'funcAsinh'],
+            'functionCall' => [MathTrig\Asinh::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'ATAN' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Atan::class, 'funcAtan'],
+            'functionCall' => [MathTrig\Atan::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'ATAN2' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Atan2::class, 'funcAtan2'],
+            'functionCall' => [MathTrig\Atan2::class, 'evaluate'],
             'argumentCount' => '2',
         ],
         'ATANH' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Atanh::class, 'funcAtanh'],
+            'functionCall' => [MathTrig\Atanh::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'AVEDEV' => [
@@ -358,7 +358,7 @@ class Calculation
         ],
         'BASE' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Base::class, 'funcBase'],
+            'functionCall' => [MathTrig\Base::class, 'evaluate'],
             'argumentCount' => '2,3',
         ],
         'BESSELI' => [
@@ -463,17 +463,17 @@ class Calculation
         ],
         'CEILING' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Ceiling::class, 'funcCeiling'],
+            'functionCall' => [MathTrig\Ceiling::class, 'evaluate'],
             'argumentCount' => '1-2', // 2 for Excel, 1-2 for Ods/Gnumeric
         ],
         'CEILING.MATH' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\CeilingMath::class, 'funcCeilingMath'],
+            'functionCall' => [MathTrig\CeilingMath::class, 'evaluate'],
             'argumentCount' => '1-3',
         ],
         'CEILING.PRECISE' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\CeilingPrecise::class, 'funcCeilingPrecise'],
+            'functionCall' => [MathTrig\CeilingPrecise::class, 'evaluate'],
             'argumentCount' => '1,2',
         ],
         'CELL' => [
@@ -605,22 +605,22 @@ class Calculation
         ],
         'COS' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Cos::class, 'funcCos'],
+            'functionCall' => [MathTrig\Cos::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'COSH' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Cosh::class, 'funcCosh'],
+            'functionCall' => [MathTrig\Cosh::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'COT' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Cot::class, 'funcCot'],
+            'functionCall' => [MathTrig\Cot::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'COTH' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Coth::class, 'funcCoth'],
+            'functionCall' => [MathTrig\Coth::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'COUNT' => [
@@ -700,12 +700,12 @@ class Calculation
         ],
         'CSC' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Csc::class, 'funcCsc'],
+            'functionCall' => [MathTrig\Csc::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'CSCH' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Csch::class, 'funcCsch'],
+            'functionCall' => [MathTrig\Csch::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'CUBEKPIMEMBER' => [
@@ -965,7 +965,7 @@ class Calculation
         ],
         'EVEN' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Even::class, 'funcEven'],
+            'functionCall' => [MathTrig\Even::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'EXACT' => [
@@ -990,7 +990,7 @@ class Calculation
         ],
         'FACT' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Fact::class, 'funcFact'],
+            'functionCall' => [MathTrig\Fact::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'FACTDOUBLE' => [
@@ -1070,17 +1070,17 @@ class Calculation
         ],
         'FLOOR' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Floor::class, 'funcFloor'],
+            'functionCall' => [MathTrig\Floor::class, 'evaluate'],
             'argumentCount' => '1-2', // Excel requries 2, Ods/Gnumeric 1-2
         ],
         'FLOOR.MATH' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\FloorMath::class, 'funcFloorMath'],
+            'functionCall' => [MathTrig\FloorMath::class, 'evaluate'],
             'argumentCount' => '1-3',
         ],
         'FLOOR.PRECISE' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\FloorPrecise::class, 'funcFloorPrecise'],
+            'functionCall' => [MathTrig\FloorPrecise::class, 'evaluate'],
             'argumentCount' => '1-2',
         ],
         'FORECAST' => [
@@ -1419,7 +1419,7 @@ class Calculation
         ],
         'INT' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\IntClass::class, 'funcInt'],
+            'functionCall' => [MathTrig\IntClass::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'INTERCEPT' => [
@@ -1536,7 +1536,7 @@ class Calculation
         ],
         'LCM' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Lcm::class, 'funcLcm'],
+            'functionCall' => [MathTrig\Lcm::class, 'evaluate'],
             'argumentCount' => '1+',
         ],
         'LEFT' => [
@@ -1636,7 +1636,7 @@ class Calculation
         ],
         'MDETERM' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\MatrixFunctions::class, 'funcMDeterm'],
+            'functionCall' => [MathTrig\MatrixFunctions::class, 'determinant'],
             'argumentCount' => '1',
         ],
         'MDURATION' => [
@@ -1686,7 +1686,7 @@ class Calculation
         ],
         'MINVERSE' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\MatrixFunctions::class, 'funcMinverse'],
+            'functionCall' => [MathTrig\MatrixFunctions::class, 'inverse'],
             'argumentCount' => '1',
         ],
         'MIRR' => [
@@ -1696,7 +1696,7 @@ class Calculation
         ],
         'MMULT' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\MatrixFunctions::class, 'funcMMult'],
+            'functionCall' => [MathTrig\MatrixFunctions::class, 'multiply'],
             'argumentCount' => '2',
         ],
         'MOD' => [
@@ -1726,17 +1726,17 @@ class Calculation
         ],
         'MROUND' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Mround::class, 'funcMround'],
+            'functionCall' => [MathTrig\Mround::class, 'evaluate'],
             'argumentCount' => '2',
         ],
         'MULTINOMIAL' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Multinomial::class, 'funcMultinomial'],
+            'functionCall' => [MathTrig\Multinomial::class, 'evaluate'],
             'argumentCount' => '1+',
         ],
         'MUNIT' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\MatrixFunctions::class, 'funcMUnit'],
+            'functionCall' => [MathTrig\MatrixFunctions::class, 'identity'],
             'argumentCount' => '1',
         ],
         'N' => [
@@ -1856,7 +1856,7 @@ class Calculation
         ],
         'ODD' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Odd::class, 'funcOdd'],
+            'functionCall' => [MathTrig\Odd::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'ODDFPRICE' => [
@@ -2003,7 +2003,7 @@ class Calculation
         ],
         'PRODUCT' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Product::class, 'funcProduct'],
+            'functionCall' => [MathTrig\Product::class, 'evaluate'],
             'argumentCount' => '1+',
         ],
         'PROPER' => [
@@ -2033,7 +2033,7 @@ class Calculation
         ],
         'QUOTIENT' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Quotient::class, 'funcQuotient'],
+            'functionCall' => [MathTrig\Quotient::class, 'evaluate'],
             'argumentCount' => '2',
         ],
         'RADIANS' => [
@@ -2108,22 +2108,22 @@ class Calculation
         ],
         'ROMAN' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Roman::class, 'funcRoman'],
+            'functionCall' => [MathTrig\Roman::class, 'evaluate'],
             'argumentCount' => '1,2',
         ],
         'ROUND' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Round::class, 'builtinROUND'],
+            'functionCall' => [MathTrig\Round::class, 'evaluate'],
             'argumentCount' => '2',
         ],
         'ROUNDDOWN' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\RoundDown::class, 'funcRoundDown'],
+            'functionCall' => [MathTrig\RoundDown::class, 'evaluate'],
             'argumentCount' => '2',
         ],
         'ROUNDUP' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\RoundUp::class, 'funcRoundUp'],
+            'functionCall' => [MathTrig\RoundUp::class, 'evaluate'],
             'argumentCount' => '2',
         ],
         'ROW' => [
@@ -2165,12 +2165,12 @@ class Calculation
         ],
         'SEC' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Sec::class, 'funcSec'],
+            'functionCall' => [MathTrig\Sec::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'SECH' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Sech::class, 'funcSech'],
+            'functionCall' => [MathTrig\Sech::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'SECOND' => [
@@ -2185,7 +2185,7 @@ class Calculation
         ],
         'SERIESSUM' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\SeriesSum::class, 'funcSeriesSum'],
+            'functionCall' => [MathTrig\SeriesSum::class, 'evaluate'],
             'argumentCount' => '4',
         ],
         'SHEET' => [
@@ -2200,17 +2200,17 @@ class Calculation
         ],
         'SIGN' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Sign::class, 'funcSign'],
+            'functionCall' => [MathTrig\Sign::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'SIN' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Sin::class, 'funcSin'],
+            'functionCall' => [MathTrig\Sin::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'SINH' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Sinh::class, 'funcSinh'],
+            'functionCall' => [MathTrig\Sinh::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'SKEW' => [
@@ -2305,7 +2305,7 @@ class Calculation
         ],
         'SUBTOTAL' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Subtotal::class, 'funcSubtotal'],
+            'functionCall' => [MathTrig\Subtotal::class, 'evaluate'],
             'argumentCount' => '2+',
             'passCellReference' => true,
         ],
@@ -2326,7 +2326,7 @@ class Calculation
         ],
         'SUMPRODUCT' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\SumProduct::class, 'funcSumProduct'],
+            'functionCall' => [MathTrig\SumProduct::class, 'evaluate'],
             'argumentCount' => '1+',
         ],
         'SUMSQ' => [
@@ -2366,12 +2366,12 @@ class Calculation
         ],
         'TAN' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Tan::class, 'funcTan'],
+            'functionCall' => [MathTrig\Tan::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'TANH' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Tanh::class, 'funcTanh'],
+            'functionCall' => [MathTrig\Tanh::class, 'evaluate'],
             'argumentCount' => '1',
         ],
         'TBILLEQ' => [
@@ -2476,7 +2476,7 @@ class Calculation
         ],
         'TRUNC' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => [MathTrig\Trunc::class, 'funcTrunc'],
+            'functionCall' => [MathTrig\Trunc::class, 'evaluate'],
             'argumentCount' => '1,2',
         ],
         'TTEST' => [

--- a/src/PhpSpreadsheet/Calculation/Database/DProduct.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DProduct.php
@@ -38,7 +38,7 @@ class DProduct extends DatabaseAbstract
             return null;
         }
 
-        return MathTrig\Product::funcProduct(
+        return MathTrig\Product::evaluate(
             self::getFilteredColumn($database, $field, $criteria)
         );
     }

--- a/src/PhpSpreadsheet/Calculation/MathTrig.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig.php
@@ -36,7 +36,7 @@ class MathTrig
      * Note that the Excel ATAN2() function accepts its arguments in the reverse order to the standard
      *        PHP atan2() function, so we need to reverse them here before calling the PHP atan() function.
      *
-     * @Deprecated 2.0.0 Use the funcAtan2 method in the MathTrig\Atan2 class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Atan2 class instead
      *
      * Excel Function:
      *        ATAN2(xCoordinate,yCoordinate)
@@ -48,7 +48,7 @@ class MathTrig
      */
     public static function ATAN2($xCoordinate = null, $yCoordinate = null)
     {
-        return MathTrig\Atan2::funcAtan2($xCoordinate, $yCoordinate);
+        return MathTrig\Atan2::evaluate($xCoordinate, $yCoordinate);
     }
 
     /**
@@ -56,7 +56,7 @@ class MathTrig
      *
      * Converts a number into a text representation with the given radix (base).
      *
-     * @Deprecated 2.0.0 Use the funcBase method in the MathTrig\Base class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Base class instead
      *
      * Excel Function:
      *        BASE(Number, Radix [Min_length])
@@ -69,7 +69,7 @@ class MathTrig
      */
     public static function BASE($number, $radix, $minLength = null)
     {
-        return MathTrig\Base::funcBase($number, $radix, $minLength);
+        return MathTrig\Base::evaluate($number, $radix, $minLength);
     }
 
     /**
@@ -85,7 +85,7 @@ class MathTrig
      *
      * @Deprecated 1.17.0
      *
-     * @see Use the funcCeiling() method in the MathTrig\Ceiling class instead
+     * @see Use the evaluate method in the MathTrig\Ceiling class instead
      *
      * @param float $number the number you want to round
      * @param float $significance the multiple to which you want to round
@@ -94,7 +94,7 @@ class MathTrig
      */
     public static function CEILING($number, $significance = null)
     {
-        return MathTrig\Ceiling::funcCeiling($number, $significance);
+        return MathTrig\Ceiling::evaluate($number, $significance);
     }
 
     /**
@@ -121,7 +121,7 @@ class MathTrig
     /**
      * EVEN.
      *
-     * @Deprecated 2.0.0 Use the funcEven method in the MathTrig\Even class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Even class instead
      *
      * Returns number rounded up to the nearest even integer.
      * You can use this function for processing items that come in twos. For example,
@@ -138,7 +138,7 @@ class MathTrig
      */
     public static function EVEN($number)
     {
-        return MathTrig\Even::funcEven($number);
+        return MathTrig\Even::evaluate($number);
     }
 
     /**
@@ -157,7 +157,7 @@ class MathTrig
      * Returns the factorial of a number.
      * The factorial of a number is equal to 1*2*3*...* number.
      *
-     * @Deprecated 2.0.0 Use the funcFact method in the MathTrig\Fact class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Fact class instead
      *
      * Excel Function:
      *        FACT(factVal)
@@ -168,7 +168,7 @@ class MathTrig
      */
     public static function FACT($factVal)
     {
-        return MathTrig\Fact::funcFact($factVal);
+        return MathTrig\Fact::evaluate($factVal);
     }
 
     /**
@@ -200,7 +200,7 @@ class MathTrig
      *
      * @Deprecated 1.17.0
      *
-     * @see Use the funcFloor() method in the MathTrig\Floor class instead
+     * @see Use the evaluate method in the MathTrig\Floor class instead
      *
      * @param float $number Number to round
      * @param float $significance Significance
@@ -209,7 +209,7 @@ class MathTrig
      */
     public static function FLOOR($number, $significance = null)
     {
-        return MathTrig\Floor::funcFloor($number, $significance);
+        return MathTrig\Floor::evaluate($number, $significance);
     }
 
     /**
@@ -222,7 +222,7 @@ class MathTrig
      *
      * @Deprecated 1.17.0
      *
-     * @see Use the funcFloorMath() method in the MathTrig\FloorMath class instead
+     * @see Use the evaluate method in the MathTrig\FloorMath class instead
      *
      * @param float $number Number to round
      * @param float $significance Significance
@@ -232,7 +232,7 @@ class MathTrig
      */
     public static function FLOORMATH($number, $significance = null, $mode = 0)
     {
-        return MathTrig\FloorMath::funcFloorMath($number, $significance, $mode);
+        return MathTrig\FloorMath::evaluate($number, $significance, $mode);
     }
 
     /**
@@ -245,7 +245,7 @@ class MathTrig
      *
      * @Deprecated 1.17.0
      *
-     * @see Use the funcFloorPrecise() method in the MathTrig\FloorPrecise class instead
+     * @see Use the evaluate method in the MathTrig\FloorPrecise class instead
      *
      * @param float $number Number to round
      * @param float $significance Significance
@@ -254,7 +254,7 @@ class MathTrig
      */
     public static function FLOORPRECISE($number, $significance = 1)
     {
-        return MathTrig\FloorPrecise::funcFloorPrecise($number, $significance);
+        return MathTrig\FloorPrecise::evaluate($number, $significance);
     }
 
     /**
@@ -267,7 +267,7 @@ class MathTrig
      *
      * @Deprecated 1.17.0
      *
-     * @see Use the funcInt() method in the MathTrig\IntClass class instead
+     * @see Use the evaluate method in the MathTrig\IntClass class instead
      *
      * @param float $number Number to cast to an integer
      *
@@ -275,7 +275,7 @@ class MathTrig
      */
     public static function INT($number)
     {
-        return MathTrig\IntClass::funcInt($number);
+        return MathTrig\IntClass::evaluate($number);
     }
 
     /**
@@ -307,7 +307,7 @@ class MathTrig
      * of all integer arguments number1, number2, and so on. Use LCM to add fractions
      * with different denominators.
      *
-     * @Deprecated 2.0.0 Use the funcLcm method in the MathTrig\Lcm class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Lcm class instead
      *
      * Excel Function:
      *        LCM(number1[,number2[, ...]])
@@ -318,7 +318,7 @@ class MathTrig
      */
     public static function LCM(...$args)
     {
-        return MathTrig\Lcm::funcLcm(...$args);
+        return MathTrig\Lcm::evaluate(...$args);
     }
 
     /**
@@ -346,7 +346,7 @@ class MathTrig
      *
      * Returns the matrix determinant of an array.
      *
-     * @Deprecated 2.0.0 Use the funcMDeterm method in the MathTrig\MatrixFuncs class instead
+     * @Deprecated 2.0.0 Use the Determinant method in the MathTrig\MatrixFuncs class instead
      *
      * Excel Function:
      *        MDETERM(array)
@@ -357,7 +357,7 @@ class MathTrig
      */
     public static function MDETERM($matrixValues)
     {
-        return MathTrig\MatrixFunctions::funcMDeterm($matrixValues);
+        return MathTrig\MatrixFunctions::determinant($matrixValues);
     }
 
     /**
@@ -365,7 +365,7 @@ class MathTrig
      *
      * Returns the inverse matrix for the matrix stored in an array.
      *
-     * @Deprecated 2.0.0 Use the funcMInverse method in the MathTrig\MatrixFuncs class instead
+     * @Deprecated 2.0.0 Use the Inverse method in the MathTrig\MatrixFuncs class instead
      *
      * Excel Function:
      *        MINVERSE(array)
@@ -376,13 +376,13 @@ class MathTrig
      */
     public static function MINVERSE($matrixValues)
     {
-        return MathTrig\MatrixFunctions::funcMInverse($matrixValues);
+        return MathTrig\MatrixFunctions::inverse($matrixValues);
     }
 
     /**
      * MMULT.
      *
-     * @Deprecated 2.0.0 Use the funcMMult method in the MathTrig\MatrixFuncs class instead
+     * @Deprecated 2.0.0 Use the Multiply method in the MathTrig\MatrixFuncs class instead
      *
      * @param array $matrixData1 A matrix of values
      * @param array $matrixData2 A matrix of values
@@ -391,7 +391,7 @@ class MathTrig
      */
     public static function MMULT($matrixData1, $matrixData2)
     {
-        return MathTrig\MatrixFunctions::funcMMult($matrixData1, $matrixData2);
+        return MathTrig\MatrixFunctions::multiply($matrixData1, $matrixData2);
     }
 
     /**
@@ -416,7 +416,7 @@ class MathTrig
      *
      * @Deprecated 1.17.0
      *
-     * @see Use the funcMround() method in the MathTrig\Mround class instead
+     * @see Use the evaluate method in the MathTrig\Mround class instead
      *
      * @param float $number Number to round
      * @param int $multiple Multiple to which you want to round $number
@@ -425,7 +425,7 @@ class MathTrig
      */
     public static function MROUND($number, $multiple)
     {
-        return MathTrig\Mround::funcMround($number, $multiple);
+        return MathTrig\Mround::evaluate($number, $multiple);
     }
 
     /**
@@ -433,7 +433,7 @@ class MathTrig
      *
      * Returns the ratio of the factorial of a sum of values to the product of factorials.
      *
-     * @Deprecated 2.0.0 Use the funcMultinomial method in the MathTrig\Multinomial class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Multinomial class instead
      *
      * @param mixed[] $args An array of mixed values for the Data Series
      *
@@ -441,7 +441,7 @@ class MathTrig
      */
     public static function MULTINOMIAL(...$args)
     {
-        return MathTrig\Multinomial::funcMultinomial(...$args);
+        return MathTrig\Multinomial::evaluate(...$args);
     }
 
     /**
@@ -449,7 +449,7 @@ class MathTrig
      *
      * Returns number rounded up to the nearest odd integer.
      *
-     * @Deprecated 2.0.0 Use the funcOdd method in the MathTrig\Odd class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Odd class instead
      *
      * @param float $number Number to round
      *
@@ -457,7 +457,7 @@ class MathTrig
      */
     public static function ODD($number)
     {
-        return MathTrig\Odd::funcOdd($number);
+        return MathTrig\Odd::evaluate($number);
     }
 
     /**
@@ -482,7 +482,7 @@ class MathTrig
      *
      * PRODUCT returns the product of all the values and cells referenced in the argument list.
      *
-     * @Deprecated 2.0.0 Use the funcProduct method in the MathTrig\Product class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Product class instead
      *
      * Excel Function:
      *        PRODUCT(value1[,value2[, ...]])
@@ -493,7 +493,7 @@ class MathTrig
      */
     public static function PRODUCT(...$args)
     {
-        return MathTrig\Product::funcProduct(...$args);
+        return MathTrig\Product::evaluate(...$args);
     }
 
     /**
@@ -502,7 +502,7 @@ class MathTrig
      * QUOTIENT function returns the integer portion of a division. Numerator is the divided number
      *        and denominator is the divisor.
      *
-     * @Deprecated 2.0.0 Use the funcQuotient method in the MathTrig\Quotient class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Quotient class instead
      *
      * Excel Function:
      *        QUOTIENT(value1[,value2[, ...]])
@@ -514,7 +514,7 @@ class MathTrig
      */
     public static function QUOTIENT($numerator, $denominator)
     {
-        return MathTrig\Quotient::funcQuotient($numerator, $denominator);
+        return MathTrig\Quotient::evaluate($numerator, $denominator);
     }
 
     /**
@@ -539,7 +539,7 @@ class MathTrig
      *
      * @Deprecated 1.17.0
      *
-     * @see Use the funcRoman() method in the MathTrig\Roman class instead
+     * @see Use the evaluate method in the MathTrig\Roman class instead
      *
      * @param mixed $aValue Number to convert
      * @param mixed $style Number indicating one of five possible forms
@@ -548,7 +548,7 @@ class MathTrig
      */
     public static function ROMAN($aValue, $style = 0)
     {
-        return MathTrig\Roman::funcRoman($aValue, $style);
+        return MathTrig\Roman::evaluate($aValue, $style);
     }
 
     /**
@@ -567,7 +567,7 @@ class MathTrig
      */
     public static function ROUNDUP($number, $digits)
     {
-        return MathTrig\RoundUp::funcRoundUp($number, $digits);
+        return MathTrig\RoundUp::evaluate($number, $digits);
     }
 
     /**
@@ -577,7 +577,7 @@ class MathTrig
      *
      * @Deprecated 1.17.0
      *
-     * @see Use the funcRoundDown() method in the MathTrig\RoundDown class instead
+     * @see Use the evaluate method in the MathTrig\RoundDown class instead
      *
      * @param float $number Number to round
      * @param int $digits Number of digits to which you want to round $number
@@ -586,7 +586,7 @@ class MathTrig
      */
     public static function ROUNDDOWN($number, $digits)
     {
-        return MathTrig\RoundDown::funcRoundDown($number, $digits);
+        return MathTrig\RoundDown::evaluate($number, $digits);
     }
 
     /**
@@ -594,7 +594,7 @@ class MathTrig
      *
      * Returns the sum of a power series
      *
-     * @Deprecated 2.0.0 Use the funcSeriesSum method in the MathTrig\SeriesSum class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\SeriesSum class instead
      *
      * @param mixed $x Input value
      * @param mixed $n Initial power
@@ -605,7 +605,7 @@ class MathTrig
      */
     public static function SERIESSUM($x, $n, $m, ...$args)
     {
-        return MathTrig\SeriesSum::funcSeriesSum($x, $n, $m, ...$args);
+        return MathTrig\SeriesSum::evaluate($x, $n, $m, ...$args);
     }
 
     /**
@@ -614,7 +614,7 @@ class MathTrig
      * Determines the sign of a number. Returns 1 if the number is positive, zero (0)
      *        if the number is 0, and -1 if the number is negative.
      *
-     * @Deprecated 2.0.0 Use the funcSign method in the MathTrig\Sign class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Sign class instead
      *
      * @param float $number Number to round
      *
@@ -622,7 +622,7 @@ class MathTrig
      */
     public static function SIGN($number)
     {
-        return MathTrig\Sign::funcSign($number);
+        return MathTrig\Sign::evaluate($number);
     }
 
     /**
@@ -656,7 +656,7 @@ class MathTrig
      *
      * Returns a subtotal in a list or database.
      *
-     * @Deprecated 2.0.0 Use the funcSubtotal method in the MathTrig\Subtotal class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Subtotal class instead
      *
      * @param int $functionType
      *            A number 1 to 11 that specifies which function to
@@ -671,7 +671,7 @@ class MathTrig
      */
     public static function SUBTOTAL($functionType, ...$args)
     {
-        return MathTrig\Subtotal::funcSubtotal($functionType, ...$args);
+        return MathTrig\Subtotal::evaluate($functionType, ...$args);
     }
 
     /**
@@ -745,7 +745,7 @@ class MathTrig
      * Excel Function:
      *        SUMPRODUCT(value1[,value2[, ...]])
      *
-     * @Deprecated 2.0.0 Use the funcSumProduct method in the MathTrig\SumProduct class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\SumProduct class instead
      *
      * @param mixed ...$args Data values
      *
@@ -753,7 +753,7 @@ class MathTrig
      */
     public static function SUMPRODUCT(...$args)
     {
-        return MathTrig\SumProduct::funcSumProduct(...$args);
+        return MathTrig\SumProduct::evaluate(...$args);
     }
 
     /**
@@ -836,7 +836,7 @@ class MathTrig
      */
     public static function TRUNC($value = 0, $digits = 0)
     {
-        return MathTrig\Trunc::funcTrunc($value, $digits);
+        return MathTrig\Trunc::evaluate($value, $digits);
     }
 
     /**
@@ -844,7 +844,7 @@ class MathTrig
      *
      * Returns the secant of an angle.
      *
-     * @Deprecated 2.0.0 Use the funcSec method in the MathTrig\Sec class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Sec class instead
      *
      * @param float $angle Number
      *
@@ -852,7 +852,7 @@ class MathTrig
      */
     public static function SEC($angle)
     {
-        return MathTrig\Sec::funcSec($angle);
+        return MathTrig\Sec::evaluate($angle);
     }
 
     /**
@@ -860,7 +860,7 @@ class MathTrig
      *
      * Returns the hyperbolic secant of an angle.
      *
-     * @Deprecated 2.0.0 Use the funcSech method in the MathTrig\Sech class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Sech class instead
      *
      * @param float $angle Number
      *
@@ -868,7 +868,7 @@ class MathTrig
      */
     public static function SECH($angle)
     {
-        return MathTrig\Sech::funcSech($angle);
+        return MathTrig\Sech::evaluate($angle);
     }
 
     /**
@@ -876,7 +876,7 @@ class MathTrig
      *
      * Returns the cosecant of an angle.
      *
-     * @Deprecated 2.0.0 Use the funcCsc method in the MathTrig\Csc class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Csc class instead
      *
      * @param float $angle Number
      *
@@ -884,7 +884,7 @@ class MathTrig
      */
     public static function CSC($angle)
     {
-        return MathTrig\Csc::funcCsc($angle);
+        return MathTrig\Csc::evaluate($angle);
     }
 
     /**
@@ -892,7 +892,7 @@ class MathTrig
      *
      * Returns the hyperbolic cosecant of an angle.
      *
-     * @Deprecated 2.0.0 Use the funcCsch method in the MathTrig\Csch class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Csch class instead
      *
      * @param float $angle Number
      *
@@ -900,7 +900,7 @@ class MathTrig
      */
     public static function CSCH($angle)
     {
-        return MathTrig\Csch::funcCsch($angle);
+        return MathTrig\Csch::evaluate($angle);
     }
 
     /**
@@ -908,7 +908,7 @@ class MathTrig
      *
      * Returns the cotangent of an angle.
      *
-     * @Deprecated 2.0.0 Use the funcCot method in the MathTrig\Cot class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Cot class instead
      *
      * @param float $angle Number
      *
@@ -916,7 +916,7 @@ class MathTrig
      */
     public static function COT($angle)
     {
-        return MathTrig\Cot::funcCot($angle);
+        return MathTrig\Cot::evaluate($angle);
     }
 
     /**
@@ -932,7 +932,7 @@ class MathTrig
      */
     public static function COTH($angle)
     {
-        return MathTrig\Coth::funcCoth($angle);
+        return MathTrig\Coth::evaluate($angle);
     }
 
     /**
@@ -940,7 +940,7 @@ class MathTrig
      *
      * Returns the arccotangent of a number.
      *
-     * @Deprecated 2.0.0 Use the funcAcot method in the MathTrig\Acot class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Acot class instead
      *
      * @param float $number Number
      *
@@ -948,7 +948,7 @@ class MathTrig
      */
     public static function ACOT($number)
     {
-        return MathTrig\Acot::funcAcot($number);
+        return MathTrig\Acot::evaluate($number);
     }
 
     /**
@@ -970,7 +970,7 @@ class MathTrig
      *
      * Returns the hyperbolic arccotangent of a number.
      *
-     * @Deprecated 2.0.0 Use the funcAcoth method in the MathTrig\Acoth class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Acoth class instead
      *
      * @param float $number Number
      *
@@ -978,7 +978,7 @@ class MathTrig
      */
     public static function ACOTH($number)
     {
-        return MathTrig\Acoth::funcAcoth($number);
+        return MathTrig\Acoth::evaluate($number);
     }
 
     /**
@@ -988,7 +988,7 @@ class MathTrig
      *
      * @Deprecated 1.17.0
      *
-     * @see Use the builtinRound() method in the MathTrig\Round class instead
+     * @see Use the evaluate method in the MathTrig\Round class instead
      *
      * @param mixed $number Should be numeric
      * @param mixed $precision Should be int
@@ -997,7 +997,7 @@ class MathTrig
      */
     public static function builtinROUND($number, $precision)
     {
-        return MathTrig\Round::builtinRound($number, $precision);
+        return MathTrig\Round::evaluate($number, $precision);
     }
 
     /**
@@ -1019,7 +1019,7 @@ class MathTrig
     /**
      * ACOS.
      *
-     * @Deprecated 2.0.0 Use the funcAcos method in the MathTrig\Acos class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Acos class instead
      *
      * Returns the result of builtin function acos after validating args.
      *
@@ -1029,7 +1029,7 @@ class MathTrig
      */
     public static function builtinACOS($number)
     {
-        return MathTrig\Acos::funcAcos($number);
+        return MathTrig\Acos::evaluate($number);
     }
 
     /**
@@ -1037,7 +1037,7 @@ class MathTrig
      *
      * Returns the result of builtin function acosh after validating args.
      *
-     * @Deprecated 2.0.0 Use the funcAcosh method in the MathTrig\Acosh class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Acosh class instead
      *
      * @param mixed $number Should be numeric
      *
@@ -1045,7 +1045,7 @@ class MathTrig
      */
     public static function builtinACOSH($number)
     {
-        return MathTrig\Acosh::funcAcosh($number);
+        return MathTrig\Acosh::evaluate($number);
     }
 
     /**
@@ -1053,7 +1053,7 @@ class MathTrig
      *
      * Returns the result of builtin function asin after validating args.
      *
-     * @Deprecated 2.0.0 Use the funcAsin method in the MathTrig\Asin class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Asin class instead
      *
      * @param mixed $number Should be numeric
      *
@@ -1061,7 +1061,7 @@ class MathTrig
      */
     public static function builtinASIN($number)
     {
-        return MathTrig\Asin::funcAsin($number);
+        return MathTrig\Asin::evaluate($number);
     }
 
     /**
@@ -1069,7 +1069,7 @@ class MathTrig
      *
      * Returns the result of builtin function asinh after validating args.
      *
-     * @Deprecated 2.0.0 Use the funcAsinh method in the MathTrig\Asinh class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Asinh class instead
      *
      * @param mixed $number Should be numeric
      *
@@ -1077,7 +1077,7 @@ class MathTrig
      */
     public static function builtinASINH($number)
     {
-        return MathTrig\Asinh::funcAsinh($number);
+        return MathTrig\Asinh::evaluate($number);
     }
 
     /**
@@ -1085,7 +1085,7 @@ class MathTrig
      *
      * Returns the result of builtin function atan after validating args.
      *
-     * @Deprecated 2.0.0 Use the funcAtan method in the MathTrig\Atan class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Atan class instead
      *
      * @param mixed $number Should be numeric
      *
@@ -1093,7 +1093,7 @@ class MathTrig
      */
     public static function builtinATAN($number)
     {
-        return MathTrig\Atan::funcAtan($number);
+        return MathTrig\Atan::evaluate($number);
     }
 
     /**
@@ -1101,7 +1101,7 @@ class MathTrig
      *
      * Returns the result of builtin function atanh after validating args.
      *
-     * @Deprecated 2.0.0 Use the funcAtanh method in the MathTrig\Atanh class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Atanh class instead
      *
      * @param mixed $number Should be numeric
      *
@@ -1109,7 +1109,7 @@ class MathTrig
      */
     public static function builtinATANH($number)
     {
-        return MathTrig\Atanh::funcAtanh($number);
+        return MathTrig\Atanh::evaluate($number);
     }
 
     /**
@@ -1117,7 +1117,7 @@ class MathTrig
      *
      * Returns the result of builtin function cos after validating args.
      *
-     * @Deprecated 2.0.0 Use the funcCos method in the MathTrig\Cos class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Cos class instead
      *
      * @param mixed $number Should be numeric
      *
@@ -1125,7 +1125,7 @@ class MathTrig
      */
     public static function builtinCOS($number)
     {
-        return MathTrig\Cos::funcCos($number);
+        return MathTrig\Cos::evaluate($number);
     }
 
     /**
@@ -1133,7 +1133,7 @@ class MathTrig
      *
      * Returns the result of builtin function cos after validating args.
      *
-     * @Deprecated 2.0.0 Use the funcCosh method in the MathTrig\Cosh class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Cosh class instead
      *
      * @param mixed $number Should be numeric
      *
@@ -1141,7 +1141,7 @@ class MathTrig
      */
     public static function builtinCOSH($number)
     {
-        return MathTrig\Cosh::funcCosh($number);
+        return MathTrig\Cosh::evaluate($number);
     }
 
     /**
@@ -1213,7 +1213,7 @@ class MathTrig
      *
      * Returns the result of builtin function deg2rad after validating args.
      *
-     * @Deprecated 2.0.0 Use the funcSin method in the MathTrig\Sin class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Radians class instead
      *
      * @param mixed $number Should be numeric
      *
@@ -1227,7 +1227,7 @@ class MathTrig
     /**
      * SIN.
      *
-     * @Deprecated 2.0.0 Use the funcSin method in the MathTrig\Sin class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Sin class instead
      *
      * Returns the result of builtin function sin after validating args.
      *
@@ -1237,13 +1237,13 @@ class MathTrig
      */
     public static function builtinSIN($number)
     {
-        return MathTrig\Sin::funcSin($number);
+        return MathTrig\Sin::evaluate($number);
     }
 
     /**
      * SINH.
      *
-     * @Deprecated 2.0.0 Use the funcSinh method in the MathTrig\Sinh class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Sinh class instead
      *
      * Returns the result of builtin function sinh after validating args.
      *
@@ -1253,7 +1253,7 @@ class MathTrig
      */
     public static function builtinSINH($number)
     {
-        return MathTrig\Sinh::funcSinh($number);
+        return MathTrig\Sinh::evaluate($number);
     }
 
     /**
@@ -1277,7 +1277,7 @@ class MathTrig
      *
      * Returns the result of builtin function tan after validating args.
      *
-     * @Deprecated 2.0.0 Use the funcTan method in the MathTrig\Tan class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Tan class instead
      *
      * @param mixed $number Should be numeric
      *
@@ -1285,7 +1285,7 @@ class MathTrig
      */
     public static function builtinTAN($number)
     {
-        return MathTrig\Tan::funcTan($number);
+        return MathTrig\Tan::evaluate($number);
     }
 
     /**
@@ -1293,7 +1293,7 @@ class MathTrig
      *
      * Returns the result of builtin function sinh after validating args.
      *
-     * @Deprecated 2.0.0 Use the funcTanh method in the MathTrig\Tanh class instead
+     * @Deprecated 2.0.0 Use the evaluate method in the MathTrig\Tanh class instead
      *
      * @param mixed $number Should be numeric
      *
@@ -1301,7 +1301,7 @@ class MathTrig
      */
     public static function builtinTANH($number)
     {
-        return MathTrig\Tanh::funcTanh($number);
+        return MathTrig\Tanh::evaluate($number);
     }
 
     /**

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Acos.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Acos.php
@@ -15,7 +15,7 @@ class Acos
      *
      * @return float|string The arccosine of the number
      */
-    public static function funcAcos($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Acosh.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Acosh.php
@@ -15,7 +15,7 @@ class Acosh
      *
      * @return float|string The arccosine of the number
      */
-    public static function funcAcosh($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Acot.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Acot.php
@@ -15,7 +15,7 @@ class Acot
      *
      * @return float|string The arccotangent of the number
      */
-    public static function funcAcot($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Acoth.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Acoth.php
@@ -15,7 +15,7 @@ class Acoth
      *
      * @return float|string The hyperbolic arccotangent of the number
      */
-    public static function funcAcoth($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Asin.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Asin.php
@@ -15,7 +15,7 @@ class Asin
      *
      * @return float|string The arcsine of the number
      */
-    public static function funcAsin($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Asinh.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Asinh.php
@@ -15,7 +15,7 @@ class Asinh
      *
      * @return float|string The arc hyperbolic sine of the number
      */
-    public static function funcAsinh($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Atan.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Atan.php
@@ -15,7 +15,7 @@ class Atan
      *
      * @return float|string The arctangent of the number
      */
-    public static function funcAtan($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Atan2.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Atan2.php
@@ -28,7 +28,7 @@ class Atan2
      *
      * @return float|string the inverse tangent of the specified x- and y-coordinates, or a string containing an error
      */
-    public static function funcAtan2($xCoordinate, $yCoordinate)
+    public static function evaluate($xCoordinate, $yCoordinate)
     {
         try {
             $xCoordinate = Helpers::validateNumericNullBool($xCoordinate);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Atanh.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Atanh.php
@@ -15,7 +15,7 @@ class Atanh
      *
      * @return float|string The arc hyperbolic tangent of the number
      */
-    public static function funcAtanh($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Base.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Base.php
@@ -21,7 +21,7 @@ class Base
      *
      * @return string the text representation with the given radix (base)
      */
-    public static function funcBase($number, $radix, $minLength = null)
+    public static function evaluate($number, $radix, $minLength = null)
     {
         try {
             $number = (int) Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Ceiling.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Ceiling.php
@@ -23,7 +23,7 @@ class Ceiling
      *
      * @return float|string Rounded Number, or a string containing an error
      */
-    public static function funcCeiling($number, $significance = null)
+    public static function evaluate($number, $significance = null)
     {
         if ($significance === null) {
             self::floorCheck1Arg();

--- a/src/PhpSpreadsheet/Calculation/MathTrig/CeilingMath.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/CeilingMath.php
@@ -20,7 +20,7 @@ class CeilingMath
      *
      * @return float|string Rounded Number, or a string containing an error
      */
-    public static function funcCeilingMath($number, $significance = null, $mode = 0)
+    public static function evaluate($number, $significance = null, $mode = 0)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/CeilingPrecise.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/CeilingPrecise.php
@@ -19,7 +19,7 @@ class CeilingPrecise
      *
      * @return float|string Rounded Number, or a string containing an error
      */
-    public static function funcCeilingPrecise($number, $significance = 1)
+    public static function evaluate($number, $significance = 1)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Combinations.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Combinations.php
@@ -31,7 +31,7 @@ class Combinations
             return $e->getMessage();
         }
 
-        return round(Fact::funcFact($numObjs) / Fact::funcFact($numObjs - $numInSet)) / Fact::funcFact($numInSet);
+        return round(Fact::evaluate($numObjs) / Fact::evaluate($numObjs - $numInSet)) / Fact::evaluate($numInSet);
     }
 
     /**
@@ -69,6 +69,6 @@ class Combinations
             return $e->getMessage();
         }
 
-        return round(Fact::funcFact($numObjs + $numInSet - 1) / Fact::funcFact($numObjs - 1)) / Fact::funcFact($numInSet);
+        return round(Fact::evaluate($numObjs + $numInSet - 1) / Fact::evaluate($numObjs - 1)) / Fact::evaluate($numInSet);
     }
 }

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Cos.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Cos.php
@@ -15,7 +15,7 @@ class Cos
      *
      * @return float|string cosine
      */
-    public static function funcCos($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Cosh.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Cosh.php
@@ -15,7 +15,7 @@ class Cosh
      *
      * @return float|string cosine
      */
-    public static function funcCosh($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Cot.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Cot.php
@@ -15,7 +15,7 @@ class Cot
      *
      * @return float|string The cotangent of the angle
      */
-    public static function funcCot($angle)
+    public static function evaluate($angle)
     {
         try {
             $angle = Helpers::validateNumericNullBool($angle);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Coth.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Coth.php
@@ -15,7 +15,7 @@ class Coth
      *
      * @return float|string The hyperbolic cotangent of the angle
      */
-    public static function funcCoth($angle)
+    public static function evaluate($angle)
     {
         try {
             $angle = Helpers::validateNumericNullBool($angle);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Csc.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Csc.php
@@ -15,7 +15,7 @@ class Csc
      *
      * @return float|string The cosecant of the angle
      */
-    public static function funcCsc($angle)
+    public static function evaluate($angle)
     {
         try {
             $angle = Helpers::validateNumericNullBool($angle);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Csch.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Csch.php
@@ -15,7 +15,7 @@ class Csch
      *
      * @return float|string The hyperbolic cosecant of the angle
      */
-    public static function funcCsch($angle)
+    public static function evaluate($angle)
     {
         try {
             $angle = Helpers::validateNumericNullBool($angle);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Even.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Even.php
@@ -22,7 +22,7 @@ class Even
      *
      * @return float|string Rounded Number, or a string containing an error
      */
-    public static function funcEven($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Fact.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Fact.php
@@ -21,7 +21,7 @@ class Fact
      *
      * @return float|int|string Factorial, or a string containing an error
      */
-    public static function funcFact($factVal)
+    public static function evaluate($factVal)
     {
         try {
             $factVal = Helpers::validateNumericNullBool($factVal);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Floor.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Floor.php
@@ -23,12 +23,12 @@ class Floor
      * Excel Function:
      *        FLOOR(number[,significance])
      *
-     * @param float $number Number to round
-     * @param float $significance Significance
+     * @param mixed $number Expect float. Number to round
+     * @param mixed $significance Expect float. Significance
      *
      * @return float|string Rounded Number, or a string containing an error
      */
-    public static function funcFloor($number, $significance = null)
+    public static function evaluate($number, $significance = null)
     {
         if ($significance === null) {
             self::floorCheck1Arg();

--- a/src/PhpSpreadsheet/Calculation/MathTrig/FloorMath.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/FloorMath.php
@@ -21,7 +21,7 @@ class FloorMath
      *
      * @return float|string Rounded Number, or a string containing an error
      */
-    public static function funcFloorMath($number, $significance = null, $mode = 0)
+    public static function evaluate($number, $significance = null, $mode = 0)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/FloorPrecise.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/FloorPrecise.php
@@ -20,7 +20,7 @@ class FloorPrecise
      *
      * @return float|string Rounded Number, or a string containing an error
      */
-    public static function funcFloorPrecise($number, $significance = 1)
+    public static function evaluate($number, $significance = 1)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/IntClass.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/IntClass.php
@@ -18,7 +18,7 @@ class IntClass
      *
      * @return int|string Integer value, or a string containing an error
      */
-    public static function funcInt($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Lcm.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Lcm.php
@@ -48,7 +48,7 @@ class Lcm
      *
      * @return int|string Lowest Common Multiplier, or a string containing an error
      */
-    public static function funcLcm(...$args)
+    public static function evaluate(...$args)
     {
         try {
             $arrayArgs = [];

--- a/src/PhpSpreadsheet/Calculation/MathTrig/MatrixFunctions.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/MatrixFunctions.php
@@ -53,7 +53,7 @@ class MatrixFunctions
      *
      * @return float|string The result, or a string containing an error
      */
-    public static function funcMDeterm($matrixValues)
+    public static function determinant($matrixValues)
     {
         try {
             $matrix = self::getMatrix($matrixValues);
@@ -78,7 +78,7 @@ class MatrixFunctions
      *
      * @return array|string The result, or a string containing an error
      */
-    public static function funcMInverse($matrixValues)
+    public static function inverse($matrixValues)
     {
         try {
             $matrix = self::getMatrix($matrixValues);
@@ -99,7 +99,7 @@ class MatrixFunctions
      *
      * @return array|string The result, or a string containing an error
      */
-    public static function funcMMult($matrixData1, $matrixData2)
+    public static function multiply($matrixData1, $matrixData2)
     {
         try {
             $matrixA = self::getMatrix($matrixData1);
@@ -120,7 +120,7 @@ class MatrixFunctions
      *
      * @return array|string The result, or a string containing an error
      */
-    public static function funcMUnit($dimension)
+    public static function identity($dimension)
     {
         try {
             $dimension = (int) Helpers::validateNumericNullBool($dimension);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Mround.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Mround.php
@@ -12,12 +12,12 @@ class Mround
      *
      * Rounds a number to the nearest multiple of a specified value
      *
-     * @param float $number Number to round
-     * @param int $multiple Multiple to which you want to round $number
+     * @param mixed $number Expect float. Number to round.
+     * @param mixed $multiple Expect int. Multiple to which you want to round.
      *
      * @return float|string Rounded Number, or a string containing an error
      */
-    public static function funcMround($number, $multiple)
+    public static function evaluate($number, $multiple)
     {
         try {
             $number = Helpers::validateNumericNullSubstitution($number, 0);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Multinomial.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Multinomial.php
@@ -16,7 +16,7 @@ class Multinomial
      *
      * @return float|string The result, or a string containing an error
      */
-    public static function funcMultinomial(...$args)
+    public static function evaluate(...$args)
     {
         $summer = 0;
         $divisor = 1;
@@ -28,13 +28,13 @@ class Multinomial
                 Helpers::validateNotNegative($arg);
                 $arg = (int) $arg;
                 $summer += $arg;
-                $divisor *= Fact::funcFact($arg);
+                $divisor *= Fact::evaluate($arg);
             }
         } catch (Exception $e) {
             return $e->getMessage();
         }
 
-        $summer = Fact::funcFact($summer);
+        $summer = Fact::evaluate($summer);
 
         return $summer / $divisor;
     }

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Odd.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Odd.php
@@ -15,7 +15,7 @@ class Odd
      *
      * @return float|string Rounded Number, or a string containing an error
      */
-    public static function funcOdd($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Product.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Product.php
@@ -18,7 +18,7 @@ class Product
      *
      * @return float|string
      */
-    public static function funcProduct(...$args)
+    public static function evaluate(...$args)
     {
         // Return value
         $returnValue = null;

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Quotient.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Quotient.php
@@ -20,7 +20,7 @@ class Quotient
      *
      * @return int|string
      */
-    public static function funcQuotient($numerator, $denominator)
+    public static function evaluate($numerator, $denominator)
     {
         try {
             $numerator = Helpers::validateNumericNullSubstitution($numerator, 0);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Roman.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Roman.php
@@ -822,7 +822,7 @@ class Roman
      *
      * @return string Roman numeral, or a string containing an error
      */
-    public static function funcRoman($aValue, $style = 0)
+    public static function evaluate($aValue, $style = 0)
     {
         try {
             $aValue = Helpers::validateNumericNullBool($aValue);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Round.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Round.php
@@ -16,7 +16,7 @@ class Round
      *
      * @return float|string Rounded number
      */
-    public static function builtinROUND($number, $precision)
+    public static function evaluate($number, $precision)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/RoundDown.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/RoundDown.php
@@ -16,7 +16,7 @@ class RoundDown
      *
      * @return float|string Rounded Number, or a string containing an error
      */
-    public static function funcRoundDown($number, $digits)
+    public static function evaluate($number, $digits)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/RoundUp.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/RoundUp.php
@@ -16,7 +16,7 @@ class RoundUp
      *
      * @return float|string Rounded Number, or a string containing an error
      */
-    public static function funcRoundUp($number, $digits)
+    public static function evaluate($number, $digits)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Sec.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Sec.php
@@ -15,7 +15,7 @@ class Sec
      *
      * @return float|string The secant of the angle
      */
-    public static function funcSec($angle)
+    public static function evaluate($angle)
     {
         try {
             $angle = Helpers::validateNumericNullBool($angle);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Sech.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Sech.php
@@ -15,7 +15,7 @@ class Sech
      *
      * @return float|string The hyperbolic secant of the angle
      */
-    public static function funcSech($angle)
+    public static function evaluate($angle)
     {
         try {
             $angle = Helpers::validateNumericNullBool($angle);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/SeriesSum.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/SeriesSum.php
@@ -19,7 +19,7 @@ class SeriesSum
      *
      * @return float|string The result, or a string containing an error
      */
-    public static function funcSeriesSum($x, $n, $m, ...$args)
+    public static function evaluate($x, $n, $m, ...$args)
     {
         try {
             $x = Helpers::validateNumericNullSubstitution($x, 0);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Sign.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Sign.php
@@ -16,7 +16,7 @@ class Sign
      *
      * @return int|string sign value, or a string containing an error
      */
-    public static function funcSign($number)
+    public static function evaluate($number)
     {
         try {
             $number = Helpers::validateNumericNullBool($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Sin.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Sin.php
@@ -15,7 +15,7 @@ class Sin
      *
      * @return float|string Rounded number
      */
-    public static function funcSin($angle)
+    public static function evaluate($angle)
     {
         try {
             $angle = Helpers::validateNumericNullBool($angle);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Sinh.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Sinh.php
@@ -15,7 +15,7 @@ class Sinh
      *
      * @return float|string Rounded number
      */
-    public static function funcSinh($angle)
+    public static function evaluate($angle)
     {
         try {
             $angle = Helpers::validateNumericNullBool($angle);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Subtotal.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Subtotal.php
@@ -48,7 +48,7 @@ class Subtotal
         [Statistical\Counts::class, 'COUNTA'], // 3
         [Statistical\Maximum::class, 'MAX'], // 4
         [Statistical\Minimum::class, 'MIN'], // 5
-        [Product::class, 'funcProduct'], // 6
+        [Product::class, 'evaluate'], // 6
         [Statistical\StandardDeviations::class, 'STDEV'], // 7
         [Statistical\StandardDeviations::class, 'STDEVP'], // 8
         [Sum::class, 'funcSum'], // 9
@@ -72,7 +72,7 @@ class Subtotal
      *
      * @return float|string
      */
-    public static function funcSubtotal($functionType, ...$args)
+    public static function evaluate($functionType, ...$args)
     {
         $cellReference = array_pop($args);
         $aArgs = Functions::flattenArrayIndexed($args);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/SumProduct.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/SumProduct.php
@@ -16,7 +16,7 @@ class SumProduct
      *
      * @return float|string The result, or a string containing an error
      */
-    public static function funcSumProduct(...$args)
+    public static function evaluate(...$args)
     {
         $arrayList = $args;
 

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Tan.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Tan.php
@@ -15,7 +15,7 @@ class Tan
      *
      * @return float|string Rounded number
      */
-    public static function funcTan($angle)
+    public static function evaluate($angle)
     {
         try {
             $angle = Helpers::validateNumericNullBool($angle);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Tanh.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Tanh.php
@@ -15,7 +15,7 @@ class Tanh
      *
      * @return float|string Rounded number
      */
-    public static function funcTanh($angle)
+    public static function evaluate($angle)
     {
         try {
             $angle = Helpers::validateNumericNullBool($angle);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Trunc.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Trunc.php
@@ -16,7 +16,7 @@ class Trunc
      *
      * @return float|string Truncated value, or a string containing an error
      */
-    public static function funcTrunc($value = 0, $digits = 0)
+    public static function evaluate($value = 0, $digits = 0)
     {
         try {
             $value = Helpers::validateNumericNullBool($value);

--- a/src/PhpSpreadsheet/Calculation/Statistical.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical.php
@@ -703,7 +703,7 @@ class Statistical
     {
         $aArgs = Functions::flattenArray($args);
 
-        $aMean = MathTrig\Product::funcProduct($aArgs);
+        $aMean = MathTrig\Product::evaluate($aArgs);
         if (is_numeric($aMean) && ($aMean > 0)) {
             $aCount = Counts::COUNT($aArgs);
             if (Minimum::MIN($aArgs) > 0) {

--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Poisson.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/Poisson.php
@@ -42,12 +42,12 @@ class Poisson
             $summer = 0;
             $floor = floor($value);
             for ($i = 0; $i <= $floor; ++$i) {
-                $summer += $mean ** $i / MathTrig\Fact::funcFact($i);
+                $summer += $mean ** $i / MathTrig\Fact::evaluate($i);
             }
 
             return exp(0 - $mean) * $summer;
         }
 
-        return (exp(0 - $mean) * $mean ** $value) / MathTrig\Fact::funcFact($value);
+        return (exp(0 - $mean) * $mean ** $value) / MathTrig\Fact::evaluate($value);
     }
 }

--- a/src/PhpSpreadsheet/Calculation/Statistical/Permutations.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Permutations.php
@@ -38,7 +38,7 @@ class Permutations
             return Functions::NAN();
         }
 
-        return (int) round(MathTrig\Fact::funcFact($numObjs) / MathTrig\Fact::funcFact($numObjs - $numInSet));
+        return (int) round(MathTrig\Fact::evaluate($numObjs) / MathTrig\Fact::evaluate($numObjs - $numInSet));
     }
 
     /**

--- a/src/PhpSpreadsheet/Calculation/TextData/Format.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Format.php
@@ -42,7 +42,7 @@ class Format
             if ($value < 0) {
                 $round = 0 - $round;
             }
-            $value = MathTrig\Mround::funcMround($value, $round);
+            $value = MathTrig\Mround::evaluate($value, $round);
         }
         $mask = "$mask;($mask)";
 
@@ -66,6 +66,8 @@ class Format
         if (!is_numeric($value) || !is_numeric($decimals)) {
             return Functions::VALUE();
         }
+        $decimals = (float) $decimals;
+        $value = (float) $value;
         $decimals = (int) floor($decimals);
 
         $valueResult = round($value, $decimals);

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MInverseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MInverseTest.php
@@ -13,7 +13,7 @@ class MInverseTest extends AllSetupTeardown
      */
     public function testMINVERSE($expectedResult, array $args): void
     {
-        $result = MathTrig\MatrixFunctions::funcMInverse($args);
+        $result = MathTrig\MatrixFunctions::Inverse($args);
         self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MInverseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MInverseTest.php
@@ -13,7 +13,7 @@ class MInverseTest extends AllSetupTeardown
      */
     public function testMINVERSE($expectedResult, array $args): void
     {
-        $result = MathTrig\MatrixFunctions::Inverse($args);
+        $result = MathTrig\MatrixFunctions::inverse($args);
         self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MMultTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MMultTest.php
@@ -13,7 +13,7 @@ class MMultTest extends AllSetupTeardown
      */
     public function testMMULT($expectedResult, ...$args): void
     {
-        $result = MathTrig\MatrixFunctions::funcMMult(...$args);
+        $result = MathTrig\MatrixFunctions::Multiply(...$args);
         self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MMultTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MMultTest.php
@@ -13,7 +13,7 @@ class MMultTest extends AllSetupTeardown
      */
     public function testMMULT($expectedResult, ...$args): void
     {
-        $result = MathTrig\MatrixFunctions::Multiply(...$args);
+        $result = MathTrig\MatrixFunctions::multiply(...$args);
         self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MUnitTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MUnitTest.php
@@ -11,13 +11,13 @@ class MUnitTest extends AllSetupTeardown
         $identity = MatrixFunctions::Identity(3);
         self::assertEquals([[1, 0, 0], [0, 1, 0], [0, 0, 1]], $identity);
         $startArray = [[1, 2, 2], [4, 5, 6], [7, 8, 9]];
-        $resultArray = MatrixFunctions::Multiply($startArray, $identity);
+        $resultArray = MatrixFunctions::multiply($startArray, $identity);
         self::assertEquals($startArray, $resultArray);
-        $inverseArray = MatrixFunctions::Inverse($startArray);
-        $resultArray = MatrixFunctions::Multiply($startArray, $inverseArray);
+        $inverseArray = MatrixFunctions::inverse($startArray);
+        $resultArray = MatrixFunctions::multiply($startArray, $inverseArray);
         self::assertEquals($identity, $resultArray);
-        self::assertEquals('#VALUE!', MatrixFunctions::Identity(0));
-        self::assertEquals('#VALUE!', MatrixFunctions::Identity(-1));
-        self::assertEquals('#VALUE!', MatrixFunctions::Identity('X'));
+        self::assertEquals('#VALUE!', MatrixFunctions::identity(0));
+        self::assertEquals('#VALUE!', MatrixFunctions::identity(-1));
+        self::assertEquals('#VALUE!', MatrixFunctions::identity('X'));
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MUnitTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MUnitTest.php
@@ -8,16 +8,16 @@ class MUnitTest extends AllSetupTeardown
 {
     public function testMUNIT(): void
     {
-        $identity = MatrixFunctions::funcMUnit(3);
+        $identity = MatrixFunctions::Identity(3);
         self::assertEquals([[1, 0, 0], [0, 1, 0], [0, 0, 1]], $identity);
         $startArray = [[1, 2, 2], [4, 5, 6], [7, 8, 9]];
-        $resultArray = MatrixFunctions::funcMMult($startArray, $identity);
+        $resultArray = MatrixFunctions::Multiply($startArray, $identity);
         self::assertEquals($startArray, $resultArray);
-        $inverseArray = MatrixFunctions::funcMInverse($startArray);
-        $resultArray = MatrixFunctions::funcMMult($startArray, $inverseArray);
+        $inverseArray = MatrixFunctions::Inverse($startArray);
+        $resultArray = MatrixFunctions::Multiply($startArray, $inverseArray);
         self::assertEquals($identity, $resultArray);
-        self::assertEquals('#VALUE!', MatrixFunctions::funcMUnit(0));
-        self::assertEquals('#VALUE!', MatrixFunctions::funcMUnit(-1));
-        self::assertEquals('#VALUE!', MatrixFunctions::funcMUnit('X'));
+        self::assertEquals('#VALUE!', MatrixFunctions::Identity(0));
+        self::assertEquals('#VALUE!', MatrixFunctions::Identity(-1));
+        self::assertEquals('#VALUE!', MatrixFunctions::Identity('X'));
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MUnitTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MUnitTest.php
@@ -8,7 +8,7 @@ class MUnitTest extends AllSetupTeardown
 {
     public function testMUNIT(): void
     {
-        $identity = MatrixFunctions::Identity(3);
+        $identity = MatrixFunctions::identity(3);
         self::assertEquals([[1, 0, 0], [0, 1, 0], [0, 0, 1]], $identity);
         $startArray = [[1, 2, 2], [4, 5, 6], [7, 8, 9]];
         $resultArray = MatrixFunctions::multiply($startArray, $identity);


### PR DESCRIPTION
Per discussions while MathTrig was being broken up, this would help standardize the code. That idea was adopted partway through the breakup. This PR applies that standardization to the earlier efforts. A similar effort is required for DateTime; that will come later.

The only 2 remaining funcWhatevers in MathTrig are both in SUM, which required two different methods depending on whether or not string parameters were to be ignored. It seems appropriate to leave those method names non-standardized in order to require a decision about which is to be used if they are invoked internally.

I also changed the MatrixFunctions method names as part of this PR. This could create a conflict with PR #2005, even though I think the names I chose in this PR and the names in that one are identical. I can remove that part of this change if desired.

3 Phpstan grandfathered errors were eliminated as part of this change, and its baseline has changed accordingly.

This is:

```
- [ ] a bugfix
- [ ] a new feature
- [x] refactoring
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
