### PR TITLE
Fix row visibility in XLS Writer

### DIFF
--- a/docs/references/features-cross-reference.md
+++ b/docs/references/features-cross-reference.md
@@ -1220,13 +1220,13 @@
     </tr>
     <tr>
         <td style="padding-left: 1em;">Merged Cells</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
+        <td style="text-align: center; color: green;">✔</td>
         <td style="text-align: center; color: green;">✔</td>
         <td></td>
-        <td></td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td>N/A</td>
+        <td>N/A</td>
         <td></td>
         <td></td>
         <td></td>

--- a/src/PhpSpreadsheet/Reader/Gnumeric.php
+++ b/src/PhpSpreadsheet/Reader/Gnumeric.php
@@ -270,7 +270,9 @@ class Gnumeric extends BaseReader
                 $commentAttributes = $comment->attributes();
                 //    Only comment objects are handled at the moment
                 if ($commentAttributes->Text) {
-                    $this->spreadsheet->getActiveSheet()->getComment((string) $commentAttributes->ObjectBound)->setAuthor((string) $commentAttributes->Author)->setText($this->parseRichText((string) $commentAttributes->Text));
+                    $this->spreadsheet->getActiveSheet()->getComment((string) $commentAttributes->ObjectBound)
+                        ->setAuthor((string) $commentAttributes->Author)
+                        ->setText($this->parseRichText((string) $commentAttributes->Text));
                 }
             }
         }

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -390,7 +390,13 @@ class Worksheet extends BIFFwriter
         // Row dimensions
         foreach ($phpSheet->getRowDimensions() as $rowDimension) {
             $xfIndex = $rowDimension->getXfIndex() + 15; // there are 15 cellXfs
-            $this->writeRow($rowDimension->getRowIndex() - 1, (int) $rowDimension->getRowHeight(), $xfIndex, $rowDimension->getVisible(), $rowDimension->getOutlineLevel());
+            $this->writeRow(
+                $rowDimension->getRowIndex() - 1,
+                (int) $rowDimension->getRowHeight(),
+                $xfIndex,
+                !$rowDimension->getVisible(),
+                $rowDimension->getOutlineLevel()
+            );
         }
 
         // Write Cells
@@ -1181,7 +1187,7 @@ class Worksheet extends BIFFwriter
         // collapsed. The zero height flag, 0x20, is used to collapse a row.
 
         $grbit |= $level;
-        if ($hidden) {
+        if ($hidden === true) {
             $grbit |= 0x0030;
         }
         if ($height !== null) {

--- a/tests/PhpSpreadsheetTests/Writer/Xls/RowVisibilityTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/RowVisibilityTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xls;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class RowVisibilityTest extends AbstractFunctional
+{
+    /**
+     * @dataProvider dataProviderReoVisibility
+     */
+    public function testRowVisibility(array $visibleRows): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $worksheet = $spreadsheet->getActiveSheet();
+        foreach ($visibleRows as $row => $visibility) {
+            $worksheet->setCellValue("A{$row}", $row);
+            $worksheet->getRowDimension($row)->setVisible($visibility);
+        }
+
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Xls');
+        $reloadedWorksheet = $reloadedSpreadsheet->getActiveSheet();
+        foreach ($visibleRows as $row => $visibility) {
+            self::assertSame($visibility, $reloadedWorksheet->getRowDimension($row)->getVisible());
+        }
+    }
+
+    public function dataProviderReoVisibility(): array
+    {
+        return [
+            [
+                [1 => true, 2 => false, 3 => false, 4 => true, 5 => true, 6 => false],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Xls Writer is reversing row visibility, so visible rows are hidden, and hidden rows are visible