### PR TITLE
add microseconds support for Date/Time objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Allow Row height and Column Width to be set using different units of measure (`px`, `pt`, `pc`, `in`, `cm`, `mm`), rather than only in points or MS Excel column width units [PR #2152](https://github.com/PHPOffice/PhpSpreadsheet/issues/2145)
 - Ability to stream to an Amazon S3 bucket [Issue #2249](https://github.com/PHPOffice/PhpSpreadsheet/issues/2249)
 - Provided a Size Helper class to validate size values (pt, px, em) [PR #1694](https://github.com/PHPOffice/PhpSpreadsheet/pull/1694)
+- Support for microseconds with Date/Time objects 
 
 ### Changed
 

--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -193,15 +193,18 @@ class Date
         $partDay = $partDay * 24 - $hours;
         $minutes = floor($partDay * 60);
         $partDay = $partDay * 60 - $minutes;
-        $seconds = round($partDay * 60);
+        $seconds = floor($partDay * 60);
+        $partDay = $partDay * 60 - $seconds;
+        $microseconds = round($partDay * 1000 * 1000);
 
         if ($days >= 0) {
             $days = '+' . $days;
         }
+
         $interval = $days . ' days';
 
         return $baseDate->modify($interval)
-            ->setTime((int) $hours, (int) $minutes, (int) $seconds);
+            ->setTime((int) $hours, (int) $minutes, (int) $seconds, (int) $microseconds);
     }
 
     /**


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [x] a new feature


Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Because there is now support for microseconds when reading Datetime cells