### PR TITLE
Expecting this new test to fail on PHP8 only

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7282,7 +7282,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method getSubscript\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\Font\\|null\\.$#"
-			count: 2
+			count: 1
 			path: src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4346,11 +4346,6 @@ parameters:
 			path: src/PhpSpreadsheet/Shared/Date.php
 
 		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Shared\\\\Drawing\\:\\:pixelsToCellDimension\\(\\) should return int but returns float\\|int\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
 			message: "#^Parameter \\#1 \\$fp of function fread expects resource, resource\\|false given\\.$#"
 			count: 2
 			path: src/PhpSpreadsheet/Shared/Drawing.php
@@ -4492,11 +4487,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$pDefaultFont of static method PhpOffice\\\\PhpSpreadsheet\\\\Shared\\\\Drawing\\:\\:pixelsToCellDimension\\(\\) expects PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\Font, PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\Font\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Font.php
-
-		-
-			message: "#^Parameter \\#1 \\$size of function imagettfbbox expects float, float\\|null given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Shared/Font.php
 
@@ -6721,11 +6711,6 @@ parameters:
 			path: src/PhpSpreadsheet/Writer/Xls/Escher.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of static method PhpOffice\\\\PhpSpreadsheet\\\\Shared\\\\Font\\:\\:getCharsetFromFontName\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xls/Font.php
-
-		-
 			message: "#^If condition is always false\\.$#"
 			count: 2
 			path: src/PhpSpreadsheet/Writer/Xls/Font.php
@@ -6737,11 +6722,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$underline of static method PhpOffice\\\\PhpSpreadsheet\\\\Writer\\\\Xls\\\\Font\\:\\:mapUnderline\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xls/Font.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of static method PhpOffice\\\\PhpSpreadsheet\\\\Shared\\\\StringHelper\\:\\:UTF8toBIFF8UnicodeShort\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Writer/Xls/Font.php
 
@@ -7287,7 +7267,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$value of method XMLWriter\\:\\:writeAttribute\\(\\) expects string, string\\|null given\\.$#"
-			count: 4
+			count: 1
 			path: src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
 
 		-
