### PR TITLE
Eliminate calls to flattenSingleValue() that are no longer required

### DIFF
--- a/src/PhpSpreadsheet/Calculation/TextData/CaseConvert.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/CaseConvert.php
@@ -3,7 +3,6 @@
 namespace PhpOffice\PhpSpreadsheet\Calculation\TextData;
 
 use PhpOffice\PhpSpreadsheet\Calculation\ArrayEnabled;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 
 class CaseConvert
@@ -28,7 +27,6 @@ class CaseConvert
             return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $mixedCaseValue);
         }
 
-        $mixedCaseValue = Functions::flattenSingleValue($mixedCaseValue);
         $mixedCaseValue = Helpers::extractString($mixedCaseValue);
 
         return StringHelper::strToLower($mixedCaseValue);
@@ -52,7 +50,6 @@ class CaseConvert
             return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $mixedCaseValue);
         }
 
-        $mixedCaseValue = Functions::flattenSingleValue($mixedCaseValue);
         $mixedCaseValue = Helpers::extractString($mixedCaseValue);
 
         return StringHelper::strToUpper($mixedCaseValue);
@@ -76,7 +73,6 @@ class CaseConvert
             return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $mixedCaseValue);
         }
 
-        $mixedCaseValue = Functions::flattenSingleValue($mixedCaseValue);
         $mixedCaseValue = Helpers::extractString($mixedCaseValue);
 
         return StringHelper::strToTitle($mixedCaseValue);

--- a/src/PhpSpreadsheet/Calculation/TextData/Concatenate.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Concatenate.php
@@ -53,8 +53,6 @@ class Concatenate
             );
         }
 
-        $delimiter = Functions::flattenSingleValue($delimiter);
-        $ignoreEmpty = Functions::flattenSingleValue($ignoreEmpty);
         // Loop through arguments
         $aArgs = Functions::flattenArray($args);
         foreach ($aArgs as $key => &$arg) {
@@ -88,7 +86,6 @@ class Concatenate
             return self::evaluateArrayArguments([self::class, __FUNCTION__], $stringValue, $repeatCount);
         }
 
-        $repeatCount = Functions::flattenSingleValue($repeatCount);
         $stringValue = Helpers::extractString($stringValue);
 
         if (!is_numeric($repeatCount) || $repeatCount < 0) {

--- a/src/PhpSpreadsheet/Calculation/TextData/Format.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Format.php
@@ -84,7 +84,6 @@ class Format
         try {
             $value = Helpers::extractFloat($value);
             $decimals = Helpers::extractInt($decimals, -100, 0, true);
-            $noCommas = Functions::flattenSingleValue($noCommas);
         } catch (CalcExp $e) {
             return $e->getMessage();
         }
@@ -140,7 +139,7 @@ class Format
      */
     private static function convertValue($value)
     {
-        $value = ($value === null) ? 0 : Functions::flattenSingleValue($value);
+        $value = $value ?? 0;
         if (is_bool($value)) {
             if (Functions::getCompatibilityMode() === Functions::COMPATIBILITY_OPENOFFICE) {
                 $value = (int) $value;
@@ -213,8 +212,6 @@ class Format
      */
     private static function getDecimalSeparator($decimalSeparator): string
     {
-        $decimalSeparator = Functions::flattenSingleValue($decimalSeparator);
-
         return empty($decimalSeparator) ? StringHelper::getDecimalSeparator() : (string) $decimalSeparator;
     }
 
@@ -223,8 +220,6 @@ class Format
      */
     private static function getGroupSeparator($groupSeparator): string
     {
-        $groupSeparator = Functions::flattenSingleValue($groupSeparator);
-
         return empty($groupSeparator) ? StringHelper::getThousandsSeparator() : (string) $groupSeparator;
     }
 

--- a/src/PhpSpreadsheet/Calculation/TextData/Helpers.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Helpers.php
@@ -22,7 +22,6 @@ class Helpers
      */
     public static function extractString($value): string
     {
-        $value = Functions::flattenSingleValue($value);
         if (is_bool($value)) {
             return self::convertBooleanValue($value);
         }
@@ -35,7 +34,6 @@ class Helpers
      */
     public static function extractInt($value, int $minValue, int $gnumericNull = 0, bool $ooBoolOk = false): int
     {
-        $value = Functions::flattenSingleValue($value);
         if ($value === null) {
             // usually 0, but sometimes 1 for Gnumeric
             $value = (Functions::getCompatibilityMode() === Functions::COMPATIBILITY_GNUMERIC) ? $gnumericNull : 0;
@@ -59,7 +57,6 @@ class Helpers
      */
     public static function extractFloat($value): float
     {
-        $value = Functions::flattenSingleValue($value);
         if ($value === null) {
             $value = 0.0;
         }
@@ -78,7 +75,6 @@ class Helpers
      */
     public static function validateInt($value): int
     {
-        $value = Functions::flattenSingleValue($value);
         if ($value === null) {
             $value = 0;
         } elseif (is_bool($value)) {

--- a/src/PhpSpreadsheet/Calculation/TextData/Replace.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Replace.php
@@ -73,7 +73,6 @@ class Replace
             $text = Helpers::extractString($text);
             $fromText = Helpers::extractString($fromText);
             $toText = Helpers::extractString($toText);
-            $instance = Functions::flattenSingleValue($instance);
             if ($instance === null) {
                 return str_replace($fromText, $toText, $text);
             }

--- a/src/PhpSpreadsheet/Calculation/TextData/Text.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Text.php
@@ -3,7 +3,6 @@
 namespace PhpOffice\PhpSpreadsheet\Calculation\TextData;
 
 use PhpOffice\PhpSpreadsheet\Calculation\ArrayEnabled;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 
 class Text
 {
@@ -71,8 +70,6 @@ class Text
         if (is_array($testValue)) {
             return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $testValue);
         }
-
-        $testValue = Functions::flattenSingleValue($testValue);
 
         if (is_string($testValue)) {
             return $testValue;


### PR DESCRIPTION
Eliminate calls in TextData Functions to flattenSingleValue() that are no longer required when we're checking for array values as arguments

This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
