### PR TITLE
Avoid memory leak

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -399,6 +399,7 @@ class Worksheet implements IComparable
         Calculation::getInstance($this->parent)->clearCalculationCacheForWorksheet($this->title);
 
         $this->disconnectCells();
+        $this->rowDimensions = [];
     }
 
     /**


### PR DESCRIPTION
When creating a spreadsheet, and writing to Xlsx, then to Xls, then
reading the Xls, it would leak memory during reading.

Fixes #2092