@@ -7322,11 +7302,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method getSize\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\Font\\|null\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method XMLWriter\\:\\:writeAttribute\\(\\) expects string, float\\|null given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
 

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -4,6 +4,10 @@ namespace PhpOffice\PhpSpreadsheet\Style;
 
 class Font extends Supervisor
 {
+    public const DEFAULT_NAME = 'Calibri';
+
+    public const DEFAULT_SIZE = 11.0;
+
     // Underline types
     const UNDERLINE_NONE = 'none';
     const UNDERLINE_DOUBLE = 'double';
@@ -16,14 +20,14 @@ class Font extends Supervisor
      *
      * @var null|string
      */
-    protected $name = 'Calibri';
+    protected $name = self::DEFAULT_NAME;
 
     /**
      * Font Size.
      *
      * @var null|float
      */
-    protected $size = 11;
+    protected $size = self::DEFAULT_SIZE;
 
     /**
      * Bold.
@@ -220,7 +224,7 @@ class Font extends Supervisor
     public function setName($pValue)
     {
         if ($pValue == '') {
-            $pValue = 'Calibri';
+            $pValue = self::DEFAULT_NAME;
         }
         if ($this->isSupervisor) {
             $styleArray = $this->getStyleArray(['name' => $pValue]);
@@ -235,7 +239,7 @@ class Font extends Supervisor
     /**
      * Get Size.
      *
-     * @return null|float
+     * @return float
      */
     public function getSize()
     {
@@ -249,14 +253,14 @@ class Font extends Supervisor
     /**
      * Set Size.
      *
-     * @param float $pValue
+     * @param float $pValue The size in pt
      *
      * @return $this
      */
-    public function setSize($pValue)
+    public function setSize(float $pValue)
     {
-        if ($pValue == '') {
-            $pValue = 10;
+        if ($pValue <= 0.0) {
+            $pValue = self::DEFAULT_SIZE;
         }
         if ($this->isSupervisor) {
             $styleArray = $this->getStyleArray(['size' => $pValue]);

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -100,14 +100,14 @@ class Font extends Supervisor
 
         // Initialise values
         if ($isConditional) {
-            $this->name = null;
-            $this->size = null;
-            $this->bold = null;
-            $this->italic = null;
-            $this->superscript = null;
-            $this->subscript = null;
-            $this->underline = null;
-            $this->strikethrough = null;
+            $this->name = self::DEFAULT_NAME;
+            $this->size = self::DEFAULT_SIZE;
+            $this->bold = false;
+            $this->italic = false;
+            $this->superscript = false;
+            $this->subscript = false;
+            $this->underline = self::UNDERLINE_NONE;
+            $this->strikethrough = false;
             $this->color = new Color(Color::COLOR_BLACK, $isSupervisor, $isConditional);
         } else {
             $this->color = new Color(Color::COLOR_BLACK, $isSupervisor);

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -203,7 +203,7 @@ class Font extends Supervisor
     /**
      * Get Name.
      *
-     * @return null|string
+     * @return string
      */
     public function getName()
     {

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -18,14 +18,14 @@ class Font extends Supervisor
     /**
      * Font Name.
      *
-     * @var null|string
+     * @var string
      */
     protected $name = self::DEFAULT_NAME;
 
     /**
      * Font Size.
      *
-     * @var null|float
+     * @var float
      */
     protected $size = self::DEFAULT_SIZE;
 

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -2938,18 +2938,10 @@ class Worksheet extends BIFFwriter
         // Data Blocks
         if ($bFormatFont == 1) {
             // Font Name
-            if ($conditional->getStyle()->getFont()->getName() === null) {
-                $dataBlockFont = pack('VVVVVVVV', 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000);
-                $dataBlockFont .= pack('VVVVVVVV', 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000);
-            } else {
-                $dataBlockFont = StringHelper::UTF8toBIFF8UnicodeLong($conditional->getStyle()->getFont()->getName());
-            }
+            $dataBlockFont = StringHelper::UTF8toBIFF8UnicodeLong($conditional->getStyle()->getFont()->getName());
             // Font Size
-            if ($conditional->getStyle()->getFont()->getSize() === null) {
-                $dataBlockFont .= pack('V', 20 * 11);
-            } else {
-                $dataBlockFont .= pack('V', 20 * $conditional->getStyle()->getFont()->getSize());
-            }
+            $dataBlockFont .= pack('V', 20 * $conditional->getStyle()->getFont()->getSize());
+
             // Font Options
             $dataBlockFont .= pack('V', 0);
             // Font weight

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -2886,22 +2886,10 @@ class Worksheet extends BIFFwriter
         } else {
             $bFormatFill = 0;
         }
+
         // Font
-        if (
-            $conditional->getStyle()->getFont()->getName() !== null
-            || $conditional->getStyle()->getFont()->getSize() !== null
-            || $conditional->getStyle()->getFont()->getBold() !== null
-            || $conditional->getStyle()->getFont()->getItalic() !== null
-            || $conditional->getStyle()->getFont()->getSuperscript() !== null
-            || $conditional->getStyle()->getFont()->getSubscript() !== null
-            || $conditional->getStyle()->getFont()->getUnderline() !== null
-            || $conditional->getStyle()->getFont()->getStrikethrough() !== null
-            || $conditional->getStyle()->getFont()->getColor()->getARGB() != null
-        ) {
-            $bFormatFont = 1;
-        } else {
-            $bFormatFont = 0;
-        }
+        $bFormatFont = (int) ($conditional->getStyle()->getFont() !== null);
+
         // Alignment
         $flags = 0;
         $flags |= (1 == $bAlignHz ? 0x00000001 : 0);

--- a/src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
@@ -171,12 +171,12 @@ class StringTable extends WriterPart
 
                 // Size
                 $objWriter->startElement($prefix . 'sz');
-                $objWriter->writeAttribute('val', $element->getFont()->getSize());
+                $objWriter->writeAttribute('val', (string) $element->getFont()->getSize());
                 $objWriter->endElement();
 
                 // Underline
                 $objWriter->startElement($prefix . 'u');
-                $objWriter->writeAttribute('val', $element->getFont()->getUnderline());
+                $objWriter->writeAttribute('val', $element->getFont()->getUnderline() ? '1' : '0');
                 $objWriter->endElement();
 
                 $objWriter->endElement();

--- a/src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
@@ -132,53 +132,7 @@ class StringTable extends WriterPart
             if ($element instanceof Run) {
                 // rPr
                 $objWriter->startElement($prefix . 'rPr');
-
-                // rFont
-                $objWriter->startElement($prefix . 'rFont');
-                $objWriter->writeAttribute('val', $element->getFont()->getName());
-                $objWriter->endElement();
-
-                // Bold
-                $objWriter->startElement($prefix . 'b');
-                $objWriter->writeAttribute('val', ($element->getFont()->getBold() ? 'true' : 'false'));
-                $objWriter->endElement();
-
-                // Italic
-                $objWriter->startElement($prefix . 'i');
-                $objWriter->writeAttribute('val', ($element->getFont()->getItalic() ? 'true' : 'false'));
-                $objWriter->endElement();
-
-                // Superscript / subscript
-                if ($element->getFont()->getSuperscript() || $element->getFont()->getSubscript()) {
-                    $objWriter->startElement($prefix . 'vertAlign');
-                    if ($element->getFont()->getSuperscript()) {
-                        $objWriter->writeAttribute('val', 'superscript');
-                    } elseif ($element->getFont()->getSubscript()) {
-                        $objWriter->writeAttribute('val', 'subscript');
-                    }
-                    $objWriter->endElement();
-                }
-
-                // Strikethrough
-                $objWriter->startElement($prefix . 'strike');
-                $objWriter->writeAttribute('val', ($element->getFont()->getStrikethrough() ? 'true' : 'false'));
-                $objWriter->endElement();
-
-                // Color
-                $objWriter->startElement($prefix . 'color');
-                $objWriter->writeAttribute('rgb', $element->getFont()->getColor()->getARGB());
-                $objWriter->endElement();
-
-                // Size
-                $objWriter->startElement($prefix . 'sz');
-                $objWriter->writeAttribute('val', (string) $element->getFont()->getSize());
-                $objWriter->endElement();
-
-                // Underline
-                $objWriter->startElement($prefix . 'u');
-                $objWriter->writeAttribute('val', $element->getFont()->getUnderline() ? '1' : '0');
-                $objWriter->endElement();
-
+                $this->writeRichTextRun($objWriter, $prefix, $element);
                 $objWriter->endElement();
             }
 
@@ -278,5 +232,53 @@ class StringTable extends WriterPart
         }
 
         return $returnValue;
+    }
+
+    protected function writeRichTextRun(XMLWriter $objWriter, ?string $prefix, Run $element): void
+    {
+        // rFont
+        $objWriter->startElement($prefix . 'rFont');
+        $objWriter->writeAttribute('val', $element->getFont()->getName());
+        $objWriter->endElement();
+
+        // Bold
+        $objWriter->startElement($prefix . 'b');
+        $objWriter->writeAttribute('val', ($element->getFont()->getBold() ? 'true' : 'false'));
+        $objWriter->endElement();
+
+        // Italic
+        $objWriter->startElement($prefix . 'i');
+        $objWriter->writeAttribute('val', ($element->getFont()->getItalic() ? 'true' : 'false'));
+        $objWriter->endElement();
+
+        // Superscript / subscript
+        if ($element->getFont()->getSuperscript() || $element->getFont()->getSubscript()) {
+            $objWriter->startElement($prefix . 'vertAlign');
+            $objWriter->writeAttribute(
+                'val',
+                $element->getFont()->getSuperscript() ? 'superscript' : 'subscript'
+            );
+            $objWriter->endElement();
+        }
+
+        // Strikethrough
+        $objWriter->startElement($prefix . 'strike');
+        $objWriter->writeAttribute('val', ($element->getFont()->getStrikethrough() ? 'true' : 'false'));
+        $objWriter->endElement();
+
+        // Color
+        $objWriter->startElement($prefix . 'color');
+        $objWriter->writeAttribute('rgb', $element->getFont()->getColor()->getARGB());
+        $objWriter->endElement();
+
+        // Size
+        $objWriter->startElement($prefix . 'sz');
+        $objWriter->writeAttribute('val', (string) $element->getFont()->getSize());
+        $objWriter->endElement();
+
+        // Underline
+        $objWriter->startElement($prefix . 'u');
+        $objWriter->writeAttribute('val', $element->getFont()->getUnderline() ? '1' : '0');
+        $objWriter->endElement();
     }
 }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Style.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Style.php
@@ -300,11 +300,9 @@ class Style extends WriterPart
         }
 
         // Size
-        if ($pFont->getSize() !== null) {
-            $objWriter->startElement('sz');
-            $objWriter->writeAttribute('val', StringHelper::formatNumber($pFont->getSize()));
-            $objWriter->endElement();
-        }
+        $objWriter->startElement('sz');
+        $objWriter->writeAttribute('val', StringHelper::formatNumber($pFont->getSize()));
+        $objWriter->endElement();
 
         // Foreground color
         if ($pFont->getColor()->getARGB() !== null) {
@@ -314,11 +312,9 @@ class Style extends WriterPart
         }
 
         // Name
-        if ($pFont->getName() !== null) {
-            $objWriter->startElement('name');
-            $objWriter->writeAttribute('val', $pFont->getName());
-            $objWriter->endElement();
-        }
+        $objWriter->startElement('name');
+        $objWriter->writeAttribute('val', $pFont->getName());
+        $objWriter->endElement();
 
         $objWriter->endElement();
     }

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/DefaultFillTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/DefaultFillTest.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheetTests\Reader;
 
 use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Style\Font;
 use PHPUnit\Framework\TestCase;
 
 class DefaultFillTest extends TestCase
@@ -49,6 +50,7 @@ class DefaultFillTest extends TestCase
         $spreadsheet = $reader->load($filename);
 
         $style = $spreadsheet->getActiveSheet()->getConditionalStyles('A1')[0]->getStyle();
-        self::assertSame(10, $style->getFont()->getSize());
+        self::assertSame(Font::DEFAULT_SIZE, $style->getFont()->getSize());
+        self::assertSame(Font::DEFAULT_NAME, $style->getFont()->getName());
     }
 }

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/DefaultFillTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/DefaultFillTest.php
@@ -40,4 +40,15 @@ class DefaultFillTest extends TestCase
         $style = $spreadsheet->getActiveSheet()->getConditionalStyles('A1')[0]->getStyle();
         self::assertSame('solid', $style->getFill()->getFillType());
     }
+
+    public function testDefaultConditionalFontSize(): void
+    {
+        // default fill pattern for a conditional style where the filltype is not defined
+        $filename = 'tests/data/Reader/XLSX/pr2050cf-fill.xlsx';
+        $reader = IOFactory::createReader('Xlsx');
+        $spreadsheet = $reader->load($filename);
+
+        $style = $spreadsheet->getActiveSheet()->getConditionalStyles('A1')[0]->getStyle();
+        self::assertSame(10, $style->getFont()->getSize());
+    }
 }


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

New test to see if PHP8 is failing to correctly set the Default Font Size, but using no size at all (i.e. 0), if none is provided by the style definition in the XML

This is an experiment triggered by a discrepancy when reading/writing the same file against PHP7.4 and PHP8 as identified by [Issue #2035](https://github.com/PHPOffice/PhpSpreadsheet/issues/2035)
