### PR TITLE
fix php 8.1 error when autoFilter['ref'] is null in AutoFilter

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx/AutoFilter.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/AutoFilter.php
@@ -22,7 +22,7 @@ class AutoFilter
     public function load(): void
     {
         // Remove all "$" in the auto filter range
-        $autoFilterRange = preg_replace('/\$/', '', $this->worksheetXml->autoFilter['ref']);
+        $autoFilterRange = preg_replace('/\$/', '', $this->worksheetXml->autoFilter['ref'] ?? '');
         if (strpos($autoFilterRange, ':') !== false) {
             $this->readAutoFilter($autoFilterRange, $this->worksheetXml);
         }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

On PHP 8.1, when loading an existing file into PhpSpreadsheet, this error does happen sometimes. This change will fix this issue. I cannot provide a testfile, as this happen only on very specific files that i cannot post here, for data protection reasons. I tried creating a reproducible file for here, but it didn't worked out.

I don't know why `autoFilter['ref']` is null, but it obviously is sometimes null. The key exists for sure, but it's null. Maybe it can cause other problems, but this fixed it for us.

![image](https://user-images.githubusercontent.com/1684236/154233856-e77803fb-33a8-41a4-9bc0-b9ce5174801f.png)

