### PR TITLE
added version detection rather then suppressing obvious error

### DIFF
--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -275,7 +275,7 @@ class Csv extends BaseReader
 
     private static function setAutoDetect(?string $value): ?string
     {
-        if(version_compare(PHP_VERSION, "8.1.0", '>=')) {
+        if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
             return null;
         }
         $retVal = null;

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -275,6 +275,9 @@ class Csv extends BaseReader
 
     private static function setAutoDetect(?string $value): ?string
     {
+        if(version_compare(PHP_VERSION, "8.1.0", '>=')) {
+            return null;
+        }
         $retVal = null;
         if ($value !== null) {
             $retVal2 = @ini_set('auto_detect_line_endings', $value);


### PR DESCRIPTION
This is:

```
- [x] a bugfix
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

With PHP 8.1 `ini_set('auto_detect_line_endings')` is deprecated, as already correctly marked in the code.
But adding an explicit version detection instead of just letting the error silently happen, which fills internal error buffer and later still is returned by `error_get_last()` which many use to detect if any uncatchable php error happened.

In our case, we catch open errors with `error_get_last()` on shutdown and throw an exception when a error exist. This function also returns errors that are suppressed with @ and there is no way to detect if this error was suppressed.

With the version detection, we omit the error before it can happen, which is a nicer way instead of ducking.
