### PR TITLE
Eliminate calls to flattenSingleValue() that are no longer required w…

### DIFF
--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/Date.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/Date.php
@@ -93,7 +93,6 @@ class Date
      */
     private static function getYear($year, int $baseYear): int
     {
-        $year = Functions::flattenSingleValue($year);
         $year = ($year !== null) ? StringHelper::testStringAsNumeric((string) $year) : 0;
         if (!is_numeric($year)) {
             throw new Exception(Functions::VALUE());
@@ -121,8 +120,6 @@ class Date
      */
     private static function getMonth($month): int
     {
-        $month = Functions::flattenSingleValue($month);
-
         if (($month !== null) && (!is_numeric($month))) {
             $month = SharedDateHelper::monthStringToNumber($month);
         }
@@ -142,8 +139,6 @@ class Date
      */
     private static function getDay($day): int
     {
-        $day = Functions::flattenSingleValue($day);
-
         if (($day !== null) && (!is_numeric($day))) {
             $day = SharedDateHelper::dayStringToNumber($day);
         }

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/DateValue.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/DateValue.php
@@ -47,7 +47,7 @@ class DateValue
 
         $dti = new DateTimeImmutable();
         $baseYear = SharedDateHelper::getExcelCalendar();
-        $dateValue = trim(Functions::flattenSingleValue($dateValue ?? ''), '"');
+        $dateValue = trim($dateValue ?? '', '"');
         //    Strip any ordinals because they're allowed in Excel (English only)
         $dateValue = preg_replace('/(\d)(st|nd|rd|th)([ -\/])/Ui', '$1$3', $dateValue) ?? '';
         //    Convert separators (/ . or space) to hyphens (should also handle dot used for ordinals in some countries, e.g. Denmark, Germany)

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/Difference.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/Difference.php
@@ -39,7 +39,7 @@ class Difference
             $startDate = Helpers::getDateValue($startDate);
             $endDate = Helpers::getDateValue($endDate);
             $difference = self::initialDiff($startDate, $endDate);
-            $unit = strtoupper(Functions::flattenSingleValue($unit));
+            $unit = strtoupper($unit);
         } catch (Exception $e) {
             return $e->getMessage();
         }

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/Time.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/Time.php
@@ -116,7 +116,6 @@ class Time
      */
     private static function toIntWithNullBool($value): int
     {
-        $value = Functions::flattenSingleValue($value);
         $value = $value ?? 0;
         if (is_bool($value)) {
             $value = (int) $value;

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/TimeParts.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/TimeParts.php
@@ -4,7 +4,6 @@ namespace PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel;
 
 use PhpOffice\PhpSpreadsheet\Calculation\ArrayEnabled;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Shared\Date as SharedDateHelper;
 
 class TimeParts
@@ -35,7 +34,6 @@ class TimeParts
         }
 
         try {
-            $timeValue = Functions::flattenSingleValue($timeValue);
             Helpers::nullFalseTrueToNumber($timeValue);
             if (!is_numeric($timeValue)) {
                 $timeValue = Helpers::getTimeValue($timeValue);
@@ -76,7 +74,6 @@ class TimeParts
         }
 
         try {
-            $timeValue = Functions::flattenSingleValue($timeValue);
             Helpers::nullFalseTrueToNumber($timeValue);
             if (!is_numeric($timeValue)) {
                 $timeValue = Helpers::getTimeValue($timeValue);
@@ -117,7 +114,6 @@ class TimeParts
         }
 
         try {
-            $timeValue = Functions::flattenSingleValue($timeValue);
             Helpers::nullFalseTrueToNumber($timeValue);
             if (!is_numeric($timeValue)) {
                 $timeValue = Helpers::getTimeValue($timeValue);

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/TimeValue.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/TimeValue.php
@@ -41,7 +41,7 @@ class TimeValue
             return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $timeValue);
         }
 
-        $timeValue = trim(Functions::flattenSingleValue($timeValue ?? ''), '"');
+        $timeValue = trim($timeValue ?? '', '"');
         $timeValue = str_replace(['/', '.'], '-', $timeValue);
 
         $arraySplit = preg_split('/[\/:\-\s]/', $timeValue) ?: [];

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/Week.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/Week.php
@@ -191,8 +191,6 @@ class Week
      */
     private static function validateStyle($style): int
     {
-        $style = Functions::flattenSingleValue($style);
-
         if (!is_numeric($style)) {
             throw new Exception(Functions::VALUE());
         }
@@ -251,7 +249,7 @@ class Week
         if ($method === null) {
             $method = Constants::STARTWEEK_SUNDAY;
         }
-        $method = Functions::flattenSingleValue($method);
+
         if (!is_numeric($method)) {
             throw new Exception(Functions::VALUE());
         }


### PR DESCRIPTION
Eliminate calls to `flattenSingleValue()` that are no longer required when we're checking for array values as arguments

This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] refactoring
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

array argument checking eliminates the need for flattening those arguments by calling `flattenSingleValue()` because the array argument handling inside the `ArrayEnabled` Trait already flattens those arguments