### PR TITLE
Allow single-cell checks on conditional styles, even when the style is configured for a range of cells

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1433,7 +1433,9 @@ class Worksheet implements IComparable
      * Get conditional styles for a cell.
      *
      * @param string $coordinate eg: 'A1' or 'A1:A3'.
-     *          If a range of cells is specified, then true will only be returned if the range matches the entire
+     *          If a single cell is referenced, then the array of conditional styles will be returned if the cell is
+     *               included in a conditional style range.
+     *          If a range of cells is specified, then the styles will only be returned if the range matches the entire
      *               range of the conditional.
      *
      * @return Conditional[]
@@ -1459,6 +1461,8 @@ class Worksheet implements IComparable
      * Do conditional styles exist for this cell?
      *
      * @param string $coordinate eg: 'A1' or 'A1:A3'.
+     *          If a single cell is specified, then this method will return true if that cell is included in a
+     *               conditional style range.
      *          If a range of cells is specified, then true will only be returned if the range matches the entire
      *               range of the conditional.
      *

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1432,30 +1432,53 @@ class Worksheet implements IComparable
     /**
      * Get conditional styles for a cell.
      *
-     * @param string $coordinate eg: 'A1'
+     * @param string $coordinate eg: 'A1' or 'A1:A3'.
+     *          If a range of cells is specified, then true will only be returned if the range matches the entire
+     *               range of the conditional.
      *
      * @return Conditional[]
      */
     public function getConditionalStyles($coordinate)
     {
         $coordinate = strtoupper($coordinate);
-        if (!isset($this->conditionalStylesCollection[$coordinate])) {
-            $this->conditionalStylesCollection[$coordinate] = [];
+        if (strpos($coordinate, ':') !== false) {
+            return $this->conditionalStylesCollection[$coordinate] ?? [];
         }
 
-        return $this->conditionalStylesCollection[$coordinate];
+        $cell = $this->getCell($coordinate);
+        foreach (array_keys($this->conditionalStylesCollection) as $conditionalRange) {
+            if ($cell->isInRange($conditionalRange)) {
+                return $this->conditionalStylesCollection[$conditionalRange];
+            }
+        }
+
+        return [];
     }
 
     /**
      * Do conditional styles exist for this cell?
      *
-     * @param string $coordinate eg: 'A1'
+     * @param string $coordinate eg: 'A1' or 'A1:A3'.
+     *          If a range of cells is specified, then true will only be returned if the range matches the entire
+     *               range of the conditional.
      *
      * @return bool
      */
     public function conditionalStylesExists($coordinate)
     {
-        return isset($this->conditionalStylesCollection[strtoupper($coordinate)]);
+        $coordinate = strtoupper($coordinate);
+        if (strpos($coordinate, ':') !== false) {
+            return isset($this->conditionalStylesCollection[strtoupper($coordinate)]);
+        }
+
+        $cell = $this->getCell($coordinate);
+        foreach (array_keys($this->conditionalStylesCollection) as $conditionalRange) {
+            if ($cell->isInRange($conditionalRange)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Worksheet/ConditionalStyleTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ConditionalStyleTest.php
@@ -9,6 +9,9 @@ use PHPUnit\Framework\TestCase;
 
 class ConditionalStyleTest extends TestCase
 {
+    /**
+     * @var Spreadsheet
+     */
     protected $spreadsheet;
 
     protected function setUp(): void

--- a/tests/PhpSpreadsheetTests/Worksheet/ConditionalStyleTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ConditionalStyleTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Conditional;
+use PhpOffice\PhpSpreadsheet\Style\Color;
+use PHPUnit\Framework\TestCase;
+
+class ConditionalStyleTest extends TestCase
+{
+    protected $spreadsheet;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->spreadsheet = new Spreadsheet();
+
+        $conditional1 = new Conditional();
+        $conditional1->setConditionType(Conditional::CONDITION_CELLIS);
+        $conditional1->setOperatorType(Conditional::OPERATOR_LESSTHAN);
+        $conditional1->addCondition('0');
+        $conditional1->getStyle()->getFont()->getColor()->setARGB(Color::COLOR_RED);
+        $conditional1->getStyle()->getFont()->setBold(true);
+
+        $conditional2 = new Conditional();
+        $conditional2->setConditionType(Conditional::CONDITION_CELLIS);
+        $conditional2->setOperatorType(Conditional::OPERATOR_EQUAL);
+        $conditional2->addCondition('0');
+        $conditional2->getStyle()->getFont()->getColor()->setARGB(Color::COLOR_YELLOW);
+        $conditional2->getStyle()->getFont()->setBold(true);
+
+        $conditional3 = new Conditional();
+        $conditional3->setConditionType(Conditional::CONDITION_CELLIS);
+        $conditional3->setOperatorType(Conditional::OPERATOR_GREATERTHAN);
+        $conditional3->addCondition('0');
+        $conditional3->getStyle()->getFont()->getColor()->setARGB(Color::COLOR_GREEN);
+        $conditional3->getStyle()->getFont()->setBold(true);
+
+        $conditionalStyles = $this->spreadsheet->getActiveSheet()->getStyle('A1:C3')->getConditionalStyles();
+        $conditionalStyles[] = $conditional1;
+        $conditionalStyles[] = $conditional2;
+        $conditionalStyles[] = $conditional3;
+
+        $this->spreadsheet->getActiveSheet()->getStyle('A1:C3')->setConditionalStyles($conditionalStyles);
+
+        $this->spreadsheet->getActiveSheet()
+            ->duplicateConditionalStyle(
+                $this->spreadsheet->getActiveSheet()->getConditionalStyles('A1:C3'),
+                'F1'
+            );
+    }
+
+    /**
+     * @dataProvider cellConditionalStylesProvider
+     */
+    public function testCellHasConditionalStyles(string $cellReference, bool $expectedHasConditionalStyles): void
+    {
+        $cellHasConditionalStyles = $this->spreadsheet->getActiveSheet()->conditionalStylesExists($cellReference);
+
+        $this->assertSame($expectedHasConditionalStyles, $cellHasConditionalStyles);
+    }
+
+    /**
+     * @dataProvider cellConditionalStylesProvider
+     */
+    public function testCellGetConditionalStyles(string $cellReference, bool $expectedGetConditionalStyles): void
+    {
+        $cellHasConditionalStyles = $this->spreadsheet->getActiveSheet()->getConditionalStyles($cellReference);
+
+        $this->assertSame($expectedGetConditionalStyles, !empty($cellHasConditionalStyles));
+    }
+
+    public function cellConditionalStylesProvider(): array
+    {
+        return [
+            ['A1', true],
+            ['B2', true],
+            ['B4', false],
+            ['A1:C3', true],
+            ['A1:B2', false],
+            ['F1', true],
+            ['F2', false],
+            ['A1:F1', false],
+        ];
+    }
+}

--- a/tests/PhpSpreadsheetTests/Worksheet/ConditionalStyleTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ConditionalStyleTest.php
@@ -3,15 +3,15 @@
 namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
-use PhpOffice\PhpSpreadsheet\Style\Conditional;
 use PhpOffice\PhpSpreadsheet\Style\Color;
+use PhpOffice\PhpSpreadsheet\Style\Conditional;
 use PHPUnit\Framework\TestCase;
 
 class ConditionalStyleTest extends TestCase
 {
     protected $spreadsheet;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -59,7 +59,7 @@ class ConditionalStyleTest extends TestCase
     {
         $cellHasConditionalStyles = $this->spreadsheet->getActiveSheet()->conditionalStylesExists($cellReference);
 
-        $this->assertSame($expectedHasConditionalStyles, $cellHasConditionalStyles);
+        self::assertSame($expectedHasConditionalStyles, $cellHasConditionalStyles);
     }
 
     /**
@@ -69,7 +69,7 @@ class ConditionalStyleTest extends TestCase
     {
         $cellHasConditionalStyles = $this->spreadsheet->getActiveSheet()->getConditionalStyles($cellReference);
 
-        $this->assertSame($expectedGetConditionalStyles, !empty($cellHasConditionalStyles));
+        self::assertSame($expectedGetConditionalStyles, !empty($cellHasConditionalStyles));
     }
 
     public function cellConditionalStylesProvider(): array


### PR DESCRIPTION
Issue #2482

This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Resolve issues when passing a single cell reference to `conditionalStylesExists()` and `getConditionalStyles()` Worksheet methods