### PR TITLE
use single quotes to wrap sheet title

### DIFF
--- a/docs/topics/recipes.md
+++ b/docs/topics/recipes.md
@@ -1104,7 +1104,7 @@ formula is allowed to be maximum 255 characters (not bytes). This sets a
 limit on how many items you can have in the string "Item A,Item B,Item
 C". Therefore it is normally a better idea to type the item values
 directly in some cell range, say A1:A3, and instead use, say,
-`$validation->setFormula1('Sheet!$A$1:$A$3')`. Another benefit is that
+`$validation->setFormula1('\'Sheet title\'!$A$1:$A$3')`. Another benefit is that
 the item values themselves can contain the comma `,` character itself.
 
 If you need data validation on multiple cells, one can clone the


### PR DESCRIPTION
This changes is to clarify that the sheet title is used to reference the sheet and that the title must be single quoted.

This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
to improve the documentation