### PR TITLE
fix implicit cast deprecation in php8.1

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpSpreadsheet\RichText\Run;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Shared\XMLWriter;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use function is_float;
 
 class StringTable extends WriterPart
 {
@@ -38,6 +39,9 @@ class StringTable extends WriterPart
         foreach ($pSheet->getCoordinates() as $coordinate) {
             $cell = $pSheet->getCell($coordinate);
             $cellValue = $cell->getValue();
+            if (is_float($cellValue)) {
+                $cellValue = (int)$cellValue;
+            }
             if (
                 !is_object($cellValue) &&
                 ($cellValue !== null) &&


### PR DESCRIPTION
This fixes a php8.1 deprecation issue. Behaviour has not changed, as implicit cast exist at least since PHP8.0, but previously not thrown a deprecation error.

This pull only contains the fix without changes to documentation, changelogs or unit test. Hope this can be done by someone else, as i don't have time to invest more time here.

This is:

```
- [x] a bugfix
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Starting with PHP8.1, implicit casts from float to int/string is now deprecated.
