### PR TITLE
PhpUnit and Jpgraph

### DIFF
--- a/tests/PhpSpreadsheetTests/Helper/SampleTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/SampleTest.php
@@ -30,6 +30,7 @@ class SampleTest extends TestCase
         $skipped = [
             'Chart/32_Chart_read_write_PDF.php', // Unfortunately JpGraph is not up to date for latest PHP and raise many warnings
             'Chart/32_Chart_read_write_HTML.php', // idem
+            'Chart/35_Chart_render.php', // idem
         ];
         // TCPDF and DomPDF libraries don't support PHP8 yet
         if (\PHP_VERSION_ID >= 80000) {
@@ -38,7 +39,6 @@ class SampleTest extends TestCase
                 [
                     'Pdf/21_Pdf_Domdf.php',
                     'Pdf/21_Pdf_TCPDF.php',
-                    'Chart/35_Chart_render.php', // idem
                 ]
             );
         }


### PR DESCRIPTION
35_Char_render.php had previously been a problem only for PHP8+. It is now a problem for PHP7.4, and will therefore be skipped all the time.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
