### PR TITLE
Eliminate a big chunck of duplicated code for reading styles

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3941,31 +3941,6 @@ parameters:
 			path: src/PhpSpreadsheet/Reader/Xlsx.php
 
 		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\:\\:readColor\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xlsx.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\:\\:readColor\\(\\) has parameter \\$background with no typehint specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xlsx.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\:\\:readColor\\(\\) has parameter \\$color with no typehint specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xlsx.php
-
-		-
-			message: "#^Parameter \\#1 \\$hex of static method PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\Color\\:\\:changeBrightness\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xlsx.php
-
-		-
-			message: "#^Parameter \\#1 \\$pValue of method PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\Font\\:\\:setSize\\(\\) expects float, string given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xlsx.php
-
-		-
 			message: "#^Cannot access property \\$r on SimpleXMLElement\\|null\\.$#"
 			count: 2
 			path: src/PhpSpreadsheet/Reader/Xlsx.php

--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -40,7 +40,7 @@ class Styles extends BaseParserClass
         $this->cellStyles = $cellStyles;
     }
 
-    private static function readFontStyle(Font $fontStyle, SimpleXMLElement $fontStyleXml): void
+    public static function readFontStyle(Font $fontStyle, SimpleXMLElement $fontStyleXml): void
     {
         $fontStyle->setName((string) $fontStyleXml->name['val']);
         $fontStyle->setSize((float) $fontStyleXml->sz['val']);
@@ -52,7 +52,9 @@ class Styles extends BaseParserClass
             $fontStyle->setItalic(!isset($fontStyleXml->i['val']) || self::boolean((string) $fontStyleXml->i['val']));
         }
         if (isset($fontStyleXml->strike)) {
-            $fontStyle->setStrikethrough(!isset($fontStyleXml->strike['val']) || self::boolean((string) $fontStyleXml->strike['val']));
+            $fontStyle->setStrikethrough(
+                !isset($fontStyleXml->strike['val']) || self::boolean((string) $fontStyleXml->strike['val'])
+            );
         }
         $fontStyle->getColor()->setARGB(self::readColor($fontStyleXml->color));
 
@@ -84,7 +86,7 @@ class Styles extends BaseParserClass
         }
     }
 
-    private static function readFillStyle(Fill $fillStyle, SimpleXMLElement $fillStyleXml): void
+    public static function readFillStyle(Fill $fillStyle, SimpleXMLElement $fillStyleXml): void
     {
         if ($fillStyleXml->gradientFill) {
             /** @var SimpleXMLElement $gradientFill */
@@ -94,15 +96,20 @@ class Styles extends BaseParserClass
             }
             $fillStyle->setRotation((float) ($gradientFill['degree']));
             $gradientFill->registerXPathNamespace('sml', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
-            $fillStyle->getStartColor()->setARGB(self::readColor(self::getArrayItem($gradientFill->xpath('sml:stop[@position=0]'))->color));
-            $fillStyle->getEndColor()->setARGB(self::readColor(self::getArrayItem($gradientFill->xpath('sml:stop[@position=1]'))->color));
+            $fillStyle->getStartColor()->setARGB(
+                self::readColor(self::getArrayItem($gradientFill->xpath('sml:stop[@position=0]'))->color)
+            );
+            $fillStyle->getEndColor()->setARGB(
+                self::readColor(self::getArrayItem($gradientFill->xpath('sml:stop[@position=1]'))->color)
+            );
         } elseif ($fillStyleXml->patternFill) {
-            $patternType = (string) $fillStyleXml->patternFill['patternType'] != '' ? (string) $fillStyleXml->patternFill['patternType'] : Fill::FILL_NONE;
+            $patternType = (string) $fillStyleXml->patternFill['patternType'] != ''
+                ? (string) $fillStyleXml->patternFill['patternType']
+                : Fill::FILL_NONE;
+
             $fillStyle->setFillType($patternType);
             if ($fillStyleXml->patternFill->fgColor) {
                 $fillStyle->getStartColor()->setARGB(self::readColor($fillStyleXml->patternFill->fgColor, true));
-            } else {
-                $fillStyle->getStartColor()->setARGB('FF000000');
             }
             if ($fillStyleXml->patternFill->bgColor) {
                 $fillStyle->getEndColor()->setARGB(self::readColor($fillStyleXml->patternFill->bgColor, true));
@@ -110,7 +117,7 @@ class Styles extends BaseParserClass
         }
     }
 
-    private static function readBorderStyle(Borders $borderStyle, SimpleXMLElement $borderStyleXml): void
+    public static function readBorderStyle(Borders $borderStyle, SimpleXMLElement $borderStyleXml): void
     {
         $diagonalUp = self::boolean((string) $borderStyleXml['diagonalUp']);
         $diagonalDown = self::boolean((string) $borderStyleXml['diagonalDown']);
@@ -141,7 +148,7 @@ class Styles extends BaseParserClass
         }
     }
 
