### PR TITLE
Allow Skipping One Unit Test

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8891,11 +8891,6 @@ parameters:
 			path: tests/PhpSpreadsheetTests/Reader/Xlsx/SheetsXlsxChartTest.php
 
 		-
-			message: "#^Expression in empty\\(\\) is not falsy\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
-
-		-
 			message: "#^Part \\$creationDate \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: tests/PhpSpreadsheetTests/Reader/Xml/XmlLoadTest.php

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
@@ -4,7 +4,6 @@ namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
-use PhpOffice\PhpSpreadsheet\Worksheet\MemoryDrawing;
 use PhpOffice\PhpSpreadsheetTests\Reader\Utility\File;
 use PHPUnit\Framework\TestCase;
 
@@ -16,50 +15,28 @@ class URLImageTest extends TestCase
             self::markTestSkipped('Skipped due to setting of environment variable');
         }
         $filename = realpath(__DIR__ . '/../../../data/Reader/XLSX/urlImage.xlsx');
-        if (!$filename) {
-            self::fail('No test file found.');
-        } else {
-            $reader = IOFactory::createReader('Xlsx');
-            $spreadsheet = $reader->load($filename);
-            $worksheet = $spreadsheet->getActiveSheet();
+        self::assertNotFalse($filename);
+        $reader = IOFactory::createReader('Xlsx');
+        $spreadsheet = $reader->load($filename);
+        $worksheet = $spreadsheet->getActiveSheet();
+        $collection = $worksheet->getDrawingCollection();
+        self::assertCount(1, $collection);
 
-            foreach ($worksheet->getDrawingCollection() as $drawing) {
-                if ($drawing instanceof MemoryDrawing) {
-                    // Skip memory drawings
-                } elseif ($drawing instanceof Drawing) {
-                    // Check if the source is a URL or a file path
-                    if ($drawing->getPath() && $drawing->getIsURL()) {
-                        $imageContents = file_get_contents($drawing->getPath());
-                        $filePath = tempnam(sys_get_temp_dir(), 'Drawing');
-                        if ($filePath) {
-                            file_put_contents($filePath, $imageContents);
-                            if (file_exists($filePath)) {
-                                $mimeType = mime_content_type($filePath);
-                                // You could use the below to find the extension from mime type.
-                                if ($mimeType) {
-                                    $extension = File::mime2ext($mimeType);
-                                    self::assertEquals('jpeg', $extension);
-                                    unlink($filePath);
-                                } else {
-                                    self::fail('Could establish mime type.');
-                                }
-                            } else {
-                                self::fail('Could not write file to disk.');
-                            }
-                        } else {
-                            self::fail('Could not create fiel path.');
-                        }
-                    } else {
-                        self::fail('Could not assert that the file contains an image that is URL sourced.');
-                    }
-                } else {
-                    self::fail('No image path found.');
-                }
-            }
-
-            if (empty($worksheet->getDrawingCollection())) {
-                self::fail('No image found in file.');
-            }
+        foreach ($collection as $drawing) {
+            self::assertInstanceOf(Drawing::class, $drawing);
+            // Check if the source is a URL or a file path
+            self::assertTrue($drawing->getIsURL());
+            self::assertSame('https://www.globalipmanager.com/DataFiles/Pics/20/Berniaga.comahp2.jpg', $drawing->getPath());
+            $imageContents = file_get_contents($drawing->getPath());
+            self::assertNotFalse($imageContents);
+            $filePath = tempnam(sys_get_temp_dir(), 'Drawing');
+            self::assertNotFalse($filePath);
+            self::assertNotFalse(file_put_contents($filePath, $imageContents));
+            $mimeType = mime_content_type($filePath);
+            unlink($filePath);
+            self::assertNotFalse($mimeType);
+            $extension = File::mime2ext($mimeType);
+            self::assertSame('jpeg', $extension);
         }
     }
 }

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
@@ -12,6 +12,9 @@ class URLImageTest extends TestCase
 {
     public function testURLImageSource(): void
     {
+        if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
+            self::markTestSkipped('Skipped due to setting of environment variable');
+        }
         $filename = realpath(__DIR__ . '/../../../data/Reader/XLSX/urlImage.xlsx');
         if (!$filename) {
             self::fail('No test file found.');


### PR DESCRIPTION
Alone in the test suite, URLImageTest needs to access the internet. It's a little fragile (the site that it's looking for may go away or change), but no real problem. However, on my system, it runs afoul of my proxy. Rather than jumping through hoops when I run the test suite (which happens very often), I am changing the test to skip if an environment variable is set to a specific value. This should not adversely affect anyone, and the test will still run in github, but it will help me a lot.

This is:

```
- [ ] a bugfix
- [ ] a new feature
- [x] unit testing in private environment 
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
