### PR TITLE
Use modification time from properties when saving Excel5

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xls.php
+++ b/src/PhpSpreadsheet/Writer/Xls.php
@@ -219,7 +219,8 @@ class Xls extends BaseWriter
             $arrRootData[] = $OLE_DocumentSummaryInformation;
         }
 
-        $root = new Root(time(), time(), $arrRootData);
+        $time = $this->spreadsheet->getProperties()->getModified();
+        $root = new Root($time, $time, $arrRootData);
         // save the OLE file
         $this->openFileHandle($pFilename);
         $root->save($this->fileHandle);


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

The hardcoded time() in the Excel5 writer causes the file to change every time it is saved, even if the creation and modification dates have not changed.

This change makes replaces the calls to time() with usage of getModified().
