### PR TITLE
Renamed "worskeet" to "worksheet" comment typo

### DIFF
--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -608,7 +608,7 @@ class Spreadsheet
     /**
      * Add sheet.
      *
-     * @param Worksheet $worksheet The worskeet to add
+     * @param Worksheet $worksheet The worksheet to add
      * @param null|int $sheetIndex Index where sheet should go (0,1,..., or null for last)
      *
      * @return Worksheet


### PR DESCRIPTION
This is:

```
- [ ] a typo fixed
```