### PR TITLE
Some refactoring improvements to parsing Style information in the Xls Reader

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3461,16 +3461,6 @@ parameters:
 			path: src/PhpSpreadsheet/Reader/Xls/RC4.php
 
 		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xls\\\\Style\\\\Border\\:\\:\\$map has no typehint specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xls/Style/Border.php
-
-		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xls\\\\Style\\\\FillPattern\\:\\:\\$map has no typehint specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xls/Style/FillPattern.php
-
-		-
 			message: "#^Cannot access property \\$Relationship on SimpleXMLElement\\|false\\.$#"
 			count: 12
 			path: src/PhpSpreadsheet/Reader/Xlsx.php

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -2196,16 +2196,8 @@ class Xls extends BaseReader
 
             // bit 3, mask 0x08; wrap text
             $wrapText = (0x08 & ord($recordData[6])) >> 3;
-            switch ($wrapText) {
-                case 0:
-                    $objStyle->getAlignment()->setWrapText(false);
+            Xls\Style\CellAlignment::wrap($objStyle->getAlignment(), $wrapText);
 
-                    break;
-                case 1:
-                    $objStyle->getAlignment()->setWrapText(true);
-
-                    break;
-            }
             // bit 6-4, mask 0x70; vertical alignment
             $vertAlign = (0x70 & ord($recordData[6])) >> 4;
             Xls\Style\CellAlignment::vertical($objStyle->getAlignment(), $vertAlign);

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -7,6 +7,7 @@ use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Cell\DataValidation;
 use PhpOffice\PhpSpreadsheet\Exception as PhpSpreadsheetException;
 use PhpOffice\PhpSpreadsheet\NamedRange;
+use PhpOffice\PhpSpreadsheet\Reader\Xls\Style\CellFont;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Shared\CodePage;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
@@ -2067,39 +2068,11 @@ class Xls extends BaseReader
 
             // offset: 8; size: 2; escapement type
             $escapement = self::getUInt2d($recordData, 8);
-            switch ($escapement) {
-                case 0x0001:
-                    $objFont->setSuperscript(true);
-
-                    break;
-                case 0x0002:
-                    $objFont->setSubscript(true);
-
-                    break;
-            }
+            CellFont::escapement($objFont, $escapement);
 
             // offset: 10; size: 1; underline type
             $underlineType = ord($recordData[10]);
-            switch ($underlineType) {
-                case 0x00:
-                    break; // no underline
-                case 0x01:
-                    $objFont->setUnderline(Font::UNDERLINE_SINGLE);
-
-                    break;
-                case 0x02:
-                    $objFont->setUnderline(Font::UNDERLINE_DOUBLE);
-
-                    break;
-                case 0x21:
-                    $objFont->setUnderline(Font::UNDERLINE_SINGLEACCOUNTING);
-
-                    break;
-                case 0x22:
-                    $objFont->setUnderline(Font::UNDERLINE_DOUBLEACCOUNTING);
-
-                    break;
-            }
+            CellFont::underline($objFont, $underlineType);
 
             // offset: 11; size: 1; font family
             // offset: 12; size: 1; character set
@@ -2219,36 +2192,8 @@ class Xls extends BaseReader
             // offset:  6; size: 1; Alignment and text break
             // bit 2-0, mask 0x07; horizontal alignment
             $horAlign = (0x07 & ord($recordData[6])) >> 0;
-            switch ($horAlign) {
-                case 0:
-                    $objStyle->getAlignment()->setHorizontal(Alignment::HORIZONTAL_GENERAL);
+            Xls\Style\CellAlignment::horizontal($objStyle->getAlignment(), $horAlign);
 
-                    break;
-                case 1:
-                    $objStyle->getAlignment()->setHorizontal(Alignment::HORIZONTAL_LEFT);
-
-                    break;
-                case 2:
-                    $objStyle->getAlignment()->setHorizontal(Alignment::HORIZONTAL_CENTER);
-
-                    break;
-                case 3:
-                    $objStyle->getAlignment()->setHorizontal(Alignment::HORIZONTAL_RIGHT);
-
-                    break;
-                case 4:
-                    $objStyle->getAlignment()->setHorizontal(Alignment::HORIZONTAL_FILL);
-
-                    break;
-                case 5:
-                    $objStyle->getAlignment()->setHorizontal(Alignment::HORIZONTAL_JUSTIFY);
-
-                    break;
-                case 6:
-                    $objStyle->getAlignment()->setHorizontal(Alignment::HORIZONTAL_CENTER_CONTINUOUS);
-
-                    break;
-            }
             // bit 3, mask 0x08; wrap text
             $wrapText = (0x08 & ord($recordData[6])) >> 3;
             switch ($wrapText) {
@@ -2263,24 +2208,7 @@ class Xls extends BaseReader
             }
             // bit 6-4, mask 0x70; vertical alignment
             $vertAlign = (0x70 & ord($recordData[6])) >> 4;
