### PR TITLE
#984 Add support notContainsText for conditional styles in xlsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Improved support for Row and Column ranges in formulae [Issue #1755](https://github.com/PHPOffice/PhpSpreadsheet/issues/1755) [PR #2028](https://github.com/PHPOffice/PhpSpreadsheet/pull/2028)
 - Implemented the CHITEST(), CHISQ.DIST() and CHISQ.INV() and equivalent Statistical functions, for both left- and right-tailed distributions.
 - Support for ActiveSheet and SelectedCells in the ODS Reader and Writer. [PR #1908](https://github.com/PHPOffice/PhpSpreadsheet/pull/1908)
+- Support for notContainsText Conditional Style in xlsx [Issue #984](https://github.com/PHPOffice/PhpSpreadsheet/issues/984)
 
 ### Changed
 

--- a/src/PhpSpreadsheet/Style/Conditional.php
+++ b/src/PhpSpreadsheet/Style/Conditional.php
@@ -15,6 +15,7 @@ class Conditional implements IComparable
     const CONDITION_CONTAINSBLANKS = 'containsBlanks';
     const CONDITION_NOTCONTAINSBLANKS = 'notContainsBlanks';
     const CONDITION_DATABAR = 'dataBar';
+    const CONDITION_NOTCONTAINSTEXT = 'notContainsText';
 
     // Operator types
     const OPERATOR_NONE = '';

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -634,15 +634,21 @@ class Worksheet extends WriterPart
 
                     self::writeAttributeif(
                         $objWriter,
-                        ($conditional->getConditionType() == Conditional::CONDITION_CELLIS || $conditional->getConditionType() == Conditional::CONDITION_CONTAINSTEXT)
-                        && $conditional->getOperatorType() != Conditional::OPERATOR_NONE,
+                        in_array($conditional->getConditionType(), [
+                            Conditional::CONDITION_CELLIS,
+                            Conditional::CONDITION_CONTAINSTEXT,
+                            Conditional::CONDITION_NOTCONTAINSTEXT,
+                        ]) && $conditional->getOperatorType() != Conditional::OPERATOR_NONE,
                         'operator',
                         $conditional->getOperatorType()
                     );
 
                     self::writeAttributeIf($objWriter, $conditional->getStopIfTrue(), 'stopIfTrue', '1');
 
-                    if ($conditional->getConditionType() == Conditional::CONDITION_CONTAINSTEXT) {
+                    if (in_array($conditional->getConditionType(), [
+                        Conditional::CONDITION_CONTAINSTEXT,
+                        Conditional::CONDITION_NOTCONTAINSTEXT,
+                    ])) {
                         self::writeTextCondElements($objWriter, $conditional, $cellCoordinate);
                     } else {
                         self::writeOtherCondElements($objWriter, $conditional, $cellCoordinate);

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/ConditionalTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/ConditionalTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Settings;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Conditional;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class ConditionalTest extends AbstractFunctional
+{
+    /**
+     * @var int
+     */
+    private $prevValue;
+
+    protected function setUp(): void
+    {
+        $this->prevValue = Settings::getLibXmlLoaderOptions();
+
+        // Disable validating XML with the DTD
+        Settings::setLibXmlLoaderOptions($this->prevValue & ~LIBXML_DTDVALID & ~LIBXML_DTDATTR & ~LIBXML_DTDLOAD);
+    }
+
+    protected function tearDown(): void
+    {
+        Settings::setLibXmlLoaderOptions($this->prevValue);
+    }
+
+    /**
+     * Test check if conditional style with type 'notContainsText' works on xlsx
+     */
+    public function testConditionalNotContainsText(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $worksheet = $spreadsheet->getActiveSheet();
+
+        $condition = new Conditional();
+        $condition->setConditionType(Conditional::CONDITION_NOTCONTAINSTEXT);
+        $condition->setOperatorType(Conditional::OPERATOR_NOTCONTAINS);
+        $condition->setText("C");
+        $condition->getStyle()->applyFromArray([
+            'fill' => [
+                'color' => ['argb' => 'FFFFC000'],
+                'fillType' => Fill::FILL_SOLID,
+            ],
+        ]);
+        $worksheet->setConditionalStyles('A1:A5', [$condition]);
+
+        $writer = new Xlsx($spreadsheet);
+        $writerWorksheet = new Xlsx\Worksheet($writer);
+        $data = $writerWorksheet->writeWorksheet($worksheet, []);
+        $needle = <<<xml
+<conditionalFormatting sqref="A1:A5"><cfRule type="notContainsText" dxfId="" priority="1" operator="notContains" text="C"><formula>ISERROR(SEARCH(&quot;C&quot;,A1:A5))</formula></cfRule></conditionalFormatting>
+xml;
+        $this->assertStringContainsString($needle, $data);
+    }
+}


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [x] a new feature

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Xlsx support notContainsText type of condition that wasn't implemented in PhpSpreadsheet. We could workaround with expression and `<>` operator, but that would required cords in condition. Now can works without cords.
