### PR TITLE
Richtext colors are not being read correctly after namespace change

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1689,7 +1689,7 @@ class Xlsx extends BaseReader
                             $objText->getFont()->setSize((float) $attr['val']);
                         }
                         $attr = $run->rPr->color->attributes();
-                        if (count($attr) > 0) {
+                        if ($attr && $attr->count() > 0) {
                             $objText->getFont()->setColor(new Color($this->styleReader->readColor($attr)));
                         }
                         if (isset($run->rPr->b)) {

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1688,8 +1688,9 @@ class Xlsx extends BaseReader
                         if (isset($attr['val'])) {
                             $objText->getFont()->setSize((float) $attr['val']);
                         }
-                        if (isset($run->rPr->color)) {
-                            $objText->getFont()->setColor(new Color($this->styleReader->readColor($run->rPr->color)));
+                        $attr = $run->rPr->color->attributes();
+                        if (count($attr) > 0) {
+                            $objText->getFont()->setColor(new Color($this->styleReader->readColor($attr)));
                         }
                         if (isset($run->rPr->b)) {
                             $attr = $run->rPr->b->attributes();


### PR DESCRIPTION
Related to:
https://github.com/PHPOffice/PhpSpreadsheet/pull/2303

This is:
- [x] a bugfix
- [ ] a new feature

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
