### PR TITLE
Move Reader Xlsx Tests from Reader to Reader/Xlsx Try 2

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7206,16 +7206,6 @@ parameters:
 			path: tests/PhpSpreadsheetTests/Reader/Xlsx/AutoFilterTest.php
 
 		-
-			message: "#^Function PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\getTitleText\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ChartsTitleTest.php
-
-		-
-			message: "#^Function PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\getTitleText\\(\\) has parameter \\$title with no typehint specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ChartsTitleTest.php
-
-		-
 			message: "#^Cannot call method setMinimumConditionalFormatValueObject\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\ConditionalFormatting\\\\ConditionalDataBar\\|null\\.$#"
 			count: 1
 			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalFormattingDataBarXlsxTest.php
@@ -7244,11 +7234,6 @@ parameters:
 			message: "#^Cannot call method getShowValue\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\ConditionalFormatting\\\\ConditionalDataBar\\|null\\.$#"
 			count: 1
 			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalFormattingDataBarXlsxTest.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\XlsxTest\\:\\:testStripsWhiteSpaceFromStyleString\\(\\) has parameter \\$string with no typehint specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/XlsxTest.php
 
 		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\Xml\\\\XmlTest\\:\\:testInvalidSimpleXML\\(\\) has parameter \\$filename with no typehint specified\\.$#"

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/ChartsTitleTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/ChartsTitleTest.php
@@ -1,23 +1,24 @@
 <?php
 
-namespace PhpOffice\PhpSpreadsheetTests\Reader;
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
 
+use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PHPUnit\Framework\TestCase;
 
-function getTitleText($title)
-{
-    if (null === $title || null === $title->getCaption()) {
-        return null;
-    }
-
-    return implode("\n", array_map(function ($rt) {
-        return $rt->getPlainText();
-    }, $title->getCaption()));
-}
-
 class ChartsTitleTest extends TestCase
 {
+    private static function getTitleText(?Title $title): ?string
+    {
+        if (null === $title || empty($title->getCaption())) {
+            return null;
+        }
+
+        return implode("\n", array_map(function ($rt) {
+            return $rt->getPlainText();
+        }, $title->getCaption())); // @phpstan-ignore-line
+    }
+
     public function testChartTitles(): void
     {
         $filename = 'tests/data/Reader/XLSX/excelChartsTest.xlsx';
@@ -31,34 +32,34 @@ class ChartsTitleTest extends TestCase
 
         // No title or axis labels
         $chart1 = $charts[0];
-        $title = getTitleText($chart1->getTitle());
+        $title = self::getTitleText($chart1->getTitle());
         self::assertEmpty($title);
-        self::assertEmpty(getTitleText($chart1->getXAxisLabel()));
-        self::assertEmpty(getTitleText($chart1->getYAxisLabel()));
+        self::assertEmpty(self::getTitleText($chart1->getXAxisLabel()));
+        self::assertEmpty(self::getTitleText($chart1->getYAxisLabel()));
 
         // Title, no axis labels
         $chart2 = $charts[1];
 
-        self::assertEquals('Chart with Title and no Axis Labels', getTitleText($chart2->getTitle()));
-        self::assertEmpty(getTitleText($chart2->getXAxisLabel()));
-        self::assertEmpty(getTitleText($chart2->getYAxisLabel()));
+        self::assertEquals('Chart with Title and no Axis Labels', self::getTitleText($chart2->getTitle()));
+        self::assertEmpty(self::getTitleText($chart2->getXAxisLabel()));
+        self::assertEmpty(self::getTitleText($chart2->getYAxisLabel()));
 
         // No title, only horizontal axis label
         $chart3 = $charts[2];
-        self::assertEmpty(getTitleText($chart3->getTitle()));
-        self::assertEquals('Horizontal Axis Title Only', getTitleText($chart3->getXAxisLabel()));
-        self::assertEmpty(getTitleText($chart3->getYAxisLabel()));
+        self::assertEmpty(self::getTitleText($chart3->getTitle()));
+        self::assertEquals('Horizontal Axis Title Only', self::getTitleText($chart3->getXAxisLabel()));
+        self::assertEmpty(self::getTitleText($chart3->getYAxisLabel()));
 
         // No title, only vertical axis label
         $chart4 = $charts[3];
-        self::assertEmpty(getTitleText($chart4->getTitle()));
-        self::assertEquals('Vertical Axis Title Only', getTitleText($chart4->getYAxisLabel()));
-        self::assertEmpty(getTitleText($chart4->getXAxisLabel()));
+        self::assertEmpty(self::getTitleText($chart4->getTitle()));
+        self::assertEquals('Vertical Axis Title Only', self::getTitleText($chart4->getYAxisLabel()));
+        self::assertEmpty(self::getTitleText($chart4->getXAxisLabel()));
 
         // Title and both axis labels
         $chart5 = $charts[4];
-        self::assertEquals('Complete Annotations', getTitleText($chart5->getTitle()));
-        self::assertEquals('Horizontal Axis Title', getTitleText($chart5->getXAxisLabel()));
-        self::assertEquals('Vertical Axis Title', getTitleText($chart5->getYAxisLabel()));
+        self::assertEquals('Complete Annotations', self::getTitleText($chart5->getTitle()));
+        self::assertEquals('Horizontal Axis Title', self::getTitleText($chart5->getXAxisLabel()));
+        self::assertEquals('Vertical Axis Title', self::getTitleText($chart5->getYAxisLabel()));
     }
 }

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/CondNumFmtTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/CondNumFmtTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpOffice\PhpSpreadsheetTests\Reader;
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 use PhpOffice\PhpSpreadsheet\Style\Conditional;

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/OddColumnReadFilter.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/OddColumnReadFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpOffice\PhpSpreadsheetTests\Reader;
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
 

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/SheetsXlsxChartTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/SheetsXlsxChartTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpOffice\PhpSpreadsheetTests\Reader;
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\Chart\DataSeries;
 use PhpOffice\PhpSpreadsheet\IOFactory;

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/Xlsx2Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/Xlsx2Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpOffice\PhpSpreadsheetTests\Reader;
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Shared\File;

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpOffice\PhpSpreadsheetTests\Reader;
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataValidation;
@@ -237,7 +237,7 @@ class XlsxTest extends TestCase
      *
      * @dataProvider providerStripsWhiteSpaceFromStyleString
      */
-    public function testStripsWhiteSpaceFromStyleString($string): void
+    public function testStripsWhiteSpaceFromStyleString(string $string): void
     {
         $string = Xlsx::stripWhiteSpaceFromStyleString($string);
         self::assertEquals(preg_match('/\s/', $string), 0);


### PR DESCRIPTION
PR #2088 is having major merge problems. This is partly because it moves some tests from Reader to Reader/Xlsx. Making this move beforehand may help. Or it may make things worse, but they are already bad enough that I am contemplating redoing the PR. If I do that, having this done beforehand will make things easier.

This PR does nothing but move some tests. This will make it easier to test changes to Xlsx Reader without having to run each test individually, or without having to run tests for all the other readers at the same time.

This is:

```
- [ ] a bugfix
- [ ] a new feature
- [x] testing
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
