### PR TITLE
Eliminate calls to flattenSingleValue() that are no longer required

### DIFF
--- a/src/PhpSpreadsheet/Calculation/MathTrig/Arabic.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Arabic.php
@@ -86,7 +86,7 @@ class Arabic
         }
 
         // An empty string should return 0
-        $roman = substr(trim(strtoupper((string) Functions::flattenSingleValue($roman))), 0, 255);
+        $roman = substr(trim(strtoupper((string) $roman)), 0, 255);
         if ($roman === '') {
             return 0;
         }

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Base.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Base.php
@@ -41,7 +41,6 @@ class Base
         } catch (Exception $e) {
             return $e->getMessage();
         }
-        $minLength = Functions::flattenSingleValue($minLength);
 
         return self::calculate($number, $radix, $minLength);
     }


### PR DESCRIPTION
Eliminate calls to flattenSingleValue() that are no longer required when we're checking for array values as arguments

This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
