### PR TITLE
Issue 2066, highlighting more validation needed for LookupRef Functions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -976,11 +976,6 @@ parameters:
 			path: src/PhpSpreadsheet/Calculation/LookupRef/LookupBase.php
 
 		-
-			message: "#^Parameter \\#3 \\$rowNum of static method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\Matrix\\:\\:extractRowValue\\(\\) expects int, float\\|int\\<0, max\\>\\|string given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/LookupRef/Matrix.php
-
-		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\Matrix\\:\\:extractRowValue\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Calculation/LookupRef/Matrix.php

--- a/src/PhpSpreadsheet/Calculation/LookupRef/LookupRefValidations.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/LookupRefValidations.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Calculation\LookupRef;
+
+use PhpOffice\PhpSpreadsheet\Calculation\Exception;
+use PhpOffice\PhpSpreadsheet\Calculation\Functions;
+
+class LookupRefValidations
+{
+    /**
+     * @param mixed $value
+     */
+    public static function validateInt($value): int
+    {
+        if (!is_numeric($value)) {
+            if (Functions::isError($value)) {
+                throw new Exception($value);
+            }
+
+            throw new Exception(Functions::VALUE());
+        }
+
+        return (int) floor((float) $value);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function validatePositiveInt($value, bool $allowZero = true): int
+    {
+        $value = self::validateInt($value);
+
+        if (($allowZero === false && $value <= 0) || $value < 0) {
+            throw new Exception(Functions::VALUE());
+        }
+
+        return $value;
+    }
+}

--- a/tests/data/Calculation/LookupRef/INDEX.php
+++ b/tests/data/Calculation/LookupRef/INDEX.php
@@ -24,6 +24,15 @@ return [
         ],
         10,
     ],
+    'Row is not a number' => [
+        '#VALUE!', // Expected
+        // Input
+        [
+            20 => ['R' => 1],
+            21 => ['R' => 2],
+        ],
+        'NaN',
+    ],
     'Row is Error' => [
         '#N/A', // Expected
         // Input
@@ -72,6 +81,16 @@ return [
         2,
         10,
     ],
+    'Column is not a number' => [
+        '#VALUE!', // Expected
+        // Input
+        [
+            20 => ['R' => 1],
+            21 => ['R' => 2],
+        ],
+        1,
+        'NaN',
+    ],
     'Column is Error' => [
         '#N/A', // Expected
         // Input
@@ -81,16 +100,6 @@ return [
         ],
         1,
         '#N/A',
-    ],
-    [
-        '#REF!', // Expected
-        // Input
-        [
-            '20' => ['R' => 1, 'S' => 3],
-            '21' => ['R' => 2, 'S' => 4],
-        ],
-        10,
-        2,
     ],
     [
         4, // Expected

--- a/tests/data/Calculation/LookupRef/INDEX.php
+++ b/tests/data/Calculation/LookupRef/INDEX.php
@@ -6,7 +6,7 @@ return [
         // Input
         [20 => ['R' => 1]],
     ],
-    [
+    'Negative Row' => [
         '#VALUE!', // Expected
         // Input
         [
@@ -15,7 +15,7 @@ return [
         ],
         -1,
     ],
-    [
+    'Row > matrix rows' => [
         '#REF!', // Expected
         // Input
         [
@@ -24,7 +24,16 @@ return [
         ],
         10,
     ],
-    [
+    'Row is Error' => [
+        '#N/A', // Expected
+        // Input
+        [
+            20 => ['R' => 1],
+            21 => ['R' => 2],
+        ],
+        '#N/A',
+    ],
+    'Return row 2' => [
         [21 => ['R' => 2]], // Expected
         // Input
         [
@@ -33,7 +42,7 @@ return [
         ],
         2,
     ],
-    [
+    'Return row 2 from larger matrix' => [
         [21 => ['R' => 2, 'S' => 4]], // Expected
         // Input
         [
@@ -43,17 +52,17 @@ return [
         2,
         0,
     ],
-    [
+    'Negative Column' => [
         '#VALUE!', // Expected
         // Input
         [
             '20' => ['R' => 1, 'S' => 3],
             '21' => ['R' => 2, 'S' => 4],
         ],
-        2,
+        0,
         -1,
     ],
-    [
+    'Column > matrix columns' => [
         '#REF!', // Expected
         // Input
         [
@@ -62,6 +71,16 @@ return [
         ],
         2,
         10,
+    ],
+    'Column is Error' => [
+        '#N/A', // Expected
+        // Input
+        [
+            20 => ['R' => 1],
+            21 => ['R' => 2],
+        ],
+        1,
+        '#N/A',
     ],
     [
         '#REF!', // Expected

--- a/tests/data/Calculation/LookupRef/INDEX.php
+++ b/tests/data/Calculation/LookupRef/INDEX.php
@@ -144,6 +144,15 @@ return [
         1,
     ],
     [
+        [1 => ['Bananas', 'Pears']],
+        [
+            ['Apples', 'Lemons'],
+            ['Bananas', 'Pears'],
+        ],
+        2,
+        0,
+    ],
+    [
         3,
         [
             [4, 6],


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Improved validation of Excel Lookup/Reference Function implementations, highlighted by [Issue #2066](https://github.com/PHPOffice/PhpSpreadsheet/issues/2066).

Code had already been modified in the recent refactoring to return an error, but a '#VALUE!' error indicating that the `INDEX()` row contained a string, rather than specifically an error value