### PR TITLE
fix 'Illegal offset type' error - authorId is SimpleXmlElement

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -896,7 +896,7 @@ class Xlsx extends BaseReader
                                     foreach ($commentsFile->commentList->comment as $comment) {
                                         $commentModel = $docSheet->getComment((string) $comment['ref']);
                                         if (!empty($comment['authorId'])) {
-                                            $commentModel->setAuthor($authors[$comment['authorId']]);
+                                            $commentModel->setAuthor($authors[(string) $comment['authorId']]);
                                         }
                                         $commentModel->setText($this->parseRichText($comment->text));
                                     }


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Got an 'illegal offset type' trying to read Excel file with comments.