### PR TITLE
Enable array-readiness for more Math/Trig functions

### DIFF
--- a/src/PhpSpreadsheet/Calculation/MathTrig.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig.php
@@ -77,7 +77,7 @@ class MathTrig
      * @param float $radix
      * @param int $minLength
      *
-     * @return string the text representation with the given radix (base)
+     * @return array|string the text representation with the given radix (base)
      */
     public static function BASE($number, $radix, $minLength = null)
     {
@@ -100,7 +100,7 @@ class MathTrig
      * @param float $number the number you want to round
      * @param float $significance the multiple to which you want to round
      *
-     * @return float|string Rounded Number, or a string containing an error
+     * @return array|float|string Rounded Number, or a string containing an error
      *
      * @see MathTrig\Ceiling::ceiling()
      *      Use the ceiling() method in the MathTrig\Ceiling class instead
@@ -231,7 +231,7 @@ class MathTrig
      * @param float $number Number to round
      * @param float $significance Significance
      *
-     * @return float|string Rounded Number, or a string containing an error
+     * @return array|float|string Rounded Number, or a string containing an error
      *
      *@see MathTrig\Floor::floor()
      *      Use the floor() method in the MathTrig\Floor class instead
@@ -255,7 +255,7 @@ class MathTrig
      * @param float $significance Significance
      * @param int $mode direction to round negative numbers
      *
-     * @return float|string Rounded Number, or a string containing an error
+     * @return array|float|string Rounded Number, or a string containing an error
      *
      *@see MathTrig\Floor::math()
      *      Use the math() method in the MathTrig\Floor class instead
@@ -278,7 +278,7 @@ class MathTrig
      * @param float $number Number to round
      * @param float $significance Significance
      *
-     * @return float|string Rounded Number, or a string containing an error
+     * @return array|float|string Rounded Number, or a string containing an error
      *
      *@see MathTrig\Floor::precise()
      *      Use the precise() method in the MathTrig\Floor class instead
@@ -375,7 +375,7 @@ class MathTrig
      * @param float $number The positive real number for which you want the logarithm
      * @param float $base The base of the logarithm. If base is omitted, it is assumed to be 10.
      *
-     * @return float|string The result, or a string containing an error
+     * @return array|float|string The result, or a string containing an error
      */
     public static function logBase($number, $base = 10)
     {
@@ -941,7 +941,7 @@ class MathTrig
      * @param float $value
      * @param int $digits
      *
-     * @return float|string Truncated value, or a string containing an error
+     * @return array|float|string Truncated value, or a string containing an error
      */
     public static function TRUNC($value = 0, $digits = 0)
     {
@@ -1358,7 +1358,7 @@ class MathTrig
      *
      * @param mixed $number Should be numeric
      *
-     * @return float|string Rounded number
+     * @return array|float|string Rounded number
      */
     public static function builtinLN($number)
     {
@@ -1377,7 +1377,7 @@ class MathTrig
      *
      * @param mixed $number Should be numeric
      *
-     * @return float|string Rounded number
+     * @return array|float|string Rounded number
      */
     public static function builtinLOG10($number)
     {

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Base.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Base.php
@@ -2,11 +2,14 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\ArrayEnabled;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 
 class Base
 {
+    use ArrayEnabled;
+
     /**
      * BASE.
      *
@@ -16,13 +19,22 @@ class Base
      *        BASE(Number, Radix [Min_length])
      *
      * @param mixed $number expect float
+     *                      Or can be an array of values
      * @param mixed $radix expect float
+     *                      Or can be an array of values
      * @param mixed $minLength expect int or null
+     *                      Or can be an array of values
      *
-     * @return string the text representation with the given radix (base)
+     * @return array|string the text representation with the given radix (base)
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function evaluate($number, $radix, $minLength = null)
     {
+        if (is_array($number) || is_array($radix) || is_array($minLength)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $number, $radix, $minLength);
+        }
+
         try {
             $number = (float) floor(Helpers::validateNumericNullBool($number));
             $radix = (int) Helpers::validateNumericNullBool($radix);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Base.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Base.php
@@ -43,6 +43,14 @@ class Base
         }
         $minLength = Functions::flattenSingleValue($minLength);
 
+        return self::calculate($number, $radix, $minLength);
+    }
+
+    /**
+     * @param mixed $minLength
+     */
+    private static function calculate(float $number, int $radix, $minLength): string
+    {
         if ($minLength === null || is_numeric($minLength)) {
             if ($number < 0 || $number >= 2 ** 53 || $radix < 2 || $radix > 36) {
                 return Functions::NAN(); // Numeric range constraints

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Ceiling.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Ceiling.php
@@ -2,11 +2,14 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\ArrayEnabled;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 
 class Ceiling
 {
+    use ArrayEnabled;
+
     /**
      * CEILING.
      *
@@ -18,13 +21,21 @@ class Ceiling
      * Excel Function:
      *        CEILING(number[,significance])
      *
-     * @param float $number the number you want the ceiling
-     * @param float $significance the multiple to which you want to round
+     * @param array|float $number the number you want the ceiling
+     *                      Or can be an array of values
+     * @param array|float $significance the multiple to which you want to round
+     *                      Or can be an array of values
      *
-     * @return float|string Rounded Number, or a string containing an error
+     * @return array|float|string Rounded Number, or a string containing an error
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function ceiling($number, $significance = null)
     {
+        if (is_array($number) || is_array($significance)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $number, $significance);
+        }
+
         if ($significance === null) {
             self::floorCheck1Arg();
         }
@@ -48,13 +59,22 @@ class Ceiling
      *        CEILING.MATH(number[,significance[,mode]])
      *
      * @param mixed $number Number to round
+     *                      Or can be an array of values
      * @param mixed $significance Significance
-     * @param int $mode direction to round negative numbers
+     *                      Or can be an array of values
+     * @param array|int $mode direction to round negative numbers
+     *                      Or can be an array of values
      *
-     * @return float|string Rounded Number, or a string containing an error
+     * @return array|float|string Rounded Number, or a string containing an error
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function math($number, $significance = null, $mode = 0)
     {
+        if (is_array($number) || is_array($significance) || is_array($mode)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $number, $significance, $mode);
+        }
+
         try {
             $number = Helpers::validateNumericNullBool($number);
             $significance = Helpers::validateNumericNullSubstitution($significance, ($number < 0) ? -1 : 1);
@@ -82,12 +102,20 @@ class Ceiling
      *        CEILING.PRECISE(number[,significance])
      *
      * @param mixed $number the number you want to round
-     * @param float $significance the multiple to which you want to round
+     *                      Or can be an array of values
+     * @param array|float $significance the multiple to which you want to round
+     *                      Or can be an array of values
      *
-     * @return float|string Rounded Number, or a string containing an error
+     * @return array|float|string Rounded Number, or a string containing an error
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function precise($number, $significance = 1)
     {
+        if (is_array($number) || is_array($significance)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $number, $significance);
+        }
+
         try {
             $number = Helpers::validateNumericNullBool($number);
             $significance = Helpers::validateNumericNullSubstitution($significance, null);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Floor.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Floor.php
@@ -2,11 +2,14 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\ArrayEnabled;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 
 class Floor
 {
+    use ArrayEnabled;
+
     private static function floorCheck1Arg(): void
     {
         $compatibility = Functions::getCompatibilityMode();
@@ -24,12 +27,20 @@ class Floor
      *        FLOOR(number[,significance])
      *
      * @param mixed $number Expect float. Number to round
+     *                      Or can be an array of values
      * @param mixed $significance Expect float. Significance
+     *                      Or can be an array of values
      *
-     * @return float|string Rounded Number, or a string containing an error
+     * @return array|float|string Rounded Number, or a string containing an error
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function floor($number, $significance = null)
     {
+        if (is_array($number) || is_array($significance)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $number, $significance);
+        }
+
         if ($significance === null) {
             self::floorCheck1Arg();
         }
@@ -53,13 +64,22 @@ class Floor
      *        FLOOR.MATH(number[,significance[,mode]])
      *
      * @param mixed $number Number to round
+     *                      Or can be an array of values
      * @param mixed $significance Significance
+     *                      Or can be an array of values
      * @param mixed $mode direction to round negative numbers
+     *                      Or can be an array of values
      *
-     * @return float|string Rounded Number, or a string containing an error
+     * @return array|float|string Rounded Number, or a string containing an error
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function math($number, $significance = null, $mode = 0)
     {
+        if (is_array($number) || is_array($significance) || is_array($mode)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $number, $significance, $mode);
+        }
+
         try {
             $number = Helpers::validateNumericNullBool($number);
             $significance = Helpers::validateNumericNullSubstitution($significance, ($number < 0) ? -1 : 1);
@@ -79,13 +99,21 @@ class Floor
      * Excel Function:
      *        FLOOR.PRECISE(number[,significance])
      *
-     * @param float $number Number to round
-     * @param float $significance Significance
+     * @param array|float $number Number to round
+     *                      Or can be an array of values
+     * @param array|float $significance Significance
+     *                      Or can be an array of values
      *
-     * @return float|string Rounded Number, or a string containing an error
+     * @return array|float|string Rounded Number, or a string containing an error
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function precise($number, $significance = 1)
     {
+        if (is_array($number) || is_array($significance)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $number, $significance);
+        }
+
         try {
             $number = Helpers::validateNumericNullBool($number);
             $significance = Helpers::validateNumericNullSubstitution($significance, null);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Logarithms.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Logarithms.php
@@ -2,10 +2,13 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\ArrayEnabled;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 
 class Logarithms
 {
+    use ArrayEnabled;
+
     /**
      * LOG_BASE.
      *
@@ -15,12 +18,20 @@ class Logarithms
      *        LOG(number[,base])
      *
      * @param mixed $number The positive real number for which you want the logarithm
+     *                      Or can be an array of values
      * @param mixed $base The base of the logarithm. If base is omitted, it is assumed to be 10.
+     *                      Or can be an array of values
      *
-     * @return float|string The result, or a string containing an error
+     * @return array|float|string The result, or a string containing an error
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function withBase($number, $base = 10)
     {
+        if (is_array($number) || is_array($base)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $number, $base);
+        }
+
         try {
             $number = Helpers::validateNumericNullBool($number);
             Helpers::validatePositive($number);
@@ -39,11 +50,18 @@ class Logarithms
      * Returns the result of builtin function log after validating args.
      *
      * @param mixed $number Should be numeric
+     *                      Or can be an array of values
      *
-     * @return float|string Rounded number
+     * @return array|float|string Rounded number
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function base10($number)
     {
+        if (is_array($number)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $number);
+        }
+
         try {
             $number = Helpers::validateNumericNullBool($number);
             Helpers::validatePositive($number);
@@ -60,11 +78,18 @@ class Logarithms
      * Returns the result of builtin function log after validating args.
      *
      * @param mixed $number Should be numeric
+     *                      Or can be an array of values
      *
-     * @return float|string Rounded number
+     * @return array|float|string Rounded number
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function natural($number)
     {
+        if (is_array($number)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $number);
+        }
+
         try {
             $number = Helpers::validateNumericNullBool($number);
             Helpers::validatePositive($number);

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Trunc.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Trunc.php
@@ -2,22 +2,33 @@
 
 namespace PhpOffice\PhpSpreadsheet\Calculation\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\ArrayEnabled;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 
 class Trunc
 {
+    use ArrayEnabled;
+
     /**
      * TRUNC.
      *
      * Truncates value to the number of fractional digits by number_digits.
      *
-     * @param float $value
-     * @param int $digits
+     * @param array|float $value
+     *                      Or can be an array of values
+     * @param array|int $digits
+     *                      Or can be an array of values
      *
-     * @return float|string Truncated value, or a string containing an error
+     * @return array|float|string Truncated value, or a string containing an error
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function evaluate($value = 0, $digits = 0)
     {
+        if (is_array($value) || is_array($digits)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $value, $digits);
+        }
+
         try {
             $value = Helpers::validateNumericNullBool($value);
             $digits = Helpers::validateNumericNullSubstitution($digits, null);

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/BaseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/BaseTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+
 class BaseTest extends AllSetupTeardown
 {
     /**
@@ -41,5 +43,24 @@ class BaseTest extends AllSetupTeardown
     public function providerBASE(): array
     {
         return require 'tests/data/Calculation/MathTrig/BASE.php';
+    }
+
+    /**
+     * @dataProvider providerBaseArray
+     */
+    public function testBaseArray(array $expectedResult, string $argument1, string $argument2): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=BASE({$argument1}, {$argument2})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+    }
+
+    public function providerBaseArray(): array
+    {
+        return [
+            'matrix' => [[['1111111', '177'], ['127', '7F']], '127', '{2, 8; 10, 16}'],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingMathTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingMathTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+
 class CeilingMathTest extends AllSetupTeardown
 {
     /**
@@ -26,5 +28,24 @@ class CeilingMathTest extends AllSetupTeardown
     public function providerCEILINGMATH(): array
     {
         return require 'tests/data/Calculation/MathTrig/CEILINGMATH.php';
+    }
+
+    /**
+     * @dataProvider providerCeilingArray
+     */
+    public function testCeilingArray(array $expectedResult, string $argument1, string $argument2): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=CEILING.MATH({$argument1}, {$argument2})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+    }
+
+    public function providerCeilingArray(): array
+    {
+        return [
+            'matrix' => [[[3.15, 3.142], [3.1416, 3.141594]], '3.1415926536', '{0.01, 0.002; 0.00005, 0.000002}'],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingPreciseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingPreciseTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+
 class CeilingPreciseTest extends AllSetupTeardown
 {
     /**
@@ -26,5 +28,24 @@ class CeilingPreciseTest extends AllSetupTeardown
     public function providerFLOORPRECISE(): array
     {
         return require 'tests/data/Calculation/MathTrig/CEILINGPRECISE.php';
+    }
+
+    /**
+     * @dataProvider providerCeilingArray
+     */
+    public function testCeilingArray(array $expectedResult, string $argument1, string $argument2): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=CEILING.PRECISE({$argument1}, {$argument2})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+    }
+
+    public function providerCeilingArray(): array
+    {
+        return [
+            'matrix' => [[[3.15, 3.142], [3.1416, 3.141594]], '3.1415926536', '{0.01, 0.002; 0.00005, 0.000002}'],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+
 class CeilingTest extends AllSetupTeardown
 {
     /**
@@ -53,5 +55,24 @@ class CeilingTest extends AllSetupTeardown
         $sheet->getCell('A1')->setValue('=CEILING(5.1)');
         $result = $sheet->getCell('A1')->getCalculatedValue();
         self::assertEqualsWithDelta(6, $result, 1E-12);
+    }
+
+    /**
+     * @dataProvider providerCeilingArray
+     */
+    public function testCeilingArray(array $expectedResult, string $argument1, string $argument2): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=CEILING({$argument1}, {$argument2})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+    }
+
+    public function providerCeilingArray(): array
+    {
+        return [
+            'matrix' => [[[3.15, 3.142], [3.1416, 3.141594]], '3.1415926536', '{0.01, 0.002; 0.00005, 0.000002}'],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorMathTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorMathTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+
 class FloorMathTest extends AllSetupTeardown
 {
     /**
@@ -26,5 +28,24 @@ class FloorMathTest extends AllSetupTeardown
     public function providerFLOORMATH(): array
     {
         return require 'tests/data/Calculation/MathTrig/FLOORMATH.php';
+    }
+
+    /**
+     * @dataProvider providerFloorArray
+     */
+    public function testFloorArray(array $expectedResult, string $argument1, string $argument2): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=FLOOR.MATH({$argument1}, {$argument2})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+    }
+
+    public function providerFloorArray(): array
+    {
+        return [
+            'matrix' => [[[3.14, 3.14], [3.14155, 3.141592]], '3.1415926536', '{0.01, 0.002; 0.00005, 0.000002}'],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorPreciseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorPreciseTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+
 class FloorPreciseTest extends AllSetupTeardown
 {
     /**
@@ -26,5 +28,24 @@ class FloorPreciseTest extends AllSetupTeardown
     public function providerFLOORPRECISE(): array
     {
         return require 'tests/data/Calculation/MathTrig/FLOORPRECISE.php';
+    }
+
+    /**
+     * @dataProvider providerFloorArray
+     */
+    public function testFloorArray(array $expectedResult, string $argument1, string $argument2): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=FLOOR.PRECISE({$argument1}, {$argument2})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+    }
+
+    public function providerFloorArray(): array
+    {
+        return [
+            'matrix' => [[[3.14, 3.14], [3.14155, 3.141592]], '3.1415926536', '{0.01, 0.002; 0.00005, 0.000002}'],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+
 class FloorTest extends AllSetupTeardown
 {
     /**
@@ -53,5 +55,24 @@ class FloorTest extends AllSetupTeardown
         $sheet->getCell('A1')->setValue('=FLOOR(5.1)');
         $result = $sheet->getCell('A1')->getCalculatedValue();
         self::assertEqualsWithDelta(5, $result, 1E-12);
+    }
+
+    /**
+     * @dataProvider providerFloorArray
+     */
+    public function testFloorArray(array $expectedResult, string $argument1, string $argument2): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=FLOOR({$argument1}, {$argument2})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+    }
+
+    public function providerFloorArray(): array
+    {
+        return [
+            'matrix' => [[[3.14, 3.14], [3.14155, 3.141592]], '3.1415926536', '{0.01, 0.002; 0.00005, 0.000002}'],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LnTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+
 class LnTest extends AllSetupTeardown
 {
     /**
@@ -29,5 +31,26 @@ class LnTest extends AllSetupTeardown
     public function providerLN(): array
     {
         return require 'tests/data/Calculation/MathTrig/LN.php';
+    }
+
+    /**
+     * @dataProvider providerLnArray
+     */
+    public function testLnArray(array $expectedResult, string $array): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=LN({$array})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+    }
+
+    public function providerLnArray(): array
+    {
+        return [
+            'row vector' => [[[-2.07944154167984, 0.85228540189824, 2.525728644308256]], '{0.125, 2.345, 12.5}'],
+            'column vector' => [[[-2.07944154167984], [0.85228540189824], [2.525728644308256]], '{0.125; 2.345; 12.5}'],
+            'matrix' => [[[-2.07944154167984, 0.85228540189824], [0.0, 2.525728644308256]], '{0.125, 2.345; 1.0, 12.5}'],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/Log10Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/Log10Test.php
@@ -2,15 +2,17 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+
 class Log10Test extends AllSetupTeardown
 {
     /**
-     * @dataProvider providerLN
+     * @dataProvider providerLOG10
      *
      * @param mixed $expectedResult
      * @param mixed $number
      */
-    public function testLN($expectedResult, $number = 'omitted'): void
+    public function testLOG10($expectedResult, $number = 'omitted'): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();
@@ -26,8 +28,29 @@ class Log10Test extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerLN(): array
+    public function providerLOG10(): array
     {
         return require 'tests/data/Calculation/MathTrig/LOG10.php';
+    }
+
+    /**
+     * @dataProvider providerLog10Array
+     */
+    public function testLog10Array(array $expectedResult, string $array): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=LOG10({$array})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+    }
+
+    public function providerLog10Array(): array
+    {
+        return [
+            'row vector' => [[[-0.90308998699194, 0.3701428470511, 1.09691001300806]], '{0.125, 2.345, 12.5}'],
+            'column vector' => [[[-0.90308998699194], [0.3701428470511], [1.09691001300806]], '{0.125; 2.345; 12.5}'],
+            'matrix' => [[[-0.90308998699194, 0.3701428470511], [0.0, 1.09691001300806]], '{0.125, 2.345; 1.0, 12.5}'],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LogTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LogTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+
 class LogTest extends AllSetupTeardown
 {
     /**
@@ -35,5 +37,31 @@ class LogTest extends AllSetupTeardown
     public function providerLOG(): array
     {
         return require 'tests/data/Calculation/MathTrig/LOG.php';
+    }
+
+    /**
+     * @dataProvider providerLogArray
+     */
+    public function testLogArray(array $expectedResult, string $argument1, string $argument2): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=LOG({$argument1}, {$argument2})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+    }
+
+    public function providerLogArray(): array
+    {
+        return [
+            'matrix' => [
+                [
+                    [-0.90308998699194, 0.3701428470511, 0.0, 1.09691001300806],
+                    [-2.07944154167984, 0.85228540189824, 0.0, 2.525728644308256],
+                ],
+                '{0.125, 2.345, 1.0, 12.5}',
+                '{10; 2.718281828459045}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TruncTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TruncTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\MathTrig;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+
 class TruncTest extends AllSetupTeardown
 {
     /**
@@ -26,5 +28,24 @@ class TruncTest extends AllSetupTeardown
     public function providerTRUNC(): array
     {
         return require 'tests/data/Calculation/MathTrig/TRUNC.php';
+    }
+
+    /**
+     * @dataProvider providerTruncArray
+     */
+    public function testTruncArray(array $expectedResult, string $argument1, string $argument2): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=TRUNC({$argument1}, {$argument2})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+    }
+
+    public function providerTruncArray(): array
+    {
+        return [
+            'matrix' => [[[3.14, 3.141], [3.14159, 3.14159265]], '3.1415926536', '{2, 3; 5, 8}'],
+        ];
     }
 }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Part of the https://github.com/PHPOffice/PhpSpreadsheet/issues/2551 update to make all relevant functions array-argument-enabled