### PR TITLE
DOCS: Gridlines when printing

### DIFF
--- a/docs/topics/recipes.md
+++ b/docs/topics/recipes.md
@@ -475,7 +475,7 @@ $spreadsheet->getActiveSheet()->setBreak('D10', \PhpOffice\PhpSpreadsheet\Worksh
 To show/hide gridlines when printing, use the following code:
 
 ```php
-$spreadsheet->getActiveSheet()->setShowGridlines(true);
+$spreadsheet->getActiveSheet()->setPrintGridlines(true);
 ```
 
 ### Setting rows/columns to repeat at top/left


### PR DESCRIPTION
This is:
```
- [X] a bugfix of docs
```

I think that right function to show/hide grid lines when printing is `setPrintGridlines()` and not `setShowGridlines()` as said in docs.