-    private static function readAlignmentStyle(Alignment $alignment, SimpleXMLElement $alignmentXml): void
+    public static function readAlignmentStyle(Alignment $alignment, SimpleXMLElement $alignmentXml): void
     {
         $alignment->setHorizontal((string) $alignmentXml['horizontal']);
         $alignment->setVertical((string) $alignmentXml['vertical']);
@@ -156,8 +163,12 @@ class Styles extends BaseParserClass
         $alignment->setTextRotation((int) $textRotation);
         $alignment->setWrapText(self::boolean((string) $alignmentXml['wrapText']));
         $alignment->setShrinkToFit(self::boolean((string) $alignmentXml['shrinkToFit']));
-        $alignment->setIndent((int) ((string) $alignmentXml['indent']) > 0 ? (int) ((string) $alignmentXml['indent']) : 0);
-        $alignment->setReadOrder((int) ((string) $alignmentXml['readingOrder']) > 0 ? (int) ((string) $alignmentXml['readingOrder']) : 0);
+        $alignment->setIndent(
+            (int) ((string) $alignmentXml['indent']) > 0 ? (int) ((string) $alignmentXml['indent']) : 0
+        );
+        $alignment->setReadOrder(
+            (int) ((string) $alignmentXml['readingOrder']) > 0 ? (int) ((string) $alignmentXml['readingOrder']) : 0
+        );
     }
 
     private function readStyle(Style $docStyle, $style): void
@@ -186,8 +197,8 @@ class Styles extends BaseParserClass
 
         // protection
         if (isset($style->protection)) {
-            $this->readProtectionLocked($docStyle, $style);
-            $this->readProtectionHidden($docStyle, $style);
+            self::readProtectionLocked($docStyle, $style);
+            self::readProtectionHidden($docStyle, $style);
         }
 
         // top-level style settings
@@ -196,7 +207,7 @@ class Styles extends BaseParserClass
         }
     }
 
-    private function readProtectionLocked(Style $docStyle, $style): void
+    public static function readProtectionLocked(Style $docStyle, $style): void
     {
         if (isset($style->protection['locked'])) {
             if (self::boolean((string) $style->protection['locked'])) {
@@ -207,7 +218,7 @@ class Styles extends BaseParserClass
         }
     }
 
-    private function readProtectionHidden(Style $docStyle, $style): void
+    public static function readProtectionHidden(Style $docStyle, $style): void
     {
         if (isset($style->protection['hidden'])) {
             if (self::boolean((string) $style->protection['hidden'])) {
@@ -218,7 +229,7 @@ class Styles extends BaseParserClass
         }
     }
 
-    private static function readColor($color, $background = false)
+    public static function readColor($color, $background = false)
     {
         if (isset($color['rgb'])) {
             return (string) $color['rgb'];


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] refactoring
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Eliminate a large block of code duplication in the Xlsx Reader when reading styles; provide one central class to handle reading styles