### PR TITLE
Null Passed to AutoFilter SetRange

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6071,11 +6071,6 @@ parameters:
 			path: src/PhpSpreadsheet/Worksheet/Worksheet.php
 
 		-
-			message: "#^Parameter \\#1 \\$range of method PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\AutoFilter\\:\\:setRange\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Worksheet/Worksheet.php
-
-		-
 			message: "#^Parameter \\#1 \\$range of static method PhpOffice\\\\PhpSpreadsheet\\\\Cell\\\\Coordinate\\:\\:rangeDimension\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Worksheet/Worksheet.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6066,11 +6066,6 @@ parameters:
 			path: src/PhpSpreadsheet/Worksheet/Worksheet.php
 
 		-
-			message: "#^Parameter \\#1 \\$range of class PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\AutoFilter constructor expects string, null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Worksheet/Worksheet.php
-
-		-
 			message: "#^Parameter \\#1 \\$range of static method PhpOffice\\\\PhpSpreadsheet\\\\Cell\\\\Coordinate\\:\\:rangeDimension\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Worksheet/Worksheet.php

--- a/src/PhpSpreadsheet/Worksheet/AutoFilter.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter.php
@@ -50,10 +50,8 @@ class AutoFilter
 
     /**
      * Create a new AutoFilter.
-     *
-     * @param string $range Cell range (i.e. A1:E10)
      */
-    public function __construct($range = '', ?Worksheet $worksheet = null)
+    public function __construct(string $range = '', ?Worksheet $worksheet = null)
     {
         $this->range = $range;
         $this->workSheet = $worksheet;

--- a/src/PhpSpreadsheet/Worksheet/AutoFilter.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter.php
@@ -93,13 +93,9 @@ class AutoFilter
     }
 
     /**
-     * Set AutoFilter Range.
-     *
-     * @param string $range Cell range (i.e. A1:E10)
-     *
-     * @return $this
+     * Set AutoFilter Cell Range.
      */
-    public function setRange($range)
+    public function setRange(string $range): self
     {
         $this->evaluated = false;
         // extract coordinate

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1914,12 +1914,10 @@ class Worksheet implements IComparable
 
     /**
      * Remove autofilter.
-     *
-     * @return $this
      */
-    public function removeAutoFilter()
+    public function removeAutoFilter(): self
     {
-        $this->autoFilter->setRange(null);
+        $this->autoFilter->setRange('');
 
         return $this;
     }

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -371,7 +371,7 @@ class Worksheet implements IComparable
         $this->defaultRowDimension = new RowDimension(null);
         // Default column dimension
         $this->defaultColumnDimension = new ColumnDimension(null);
-        $this->autoFilter = new AutoFilter(null, $this);
+        $this->autoFilter = new AutoFilter('', $this);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/DeleteAutoFilterTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/DeleteAutoFilterTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Worksheet\AutoFilter;
+
+class DeleteAutoFilterTest extends SetupTeardown
+{
+    public function testDelete(): void
+    {
+        // Issue 2281 - deprecation in PHP81 when deleting filter
+        $sheet = $this->getSheet();
+        $autoFilter = $sheet->getAutoFilter();
+        $autoFilter->setRange('H2:O256');
+        $sheet->removeAutoFilter();
+        self::assertSame('', $sheet->getAutoFilter()->getRange());
+    }
+}


### PR DESCRIPTION
Fix #2281. Delete auto filter set range to null, but should set it to null string. This causes a deprecation warning in Php8.1.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
