### PR TITLE
Fix error in PercentageFormatter rounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Fix rounding error in NumberFormat::NUMBER_PERCENTAGE, NumberFormat::NUMBER_PERCENTAGE_00
 - Fix partial function name matching when translating formulae from Russian to English [Issue #2533](https://github.com/PHPOffice/PhpSpreadsheet/issues/2533) [PR #2534](https://github.com/PHPOffice/PhpSpreadsheet/pull/2534)
 - Various bugs related to Conditional Formatting Rules, and errors in the Xlsx Writer for Conditional Formatting [PR #2491](https://github.com/PHPOffice/PhpSpreadsheet/pull/2491)
 - Xlsx Reader merge range fixes.

--- a/src/PhpSpreadsheet/Calculation/locale/ru/functions
+++ b/src/PhpSpreadsheet/Calculation/locale/ru/functions
@@ -177,6 +177,7 @@ SYD = АСЧ
 TBILLEQ = РАВНОКЧЕК
 TBILLPRICE = ЦЕНАКЧЕК
 TBILLYIELD = ДОХОДКЧЕК
+USDOLLAR = ДОЛЛСША
 VDB = ПУО
 XIRR = ЧИСТВНДОХ
 XNPV = ЧИСТНЗ
@@ -231,6 +232,7 @@ AREAS = ОБЛАСТИ
 CHOOSE = ВЫБОР
 COLUMN = СТОЛБЕЦ
 COLUMNS = ЧИСЛСТОЛБ
+FILTER = ФИЛЬТР
 FORMULATEXT = Ф.ТЕКСТ
 GETPIVOTDATA = ПОЛУЧИТЬ.ДАННЫЕ.СВОДНОЙ.ТАБЛИЦЫ
 HLOOKUP = ГПР
@@ -243,8 +245,13 @@ OFFSET = СМЕЩ
 ROW = СТРОКА
 ROWS = ЧСТРОК
 RTD = ДРВ
+SORT = СОРТ
+SORTBY = СОРТПО
 TRANSPOSE = ТРАНСП
+UNIQUE = УНИК
 VLOOKUP = ВПР
+XLOOKUP = ПРОСМОТРX
+XMATCH = ПОИСКПОЗX
 
 ##
 ## Математические и тригонометрические функции (Math & Trig Functions)
@@ -302,6 +309,7 @@ PRODUCT = ПРОИЗВЕД
 QUOTIENT = ЧАСТНОЕ
 RADIANS = РАДИАНЫ
 RAND = СЛЧИС
+RANDARRAY = СЛУЧМАССИВ
 RANDBETWEEN = СЛУЧМЕЖДУ
 ROMAN = РИМСКОЕ
 ROUND = ОКРУГЛ
@@ -312,6 +320,7 @@ ROUNDUP = ОКРУГЛВВЕРХ
 SEC = SEC
 SECH = SECH
 SERIESSUM = РЯД.СУММ
+SEQUENCE = ПОСЛЕДОВ
 SIGN = ЗНАК
 SIN = SIN
 SINH = SINH
@@ -447,27 +456,36 @@ Z.TEST = Z.ТЕСТ
 ##
 ## Текстовые функции (Text Functions)
 ##
+ARRAYTOTEXT = МАССИВВТЕКСТ
 BAHTTEXT = БАТТЕКСТ
 CHAR = СИМВОЛ
 CLEAN = ПЕЧСИМВ
 CODE = КОДСИМВ
 CONCAT = СЦЕП
+DBCS = БДЦС
 DOLLAR = РУБЛЬ
 EXACT = СОВПАД
 FIND = НАЙТИ
+FINDB = НАЙТИБ
 FIXED = ФИКСИРОВАННЫЙ
-ISTHAIDIGIT = TAYRAKAMIYSA
+ISTHAIDIGIT = ЕТАЙЦИФРЫ
 LEFT = ЛЕВСИМВ
+LEFTB = ЛЕВБ
 LEN = ДЛСТР
+LENB = ДЛИНБ
 LOWER = СТРОЧН
 MID = ПСТР
+MIDB = ПСТРБ
 NUMBERSTRING = СТРОКАЧИСЕЛ
 NUMBERVALUE = ЧЗНАЧ
 PROPER = ПРОПНАЧ
 REPLACE = ЗАМЕНИТЬ
+REPLACEB = ЗАМЕНИТЬБ
 REPT = ПОВТОР
 RIGHT = ПРАВСИМВ
+RIGHTB = ПРАВБ
 SEARCH = ПОИСК
+SEARCHB = ПОИСКБ
 SUBSTITUTE = ПОДСТАВИТЬ
 T = Т
 TEXT = ТЕКСТ
@@ -481,6 +499,7 @@ UNICHAR = ЮНИСИМВ
 UNICODE = UNICODE
 UPPER = ПРОПИСН
 VALUE = ЗНАЧЕН
+VALUETOTEXT = ЗНАЧЕНИЕВТЕКСТ
 
 ##
 ## Веб-функции (Web Functions)

--- a/src/PhpSpreadsheet/Style/NumberFormat/PercentageFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/PercentageFormatter.php
@@ -40,5 +40,6 @@ class PercentageFormatter extends BaseFormatter
         /** @var float */
         $valueFloat = $value;
 
-        return sprintf($mask, round($valueFloat, $decimalPartSize));    }
+        return sprintf($mask, round($valueFloat, $decimalPartSize));
+    }
 }

