### PR TITLE
Updates to documentation concerning Value Binders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
-- Nothing.
+- More flexibility in the StringValueBinder to determine what datatypes should be treated as strings [PR #2138](https://github.com/PHPOffice/PhpSpreadsheet/pull/2138)
 
 ### Changed
 

--- a/docs/topics/accessing-cells.md
+++ b/docs/topics/accessing-cells.md
@@ -561,7 +561,9 @@ $spreadsheet->getActiveSheet()->setCellValue('B5', '21 December 1983');
 Alternatively, a `\PhpOffice\PhpSpreadsheet\Cell\StringValueBinder` class is available
 if you want to preserve all string content as strings. This might be appropriate if you
 were loading a file containing values that could be interpreted as numbers (e.g. numbers
-with leading zeroes such as phone numbers), but that should be retained as strings.
+with leading sign such as international phone numbers like `+441615579382`), but that
+should be retained as strings (non-international phone numbers with leading zeroes are
+already maintained as strings).
 
 **Creating your own value binder is relatively straightforward.** When more specialised
 value binding is required, you can implement the

--- a/docs/topics/accessing-cells.md
+++ b/docs/topics/accessing-cells.md
@@ -559,11 +559,23 @@ $spreadsheet->getActiveSheet()->setCellValue('B5', '21 December 1983');
 ```
 
 Alternatively, a `\PhpOffice\PhpSpreadsheet\Cell\StringValueBinder` class is available
-if you want to preserve all string content as strings. This might be appropriate if you
+if you want to preserve all content as strings. This might be appropriate if you
 were loading a file containing values that could be interpreted as numbers (e.g. numbers
 with leading sign such as international phone numbers like `+441615579382`), but that
 should be retained as strings (non-international phone numbers with leading zeroes are
 already maintained as strings).
+
+By default, the StringValueBinder will cast any datatype passed to it into a string. However, there are a number of settings which allow you to specify that certain datatypes shouldn't be cast to strings, but left "as is":
+
+```php
+// Set value binder
+$stringValueBinder = new \PhpOffice\PhpSpreadsheet\Cell\StringValueBinder();
+$stringValueBinder->setNumericConversion(false)
+    ->setBooleanConversion(false)
+    ->setNullConversion(false)
+    ->setFormulaConversion(false);
+\PhpOffice\PhpSpreadsheet\Cell\Cell::setValueBinder( $stringValueBinder );
+```
 
 **Creating your own value binder is relatively straightforward.** When more specialised
 value binding is required, you can implement the

--- a/docs/topics/accessing-cells.md
+++ b/docs/topics/accessing-cells.md
@@ -110,6 +110,11 @@ values beginning with `=` will be converted to a formula. Strings that
 aren't numeric, or that don't begin with a leading `=` will be treated
 as genuine string values.
 
+Note that a numeric string that begins with a leading zero (that isn't
+immediately followed by a decimal separator) will not be converted to a
+numeric, so values like phone numbers (e.g. `01615991375``will remain as
+strings).
+
 This "conversion" is handled by a cell "value binder", and you can write
 custom "value binders" to change the behaviour of these "conversions".
 The standard PhpSpreadsheet package also provides an "advanced value
@@ -138,8 +143,10 @@ Formats handled by the advanced value binder include:
 - When strings contain a newline character (`\n`), then the cell styling is
   set to wrap.
 
