### PR TITLE
Fix Xlsx Writer Data Validation

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -85,9 +85,6 @@ class Worksheet extends WriterPart
         // conditionalFormatting
         $this->writeConditionalFormatting($objWriter, $worksheet);
 
-        // dataValidations
-        $this->writeDataValidations($objWriter, $worksheet);
-
         // hyperlinks
         $this->writeHyperlinks($objWriter, $worksheet);
 


### PR DESCRIPTION
Fix issue #2368. PR #2265 moved the place where data validations were written to the worksheet. PR #1694 was installed afterwards, and accidentally restored the original location, so validations are now being written twice.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
