### PR TITLE
Address some of the deprecations in PHP 8.1

### DIFF
--- a/src/PhpSpreadsheet/Helper/Dimension.php
+++ b/src/PhpSpreadsheet/Helper/Dimension.php
@@ -58,7 +58,7 @@ class Dimension
     public function __construct(string $dimension)
     {
         [$size, $unit] = sscanf($dimension, '%[1234567890.]%s');
-        $unit = strtolower(trim($unit));
+        $unit = strtolower(trim($unit ?? ''));
 
         // If a UoM is specified, then convert the size to pixels for internal storage
         if (isset(self::ABSOLUTE_UNITS[$unit])) {

--- a/src/PhpSpreadsheet/Worksheet/AutoFilter.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter.php
@@ -437,27 +437,27 @@ class AutoFilter
                 //    String values are always tested for equality, factoring in for wildcards (hence a regexp test)
                 switch ($ruleOperator) {
                     case Rule::AUTOFILTER_COLUMN_RULE_EQUAL:
-                        $retVal = (bool) preg_match('/^' . $ruleValue . '$/i', $cellValueString);
+                        $retVal = (bool) preg_match('/^' . $ruleValue . '$/i', $cellValueString ?? '');
 
                         break;
                     case Rule::AUTOFILTER_COLUMN_RULE_NOTEQUAL:
-                        $retVal = !((bool) preg_match('/^' . $ruleValue . '$/i', $cellValueString));
+                        $retVal = !((bool) preg_match('/^' . $ruleValue . '$/i', $cellValueString ?? ''));
 
                         break;
                     case Rule::AUTOFILTER_COLUMN_RULE_GREATERTHAN:
-                        $retVal = strcasecmp($cellValueString, $ruleValue) > 0;
+                        $retVal = strcasecmp($cellValueString ?? '', $ruleValue) > 0;
 
                         break;
                     case Rule::AUTOFILTER_COLUMN_RULE_GREATERTHANOREQUAL:
-                        $retVal = strcasecmp($cellValueString, $ruleValue) >= 0;
+                        $retVal = strcasecmp($cellValueString ?? '', $ruleValue) >= 0;
 
                         break;
                     case Rule::AUTOFILTER_COLUMN_RULE_LESSTHAN:
-                        $retVal = strcasecmp($cellValueString, $ruleValue) < 0;
+                        $retVal = strcasecmp($cellValueString ?? '', $ruleValue) < 0;
 
                         break;
                     case Rule::AUTOFILTER_COLUMN_RULE_LESSTHANOREQUAL:
-                        $retVal = strcasecmp($cellValueString, $ruleValue) <= 0;
+                        $retVal = strcasecmp($cellValueString ?? '', $ruleValue) <= 0;
 
                         break;
                 }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1223,7 +1223,7 @@ class Worksheet extends WriterPart
                 $objWriter,
                 $this->getParentWriter()->getOffice2003Compatibility() === false,
                 'v',
-                ($this->getParentWriter()->getPreCalculateFormulas() && !is_array($calculatedValue) && substr($calculatedValue, 0, 1) !== '#')
+                ($this->getParentWriter()->getPreCalculateFormulas() && !is_array($calculatedValue) && substr($calculatedValue ?? '', 0, 1) !== '#')
                     ? StringHelper::formatNumber($calculatedValue) : '0'
             );
         }


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Resolve a few of the PHP 8.1 Deprecation messages