### PR TITLE
Resolve issue with conditional font size set to zero in PHP8

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -71,8 +71,7 @@ class Styles extends BaseParserClass
             $verticalAlign = strtolower((string) $fontStyleXml->vertAlign['val']);
             if ($verticalAlign === 'superscript') {
                 $fontStyle->setSuperscript(true);
-            }
-            if ($verticalAlign === 'subscript') {
+            } elseif ($verticalAlign === 'subscript') {
                 $fontStyle->setSubscript(true);
             }
         }

--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -42,9 +42,12 @@ class Styles extends BaseParserClass
 
     public static function readFontStyle(Font $fontStyle, SimpleXMLElement $fontStyleXml): void
     {
-        $fontStyle->setName((string) $fontStyleXml->name['val']);
-        $fontStyle->setSize((float) $fontStyleXml->sz['val']);
-
+        if (isset($fontStyleXml->name, $fontStyleXml->name['val'])) {
+            $fontStyle->setName((string) $fontStyleXml->name['val']);
+        }
+        if (isset($fontStyleXml->sz, $fontStyleXml->sz['val'])) {
+            $fontStyle->setSize((float) $fontStyleXml->sz['val']);
+        }
         if (isset($fontStyleXml->b)) {
             $fontStyle->setBold(!isset($fontStyleXml->b['val']) || self::boolean((string) $fontStyleXml->b['val']));
         }

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/DefaultFillTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/DefaultFillTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpOffice\PhpSpreadsheetTests\Reader;
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PHPUnit\Framework\TestCase;

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/DefaultFontTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/DefaultFontTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PHPUnit\Framework\TestCase;
+
+class DefaultFontTest extends TestCase
+{
+    public function testDefaultConditionalFont(): void
+    {
+        // default fill pattern for a conditional style where the filltype is not defined
+        $filename = 'tests/data/Reader/XLSX/pr2050cf-fill.xlsx';
+        $reader = IOFactory::createReader('Xlsx');
+        $spreadsheet = $reader->load($filename);
+
+        $style = $spreadsheet->getActiveSheet()->getConditionalStyles('A1')[0]->getStyle();
+        self::assertSame('9C0006', $style->getFont()->getColor()->getRGB());
+        self::assertNull($style->getFont()->getName());
+        self::assertNull($style->getFont()->getSize());
+    }
+}


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

PHP 8 is setting conditional font size to 0 if no font size defined in the dxfs, which results in a corrupted output file when saving again