-You can read more about value binders later in this section of the
-documentation.
+Basically, it attempts to mimic the behaviour of the MS Excel GUI.
+
+You can read more about value binders [later in this section of the
+documentation](#using-value-binders-to-facilitate-data-entry).
 
 ### Setting a formula in a Cell
 
@@ -551,8 +558,13 @@ $spreadsheet->getActiveSheet()->setCellValue('A5', 'Date/time value:');
 $spreadsheet->getActiveSheet()->setCellValue('B5', '21 December 1983');
 ```
 
-**Creating your own value binder is easy.** When advanced value binding
-is required, you can implement the
-`\PhpOffice\PhpSpreadsheet\Cell\IValueBinder` interface or extend the
+Alternatively, a `\PhpOffice\PhpSpreadsheet\Cell\StringValueBinder` class is available
+if you want to preserve all string content as strings. This might be appropriate if you
+were loading a file containing values that could be interpreted as numbers (e.g. numbers
+with leading zeroes such as phone numbers), but that should be retained as strings.
+
+**Creating your own value binder is relatively straightforward.** When more specialised
+value binding is required, you can implement the
+`\PhpOffice\PhpSpreadsheet\Cell\IValueBinder` interface or extend the existing
 `\PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder` or
 `\PhpOffice\PhpSpreadsheet\Cell\AdvancedValueBinder` classes.

--- a/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
@@ -26,6 +26,7 @@ class DefaultValueBinder implements IValueBinder
             if ($value instanceof DateTimeInterface) {
                 $value = $value->format('Y-m-d H:i:s');
             } elseif (!($value instanceof RichText)) {
+                // Attempt to cast any unexpected objects to string
                 $value = (string) $value;
             }
         }

--- a/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
@@ -57,11 +57,11 @@ class DefaultValueBinder implements IValueBinder
             return DataType::TYPE_STRING;
         } elseif ($value instanceof RichText) {
             return DataType::TYPE_INLINE;
-        } elseif (is_string($value) && $value[0] === '=' && strlen($value) > 1) {
+        } elseif (is_string($value) && strlen($value) > 1 && $value[0] === '=') {
             return DataType::TYPE_FORMULA;
         } elseif (preg_match('/^[\+\-]?(\d+\\.?\d*|\d*\\.?\d+)([Ee][\-\+]?[0-2]?\d{1,3})?$/', $value)) {
             $tValue = ltrim($value, '+-');
-            if (is_string($value) && $tValue[0] === '0' && strlen($tValue) > 1 && $tValue[1] !== '.') {
+            if (is_string($value) && strlen($tValue) > 1 && $tValue[0] === '0' && $tValue[1] !== '.') {
                 return DataType::TYPE_STRING;
             } elseif ((strpos($value, '.') === false) && ($value > PHP_INT_MAX)) {
                 return DataType::TYPE_STRING;

--- a/src/PhpSpreadsheet/Cell/StringValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/StringValueBinder.php
@@ -9,22 +9,22 @@ use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 class StringValueBinder implements IValueBinder
 {
     /**
-     * @var bool $convertNull
+     * @var bool
      */
     protected $convertNull = true;
 
     /**
-     * @var bool $convertBoolean
+     * @var bool
      */
     protected $convertBoolean = true;
 
     /**
-     * @var bool $convertNumeric
+     * @var bool
      */
     protected $convertNumeric = true;
 
     /**
-     * @var bool $convertFormula
+     * @var bool
      */
     protected $convertFormula = true;
 

--- a/src/PhpSpreadsheet/Cell/StringValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/StringValueBinder.php
@@ -86,12 +86,9 @@ class StringValueBinder implements IValueBinder
             if ($value instanceof DateTimeInterface) {
                 $value = $value->format('Y-m-d H:i:s');
             } elseif ($value instanceof RichText) {
-                $cell->setValueExplicit((string) $value, DataType::TYPE_INLINE);
+                $cell->setValueExplicit((string)$value, DataType::TYPE_INLINE);
 
                 return true;
-            } else {
-                // Attempt to cast any unexpected objects to string
-                $value = (string) $value;
             }
         }
 

--- a/src/PhpSpreadsheet/Cell/StringValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/StringValueBinder.php
@@ -8,12 +8,24 @@ use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 
 class StringValueBinder implements IValueBinder
 {
+    /**
+     * @var bool $convertNull
+     */
     protected $convertNull = true;
 
+    /**
+     * @var bool $convertBoolean
+     */
     protected $convertBoolean = true;
 
+    /**
+     * @var bool $convertNumeric
+     */
     protected $convertNumeric = true;
 
+    /**
+     * @var bool $convertFormula
+     */
     protected $convertFormula = true;
 
     public function setNullConversion(bool $suppressConversion = false): self

--- a/src/PhpSpreadsheet/Cell/StringValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/StringValueBinder.php
@@ -71,25 +71,16 @@ class StringValueBinder implements IValueBinder
      *
      * @param Cell $cell Cell to bind value to
      * @param mixed $value Value to bind in cell
-     *
-     * @return bool
      */
     public function bindValue(Cell $cell, $value)
     {
+        if (is_object($value)) {
+            return $this->bindObjectValue($cell, $value);
+        }
+
         // sanitize UTF-8 strings
         if (is_string($value)) {
             $value = StringHelper::sanitizeUTF8($value);
-        }
-
-        if (is_object($value)) {
-            // Handle any objects that might be injected
-            if ($value instanceof DateTimeInterface) {
-                $value = $value->format('Y-m-d H:i:s');
-            } elseif ($value instanceof RichText) {
-                $cell->setValueExplicit($value, DataType::TYPE_INLINE);
-
-                return true;
-            }
         }
 
         if ($value === null && $this->convertNull === false) {
@@ -106,6 +97,22 @@ class StringValueBinder implements IValueBinder
             }
             $cell->setValueExplicit((string) $value, DataType::TYPE_STRING);
         }
+
+        return true;
+    }
+
+    protected function bindObjectValue(Cell $cell, $value): bool
+    {
+        // Handle any objects that might be injected
+        if ($value instanceof DateTimeInterface) {
+            $value = $value->format('Y-m-d H:i:s');
+        } elseif ($value instanceof RichText) {
+            $cell->setValueExplicit($value, DataType::TYPE_INLINE);
+
+            return true;
+        }
+
+        $cell->setValueExplicit((string) $value, DataType::TYPE_STRING);
 
         return true;
     }

--- a/src/PhpSpreadsheet/Cell/StringValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/StringValueBinder.php
@@ -101,7 +101,7 @@ class StringValueBinder implements IValueBinder
         return true;
     }
 
-    protected function bindObjectValue(Cell $cell, $value): bool
+    protected function bindObjectValue(Cell $cell, object $value): bool
     {
         // Handle any objects that might be injected
         if ($value instanceof DateTimeInterface) {

--- a/src/PhpSpreadsheet/Cell/StringValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/StringValueBinder.php
@@ -86,7 +86,7 @@ class StringValueBinder implements IValueBinder
             if ($value instanceof DateTimeInterface) {
                 $value = $value->format('Y-m-d H:i:s');
             } elseif ($value instanceof RichText) {
-                $cell->setValueExplicit((string)$value, DataType::TYPE_INLINE);
+                $cell->setValueExplicit($value, DataType::TYPE_INLINE);
 
                 return true;
             }

--- a/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
@@ -43,7 +43,7 @@ class AdvancedValueBinderTest extends TestCase
         StringHelper::setThousandsSeparator($this->thousandsSeparator);
     }
 
-    public function testNullValue()
+    public function testNullValue(): void
     {
         /** @var Cell&MockObject $cellStub */
         $cellStub = $this->getMockBuilder(Cell::class)

--- a/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
@@ -9,6 +9,7 @@ use PhpOffice\PhpSpreadsheet\Collection\Cells;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AdvancedValueBinderTest extends TestCase
@@ -40,6 +41,23 @@ class AdvancedValueBinderTest extends TestCase
         StringHelper::setCurrencyCode($this->currencyCode);
         StringHelper::setDecimalSeparator($this->decimalSeparator);
         StringHelper::setThousandsSeparator($this->thousandsSeparator);
+    }
+
+    public function testNullValue()
+    {
+        /** @var Cell&MockObject $cellStub */
+        $cellStub = $this->getMockBuilder(Cell::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // Configure the stub.
+        $cellStub->expects(self::once())
+            ->method('setValueExplicit')
+            ->with(null, DataType::TYPE_NULL)
+            ->willReturn(true);
+
+        $binder = new AdvancedValueBinder();
+        $binder->bindValue($cellStub, null);
     }
 
     /**
@@ -105,6 +123,7 @@ class AdvancedValueBinderTest extends TestCase
             ['€2.020,20', 2020.2, $currencyEURO, '.', ',', '€'],
             ['€ 2.020,20', 2020.2, $currencyEURO, '.', ',', '€'],
             ['€2,020.22', 2020.22, $currencyEURO, ',', '.', '€'],
+            ['$10.11', 10.11, $currencyUSD, ',', '.', '€'],
         ];
     }
 

--- a/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
 
 class StringValueBinderTest extends TestCase
 {
+    /**
+     * @param mixed $expectedValue
+     */
     protected function createCellStub($expectedValue, string $expectedDataType, bool $quotePrefix = false): Cell
     {
         /** @var Style&MockObject $styleStub */
@@ -39,6 +42,9 @@ class StringValueBinderTest extends TestCase
 
     /**
      * @dataProvider providerDataValuesDefault
+     *
+     * @param mixed $value
+     * @param mixed $expectedValue
      */
     public function testStringValueBinderDefaultBehaviour(
         $value,
@@ -82,6 +88,9 @@ class StringValueBinderTest extends TestCase
 
     /**
      * @dataProvider providerDataValuesSuppressNullConversion
+     *
+     * @param mixed $value
+     * @param mixed $expectedValue
      */
     public function testStringValueBinderSuppressNullConversion(
         $value,
@@ -105,6 +114,9 @@ class StringValueBinderTest extends TestCase
 
     /**
      * @dataProvider providerDataValuesSuppressBooleanConversion
+     *
+     * @param mixed $value
+     * @param mixed $expectedValue
      */
     public function testStringValueBinderSuppressBooleanConversion(
         $value,
@@ -129,6 +141,9 @@ class StringValueBinderTest extends TestCase
 
     /**
      * @dataProvider providerDataValuesSuppressNumericConversion
+     *
+     * @param mixed $value
+     * @param mixed $expectedValue
      */
     public function testStringValueBinderSuppressNumericConversion(
         $value,
@@ -159,6 +174,9 @@ class StringValueBinderTest extends TestCase
 
     /**
      * @dataProvider providerDataValuesSuppressFormulaConversion
+     *
+     * @param mixed $value
+     * @param mixed $expectedValue
      */
     public function testStringValueBinderSuppressFormulaConversion(
         $value,
@@ -182,6 +200,9 @@ class StringValueBinderTest extends TestCase
 
     /**
      * @dataProvider providerDataValuesSuppressAllConversion
+     *
+     * @param mixed $value
+     * @param mixed $expectedValue
      */
     public function testStringValueBinderSuppressAllConversion(
         $value,

--- a/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
@@ -6,7 +6,6 @@ use DateTime;
 use DateTimeZone;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
-use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
 use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Style\Style;

--- a/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
@@ -6,7 +6,9 @@ use DateTime;
 use DateTimeZone;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
 use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
+use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -244,5 +246,17 @@ class StringValueBinderTest extends TestCase
             [1.23e-4, 0.000123, DataType::TYPE_NUMERIC],
             [1.23e-24, 1.23E-24, DataType::TYPE_NUMERIC],
         ];
+    }
+
+    public function testStringValueBinderForRichTextObject(): void
+    {
+        $objRichText = new RichText();
+        $objRichText->createText('Hello World');
+
+        $cellStub = $this->createCellStub($objRichText, DataType::TYPE_INLINE);
+
+        $binder = new StringValueBinder();
+        $binder->setConversionForAllValueTypes(false);
+        $binder->bindValue($cellStub, $objRichText);
     }
 }

--- a/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
@@ -15,8 +15,10 @@ class StringValueBinderTest extends TestCase
 {
     /**
      * @param mixed $expectedValue
+     *
+     * @return Cell&MockObject
      */
-    protected function createCellStub($expectedValue, string $expectedDataType, bool $quotePrefix = false): Cell
+    protected function createCellStub($expectedValue, string $expectedDataType, bool $quotePrefix = false): MockObject
     {
         /** @var Style&MockObject $styleStub */
         $styleStub = $this->getMockBuilder(Style::class)

--- a/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Cell;
+
+use DateTime;
+use DateTimeZone;
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
+use PhpOffice\PhpSpreadsheet\Style\Style;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class StringValueBinderTest extends TestCase
+{
+    protected function createCellStub($expectedValue, string $expectedDataType, bool $quotePrefix = false): Cell
+    {
+        /** @var Style&MockObject $styleStub */
+        $styleStub = $this->getMockBuilder(Style::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        /** @var Cell&MockObject $cellStub */
+        $cellStub = $this->getMockBuilder(Cell::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // Configure the stub.
+        $cellStub->expects(self::once())
+            ->method('setValueExplicit')
+            ->with($expectedValue, $expectedDataType)
+            ->willReturn(true);
+        $cellStub->expects($quotePrefix ? self::once() : self::never())
+            ->method('getStyle')
+            ->willReturn($styleStub);
+
+        return $cellStub;
+    }
+
+    /**
+     * @dataProvider providerDataValuesDefault
+     */
+    public function testStringValueBinderDefaultBehaviour(
+        $value,
+        $expectedValue,
+        string $expectedDataType,
+        bool $quotePrefix = false
+    ): void {
+        $cellStub = $this->createCellStub($expectedValue, $expectedDataType, $quotePrefix);
+
+        $binder = new StringValueBinder();
+        $binder->bindValue($cellStub, $value);
+    }
+
+    public function providerDataValuesDefault(): array
+    {
+        return [
+            [null, '', DataType::TYPE_STRING],
+            [true, '1', DataType::TYPE_STRING],
+            [false, '', DataType::TYPE_STRING],
+            ['', '', DataType::TYPE_STRING],
+            ['123', '123', DataType::TYPE_STRING],
+            ['123.456', '123.456', DataType::TYPE_STRING],
+            ['0.123', '0.123', DataType::TYPE_STRING],
+            ['.123', '.123', DataType::TYPE_STRING],
+            ['-0.123', '-0.123', DataType::TYPE_STRING],
+            ['-.123', '-.123', DataType::TYPE_STRING],
+            ['1.23e-4', '1.23e-4', DataType::TYPE_STRING],
+            ['ABC', 'ABC', DataType::TYPE_STRING],
+            ['=SUM(A1:C3)', '=SUM(A1:C3)', DataType::TYPE_STRING, true],
+            [123, '123', DataType::TYPE_STRING],
+            [123.456, '123.456', DataType::TYPE_STRING],
+            [0.123, '0.123', DataType::TYPE_STRING],
+            [.123, '0.123', DataType::TYPE_STRING],
+            [-0.123, '-0.123', DataType::TYPE_STRING],
+            [-.123, '-0.123', DataType::TYPE_STRING],
+            [1.23e-4, '0.000123', DataType::TYPE_STRING],
+            [1.23e-24, '1.23E-24', DataType::TYPE_STRING],
+            [new DateTime('2021-06-01 00:00:00', new DateTimeZone('UTC')), '2021-06-01 00:00:00', DataType::TYPE_STRING],
+        ];
+    }
+
+    /**
+     * @dataProvider providerDataValuesSuppressNullConversion
+     */
+    public function testStringValueBinderSuppressNullConversion(
+        $value,
+        $expectedValue,
+        string $expectedDataType,
+        bool $quotePrefix = false
+    ): void {
+        $cellStub = $this->createCellStub($expectedValue, $expectedDataType, $quotePrefix);
+
+        $binder = new StringValueBinder();
+        $binder->setNullConversion(false);
+        $binder->bindValue($cellStub, $value);
+    }
+
+    public function providerDataValuesSuppressNullConversion(): array
+    {
+        return [
+            [null, null, DataType::TYPE_NULL],
+        ];
+    }
+
+    /**
+     * @dataProvider providerDataValuesSuppressBooleanConversion
+     */
+    public function testStringValueBinderSuppressBooleanConversion(
+        $value,
+        $expectedValue,
+        string $expectedDataType,
+        bool $quotePrefix = false
+    ): void {
+        $cellStub = $this->createCellStub($expectedValue, $expectedDataType, $quotePrefix);
+
+        $binder = new StringValueBinder();
+        $binder->setBooleanConversion(false);
+        $binder->bindValue($cellStub, $value);
+    }
+
+    public function providerDataValuesSuppressBooleanConversion(): array
+    {
+        return [
+            [true, true, DataType::TYPE_BOOL],
+            [false, false, DataType::TYPE_BOOL],
+        ];
+    }
+
+    /**
+     * @dataProvider providerDataValuesSuppressNumericConversion
+     */
+    public function testStringValueBinderSuppressNumericConversion(
+        $value,
+        $expectedValue,
+        string $expectedDataType,
+        bool $quotePrefix = false
+    ): void {
+        $cellStub = $this->createCellStub($expectedValue, $expectedDataType, $quotePrefix);
+
+        $binder = new StringValueBinder();
+        $binder->setNumericConversion(false);
+        $binder->bindValue($cellStub, $value);
+    }
+
+    public function providerDataValuesSuppressNumericConversion(): array
+    {
+        return [
+            [123, 123, DataType::TYPE_NUMERIC],
+            [123.456, 123.456, DataType::TYPE_NUMERIC],
+            [0.123, 0.123, DataType::TYPE_NUMERIC],
+            [.123, 0.123, DataType::TYPE_NUMERIC],
+            [-0.123, -0.123, DataType::TYPE_NUMERIC],
+            [-.123, -0.123, DataType::TYPE_NUMERIC],
+            [1.23e-4, 0.000123, DataType::TYPE_NUMERIC],
+            [1.23e-24, 1.23E-24, DataType::TYPE_NUMERIC],
+        ];
+    }
+
+    /**
+     * @dataProvider providerDataValuesSuppressFormulaConversion
+     */
+    public function testStringValueBinderSuppressFormulaConversion(
+        $value,
+        $expectedValue,
+        string $expectedDataType,
+        bool $quotePrefix = false
+    ): void {
+        $cellStub = $this->createCellStub($expectedValue, $expectedDataType, $quotePrefix);
+
+        $binder = new StringValueBinder();
+        $binder->setFormulaConversion(false);
+        $binder->bindValue($cellStub, $value);
+    }
+
+    public function providerDataValuesSuppressFormulaConversion(): array
+    {
+        return [
+            ['=SUM(A1:C3)', '=SUM(A1:C3)', DataType::TYPE_FORMULA, false],
+        ];
+    }
+
+    /**
+     * @dataProvider providerDataValuesSuppressAllConversion
+     */
+    public function testStringValueBinderSuppressAllConversion(
+        $value,
+        $expectedValue,
+        string $expectedDataType,
+        bool $quotePrefix = false
+    ): void {
+        $cellStub = $this->createCellStub($expectedValue, $expectedDataType, $quotePrefix);
+
+        $binder = new StringValueBinder();
+        $binder->setConversionForAllValueTypes(false);
+        $binder->bindValue($cellStub, $value);
+    }
+
+    public function providerDataValuesSuppressAllConversion(): array
+    {
+        return [
+            [null, null, DataType::TYPE_NULL],
+            [true, true, DataType::TYPE_BOOL],
+            [false, false, DataType::TYPE_BOOL],
+            ['', '', DataType::TYPE_STRING],
+            ['123', '123', DataType::TYPE_STRING],
+            ['123.456', '123.456', DataType::TYPE_STRING],
+            ['0.123', '0.123', DataType::TYPE_STRING],
+            ['.123', '.123', DataType::TYPE_STRING],
+            ['-0.123', '-0.123', DataType::TYPE_STRING],
+            ['-.123', '-.123', DataType::TYPE_STRING],
+            ['1.23e-4', '1.23e-4', DataType::TYPE_STRING],
+            ['ABC', 'ABC', DataType::TYPE_STRING],
+            ['=SUM(A1:C3)', '=SUM(A1:C3)', DataType::TYPE_FORMULA, false],
+            [123, 123, DataType::TYPE_NUMERIC],
+            [123.456, 123.456, DataType::TYPE_NUMERIC],
+            [0.123, 0.123, DataType::TYPE_NUMERIC],
+            [.123, 0.123, DataType::TYPE_NUMERIC],
+            [-0.123, -0.123, DataType::TYPE_NUMERIC],
+            [-.123, -0.123, DataType::TYPE_NUMERIC],
+            [1.23e-4, 0.000123, DataType::TYPE_NUMERIC],
+            [1.23e-24, 1.23E-24, DataType::TYPE_NUMERIC],
+        ];
+    }
+}

--- a/tests/data/Cell/DefaultValueBinder.php
+++ b/tests/data/Cell/DefaultValueBinder.php
@@ -77,4 +77,8 @@ return [
         's',
         '123456\n',
     ],
+    'Numeric that exceeds PHP MAX_INT Size' => [
+        's',
+        '1234567890123459012345689012345690',
+    ]
 ];

--- a/tests/data/Cell/DefaultValueBinder.php
+++ b/tests/data/Cell/DefaultValueBinder.php
@@ -80,5 +80,5 @@ return [
     'Numeric that exceeds PHP MAX_INT Size' => [
         's',
         '1234567890123459012345689012345690',
-    ]
+    ],
 ];


### PR DESCRIPTION
Fix a couple of checks on characters at positions within a string before checking the length of the string when the offset may not exist

This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] documentation
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [X] Documentation is updated as necessary

### Why this change is needed?

Update the documentation on Value Binders to include the case where numeric strings won't be converted to numbers, and reference the StringValueBinder