### PR TITLE
Fix to export csv file with numbers in an element

### DIFF
--- a/src/PhpSpreadsheet/Writer/Csv.php
+++ b/src/PhpSpreadsheet/Writer/Csv.php
@@ -367,7 +367,7 @@ class Csv extends BaseWriter
                 if (!$this->enclosureRequired && strpbrk($element, "$delimiter$enclosure\n") === false) {
                     $enclosure = '';
                 } else {
-                    $element = str_replace($enclosure, $enclosure . $enclosure, $element);
+                    $element = str_replace($enclosure, $enclosure . $enclosure, strval($element));
                 }
             }
             // Add enclosed string


### PR DESCRIPTION
When trying to export an Spreadsheet with an field only containing numbers, the following error occurs:
PHP Fatal error:  Uncaught TypeError: str_replace(): Argument #3 ($subject) must be of type array|string, int given
Fixed by wrapping the element with strval

This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
