### PR TITLE
Html Reader Comments

### DIFF
--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -349,8 +349,9 @@ class Html extends BaseReader
                 $sheet->getComment($column . $row)
                     ->getText()
                     ->createTextRun($child->textContent);
+            } else {
+                $this->processDomElement($child, $sheet, $row, $column, $cellContent);
             }
-            $this->processDomElement($child, $sheet, $row, $column, $cellContent);
 
             if (isset($this->formats[$child->nodeName])) {
                 $sheet->getStyle($column . $row)->applyFromArray($this->formats[$child->nodeName]);

--- a/tests/PhpSpreadsheetTests/Functional/CommentsTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/CommentsTest.php
@@ -40,8 +40,9 @@ class CommentsTest extends AbstractFunctional
 
         $commentCoordinate = key($commentsLoaded);
         self::assertSame('E10', $commentCoordinate);
+        self::assertSame('Comment', $sheet->getCell('E10')->getValue());
         $comment = $commentsLoaded[$commentCoordinate];
-        self::assertEquals('Comment to test', (string) $comment);
+        self::assertSame('Comment to test', (string) $comment);
         $commentClone = clone $comment;
         self::assertEquals($comment, $commentClone);
         self::assertNotSame($comment, $commentClone);

--- a/tests/PhpSpreadsheetTests/Functional/CommentsTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/CommentsTest.php
@@ -52,5 +52,7 @@ class CommentsTest extends AbstractFunctional
             $comment->setAlignment(Alignment::HORIZONTAL_RIGHT);
             self::assertEquals(Alignment::HORIZONTAL_RIGHT, $comment->getAlignment());
         }
+        $spreadsheet->disconnectWorksheets();
+        $reloadedSpreadsheet->disconnectWorksheets();
     }
 }


### PR DESCRIPTION
See issue #2234. Html Reader processes Comment as comment, then processes it as part of cell contents. Change to only do the first. Comment Test checks that comment read by Html Reader is okay, but neglects to check the value of the cell to which the comment is attached. Added that check.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
