### PR TITLE
Xlsx Writer Formula with Bool Result of False

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1230,6 +1230,7 @@ class Worksheet extends WriterPart
             $objWriter->writeAttribute('t', 'str');
         } elseif (is_bool($calculatedValue)) {
             $objWriter->writeAttribute('t', 'b');
+            $calculatedValue = (int) $calculatedValue;
         }
         // array values are not yet supported
         //$attributes = $pCell->getFormulaAttributes();

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue2082Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue2082Test.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as Writer;
+use PHPUnit\Framework\TestCase;
+
+class Issue2082Test extends TestCase
+{
+    public function testBoolWrite(): void
+    {
+        // Problem writing boolean function values is detected only when
+        // opening spreadsheet in Excel 2007-2016. Test verifies that
+        // value field is written correctly for those versions.
+        $outputFilename = File::temporaryFilename();
+        $spreadsheet = new Spreadsheet();
+        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet->fromArray(['A', 'B', 'C', 'D']);
+        $worksheet->getCell('A2')->setValue('=A1<>"A"');
+        $worksheet->getCell('A3')->setValue('=A1="A"');
+        $worksheet->getCell('B2')->setValue('=LEFT(B1, 0)');
+        $worksheet->getCell('B3')->setValue('=B2=""');
+
+        $writer = new Writer($spreadsheet);
+        $writer->save($outputFilename);
+        $zipfile = "zip://$outputFilename#xl/worksheets/sheet1.xml";
+        $contents = file_get_contents($zipfile);
+        unlink($outputFilename);
+        if ($contents === false) {
+            self::fail('Unable to open file');
+        } else {
+            self::assertStringContainsString('<c r="A2" t="b"><f>A1&lt;&gt;&quot;A&quot;</f><v>0</v></c>', $contents);
+            self::assertStringContainsString('<c r="A3" t="b"><f>A1=&quot;A&quot;</f><v>1</v></c>', $contents);
+            self::assertStringContainsString('<c r="B2" t="str"><f>LEFT(B1, 0)</f><v></v></c>', $contents);
+            self::assertStringContainsString('<c r="B3" t="b"><f>B2=&quot;&quot;</f><v>1</v></c>', $contents);
+        }
+    }
+}


### PR DESCRIPTION
Fix for #2082. Xlsx Writer was writing a cell which is a formula which evaluates to boolean false as an empty XML tag. This is okay for Excel 365, but not for Excel 2016-. Change to write the tag as a value of 0 instead, which works for all Excel releases. Add test.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
