### PR TITLE
Only calculate column autosize for a cell if it contains data

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -757,15 +757,17 @@ class Worksheet implements IComparable
                             $this->getParent()->getCellXfByIndex($cell->getXfIndex())->getNumberFormat()->getFormatCode()
                         );
 
-                        $autoSizes[$this->cellCollection->getCurrentColumn()] = max(
-                            (float) $autoSizes[$this->cellCollection->getCurrentColumn()],
-                            (float) Shared\Font::calculateColumnWidth(
-                                $this->getParent()->getCellXfByIndex($cell->getXfIndex())->getFont(),
-                                $cellValue,
-                                $this->getParent()->getCellXfByIndex($cell->getXfIndex())->getAlignment()->getTextRotation(),
-                                $this->getParent()->getDefaultStyle()->getFont()
-                            )
-                        );
+                        if ($cellValue !== null && $cellValue !== '') {
+                            $autoSizes[$this->cellCollection->getCurrentColumn()] = max(
+                                (float)$autoSizes[$this->cellCollection->getCurrentColumn()],
+                                (float)Shared\Font::calculateColumnWidth(
+                                    $this->getParent()->getCellXfByIndex($cell->getXfIndex())->getFont(),
+                                    $cellValue,
+                                    $this->getParent()->getCellXfByIndex($cell->getXfIndex())->getAlignment()->getTextRotation(),
+                                    $this->getParent()->getDefaultStyle()->getFont()
+                                )
+                            );
+                        }
                     }
                 }
             }

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -759,8 +759,8 @@ class Worksheet implements IComparable
 
                         if ($cellValue !== null && $cellValue !== '') {
                             $autoSizes[$this->cellCollection->getCurrentColumn()] = max(
-                                (float)$autoSizes[$this->cellCollection->getCurrentColumn()],
-                                (float)Shared\Font::calculateColumnWidth(
+                                (float) $autoSizes[$this->cellCollection->getCurrentColumn()],
+                                (float) Shared\Font::calculateColumnWidth(
                                     $this->getParent()->getCellXfByIndex($cell->getXfIndex())->getFont(),
                                     $cellValue,
                                     $this->getParent()->getCellXfByIndex($cell->getXfIndex())->getAlignment()->getTextRotation(),


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Fix for [Issue #2165](https://github.com/PHPOffice/PhpSpreadsheet/issues/2165)