### PR TITLE
Rename Two Test Files

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8531,16 +8531,6 @@ parameters:
 			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalFormattingDataBarXlsxTest.php
 
 		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/Namespace.Issue2109bTest.php
-
-		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/Namespace.Openpyxl35Test.php
-
-		-
 			message: "#^Part \\$result \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 2
 			path: tests/PhpSpreadsheetTests/Reader/Xlsx/PropertiesTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8416,16 +8416,6 @@ parameters:
 			path: tests/PhpSpreadsheetTests/NamedRangeTest.php
 
 		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\Csv\\\\CsvContiguousFilter\\:\\:\\$startRow \\(int\\) does not accept mixed\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Csv/CsvContiguousFilter.php
-
-		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Csv/CsvContiguousTest.php
-
-		-
 			message: "#^Part \\$result \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 2
 			path: tests/PhpSpreadsheetTests/Reader/Ods/OdsPropertiesTest.php

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvContiguousFilter.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvContiguousFilter.php
@@ -24,11 +24,8 @@ class CsvContiguousFilter implements IReadFilter
 
     /**
      * Set the list of rows that we want to read.
-     *
-     * @param mixed $startRow
-     * @param mixed $chunkSize
      */
-    public function setRows($startRow, $chunkSize): void
+    public function setRows(int $startRow, int $chunkSize): void
     {
         $this->startRow = $startRow;
         $this->endRow = $startRow + $chunkSize;

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvContiguousTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvContiguousTest.php
@@ -57,11 +57,15 @@ class CsvContiguousTest extends TestCase
     private static function getCellValue(Spreadsheet $spreadsheet, string $sheetName, string $cellAddress): string
     {
         $sheet = $spreadsheet->getSheetByName($sheetName);
-        if ($sheet === null) {
-            return '';
+        $result = '';
+        if ($sheet !== null) {
+            $value = $sheet->getCell($cellAddress)->getValue();
+            if (is_scalar($value) || (is_object($value) && method_exists($value, '__toString'))) {
+                $result = (string) $value;
+            }
         }
 
-        return (string) $sheet->getCell($cellAddress)->getValue();
+        return $result;
     }
 
     public function testContiguous2(): void

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/NamespaceIssue2109bTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/NamespaceIssue2109bTest.php
@@ -60,11 +60,11 @@ class NamespaceIssue2109bTest extends \PHPUnit\Framework\TestCase
     private static function getCellValue(Worksheet $sheet, string $cell): string
     {
         $result = $sheet->getCell($cell)->getValue();
+        if (is_scalar($result) || (is_object($result) && method_exists($result, '__toString'))) {
+            return (string) $result;
+        }
 
-        // Phpstan doesn't allow cast from mixed to string,
-        // and also doesn't allow us to put line in a try block,
-        // because it thinks (incorrectly) that nothing can be thrown.
-        return (string) $result; // @phpstan-ignore-line
+        return '';
     }
 
     public function testLoadXlsx(): void

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/NamespaceIssue2109bTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/NamespaceIssue2109bTest.php
@@ -61,7 +61,10 @@ class NamespaceIssue2109bTest extends \PHPUnit\Framework\TestCase
     {
         $result = $sheet->getCell($cell)->getValue();
 
-        return (string) $result;
+        // Phpstan doesn't allow cast from mixed to string,
+        // and also doesn't allow us to put line in a try block,
+        // because it thinks (incorrectly) that nothing can be thrown.
+        return (string) $result; // @phpstan-ignore-line
     }
 
     public function testLoadXlsx(): void

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/NamespaceOpenpyxl35Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/NamespaceOpenpyxl35Test.php
@@ -60,11 +60,11 @@ class NamespaceOpenpyxl35Test extends \PHPUnit\Framework\TestCase
     private static function getCellValue(Worksheet $sheet, string $cell): string
     {
         $result = $sheet->getCell($cell)->getValue();
+        if (is_scalar($result) || (is_object($result) && method_exists($result, '__toString'))) {
+            return (string) $result;
+        }
 
-        // Phpstan doesn't allow cast from mixed to string,
-        // and also doesn't allow us to put line in a try block,
-        // because it thinks (incorrectly) that nothing can be thrown.
-        return (string) $result; // @phpstan-ignore-line
+        return '';
     }
 
     public function testLoadXlsx(): void

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/NamespaceOpenpyxl35Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/NamespaceOpenpyxl35Test.php
@@ -61,7 +61,10 @@ class NamespaceOpenpyxl35Test extends \PHPUnit\Framework\TestCase
     {
         $result = $sheet->getCell($cell)->getValue();
 
-        return (string) $result;
+        // Phpstan doesn't allow cast from mixed to string,
+        // and also doesn't allow us to put line in a try block,
+        // because it thinks (incorrectly) that nothing can be thrown.
+        return (string) $result; // @phpstan-ignore-line
     }
 
     public function testLoadXlsx(): void


### PR DESCRIPTION
When I run unit tests only for Reader/Xlsx, phpunit is issuing a deprecation message because the names of 2 files have an extra dot in them and thus don't match the class name in the file. I do not see these warnings when I run the entire test suite.

This is:

```
- [ ] a bugfix
- [ ] a new feature
- [x] testing
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
