### PR TITLE
Always access cells in the same order as they was inserted

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xls.php
+++ b/src/PhpSpreadsheet/Writer/Xls.php
@@ -161,7 +161,7 @@ class Xls extends BaseWriter
 
         // add fonts from rich text eleemnts
         for ($i = 0; $i < $countSheets; ++$i) {
-            foreach ($this->writerWorksheets[$i]->phpSheet->getCoordinates() as $coordinate) {
+            foreach ($this->writerWorksheets[$i]->phpSheet->getCoordinates(false) as $coordinate) {
                 $cell = $this->writerWorksheets[$i]->phpSheet->getCell($coordinate);
                 $cVal = $cell->getValue();
                 if ($cVal instanceof RichText) {

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -400,7 +400,7 @@ class Worksheet extends BIFFwriter
         }
 
         // Write Cells
-        foreach ($phpSheet->getCoordinates() as $coordinate) {
+        foreach ($phpSheet->getCoordinates(false) as $coordinate) {
             $cell = $phpSheet->getCell($coordinate);
             $row = $cell->getRow() - 1;
             $column = Coordinate::columnIndexFromString($cell->getColumn()) - 1;

--- a/src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
@@ -35,7 +35,7 @@ class StringTable extends WriterPart
         $aFlippedStringTable = $this->flipStringTable($aStringTable);
 
         // Loop through cells
-        foreach ($worksheet->getCoordinates() as $coordinate) {
+        foreach ($worksheet->getCoordinates(false) as $coordinate) {
             $cell = $worksheet->getCell($coordinate);
             $cellValue = $cell->getValue();
             if (

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1068,7 +1068,7 @@ class Worksheet extends WriterPart
 
         // Loop through cells
         $cellsByRow = [];
-        foreach ($worksheet->getCoordinates() as $coordinate) {
+        foreach ($worksheet->getCoordinates(false) as $coordinate) {
             $cellAddress = Coordinate::coordinateFromString($coordinate);
             $cellsByRow[$cellAddress[1]][] = $coordinate;
         }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
This will make it easier to create an optimized cache.

As a sideeffect, not calling Cells::getSortedCoordinates() reduces some
memory usage as the current state of that method allocates a lot of memory (see #2529)


⚠️ I have not created the cache impl yet, so not sure how well it will perform regardless of these changes. But the memory savings is nice.