### PR TITLE
Update Phpunit Configuration File

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,25 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-        bootstrap="./tests/bootstrap.php"
-        backupGlobals="true"
-        colors="true"
-        cacheResultFile="/tmp/.phpspreadsheet.phpunit.result.cache"
->
-    <php>
-        <ini name="memory_limit" value="2048M"/>
-    </php>
-    <testsuite name="PhpSpreadsheet Unit Test Suite">
-        <directory>./tests/PhpSpreadsheetTests</directory>
-    </testsuite>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-                <directory>./src/PhpSpreadsheet/Shared/JAMA</directory>
-                <directory>./src/PhpSpreadsheet/Writer/PDF</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="./tests/bootstrap.php" backupGlobals="true" colors="true" cacheResultFile="/tmp/.phpspreadsheet.phpunit.result.cache">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./src/PhpSpreadsheet/Shared/JAMA</directory>
+      <directory>./src/PhpSpreadsheet/Writer/PDF</directory>
+    </exclude>
+  </coverage>
+  <php>
+    <ini name="memory_limit" value="2048M"/>
+  </php>
+  <testsuite name="PhpSpreadsheet Unit Test Suite">
+    <directory>./tests/PhpSpreadsheetTests</directory>
+  </testsuite>
 </phpunit>


### PR DESCRIPTION
After upgrading, Phpunit indicates that the current schema is deprecated. Used Phpunit's own `--migrate-configuration` option to create current version.

This is:

```
- [ ] a bugfix
- [ ] a new feature
- [x] phpunit configuration
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
