### PR TITLE
Converting Engineering functions to be array-enabled

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -371,11 +371,6 @@ parameters:
 			path: src/PhpSpreadsheet/Calculation/Engineering/BitWise.php
 
 		-
-			message: "#^Parameter \\#1 \\$power of method Complex\\\\Complex\\:\\:pow\\(\\) expects float\\|int, float\\|int\\|string given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/Engineering/ComplexFunctions.php
-
-		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\Engineering\\\\ConvertBase\\:\\:validatePlaces\\(\\) has parameter \\$places with no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Calculation/Engineering/ConvertBase.php

--- a/src/PhpSpreadsheet/Calculation/Engineering.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering.php
@@ -563,12 +563,12 @@ class Engineering
      *
      * @see Use the COMPLEX() method in the Engineering\Complex class instead
      *
-     * @param float $realNumber the real coefficient of the complex number
-     * @param float $imaginary the imaginary coefficient of the complex number
-     * @param string $suffix The suffix for the imaginary component of the complex number.
+     * @param array|float $realNumber the real coefficient of the complex number
+     * @param array|float $imaginary the imaginary coefficient of the complex number
+     * @param array|string $suffix The suffix for the imaginary component of the complex number.
      *                                        If omitted, the suffix is assumed to be "i".
      *
-     * @return string
+     * @return array|string
      */
     public static function COMPLEX($realNumber = 0.0, $imaginary = 0.0, $suffix = 'i')
     {
@@ -590,7 +590,7 @@ class Engineering
      * @param string $complexNumber the complex number for which you want the imaginary
      *                                         coefficient
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMAGINARY($complexNumber)
     {
@@ -611,7 +611,7 @@ class Engineering
      *
      * @param string $complexNumber the complex number for which you want the real coefficient
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMREAL($complexNumber)
     {
@@ -632,7 +632,7 @@ class Engineering
      *
      * @param string $complexNumber the complex number for which you want the absolute value
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMABS($complexNumber)
     {
@@ -652,9 +652,9 @@ class Engineering
      *
      * @see Use the IMARGUMENT() method in the Engineering\ComplexFunctions class instead
      *
-     * @param string $complexNumber the complex number for which you want the argument theta
+     * @param array|string $complexNumber the complex number for which you want the argument theta
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMARGUMENT($complexNumber)
     {
@@ -673,9 +673,9 @@ class Engineering
      *
      * @see Use the IMARGUMENT() method in the Engineering\ComplexFunctions class instead
      *
-     * @param string $complexNumber the complex number for which you want the conjugate
+     * @param array|string $complexNumber the complex number for which you want the conjugate
      *
-     * @return string
+     * @return array|string
      */
     public static function IMCONJUGATE($complexNumber)
     {
@@ -694,9 +694,9 @@ class Engineering
      *
      * @see Use the IMCOS() method in the Engineering\ComplexFunctions class instead
      *
-     * @param string $complexNumber the complex number for which you want the cosine
+     * @param array|string $complexNumber the complex number for which you want the cosine
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMCOS($complexNumber)
     {
@@ -715,9 +715,9 @@ class Engineering
      *
      * @see Use the IMCOSH() method in the Engineering\ComplexFunctions class instead
      *
-     * @param string $complexNumber the complex number for which you want the hyperbolic cosine
+     * @param array|string $complexNumber the complex number for which you want the hyperbolic cosine
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMCOSH($complexNumber)
     {
@@ -736,9 +736,9 @@ class Engineering
      *
      * @see Use the IMCOT() method in the Engineering\ComplexFunctions class instead
      *
-     * @param string $complexNumber the complex number for which you want the cotangent
+     * @param array|string $complexNumber the complex number for which you want the cotangent
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMCOT($complexNumber)
     {
@@ -757,9 +757,9 @@ class Engineering
      *
      * @see Use the IMCSC() method in the Engineering\ComplexFunctions class instead
      *
-     * @param string $complexNumber the complex number for which you want the cosecant
+     * @param array|string $complexNumber the complex number for which you want the cosecant
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMCSC($complexNumber)
     {
@@ -778,9 +778,9 @@ class Engineering
      *
      * @see Use the IMCSCH() method in the Engineering\ComplexFunctions class instead
      *
-     * @param string $complexNumber the complex number for which you want the hyperbolic cosecant
+     * @param array|string $complexNumber the complex number for which you want the hyperbolic cosecant
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMCSCH($complexNumber)
     {
@@ -801,7 +801,7 @@ class Engineering
      *
      * @param string $complexNumber the complex number for which you want the sine
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMSIN($complexNumber)
     {
@@ -822,7 +822,7 @@ class Engineering
      *
      * @param string $complexNumber the complex number for which you want the hyperbolic sine
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMSINH($complexNumber)
     {
@@ -843,7 +843,7 @@ class Engineering
      *
      * @param string $complexNumber the complex number for which you want the secant
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMSEC($complexNumber)
     {
@@ -864,7 +864,7 @@ class Engineering
      *
      * @param string $complexNumber the complex number for which you want the hyperbolic secant
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMSECH($complexNumber)
     {
@@ -885,7 +885,7 @@ class Engineering
      *
      * @param string $complexNumber the complex number for which you want the tangent
      *
-     * @return float|string
+     * @return array|float|string
      */
     public static function IMTAN($complexNumber)
     {
@@ -906,7 +906,7 @@ class Engineering
      *
      * @param string $complexNumber the complex number for which you want the square root
      *
-     * @return string
+     * @return array|string
      */
     public static function IMSQRT($complexNumber)
     {
@@ -927,7 +927,7 @@ class Engineering
      *
      * @param string $complexNumber the complex number for which you want the natural logarithm
      *
-     * @return string
+     * @return array|string
      */
     public static function IMLN($complexNumber)
     {
@@ -948,7 +948,7 @@ class Engineering
      *
      * @param string $complexNumber the complex number for which you want the common logarithm
      *
-     * @return string
+     * @return array|string
      */
     public static function IMLOG10($complexNumber)
     {
@@ -969,7 +969,7 @@ class Engineering
      *
      * @param string $complexNumber the complex number for which you want the base-2 logarithm
      *
-     * @return string
+     * @return array|string
      */
     public static function IMLOG2($complexNumber)
     {
@@ -990,7 +990,7 @@ class Engineering
      *
      * @param string $complexNumber the complex number for which you want the exponential
      *
-     * @return string
+     * @return array|string
      */
     public static function IMEXP($complexNumber)
     {
@@ -1012,7 +1012,7 @@ class Engineering
      * @param string $complexNumber the complex number you want to raise to a power
      * @param float $realNumber the power to which you want to raise the complex number
      *
-     * @return string
+     * @return array|string
      */
     public static function IMPOWER($complexNumber, $realNumber)
     {
@@ -1034,7 +1034,7 @@ class Engineering
      * @param string $complexDividend the complex numerator or dividend
      * @param string $complexDivisor the complex denominator or divisor
      *
-     * @return string
+     * @return array|string
      */
     public static function IMDIV($complexDividend, $complexDivisor)
     {
@@ -1056,7 +1056,7 @@ class Engineering
      * @param string $complexNumber1 the complex number from which to subtract complexNumber2
      * @param string $complexNumber2 the complex number to subtract from complexNumber1
      *
-     * @return string
+     * @return array|string
      */
     public static function IMSUB($complexNumber1, $complexNumber2)
     {

--- a/src/PhpSpreadsheet/Calculation/Engineering/Complex.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/Complex.php
@@ -4,11 +4,14 @@ namespace PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 
 use Complex\Complex as ComplexObject;
 use Complex\Exception as ComplexException;
+use PhpOffice\PhpSpreadsheet\Calculation\ArrayEnabled;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 
 class Complex
 {
+    use ArrayEnabled;
+
     /**
      * COMPLEX.
      *
@@ -18,17 +21,26 @@ class Complex
      *        COMPLEX(realNumber,imaginary[,suffix])
      *
      * @param mixed $realNumber the real float coefficient of the complex number
+     *                      Or can be an array of values
      * @param mixed $imaginary the imaginary float coefficient of the complex number
+     *                      Or can be an array of values
      * @param mixed $suffix The character suffix for the imaginary component of the complex number.
      *                          If omitted, the suffix is assumed to be "i".
+     *                      Or can be an array of values
      *
-     * @return string
+     * @return array|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function COMPLEX($realNumber = 0.0, $imaginary = 0.0, $suffix = 'i')
     {
-        $realNumber = ($realNumber === null) ? 0.0 : Functions::flattenSingleValue($realNumber);
-        $imaginary = ($imaginary === null) ? 0.0 : Functions::flattenSingleValue($imaginary);
-        $suffix = ($suffix === null) ? 'i' : Functions::flattenSingleValue($suffix);
+        if (is_array($realNumber) || is_array($imaginary) || is_array($suffix)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $realNumber, $imaginary, $suffix);
+        }
+
+        $realNumber = $realNumber ?? 0.0;
+        $imaginary = $imaginary ?? 0.0;
+        $suffix = $suffix ?? 'i';
 
         try {
             $realNumber = EngineeringValidations::validateFloat($realNumber);
@@ -54,14 +66,19 @@ class Complex
      * Excel Function:
      *        IMAGINARY(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the imaginary
+     * @param array|string $complexNumber the complex number for which you want the imaginary
      *                                         coefficient
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string (string if an error)
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMAGINARY($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -80,13 +97,18 @@ class Complex
      * Excel Function:
      *        IMREAL(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the real coefficient
+     * @param array|string $complexNumber the complex number for which you want the real coefficient
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string (string if an error)
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMREAL($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);

--- a/src/PhpSpreadsheet/Calculation/Engineering/ComplexFunctions.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/ComplexFunctions.php
@@ -4,10 +4,13 @@ namespace PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 
 use Complex\Complex as ComplexObject;
 use Complex\Exception as ComplexException;
+use PhpOffice\PhpSpreadsheet\Calculation\ArrayEnabled;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 
 class ComplexFunctions
 {
+    use ArrayEnabled;
+
     /**
      * IMABS.
      *
@@ -16,13 +19,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMABS(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the absolute value
+     * @param array|string $complexNumber the complex number for which you want the absolute value
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMABS($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -42,13 +50,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMARGUMENT(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the argument theta
+     * @param array|string $complexNumber the complex number for which you want the argument theta
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMARGUMENT($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -71,13 +84,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMCONJUGATE(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the conjugate
+     * @param array|string $complexNumber the complex number for which you want the conjugate
+     *                      Or can be an array of values
      *
-     * @return string
+     * @return array|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMCONJUGATE($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -96,13 +114,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMCOS(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the cosine
+     * @param array|string $complexNumber the complex number for which you want the cosine
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMCOS($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -121,13 +144,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMCOSH(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the hyperbolic cosine
+     * @param array|string $complexNumber the complex number for which you want the hyperbolic cosine
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMCOSH($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -146,13 +174,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMCOT(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the cotangent
+     * @param array|string $complexNumber the complex number for which you want the cotangent
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMCOT($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -171,13 +204,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMCSC(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the cosecant
+     * @param array|string $complexNumber the complex number for which you want the cosecant
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMCSC($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -196,13 +234,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMCSCH(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the hyperbolic cosecant
+     * @param array|string $complexNumber the complex number for which you want the hyperbolic cosecant
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMCSCH($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -221,13 +264,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMSIN(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the sine
+     * @param array|string $complexNumber the complex number for which you want the sine
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMSIN($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -246,13 +294,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMSINH(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the hyperbolic sine
+     * @param array|string $complexNumber the complex number for which you want the hyperbolic sine
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMSINH($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -271,13 +324,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMSEC(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the secant
+     * @param array|string $complexNumber the complex number for which you want the secant
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMSEC($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -296,13 +354,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMSECH(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the hyperbolic secant
+     * @param array|string $complexNumber the complex number for which you want the hyperbolic secant
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMSECH($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -321,13 +384,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMTAN(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the tangent
+     * @param array|string $complexNumber the complex number for which you want the tangent
+     *                      Or can be an array of values
      *
-     * @return float|string
+     * @return array|float|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMTAN($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -346,13 +414,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMSQRT(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the square root
+     * @param array|string $complexNumber the complex number for which you want the square root
+     *                      Or can be an array of values
      *
-     * @return string
+     * @return array|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMSQRT($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -376,13 +449,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMLN(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the natural logarithm
+     * @param array|string $complexNumber the complex number for which you want the natural logarithm
+     *                      Or can be an array of values
      *
-     * @return string
+     * @return array|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMLN($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -405,13 +483,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMLOG10(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the common logarithm
+     * @param array|string $complexNumber the complex number for which you want the common logarithm
+     *                      Or can be an array of values
      *
-     * @return string
+     * @return array|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMLOG10($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -434,13 +517,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMLOG2(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the base-2 logarithm
+     * @param array|string $complexNumber the complex number for which you want the base-2 logarithm
+     *                      Or can be an array of values
      *
-     * @return string
+     * @return array|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMLOG2($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -463,13 +551,18 @@ class ComplexFunctions
      * Excel Function:
      *        IMEXP(complexNumber)
      *
-     * @param string $complexNumber the complex number for which you want the exponential
+     * @param array|string $complexNumber the complex number for which you want the exponential
+     *                      Or can be an array of values
      *
-     * @return string
+     * @return array|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMEXP($complexNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
+        if (is_array($complexNumber)) {
+            return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $complexNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -488,15 +581,20 @@ class ComplexFunctions
      * Excel Function:
      *        IMPOWER(complexNumber,realNumber)
      *
-     * @param string $complexNumber the complex number you want to raise to a power
-     * @param float $realNumber the power to which you want to raise the complex number
+     * @param array|string $complexNumber the complex number you want to raise to a power
+     *                      Or can be an array of values
+     * @param array|float|int|string $realNumber the power to which you want to raise the complex number
+     *                      Or can be an array of values
      *
-     * @return string
+     * @return array|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMPOWER($complexNumber, $realNumber)
     {
-        $complexNumber = Functions::flattenSingleValue($complexNumber);
-        $realNumber = Functions::flattenSingleValue($realNumber);
+        if (is_array($complexNumber) || is_array($realNumber)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $complexNumber, $realNumber);
+        }
 
         try {
             $complex = new ComplexObject($complexNumber);
@@ -508,6 +606,6 @@ class ComplexFunctions
             return Functions::VALUE();
         }
 
-        return (string) $complex->pow($realNumber);
+        return (string) $complex->pow((float) $realNumber);
     }
 }

--- a/src/PhpSpreadsheet/Calculation/Engineering/ComplexOperations.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/ComplexOperations.php
@@ -4,10 +4,13 @@ namespace PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 
 use Complex\Complex as ComplexObject;
 use Complex\Exception as ComplexException;
+use PhpOffice\PhpSpreadsheet\Calculation\ArrayEnabled;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 
 class ComplexOperations
 {
+    use ArrayEnabled;
+
     /**
      * IMDIV.
      *
@@ -16,15 +19,20 @@ class ComplexOperations
      * Excel Function:
      *        IMDIV(complexDividend,complexDivisor)
      *
-     * @param string $complexDividend the complex numerator or dividend
-     * @param string $complexDivisor the complex denominator or divisor
+     * @param array|string $complexDividend the complex numerator or dividend
+     *                      Or can be an array of values
+     * @param array|string $complexDivisor the complex denominator or divisor
+     *                      Or can be an array of values
      *
-     * @return string
+     * @return array|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMDIV($complexDividend, $complexDivisor)
     {
-        $complexDividend = Functions::flattenSingleValue($complexDividend);
-        $complexDivisor = Functions::flattenSingleValue($complexDivisor);
+        if (is_array($complexDividend) || is_array($complexDivisor)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $complexDividend, $complexDivisor);
+        }
 
         try {
             return (string) (new ComplexObject($complexDividend))->divideby(new ComplexObject($complexDivisor));
@@ -41,15 +49,20 @@ class ComplexOperations
      * Excel Function:
      *        IMSUB(complexNumber1,complexNumber2)
      *
-     * @param string $complexNumber1 the complex number from which to subtract complexNumber2
-     * @param string $complexNumber2 the complex number to subtract from complexNumber1
+     * @param array|string $complexNumber1 the complex number from which to subtract complexNumber2
+     *                      Or can be an array of values
+     * @param array|string $complexNumber2 the complex number to subtract from complexNumber1
+     *                      Or can be an array of values
      *
-     * @return string
+     * @return array|string
+     *         If an array of numbers is passed as an argument, then the returned result will also be an array
+     *            with the same dimensions
      */
     public static function IMSUB($complexNumber1, $complexNumber2)
     {
-        $complexNumber1 = Functions::flattenSingleValue($complexNumber1);
-        $complexNumber2 = Functions::flattenSingleValue($complexNumber2);
+        if (is_array($complexNumber1) || is_array($complexNumber2)) {
+            return self::evaluateArrayArguments([self::class, __FUNCTION__], $complexNumber1, $complexNumber2);
+        }
 
         try {
             return (string) (new ComplexObject($complexNumber1))->subtract(new ComplexObject($complexNumber2));

--- a/src/PhpSpreadsheet/Calculation/Engineering/ConvertUOM.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/ConvertUOM.php
@@ -553,6 +553,7 @@ class ConvertUOM
             return Functions::NA();
         }
 
+        // @var float $value
         $value *= $fromMultiplier;
 
         if (($fromUOM === $toUOM) && ($fromMultiplier === $toMultiplier)) {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ComplexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ComplexTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PHPUnit\Framework\TestCase;
@@ -27,5 +28,34 @@ class ComplexTest extends TestCase
     public function providerCOMPLEX(): array
     {
         return require 'tests/data/Calculation/Engineering/COMPLEX.php';
+    }
+
+    /**
+     * @dataProvider providerComplexArray
+     */
+    public function testComplexArray(array $expectedResult, string $real, string $imaginary): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=COMPLEX({$real}, {$imaginary})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerComplexArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['-2.5-2.5i', '-1-2.5i', '-2.5i', '1-2.5i', '2.5-2.5i'],
+                    ['-2.5-i', '-1-i', '-i', '1-i', '2.5-i'],
+                    ['-2.5', '-1', '0.0', '1', '2.5'],
+                    ['-2.5+i', '-1+i', 'i', '1+i', '2.5+i'],
+                    ['-2.5+2.5i', '-1+2.5i', '2.5i', '1+2.5i', '2.5+2.5i'],
+                ],
+                '{-2.5, -1, 0, 1, 2.5}',
+                '{-2.5; -1; 0; 1; 2.5}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImAbsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImAbsTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PHPUnit\Framework\TestCase;
@@ -30,5 +31,32 @@ class ImAbsTest extends TestCase
     public function providerIMABS(): array
     {
         return require 'tests/data/Calculation/Engineering/IMABS.php';
+    }
+
+    /**
+     * @dataProvider providerImAbsArray
+     */
+    public function testImAbsArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMABS({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImAbsArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    [2.692582403567252, 2.5, 2.692582403567252],
+                    [1.4142135623730951, 1.0, 1.4142135623730951],
+                    [1.4142135623730951, 1.0, 1.4142135623730951],
+                    [2.692582403567252, 2.5, 2.692582403567252],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImArgumentTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImArgumentTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PHPUnit\Framework\TestCase;
@@ -30,5 +31,32 @@ class ImArgumentTest extends TestCase
     public function providerIMARGUMENT(): array
     {
         return require 'tests/data/Calculation/Engineering/IMARGUMENT.php';
+    }
+
+    /**
+     * @dataProvider providerImArgumentArray
+     */
+    public function testImArgumentArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMARGUMENT({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImArgumentArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    [-1.9513027039072615, -1.5707963267948966, -1.1902899496825317],
+                    [-2.356194490192345, -1.5707963267948966, -0.7853981633974483],
+                    [2.356194490192345, 1.5707963267948966, 0.7853981633974483],
+                    [1.9513027039072615, 1.5707963267948966, 1.1902899496825317],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImConjugateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImConjugateTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImConjugateTest extends TestCase
     public function providerIMCONJUGATE(): array
     {
         return require 'tests/data/Calculation/Engineering/IMCONJUGATE.php';
+    }
+
+    /**
+     * @dataProvider providerImConjugateArray
+     */
+    public function testImConjugateArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMCONJUGATE({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImConjugateArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['-1+2.5i', '2.5i', '1+2.5i'],
+                    ['-1+i', 'i', '1+i'],
+                    ['-1-i', '-i', '1-i'],
+                    ['-1-2.5i', '-2.5i', '1-2.5i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCosTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCosTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImCosTest extends TestCase
     public function providerIMCOS(): array
     {
         return require 'tests/data/Calculation/Engineering/IMCOS.php';
+    }
+
+    /**
+     * @dataProvider providerImCosArray
+     */
+    public function testImCosArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMCOS({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImCosArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['3.3132901461132-5.0910715229497i', 6.1322894796637, '3.3132901461132+5.0910715229497i'],
+                    ['0.83373002513115-0.98889770576287i', 1.5430806348152, '0.83373002513115+0.98889770576287i'],
+                    ['0.83373002513115+0.98889770576287i', 1.5430806348152, '0.83373002513115-0.98889770576287i'],
+                    ['3.3132901461132+5.0910715229497i', 6.1322894796637, '3.3132901461132-5.0910715229497i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCoshTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCoshTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImCoshTest extends TestCase
     public function providerIMCOSH(): array
     {
         return require 'tests/data/Calculation/Engineering/IMCOSH.php';
+    }
+
+    /**
+     * @dataProvider providerImCoshArray
+     */
+    public function testImCoshArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMCOSH({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImCoshArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['-1.2362291988563+0.70332517811353i', -0.80114361554693, '-1.2362291988563-0.70332517811353i'],
+                    ['0.83373002513115+0.98889770576287i', 0.54030230586814, '0.83373002513115-0.98889770576287i'],
+                    ['0.83373002513115-0.98889770576287i', 0.54030230586814, '0.83373002513115+0.98889770576287i'],
+                    ['-1.2362291988563-0.70332517811353i', -0.80114361554693, '-1.2362291988563+0.70332517811353i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCotTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCotTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImCotTest extends TestCase
     public function providerIMCOT(): array
     {
         return require 'tests/data/Calculation/Engineering/IMCOT.php';
+    }
+
+    /**
+     * @dataProvider providerImCotArray
+     */
+    public function testImCotArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMCOT({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImCotArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['-0.012184711291981+0.99433328540776i', '1.0135673098126i', '0.012184711291981+0.99433328540776i'],
+                    ['-0.2176215618544+0.86801414289593i', '1.3130352854993i', '0.2176215618544+0.86801414289593i'],
+                    ['-0.2176215618544-0.86801414289593i', '-1.3130352854993i', '0.2176215618544-0.86801414289593i'],
+                    ['-0.012184711291981-0.99433328540776i', '-1.0135673098126i', '0.012184711291981-0.99433328540776i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCscTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCscTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImCscTest extends TestCase
     public function providerIMCSC(): array
     {
         return require 'tests/data/Calculation/Engineering/IMCSC.php';
+    }
+
+    /**
+     * @dataProvider providerImCscArray
+     */
+    public function testImCscArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMCSC({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImCscArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['-0.13829327777622+0.087608481088326i', '0.1652836698551i', '0.13829327777622+0.087608481088326i'],
+                    ['-0.62151801717043+0.30393100162843i', '0.85091812823932i', '0.62151801717043+0.30393100162843i'],
+                    ['-0.62151801717043-0.30393100162843i', '-0.85091812823932i', '0.62151801717043-0.30393100162843i'],
+                    ['-0.13829327777622-0.087608481088326i', '-0.1652836698551i', '0.13829327777622-0.087608481088326i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCschTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCschTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImCschTest extends TestCase
     public function providerIMCSCH(): array
     {
         return require 'tests/data/Calculation/Engineering/IMCSCH.php';
+    }
+
+    /**
+     * @dataProvider providerImCschArray
+     */
+    public function testImCschArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMCSCH({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImCschArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['0.54132290619+0.53096557762117i', '1.6709215455587i', '-0.54132290619+0.53096557762117i'],
+                    ['-0.30393100162843+0.62151801717043i', '1.1883951057781i', '0.30393100162843+0.62151801717043i'],
+                    ['-0.30393100162843-0.62151801717043i', '-1.1883951057781i', '0.30393100162843-0.62151801717043i'],
+                    ['0.54132290619-0.53096557762117i', '-1.6709215455587i', '-0.54132290619-0.53096557762117i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImDivTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImDivTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -39,5 +40,33 @@ class ImDivTest extends TestCase
     public function providerIMDIV(): array
     {
         return require 'tests/data/Calculation/Engineering/IMDIV.php';
+    }
+
+    /**
+     * @dataProvider providerImDivArray
+     */
+    public function testImDivArray(array $expectedResult, string $dividend, string $divisor): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMDIV({$dividend}, {$divisor})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImDivArray(): array
+    {
+        return [
+            'matrix' => [
+                [
+                    ['-0.36206896551724+0.3448275862069i', '-1.25i', '-0.375-0.875i'],
+                    ['-0.10344827586207+0.24137931034483i', '-0.5i', '-0.5i'],
+                    ['0.24137931034483+0.10344827586207i', '0.5i', '0.5'],
+                    ['0.5', '1.25i', '0.875+0.375i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+                '{"-2+5i", 2, "2+2i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImExpTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImExpTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImExpTest extends TestCase
     public function providerIMEXP(): array
     {
         return require 'tests/data/Calculation/Engineering/IMEXP.php';
+    }
+
+    /**
+     * @dataProvider providerImExpArray
+     */
+    public function testImExpArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMEXP({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImExpArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['-0.29472426558547-0.22016559792964i', '-0.80114361554693-0.59847214410396i', '-2.1777341321272-1.6268159541567i'],
+                    ['0.19876611034641-0.30955987565311i', '0.54030230586814-0.8414709848079i', '1.4686939399159-2.2873552871788i'],
+                    ['0.19876611034641+0.30955987565311i', '0.54030230586814+0.8414709848079i', '1.4686939399159+2.2873552871788i'],
+                    ['-0.29472426558547+0.22016559792964i', '-0.80114361554693+0.59847214410396i', '-2.1777341321272+1.6268159541567i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLnTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImLnTest extends TestCase
     public function providerIMLN(): array
     {
         return require 'tests/data/Calculation/Engineering/IMLN.php';
+    }
+
+    /**
+     * @dataProvider providerImLnArray
+     */
+    public function testImLnArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMLN({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImLnArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['0.99050073443329-1.9513027039073i', '0.91629073187416-1.5707963267949i', '0.99050073443329-1.1902899496825i'],
+                    ['0.34657359027997-2.3561944901923i', '-1.5707963267949i', '0.34657359027997-0.78539816339745i'],
+                    ['0.34657359027997+2.3561944901923i', '1.5707963267949i', '0.34657359027997+0.78539816339745i'],
+                    ['0.99050073443329+1.9513027039073i', '0.91629073187416+1.5707963267949i', '0.99050073443329+1.1902899496825i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog10Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog10Test.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImLog10Test extends TestCase
     public function providerIMLOG10(): array
     {
         return require 'tests/data/Calculation/Engineering/IMLOG10.php';
+    }
+
+    /**
+     * @dataProvider providerImLog10Array
+     */
+    public function testImLog10Array(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMLOG10({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImLog10Array(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['0.4301690032855-0.84743999682982i', '0.39794000867204-0.68218817692092i', '0.4301690032855-0.51693635701202i'],
+                    ['0.15051499783199-1.0232822653814i', '-0.68218817692092i', '0.15051499783199-0.34109408846046i'],
+                    ['0.15051499783199+1.0232822653814i', '0.68218817692092i', '0.15051499783199+0.34109408846046i'],
+                    ['0.4301690032855+0.84743999682982i', '0.39794000867204+0.68218817692092i', '0.4301690032855+0.51693635701202i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog2Test.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImLog2Test extends TestCase
     public function providerIMLOG2(): array
     {
         return require 'tests/data/Calculation/Engineering/IMLOG2.php';
+    }
+
+    /**
+     * @dataProvider providerImLog2Array
+     */
+    public function testImLog2Array(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMLOG2({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImLog2Array(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['1.4289904975638-2.8151347342002i', '1.3219280948874-2.2661800709136i', '1.4289904975638-1.717225407627i'],
+                    ['0.5-3.3992701063704i', '-2.2661800709136i', '0.5-1.1330900354568i'],
+                    ['0.5+3.3992701063704i', '2.2661800709136i', '0.5+1.1330900354568i'],
+                    ['1.4289904975638+2.8151347342002i', '1.3219280948874+2.2661800709136i', '1.4289904975638+1.717225407627i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImPowerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImPowerTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -39,5 +40,33 @@ class ImPowerTest extends TestCase
     public function providerIMPOWER(): array
     {
         return require 'tests/data/Calculation/Engineering/IMPOWER.php';
+    }
+
+    /**
+     * @dataProvider providerImPowerArray
+     */
+    public function testImPowerArray(array $expectedResult, string $complex, string $real): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMPOWER({$complex}, {$real})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImPowerArray(): array
+    {
+        return [
+            'matrix' => [
+                [
+                    ['-5.25+5i', '-2.8702659355016E-15+15.625i', '2.5625+52.5i'],
+                    ['-3.6739403974421E-16+2i', '-1.836970198721E-16+i', '-4-4.8985871965894E-16i'],
+                    ['-3.6739403974421E-16-2i', '-1.836970198721E-16-i', '-4+4.8985871965894E-16i'],
+                    ['-5.25-5i', '-2.8702659355016E-15-15.625i', '2.5625-52.5i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+                '{2, 3, 4}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImRealTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImRealTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PHPUnit\Framework\TestCase;
@@ -30,5 +31,32 @@ class ImRealTest extends TestCase
     public function providerIMREAL(): array
     {
         return require 'tests/data/Calculation/Engineering/IMREAL.php';
+    }
+
+    /**
+     * @dataProvider providerImRealArray
+     */
+    public function testImRealArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMREAL({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImRealArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    [-1.0, 0.0, 1.0],
+                    [-1.0, 0.0, 1.0],
+                    [-1.0, 0.0, 1.0],
+                    [-1.0, 0.0, 1.0],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSecTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImSecTest extends TestCase
     public function providerIMSEC(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSEC.php';
+    }
+
+    /**
+     * @dataProvider providerImSecArray
+     */
+    public function testImSecArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMSEC({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImSecArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['0.089798602872122+0.13798100670997i', '0.16307123192998', '0.089798602872122-0.13798100670997i'],
+                    ['0.49833703055519+0.59108384172105i', '0.64805427366389', '0.49833703055519-0.59108384172105i'],
+                    ['0.49833703055519-0.59108384172105i', '0.64805427366389', '0.49833703055519+0.59108384172105i'],
+                    ['0.089798602872122-0.13798100670997i', '0.16307123192998', '0.089798602872122+0.13798100670997i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSechTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSechTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImSechTest extends TestCase
     public function providerIMSECH(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSECH.php';
+    }
+
+    /**
+     * @dataProvider providerImSecHArray
+     */
+    public function testImSecHArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMSECH({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImSecHArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['-0.61110856415523-0.3476766607105i', '-1.2482156514688', '-0.61110856415523+0.3476766607105i'],
+                    ['0.49833703055519-0.59108384172105i', '1.8508157176809', '0.49833703055519+0.59108384172105i'],
+                    ['0.49833703055519+0.59108384172105i', '1.8508157176809', '0.49833703055519-0.59108384172105i'],
+                    ['-0.61110856415523+0.3476766607105i', '-1.2482156514688', '-0.61110856415523-0.3476766607105i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImSinTest extends TestCase
     public function providerIMSIN(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSIN.php';
+    }
+
+    /**
+     * @dataProvider providerImSinArray
+     */
+    public function testImSinArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMSIN({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImSinArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['-5.1601436675797-3.2689394320795i', '-6.0502044810398i', '5.1601436675797-3.2689394320795i'],
+                    ['-1.298457581416-0.63496391478474i', '-1.1752011936438i', '1.298457581416-0.63496391478474i'],
+                    ['-1.298457581416+0.63496391478474i', '1.1752011936438i', '1.298457581416+0.63496391478474i'],
+                    ['-5.1601436675797+3.2689394320795i', '6.0502044810398i', '5.1601436675797+3.2689394320795i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinhTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinhTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImSinhTest extends TestCase
     public function providerIMSINH(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSINH.php';
+    }
+
+    /**
+     * @dataProvider providerImSinHArray
+     */
+    public function testImSinHArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMSINH({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImSinHArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['0.94150493327087-0.92349077604317i', '-0.59847214410396i', '-0.94150493327087-0.92349077604317i'],
+                    ['-0.63496391478474-1.298457581416i', '-0.8414709848079i', '0.63496391478474-1.298457581416i'],
+                    ['-0.63496391478474+1.298457581416i', '0.8414709848079i', '0.63496391478474+1.298457581416i'],
+                    ['0.94150493327087+0.92349077604317i', '0.59847214410396i', '-0.94150493327087+0.92349077604317i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSqrtTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSqrtTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImSqrtTest extends TestCase
     public function providerIMSQRT(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSQRT.php';
+    }
+
+    /**
+     * @dataProvider providerImSqrtArray
+     */
+    public function testImSqrtArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMSQRT({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImSqrtArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['0.9199408686343-1.3587829855366i', '1.1180339887499-1.1180339887499i', '1.3587829855366-0.9199408686343i'],
+                    ['0.45508986056223-1.0986841134678i', '0.70710678118655-0.70710678118655i', '1.0986841134678-0.45508986056223i'],
+                    ['0.45508986056223+1.0986841134678i', '0.70710678118655+0.70710678118655i', '1.0986841134678+0.45508986056223i'],
+                    ['0.9199408686343+1.3587829855366i', '1.1180339887499+1.1180339887499i', '1.3587829855366+0.9199408686343i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSubTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSubTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -39,5 +40,33 @@ class ImSubTest extends TestCase
     public function providerIMSUB(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSUB.php';
+    }
+
+    /**
+     * @dataProvider providerImSubArray
+     */
+    public function testImSubArray(array $expectedResult, string $subidend, string $subisor): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMSUB({$subidend}, {$subisor})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImSubArray(): array
+    {
+        return [
+            'matrix' => [
+                [
+                    ['1-7.5i', '-2-2.5i', '-1-4.5i'],
+                    ['1-6i', '-2-i', '-1-3i'],
+                    ['1-4i', '-2+i', '-1-i'],
+                    ['1-2.5i', '-2+2.5i', '-1+0.5i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+                '{"-2+5i", 2, "2+2i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImTanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImTanTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
@@ -40,5 +41,32 @@ class ImTanTest extends TestCase
     public function providerIMTAN(): array
     {
         return require 'tests/data/Calculation/Engineering/IMTAN.php';
+    }
+
+    /**
+     * @dataProvider providerImTanArray
+     */
+    public function testImTanArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMTAN({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImTanArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    ['-0.012322138255828-1.0055480118951i', '-0.98661429815143i', '0.012322138255828-1.0055480118951i'],
+                    ['-0.27175258531951-1.0839233273387i', '-0.76159415595576i', '0.27175258531951-1.0839233273387i'],
+                    ['-0.27175258531951+1.0839233273387i', '0.76159415595576i', '0.27175258531951+1.0839233273387i'],
+                    ['-0.012322138255828+1.0055480118951i', '0.98661429815143i', '0.012322138255828+1.0055480118951i'],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImaginaryTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImaginaryTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PHPUnit\Framework\TestCase;
@@ -30,5 +31,32 @@ class ImaginaryTest extends TestCase
     public function providerIMAGINARY(): array
     {
         return require 'tests/data/Calculation/Engineering/IMAGINARY.php';
+    }
+
+    /**
+     * @dataProvider providerImaginaryArray
+     */
+    public function testImaginaryArray(array $expectedResult, string $complex): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=IMAGINARY({$complex})";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerImaginaryArray(): array
+    {
+        return [
+            'row/column vector' => [
+                [
+                    [-2.5, -2.5, -2.5],
+                    [-1.0, -1.0, -1.0],
+                    [1.0, 1.0, 1.0],
+                    [2.5, 2.5, 2.5],
+                ],
+                '{"-1-2.5i", "-2.5i", "1-2.5i"; "-1-i", "-i", "1-i"; "-1+i", "i", "1+1"; "-1+2.5i", "+2.5i", "1+2.5i"}',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Part of the https://github.com/PHPOffice/PhpSpreadsheet/issues/2551 update to make all relevant functions array-argument-enabled