### PR TITLE
fix: Set font size to 10 when given 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Fixed issue with Xlsx@listWorksheetInfo not returning any data
 - Fixed invalid arguments triggering mb_substr() error in LEFT(), MID() and RIGHT() text functions. [Issue #640](https://github.com/PHPOffice/PhpSpreadsheet/issues/640)
 - Fix for [Issue #1916](https://github.com/PHPOffice/PhpSpreadsheet/issues/1916) - Invalid signature check for XML files
+- Fix change in `Font::setSize()` behavior for PHP8. [PR #2100](https://github.com/PHPOffice/PhpSpreadsheet/pull/2100)
 
 ## 1.17.1 - 2021-03-01
 

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -249,15 +249,22 @@ class Font extends Supervisor
     /**
      * Set Size.
      *
-     * @param float $pValue
+     * @param mixed $pValue A float representing the value of a positive measurement in points (1/72 of an inch)
      *
      * @return $this
      */
     public function setSize($pValue)
     {
-        if ($pValue == '') {
-            $pValue = 10;
+        if (is_string($pValue) || is_int($pValue)) {
+            $pValue = (float) $pValue; // $pValue = 0 if given string is not numeric
         }
+
+        // Size must be a positive floating point number
+        // ECMA-376-1:2016, part 1, chapter 18.4.11 sz (Font Size), p. 1536
+        if (!is_float($pValue) || !($pValue > 0)) {
+            $pValue = 10.0;
+        }
+
         if ($this->isSupervisor) {
             $styleArray = $this->getStyleArray(['size' => $pValue]);
             $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($styleArray);

--- a/tests/PhpSpreadsheetTests/Style/FontTest.php
+++ b/tests/PhpSpreadsheetTests/Style/FontTest.php
@@ -39,4 +39,36 @@ class FontTest extends TestCase
         self::assertTrue($font->getSuperscript());
         self::assertFalse($font->getSubscript(), 'False remains unchanged');
     }
+
+    public function testSize(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $cell = $sheet->getCell('A1');
+        $cell->setValue('Cell A1');
+        $font = $cell->getStyle()->getFont();
+
+        self::assertEquals(11, $font->getSize(), 'The default is 11');
+
+        $font->setSize(12);
+        self::assertEquals(12, $font->getSize(), 'Accepted new font size');
+
+        $invalidFontSizeValues = [
+            '',
+            false,
+            true,
+            'non_numeric_string',
+            '-1.0',
+            -1.0,
+            0,
+            [],
+            (object) [],
+            null,
+        ];
+        foreach ($invalidFontSizeValues as $invalidFontSizeValue) {
+            $font->setSize(12);
+            $font->setSize($invalidFontSizeValue);
+            self::assertEquals(10, $font->getSize(), 'Set to 10 after trying to set an invalid value.');
+        }
+    }
 }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

This change restored behavior from PHP7 in PHP8. In PHP7 calling
setSize(0) resulted in font size being set to 10. The fix addresses
change to equal comparisons in PHP8. Extra comparison is added to keep
 result from PHP7 in PHP8 for the setSize(0) case.
