### PR TITLE
Initial work on implementing Array-enabled for the HLOOKUP() and VLOOKUP() functions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -766,22 +766,7 @@ parameters:
 			path: src/PhpSpreadsheet/Calculation/LookupRef/Lookup.php
 
 		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\LookupBase\\:\\:checkMatch\\(\\) has parameter \\$notExactMatch with no type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/LookupRef/LookupBase.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\LookupBase\\:\\:validateIndexLookup\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/LookupRef/LookupBase.php
-
-		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\LookupBase\\:\\:validateIndexLookup\\(\\) has parameter \\$index_number with no type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/LookupRef/LookupBase.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\LookupBase\\:\\:validateIndexLookup\\(\\) has parameter \\$lookup_array with no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Calculation/LookupRef/LookupBase.php
 
@@ -844,31 +829,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$high of function range expects float\\|int\\|string, string\\|null given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\VLookup\\:\\:vLookupSearch\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/LookupRef/VLookup.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\VLookup\\:\\:vLookupSearch\\(\\) has parameter \\$column with no type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/LookupRef/VLookup.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\VLookup\\:\\:vLookupSearch\\(\\) has parameter \\$lookupArray with no type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/LookupRef/VLookup.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\VLookup\\:\\:vLookupSearch\\(\\) has parameter \\$lookupValue with no type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/LookupRef/VLookup.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\VLookup\\:\\:vLookupSearch\\(\\) has parameter \\$notExactMatch with no type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/LookupRef/VLookup.php
 
 		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\VLookup\\:\\:vlookupSort\\(\\) has no return type specified\\.$#"

--- a/src/PhpSpreadsheet/Calculation/LookupRef/ExcelMatch.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/ExcelMatch.php
@@ -35,7 +35,7 @@ class ExcelMatch
     public static function MATCH($lookupValue, $lookupArray, $matchType = self::MATCHTYPE_LARGEST_VALUE)
     {
         if (is_array($lookupValue)) {
-            return self::evaluateArrayArgumentsSubset([self::class, __FUNCTION__], 1, $lookupValue, $lookupArray, $matchType);
+            return self::evaluateArrayArgumentsIgnore([self::class, __FUNCTION__], 1, $lookupValue, $lookupArray, $matchType);
         }
 
         $lookupArray = Functions::flattenArray($lookupArray);

--- a/src/PhpSpreadsheet/Calculation/LookupRef/LookupBase.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/LookupBase.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
 
 abstract class LookupBase
 {
-    protected static function validateIndexLookup($lookup_array, $index_number)
+    protected static function validateIndexLookup(array $lookup_array, $index_number): int
     {
         // index_number must be a number greater than or equal to 1
         if (!is_numeric($index_number) || $index_number < 1) {
@@ -25,7 +25,7 @@ abstract class LookupBase
     protected static function checkMatch(
         bool $bothNumeric,
         bool $bothNotNumeric,
-        $notExactMatch,
+        bool $notExactMatch,
         int $rowKey,
         string $cellDataLower,
         string $lookupLower,

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/HLookupTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/HLookupTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\LookupRef;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
@@ -88,5 +89,41 @@ class HLookupTest extends TestCase
             false
         );
         self::assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @dataProvider providerHLookupArray
+     */
+    public function testHLookupArray(array $expectedResult, string $values, string $database, string $index): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=HLOOKUP({$values}, {$database}, {$index}, false)";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerHLookupArray(): array
+    {
+        return [
+            'row vector #1' => [
+                [[4, 9]],
+                '{"Axles", "Bolts"}',
+                '{"Axles", "Bearings", "Bolts"; 4, 4, 9; 5, 7, 10; 6, 8, 11}',
+                '2',
+            ],
+            'row vector #2' => [
+                [[5, 7]],
+                '{"Axles", "Bearings"}',
+                '{"Axles", "Bearings", "Bolts"; 4, 4, 9; 5, 7, 10; 6, 8, 11}',
+                '3',
+            ],
+            'row/column vectors' => [
+                [[4, 9], [5, 10]],
+                '{"Axles", "Bolts"}',
+                '{"Axles", "Bearings", "Bolts"; 4, 4, 9; 5, 7, 10; 6, 8, 11}',
+                '{2; 3}',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/VLookupTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/VLookupTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\LookupRef;
 use PHPUnit\Framework\TestCase;
@@ -27,5 +28,29 @@ class VLookupTest extends TestCase
     public function providerVLOOKUP(): array
     {
         return require 'tests/data/Calculation/LookupRef/VLOOKUP.php';
+    }
+
+    /**
+     * @dataProvider providerVLookupArray
+     */
+    public function testVLookupArray(array $expectedResult, string $values, string $database, string $index): void
+    {
+        $calculation = Calculation::getInstance();
+
+        $formula = "=VLOOKUP({$values}, {$database}, {$index}, false)";
+        $result = $calculation->_calculateFormulaValue($formula);
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function providerVLookupArray(): array
+    {
+        return [
+            'row vector' => [
+                [[4.19, 5.77, 4.14]],
+                '{"Orange", "Green", "Red"}',
+                '{"Red", 4.14; "Orange", 4.19; "Yellow", 5.17; "Green", 5.77; "Blue", 6.39}',
+                '2',
+            ],
+        ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AbsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AbsTest.php
@@ -12,7 +12,7 @@ class AbsTest extends AllSetupTeardown
      * @param mixed $expectedResult
      * @param mixed $number
      */
-    public function testRound($expectedResult, $number = 'omitted'): void
+    public function testAbs($expectedResult, $number = 'omitted'): void
     {
         $sheet = $this->getSheet();
         $this->mightHaveException($expectedResult);


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Part of the [Issue #2551](https://github.com/PHPOffice/PhpSpreadsheet/issues/2551) update to make all relevant functions array-argument-enabled