-            switch ($vertAlign) {
-                case 0:
-                    $objStyle->getAlignment()->setVertical(Alignment::VERTICAL_TOP);
-
-                    break;
-                case 1:
-                    $objStyle->getAlignment()->setVertical(Alignment::VERTICAL_CENTER);
-
-                    break;
-                case 2:
-                    $objStyle->getAlignment()->setVertical(Alignment::VERTICAL_BOTTOM);
-
-                    break;
-                case 3:
-                    $objStyle->getAlignment()->setVertical(Alignment::VERTICAL_JUSTIFY);
-
-                    break;
-            }
+            Xls\Style\CellAlignment::vertical($objStyle->getAlignment(), $vertAlign);
 
             if ($this->version == self::XLS_BIFF8) {
                 // offset:  7; size: 1; XF_ROTATION: Text rotation angle

--- a/src/PhpSpreadsheet/Reader/Xls/Style/Border.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Style/Border.php
@@ -6,6 +6,9 @@ use PhpOffice\PhpSpreadsheet\Style\Border as StyleBorder;
 
 class Border
 {
+    /**
+     * @var array<string, int>
+     */
     protected static $map = [
         0x00 => StyleBorder::BORDER_NONE,
         0x01 => StyleBorder::BORDER_THIN,

--- a/src/PhpSpreadsheet/Reader/Xls/Style/Border.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Style/Border.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\Border as StyleBorder;
 class Border
 {
     /**
-     * @var array<string, int>
+     * @var array<int, string>
      */
     protected static $borderStyleMap = [
         0x00 => StyleBorder::BORDER_NONE,

--- a/src/PhpSpreadsheet/Reader/Xls/Style/Border.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Style/Border.php
@@ -9,7 +9,7 @@ class Border
     /**
      * @var array<string, int>
      */
-    protected static $map = [
+    protected static $borderStyleMap = [
         0x00 => StyleBorder::BORDER_NONE,
         0x01 => StyleBorder::BORDER_THIN,
         0x02 => StyleBorder::BORDER_MEDIUM,
@@ -26,18 +26,10 @@ class Border
         0x0D => StyleBorder::BORDER_SLANTDASHDOT,
     ];
 
-    /**
-     * Map border style
-     * OpenOffice documentation: 2.5.11.
-     *
-     * @param int $index
-     *
-     * @return string
-     */
-    public static function lookup($index)
+    public static function lookup(int $index): string
     {
-        if (isset(self::$map[$index])) {
-            return self::$map[$index];
+        if (isset(self::$borderStyleMap[$index])) {
+            return self::$borderStyleMap[$index];
         }
 
         return StyleBorder::BORDER_NONE;

--- a/src/PhpSpreadsheet/Reader/Xls/Style/CellAlignment.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Style/CellAlignment.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Reader\Xls\Style;
+
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+
+class CellAlignment
+{
+    protected static $horizontalAlignmentMap = [
+        0 => Alignment::HORIZONTAL_GENERAL,
+        1 => Alignment::HORIZONTAL_LEFT,
+        2 => Alignment::HORIZONTAL_CENTER,
+        3 => Alignment::HORIZONTAL_RIGHT,
+        4 => Alignment::HORIZONTAL_FILL,
+        5 => Alignment::HORIZONTAL_JUSTIFY,
+        6 => Alignment::HORIZONTAL_CENTER_CONTINUOUS,
+    ];
+
+    protected static $verticalAlignmentMap = [
+        0 => Alignment::VERTICAL_TOP,
+        1 => Alignment::VERTICAL_CENTER,
+        2 => Alignment::VERTICAL_BOTTOM,
+        3 => Alignment::VERTICAL_JUSTIFY,
+    ];
+
+    public static function horizontal(Alignment $alignment, int $horizontal)
+    {
+        if (array_key_exists($horizontal, self::$horizontalAlignmentMap)) {
+            $alignment->setHorizontal(self::$horizontalAlignmentMap[$horizontal]);
+        }
+    }
+
+    public static function vertical(Alignment $alignment, int $vertical)
+    {
+        if (array_key_exists($vertical, self::$verticalAlignmentMap)) {
+            $alignment->setVertical(self::$verticalAlignmentMap[$vertical]);
+        }
+    }
+}

--- a/src/PhpSpreadsheet/Reader/Xls/Style/CellAlignment.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Style/CellAlignment.php
@@ -6,6 +6,9 @@ use PhpOffice\PhpSpreadsheet\Style\Alignment;
 
 class CellAlignment
 {
+    /**
+     * @var array<string, int>
+     */
     protected static $horizontalAlignmentMap = [
         0 => Alignment::HORIZONTAL_GENERAL,
         1 => Alignment::HORIZONTAL_LEFT,
@@ -16,6 +19,9 @@ class CellAlignment
         6 => Alignment::HORIZONTAL_CENTER_CONTINUOUS,
     ];
 
+    /**
+     * @var array<string, int>
+     */
     protected static $verticalAlignmentMap = [
         0 => Alignment::VERTICAL_TOP,
         1 => Alignment::VERTICAL_CENTER,
@@ -23,14 +29,14 @@ class CellAlignment
         3 => Alignment::VERTICAL_JUSTIFY,
     ];
 
-    public static function horizontal(Alignment $alignment, int $horizontal)
+    public static function horizontal(Alignment $alignment, int $horizontal): void
     {
         if (array_key_exists($horizontal, self::$horizontalAlignmentMap)) {
             $alignment->setHorizontal(self::$horizontalAlignmentMap[$horizontal]);
         }
     }
 
-    public static function vertical(Alignment $alignment, int $vertical)
+    public static function vertical(Alignment $alignment, int $vertical): void
     {
         if (array_key_exists($vertical, self::$verticalAlignmentMap)) {
             $alignment->setVertical(self::$verticalAlignmentMap[$vertical]);

--- a/src/PhpSpreadsheet/Reader/Xls/Style/CellAlignment.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Style/CellAlignment.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\Alignment;
 class CellAlignment
 {
     /**
-     * @var array<string, int>
+     * @var array<int, string>
      */
     protected static $horizontalAlignmentMap = [
         0 => Alignment::HORIZONTAL_GENERAL,
@@ -20,7 +20,7 @@ class CellAlignment
     ];
 
     /**
-     * @var array<string, int>
+     * @var array<int, string>
      */
     protected static $verticalAlignmentMap = [
         0 => Alignment::VERTICAL_TOP,

--- a/src/PhpSpreadsheet/Reader/Xls/Style/CellAlignment.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Style/CellAlignment.php
@@ -42,4 +42,9 @@ class CellAlignment
             $alignment->setVertical(self::$verticalAlignmentMap[$vertical]);
         }
     }
+
+    public static function wrap(Alignment $alignment, int $wrap): void
+    {
+        $alignment->setWrapText((bool) $wrap);
+    }
 }

--- a/src/PhpSpreadsheet/Reader/Xls/Style/CellFont.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Style/CellFont.php
@@ -20,6 +20,9 @@ class CellFont
         }
     }
 
+    /**
+     * @var array<string, int>
+     */
     protected static $underlineMap = [
         0x01 => Font::UNDERLINE_SINGLE,
         0x02 => Font::UNDERLINE_DOUBLE,

--- a/src/PhpSpreadsheet/Reader/Xls/Style/CellFont.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Style/CellFont.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Reader\Xls\Style;
+
+use PhpOffice\PhpSpreadsheet\Style\Font;
+
+class CellFont
+{
+    public static function escapement(Font $font, int $escapement): void
+    {
+        switch ($escapement) {
+            case 0x0001:
+                $font->setSuperscript(true);
+
+                break;
+            case 0x0002:
+                $font->setSubscript(true);
+
+                break;
+        }
+    }
+
+    protected static $underlineMap = [
+        0x01 => Font::UNDERLINE_SINGLE,
+        0x02 => Font::UNDERLINE_DOUBLE,
+        0x21 => Font::UNDERLINE_SINGLEACCOUNTING,
+        0x22 => Font::UNDERLINE_DOUBLEACCOUNTING,
+    ];
+
+    public static function underline(Font $font, int $underline): void
+    {
+        if (array_key_exists($underline, self::$underlineMap)) {
+            $font->setUnderline(self::$underlineMap[$underline]);
+        }
+    }
+}

--- a/src/PhpSpreadsheet/Reader/Xls/Style/CellFont.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Style/CellFont.php
@@ -21,7 +21,7 @@ class CellFont
     }
 
     /**
-     * @var array<string, int>
+     * @var array<int, string>
      */
     protected static $underlineMap = [
         0x01 => Font::UNDERLINE_SINGLE,

--- a/src/PhpSpreadsheet/Reader/Xls/Style/FillPattern.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Style/FillPattern.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\Fill;
 class FillPattern
 {
     /**
-     * @var array<string, int>
+     * @var array<int, string>
      */
     protected static $fillPatternMap = [
         0x00 => Fill::FILL_NONE,

--- a/src/PhpSpreadsheet/Reader/Xls/Style/FillPattern.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Style/FillPattern.php
@@ -6,7 +6,10 @@ use PhpOffice\PhpSpreadsheet\Style\Fill;
 
 class FillPattern
 {
-    protected static $map = [
+    /**
+     * @var array<string, int>
+     */
+    protected static $fillPatternMap = [
         0x00 => Fill::FILL_NONE,
         0x01 => Fill::FILL_SOLID,
         0x02 => Fill::FILL_PATTERN_MEDIUMGRAY,
@@ -38,8 +41,8 @@ class FillPattern
      */
     public static function lookup($index)
     {
-        if (isset(self::$map[$index])) {
-            return self::$map[$index];
+        if (isset(self::$fillPatternMap[$index])) {
+            return self::$fillPatternMap[$index];
         }
 
         return Fill::FILL_NONE;


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] refactoring
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Improvements to reading style information for xls