--- a/src/PhpSpreadsheet/Style/NumberFormat/PercentageFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/PercentageFormatter.php
@@ -37,6 +37,8 @@ class PercentageFormatter extends BaseFormatter
         $replacement = "{$wholePartSize}.{$decimalPartSize}";
         $mask = preg_replace('/[#0,]+\.?[?#0,]*/ui', "%{$replacement}f{$placeHolders}", $format);
 
-        return sprintf($mask, $value);
-    }
+        /** @var float */
+        $valueFloat = $value;
+
+        return sprintf($mask, round($valueFloat, $decimalPartSize));    }
 }

--- a/tests/data/Style/NumberFormat.php
+++ b/tests/data/Style/NumberFormat.php
@@ -542,6 +542,66 @@ return [
         '"pfx." 0.00;"pfx." -0.00;"pfx." 0.00;',
     ],
     [
+        '0%',
+        '0',
+        NumberFormat::FORMAT_PERCENTAGE,
+    ],
+    [
+        '1%',
+        '0.01',
+        NumberFormat::FORMAT_PERCENTAGE,
+    ],
+    [
+        '1%',
+        '0.011',
+        NumberFormat::FORMAT_PERCENTAGE,
+    ],
+    [
+        '1%',
+        '0.014',
+        NumberFormat::FORMAT_PERCENTAGE,
+    ],
+    [
+        '2%',
+        '0.015',
+        NumberFormat::FORMAT_PERCENTAGE,
+    ],
+    [
+        '2%',
+        '0.019',
+        NumberFormat::FORMAT_PERCENTAGE,
+    ],
+    [
+        '0%',
+        '-0',
+        NumberFormat::FORMAT_PERCENTAGE,
+    ],
+    [
+        '-1%',
+        '-0.01',
+        NumberFormat::FORMAT_PERCENTAGE,
+    ],
+    [
+        '-1%',
+        '-0.011',
+        NumberFormat::FORMAT_PERCENTAGE,
+    ],
+    [
+        '-1%',
+        '-0.014',
+        NumberFormat::FORMAT_PERCENTAGE,
+    ],
+    [
+        '-2%',
+        '-0.015',
+        NumberFormat::FORMAT_PERCENTAGE,
+    ],
+    [
+        '-2%',
+        '-0.019',
+        NumberFormat::FORMAT_PERCENTAGE,
+    ],
+    [
         '0.00%',
         '0',
         NumberFormat::FORMAT_PERCENTAGE_00,

--- a/tests/data/Style/NumberFormat.php
+++ b/tests/data/Style/NumberFormat.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+
 //  value, format, result
 
 return [
@@ -538,5 +540,65 @@ return [
         'pfx. 25.26',
         25.255555555555555,
         '"pfx." 0.00;"pfx." -0.00;"pfx." 0.00;',
+    ],
+    [
+        '0.00%',
+        '0',
+        NumberFormat::FORMAT_PERCENTAGE_00,
+    ],
+    [
+        '1.00%',
+        '0.01',
+        NumberFormat::FORMAT_PERCENTAGE_00,
+    ],
+    [
+        '1.11%',
+        '0.0111',
+        NumberFormat::FORMAT_PERCENTAGE_00,
+    ],
+    [
+        '1.11%',
+        '0.01114',
+        NumberFormat::FORMAT_PERCENTAGE_00,
+    ],
+    [
+        '1.12%',
+        '0.01115',
+        NumberFormat::FORMAT_PERCENTAGE_00,
+    ],
+    [
+        '1.12%',
+        '0.01119',
+        NumberFormat::FORMAT_PERCENTAGE_00,
+    ],
+    [
+        '0.00%',
+        '-0',
+        NumberFormat::FORMAT_PERCENTAGE_00,
+    ],
+    [
+        '-1.00%',
+        '-0.01',
+        NumberFormat::FORMAT_PERCENTAGE_00,
+    ],
+    [
+        '-1.11%',
+        '-0.0111',
+        NumberFormat::FORMAT_PERCENTAGE_00,
+    ],
+    [
+        '-1.11%',
+        '-0.01114',
+        NumberFormat::FORMAT_PERCENTAGE_00,
+    ],
+    [
+        '-1.12%',
+        '-0.01115',
+        NumberFormat::FORMAT_PERCENTAGE_00,
+    ],
+    [
+        '-1.12%',
+        '-0.01119',
+        NumberFormat::FORMAT_PERCENTAGE_00,
     ],
 ];


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Percentages are rounded incorreclty, see https://github.com/PHPOffice/PhpSpreadsheet/pull/2525#issuecomment-1030244775

Fix proposed by @oleibman 