### PR TITLE
Two Cell Anchor Drawing

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4506,26 +4506,6 @@ parameters:
 			path: src/PhpSpreadsheet/Style/NumberFormat/PercentageFormatter.php
 
 		-
-			message: "#^Cannot call method getCell\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\Worksheet\\|null\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Worksheet/BaseDrawing.php
-
-		-
-			message: "#^Cannot call method getDrawingCollection\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\Worksheet\\|null\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Worksheet/BaseDrawing.php
-
-		-
-			message: "#^Cannot call method getHashCode\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\Worksheet\\|null\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Worksheet/BaseDrawing.php
-
-		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\BaseDrawing\\:\\:\\$shadow \\(PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\Drawing\\\\Shadow\\) does not accept PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\Drawing\\\\Shadow\\|null\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Worksheet/BaseDrawing.php
-
-		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\CellIterator\\:\\:adjustForExistingOnlyRange\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Worksheet/CellIterator.php
@@ -5599,31 +5579,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$value of method XMLWriter\\:\\:writeAttribute\\(\\) expects string, int given\\.$#"
 			count: 2
 			path: src/PhpSpreadsheet/Writer/Xlsx/DocProps.php
-
-		-
-			message: "#^Parameter \\#1 \\$index of method PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\Worksheet\\:\\:getChartByIndex\\(\\) expects string, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xlsx/Drawing.php
-
-		-
-			message: "#^Parameter \\#2 \\$chart of method PhpOffice\\\\PhpSpreadsheet\\\\Writer\\\\Xlsx\\\\Drawing\\:\\:writeChart\\(\\) expects PhpOffice\\\\PhpSpreadsheet\\\\Chart\\\\Chart, PhpOffice\\\\PhpSpreadsheet\\\\Chart\\\\Chart\\|false given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xlsx/Drawing.php
-
-		-
-			message: "#^Parameter \\#2 \\$content of method XMLWriter\\:\\:writeElement\\(\\) expects string\\|null, int given\\.$#"
-			count: 12
-			path: src/PhpSpreadsheet/Writer/Xlsx/Drawing.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method XMLWriter\\:\\:writeAttribute\\(\\) expects string, int given\\.$#"
-			count: 8
-			path: src/PhpSpreadsheet/Writer/Xlsx/Drawing.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method XMLWriter\\:\\:writeAttribute\\(\\) expects string, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xlsx/Drawing.php
 
 		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Writer\\\\Xlsx\\\\Rels\\:\\:writeUnparsedRelationship\\(\\) has parameter \\$relationship with no type specified\\.$#"

--- a/samples/Basic/48_Image_move_size_with_cells.php
+++ b/samples/Basic/48_Image_move_size_with_cells.php
@@ -1,0 +1,78 @@
+<?php
+
+// Create new Spreadsheet object
+use PhpOffice\PhpSpreadsheet\Helper\Dimension;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
+
+require __DIR__ . '/../Header.php';
+
+$helper->log('Create new Spreadsheet object');
+$spreadsheet = new Spreadsheet();
+$sheet = $spreadsheet->getActiveSheet();
+$sheet->getCell('A1')->setValue('twocell');
+$sheet->getCell('A2')->setValue('twocell');
+$sheet->getCell('A3')->setValue('onecell');
+$sheet->getCell('A6')->setValue('absolute');
+
+// Add a drawing to the worksheet
+$helper->log('Add a drawing to the worksheet two-cell anchor not resized');
+$drawing = new Drawing();
+$drawing->setName('PhpSpreadsheet');
+$drawing->setDescription('PhpSpreadsheet');
+$drawing->setPath(__DIR__ . '/../images/PhpSpreadsheet_logo.png');
+// anchor type will be two-cell because Coordinates2 is set
+//$drawing->setAnchorType(Drawing::ANCHORTYPE_TWOCELL);
+$drawing->setCoordinates('B1');
+$drawing->setCoordinates2('B1');
+$drawing->setOffsetX2($drawing->getImageWidth());
+$drawing->setOffsetY2($drawing->getImageHeight());
+$drawing->setWorksheet($spreadsheet->getActiveSheet());
+
+// Add a drawing to the worksheet
+$helper->log('Add a drawing to the worksheet two-cell anchor resized');
+$drawing2 = new Drawing();
+$drawing2->setName('PhpSpreadsheet');
+$drawing2->setDescription('PhpSpreadsheet');
+$drawing2->setPath(__DIR__ . '/../images/PhpSpreadsheet_logo.png');
+// anchor type will be two-cell because Coordinates2 is set
+//$drawing->setAnchorType(Drawing::ANCHORTYPE_TWOCELL);
+$drawing2->setCoordinates('C2');
+$drawing2->setCoordinates2('C2');
+$drawing2->setOffsetX2($drawing->getImageWidth());
+$drawing2->setOffsetY2($drawing->getImageHeight());
+$drawing2->setWorksheet($spreadsheet->getActiveSheet());
+
+$spreadsheet->getActiveSheet()->getColumnDimension('C')->setWidth($drawing->getImageWidth(), Dimension::UOM_PIXELS);
+$spreadsheet->getActiveSheet()->getRowDimension(2)->setRowHeight($drawing->getImageHeight(), Dimension::UOM_PIXELS);
+
+// Add a drawing to the worksheet one cell anchor
+$helper->log('Add a drawing to the worksheet one-cell anchor');
+$drawing3 = new Drawing();
+$drawing3->setName('PhpSpreadsheet');
+$drawing3->setDescription('PhpSpreadsheet');
+$drawing3->setPath(__DIR__ . '/../images/PhpSpreadsheet_logo.png');
+// anchor type will be one-cell because Coordinates2 is not set
+//$drawing->setAnchorType(Drawing::ANCHORTYPE_ONECELL);
+$drawing3->setCoordinates('D3');
+$drawing3->setWorksheet($spreadsheet->getActiveSheet());
+
+// Add a drawing to the worksheet
+$helper->log('Add a drawing to the worksheet two-cell anchor resized absolute');
+$drawing4 = new Drawing();
+$drawing4->setName('PhpSpreadsheet');
+$drawing4->setDescription('PhpSpreadsheet');
+$drawing4->setPath(__DIR__ . '/../images/PhpSpreadsheet_logo.png');
+// anchor type will be two-cell because Coordinates2 is set
+//$drawing->setAnchorType(Drawing::ANCHORTYPE_TWOCELL);
+$drawing4->setCoordinates('C6');
+$drawing4->setCoordinates2('C6');
+$drawing4->setOffsetX2($drawing->getImageWidth());
+$drawing4->setOffsetY2($drawing->getImageHeight());
+$drawing4->setWorksheet($spreadsheet->getActiveSheet());
+$drawing4->setEditAs(Drawing::EDIT_AS_ABSOLUTE);
+
+//$spreadsheet->getActiveSheet()->getColumnDimension('C')->setWidth($drawing->getImageWidth(), Dimension::UOM_PIXELS);
+$spreadsheet->getActiveSheet()->getRowDimension(6)->setRowHeight($drawing->getImageHeight(), Dimension::UOM_PIXELS);
+
+$helper->write($spreadsheet, __FILE__, ['Xlsx']);

--- a/src/PhpSpreadsheet/Calculation/Functions.php
+++ b/src/PhpSpreadsheet/Calculation/Functions.php
@@ -401,7 +401,7 @@ class Functions
             return self::VALUE();
         }
 
-        return $value % 2 == 0;
+        return (int) fmod($value, 2.0) === 0;
     }
 
     /**
@@ -421,7 +421,7 @@ class Functions
             return self::VALUE();
         }
 
-        return abs($value) % 2 == 1;
+        return (int) fmod($value, 2.0) !== 0;
     }
 
     /**

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -92,6 +92,7 @@ abstract class Coordinate
         }
 
         // Create absolute coordinate
+        $cellAddress = "$cellAddress";
         if (ctype_digit($cellAddress)) {
             return $worksheet . '$' . $cellAddress;
         } elseif (ctype_alpha($cellAddress)) {

--- a/src/PhpSpreadsheet/Helper/Dimension.php
+++ b/src/PhpSpreadsheet/Helper/Dimension.php
@@ -58,7 +58,7 @@ class Dimension
     public function __construct(string $dimension)
     {
         [$size, $unit] = sscanf($dimension, '%[1234567890.]%s');
-        $unit = strtolower(trim($unit));
+        $unit = strtolower(trim($unit ?? ''));
 
         // If a UoM is specified, then convert the size to pixels for internal storage
         if (isset(self::ABSOLUTE_UNITS[$unit])) {

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -1105,8 +1105,8 @@ class Xls extends BaseReader
                     $height = SharedXls::getDistanceY($this->phpSheet, $startRow, $startOffsetY, $endRow, $endOffsetY);
 
                     // calculate offsetX and offsetY of the shape
-                    $offsetX = $startOffsetX * SharedXls::sizeCol($this->phpSheet, $startColumn) / 1024;
-                    $offsetY = $startOffsetY * SharedXls::sizeRow($this->phpSheet, $startRow) / 256;
+                    $offsetX = (int) ($startOffsetX * SharedXls::sizeCol($this->phpSheet, $startColumn) / 1024);
+                    $offsetY = (int) ($startOffsetY * SharedXls::sizeRow($this->phpSheet, $startRow) / 256);
 
                     switch ($obj['otObjType']) {
                         case 0x19:

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1313,6 +1313,10 @@ class Xlsx extends BaseReader
                                                     $outerShdw = $twoCellAnchor->pic->spPr->children(Namespaces::DRAWINGML)->effectLst->outerShdw;
                                                     $hlinkClick = $twoCellAnchor->pic->nvPicPr->cNvPr->children(Namespaces::DRAWINGML)->hlinkClick;
                                                     $objDrawing = new \PhpOffice\PhpSpreadsheet\Worksheet\Drawing();
+                                                    $editAs = $twoCellAnchor->attributes();
+                                                    if (isset($editAs, $editAs['editAs'])) {
+                                                        $objDrawing->setEditAs($editAs['editAs']);
+                                                    }
                                                     $objDrawing->setName((string) self::getArrayItem(self::getAttributes($twoCellAnchor->pic->nvPicPr->cNvPr), 'name'));
                                                     $objDrawing->setDescription((string) self::getArrayItem(self::getAttributes($twoCellAnchor->pic->nvPicPr->cNvPr), 'descr'));
                                                     $embedImageKey = (string) self::getArrayItem(
@@ -1339,6 +1343,10 @@ class Xlsx extends BaseReader
 
                                                     $objDrawing->setOffsetX(Drawing::EMUToPixels($twoCellAnchor->from->colOff));
                                                     $objDrawing->setOffsetY(Drawing::EMUToPixels($twoCellAnchor->from->rowOff));
+                                                    $objDrawing->setCoordinates2(Coordinate::stringFromColumnIndex(((int) $twoCellAnchor->to->col) + 1) . ($twoCellAnchor->to->row + 1));
+
+                                                    $objDrawing->setOffsetX2(Drawing::EMUToPixels($twoCellAnchor->to->colOff));
+                                                    $objDrawing->setOffsetY2(Drawing::EMUToPixels($twoCellAnchor->to->rowOff));
                                                     $objDrawing->setResizeProportional(false);
 
                                                     if ($xfrm) {

--- a/src/PhpSpreadsheet/Worksheet/AutoFilter.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter.php
@@ -386,7 +386,7 @@ class AutoFilter
             /** @var string */
             $ruleOperator = $rule['operator'];
             /** @var string */
-            $cellValueString = $cellValue;
+            $cellValueString = $cellValue ?? '';
             $retVal = false;
 
             if (is_numeric($ruleValue)) {

--- a/src/PhpSpreadsheet/Worksheet/BaseDrawing.php
+++ b/src/PhpSpreadsheet/Worksheet/BaseDrawing.php
@@ -8,6 +8,22 @@ use PhpOffice\PhpSpreadsheet\IComparable;
 
 class BaseDrawing implements IComparable
 {
+    const EDIT_AS_ABSOLUTE = 'absolute';
+    const EDIT_AS_ONECELL = 'onecell';
+    const EDIT_AS_TWOCELL = 'twocell';
+    private const VALID_EDIT_AS = [
+        self::EDIT_AS_ABSOLUTE,
+        self::EDIT_AS_ONECELL,
+        self::EDIT_AS_TWOCELL,
+    ];
+
+    /**
+     * The editAs attribute, used only with two cell anchor.
+     *
+     * @var string
+     */
+    protected $editAs = '';
+
     /**
      * Image counter.
      *
@@ -65,6 +81,27 @@ class BaseDrawing implements IComparable
     protected $offsetY;
 
     /**
+     * Coordinates2.
+     *
+     * @var string
+     */
+    protected $coordinates2;
+
+    /**
+     * Offset X2.
+     *
+     * @var int
+     */
+    protected $offsetX2;
+
+    /**
+     * Offset Y2.
+     *
+     * @var int
+     */
+    protected $offsetY2;
+
+    /**
      * Width.
      *
      * @var int
@@ -77,6 +114,20 @@ class BaseDrawing implements IComparable
      * @var int
      */
     protected $height;
+
+    /**
+     * Pixel width of image. See $width for the size the Drawing will be in the sheet.
+     *
+     * @var int
+     */
+    protected $imageWidth;
+
+    /**
+     * Pixel width of image. See $height for the size the Drawing will be in the sheet.
+     *
+     * @var int
+     */
+    protected $imageHeight;
 
     /**
      * Proportional resize.
@@ -125,8 +176,13 @@ class BaseDrawing implements IComparable
         $this->coordinates = 'A1';
         $this->offsetX = 0;
         $this->offsetY = 0;
+        $this->coordinates2 = '';
+        $this->offsetX2 = 0;
+        $this->offsetY2 = 0;
         $this->width = 0;
+        $this->imageWidth = 0;
         $this->height = 0;
+        $this->imageHeight = 0;
         $this->resizeProportional = true;
         $this->rotation = 0;
         $this->shadow = new Drawing\Shadow();
@@ -137,70 +193,36 @@ class BaseDrawing implements IComparable
         $this->imageIndex = self::$imageCounter;
     }
 
-    /**
-     * Get image index.
-     *
-     * @return int
-     */
-    public function getImageIndex()
+    public function getImageIndex(): int
     {
         return $this->imageIndex;
     }
 
-    /**
-     * Get Name.
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set Name.
-     *
-     * @param string $name
-     *
-     * @return $this
-     */
-    public function setName($name)
+    public function setName(string $name): self
     {
         $this->name = $name;
 
         return $this;
     }
 
-    /**
-     * Get Description.
-     *
-     * @return string
-     */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * Set Description.
-     *
-     * @param string $description
-     *
-     * @return $this
-     */
-    public function setDescription($description)
+    public function setDescription(string $description): self
     {
         $this->description = $description;
 
         return $this;
     }
 
-    /**
-     * Get Worksheet.
-     *
-     * @return null|Worksheet
-     */
-    public function getWorksheet()
+    public function getWorksheet(): ?Worksheet
     {
         return $this->worksheet;
     }
@@ -209,16 +231,16 @@ class BaseDrawing implements IComparable
      * Set Worksheet.
      *
      * @param bool $overrideOld If a Worksheet has already been assigned, overwrite it and remove image from old Worksheet?
-     *
-     * @return $this
      */
-    public function setWorksheet(?Worksheet $worksheet = null, $overrideOld = false)
+    public function setWorksheet(?Worksheet $worksheet = null, bool $overrideOld = false): self
     {
         if ($this->worksheet === null) {
             // Add drawing to \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet
-            $this->worksheet = $worksheet;
-            $this->worksheet->getCell($this->coordinates);
-            $this->worksheet->getDrawingCollection()->append($this);
+            if ($worksheet !== null) {
+                $this->worksheet = $worksheet;
+                $this->worksheet->getCell($this->coordinates);
+                $this->worksheet->getDrawingCollection()->append($this);
+            }
         } else {
             if ($overrideOld) {
                 // Remove drawing from old \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet
@@ -243,96 +265,48 @@ class BaseDrawing implements IComparable
         return $this;
     }
 
-    /**
-     * Get Coordinates.
-     *
-     * @return string
-     */
-    public function getCoordinates()
+    public function getCoordinates(): string
     {
         return $this->coordinates;
     }
 
-    /**
-     * Set Coordinates.
-     *
-     * @param string $coordinates eg: 'A1'
-     *
-     * @return $this
-     */
-    public function setCoordinates($coordinates)
+    public function setCoordinates(string $coordinates): self
     {
         $this->coordinates = $coordinates;
 
         return $this;
     }
 
-    /**
-     * Get OffsetX.
-     *
-     * @return int
-     */
-    public function getOffsetX()
+    public function getOffsetX(): int
     {
         return $this->offsetX;
     }
 
-    /**
-     * Set OffsetX.
-     *
-     * @param int $offsetX
-     *
-     * @return $this
-     */
-    public function setOffsetX($offsetX)
+    public function setOffsetX(int $offsetX): self
     {
         $this->offsetX = $offsetX;
 
         return $this;
     }
 
-    /**
-     * Get OffsetY.
-     *
-     * @return int
-     */
-    public function getOffsetY()
+    public function getOffsetY(): int
     {
         return $this->offsetY;
     }
 
-    /**
-     * Set OffsetY.
-     *
-     * @param int $offsetY
-     *
-     * @return $this
-     */
-    public function setOffsetY($offsetY)
+    public function setOffsetY(int $offsetY): self
     {
         $this->offsetY = $offsetY;
 
         return $this;
     }
 
-    /**
-     * Get Width.
-     *
-     * @return int
-     */
-    public function getWidth()
+    public function getWidth(): int
     {
         return $this->width;
     }
 
-    /**
-     * Set Width.
-     *
-     * @param int $width
-     *
-     * @return $this
-     */
-    public function setWidth($width)
+    public function setWidth(int $width): self
     {
         // Resize proportional?
         if ($this->resizeProportional && $width != 0) {
@@ -346,24 +320,12 @@ class BaseDrawing implements IComparable
         return $this;
     }
 
-    /**
-     * Get Height.
-     *
-     * @return int
-     */
-    public function getHeight()
+    public function getHeight(): int
     {
         return $this->height;
     }
 
-    /**
-     * Set Height.
-     *
-     * @param int $height
-     *
-     * @return $this
-     */
-    public function setHeight($height)
+    public function setHeight(int $height): self
     {
         // Resize proportional?
         if ($this->resizeProportional && $height != 0) {
@@ -386,14 +348,9 @@ class BaseDrawing implements IComparable
      * $objDrawing->setWidthAndHeight(160,120);
      * </code>
      *
-     * @param int $width
-     * @param int $height
-     *
-     * @return $this
-     *
      * @author Vincent@luo MSN:kele_100@hotmail.com
      */
-    public function setWidthAndHeight($width, $height)
+    public function setWidthAndHeight(int $width, int $height): self
     {
         $xratio = $width / ($this->width != 0 ? $this->width : 1);
         $yratio = $height / ($this->height != 0 ? $this->height : 1);
@@ -413,72 +370,38 @@ class BaseDrawing implements IComparable
         return $this;
     }
 
-    /**
-     * Get ResizeProportional.
-     *
-     * @return bool
-     */
-    public function getResizeProportional()
+    public function getResizeProportional(): bool
     {
         return $this->resizeProportional;
     }
 
-    /**
-     * Set ResizeProportional.
-     *
-     * @param bool $resizeProportional
-     *
-     * @return $this
-     */
-    public function setResizeProportional($resizeProportional)
+    public function setResizeProportional(bool $resizeProportional): self
     {
         $this->resizeProportional = $resizeProportional;
 
         return $this;
     }
 
-    /**
-     * Get Rotation.
-     *
-     * @return int
-     */
-    public function getRotation()
+    public function getRotation(): int
     {
         return $this->rotation;
     }
 
-    /**
-     * Set Rotation.
-     *
-     * @param int $rotation
-     *
-     * @return $this
-     */
-    public function setRotation($rotation)
+    public function setRotation(int $rotation): self
     {
         $this->rotation = $rotation;
 
         return $this;
     }
 
-    /**
-     * Get Shadow.
-     *
-     * @return Drawing\Shadow
-     */
-    public function getShadow()
+    public function getShadow(): Drawing\Shadow
     {
         return $this->shadow;
     }
 
-    /**
-     * Set Shadow.
-     *
-     * @return $this
-     */
-    public function setShadow(?Drawing\Shadow $shadow = null)
+    public function setShadow(?Drawing\Shadow $shadow = null): self
     {
-        $this->shadow = $shadow;
+        $this->shadow = $shadow ?? new Drawing\Shadow();
 
         return $this;
     }
@@ -493,10 +416,13 @@ class BaseDrawing implements IComparable
         return md5(
             $this->name .
             $this->description .
-            $this->worksheet->getHashCode() .
+            ($this->worksheet === null ? '' : $this->worksheet->getHashCode()) .
             $this->coordinates .
             $this->offsetX .
             $this->offsetY .
+            $this->coordinates2 .
+            $this->offsetX2 .
+            $this->offsetY2 .
             $this->width .
             $this->height .
             $this->rotation .
@@ -527,10 +453,7 @@ class BaseDrawing implements IComparable
         $this->hyperlink = $hyperlink;
     }
 
-    /**
-     * @return null|Hyperlink
-     */
-    public function getHyperlink()
+    public function getHyperlink(): ?Hyperlink
     {
         return $this->hyperlink;
     }
@@ -540,14 +463,18 @@ class BaseDrawing implements IComparable
      */
     protected function setSizesAndType(string $path): void
     {
-        if ($this->width == 0 && $this->height == 0 && $this->type == IMAGETYPE_UNKNOWN) {
+        if ($this->imageWidth === 0 && $this->imageHeight === 0 && $this->type == IMAGETYPE_UNKNOWN) {
             $imageData = getimagesize($path);
 
             if (is_array($imageData)) {
-                $this->width = $imageData[0];
-                $this->height = $imageData[1];
+                $this->imageWidth = $imageData[0];
+                $this->imageHeight = $imageData[1];
                 $this->type = $imageData[2];
             }
+        }
+        if ($this->width === 0 && $this->height === 0) {
+            $this->width = $this->imageWidth;
+            $this->height = $this->imageHeight;
         }
     }
 
@@ -557,5 +484,68 @@ class BaseDrawing implements IComparable
     public function getType(): int
     {
         return $this->type;
+    }
+
+    public function getCoordinates2(): string
+    {
+        return $this->coordinates2;
+    }
+
+    public function setCoordinates2(string $coordinates2): self
+    {
+        $this->coordinates2 = $coordinates2;
+
+        return $this;
+    }
+
+    public function getOffsetX2(): int
+    {
+        return $this->offsetX2;
+    }
+
+    public function setOffsetX2(int $offsetX2): self
+    {
+        $this->offsetX2 = $offsetX2;
+
+        return $this;
+    }
+
+    public function getOffsetY2(): int
+    {
+        return $this->offsetY2;
+    }
+
+    public function setOffsetY2(int $offsetY2): self
+    {
+        $this->offsetY2 = $offsetY2;
+
+        return $this;
+    }
+
+    public function getImageWidth(): int
+    {
+        return $this->imageWidth;
+    }
+
+    public function getImageHeight(): int
+    {
+        return $this->imageHeight;
+    }
+
+    public function getEditAs(): string
+    {
+        return $this->editAs;
+    }
+
+    public function setEditAs(string $editAs): self
+    {
+        $this->editAs = $editAs;
+
+        return $this;
+    }
+
+    public function validEditAs(): bool
+    {
+        return in_array($this->editAs, self::VALID_EDIT_AS);
     }
 }

--- a/src/PhpSpreadsheet/Worksheet/MemoryDrawing.php
+++ b/src/PhpSpreadsheet/Worksheet/MemoryDrawing.php
@@ -64,7 +64,7 @@ class MemoryDrawing extends BaseDrawing
     public function __destruct()
     {
         if ($this->imageResource) {
-            imagedestroy($this->imageResource);
+            @imagedestroy($this->imageResource);
             $this->imageResource = null;
         }
     }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1277,7 +1277,7 @@ class Worksheet extends WriterPart
                 $objWriter,
                 $this->getParentWriter()->getOffice2003Compatibility() === false,
                 'v',
-                ($this->getParentWriter()->getPreCalculateFormulas() && !is_array($calculatedValue) && substr($calculatedValue, 0, 1) !== '#')
+                ($this->getParentWriter()->getPreCalculateFormulas() && !is_array($calculatedValue) && substr($calculatedValue ?? '', 0, 1) !== '#')
                     ? StringHelper::formatNumber($calculatedValue) : '0'
             );
         }

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/DrawingsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/DrawingsTest.php
@@ -8,7 +8,9 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 use PhpOffice\PhpSpreadsheet\Shared\File;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\BaseDrawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
+use PhpOffice\PhpSpreadsheet\Worksheet\MemoryDrawing;
 use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
 class DrawingsTest extends AbstractFunctional
@@ -28,6 +30,8 @@ class DrawingsTest extends AbstractFunctional
 
         // Fake assert. The only thing we need is to ensure the file is loaded without exception
         self::assertNotNull($reloadedSpreadsheet);
+        $spreadsheet->disconnectWorksheets();
+        $reloadedSpreadsheet->disconnectWorksheets();
     }
 
     /**
@@ -59,6 +63,8 @@ class DrawingsTest extends AbstractFunctional
 
         // Fake assert. The only thing we need is to ensure the file is loaded without exception
         self::assertNotNull($reloadedSpreadsheet);
+        $spreadsheet->disconnectWorksheets();
+        $reloadedSpreadsheet->disconnectWorksheets();
     }
 
     /**
@@ -96,6 +102,8 @@ class DrawingsTest extends AbstractFunctional
         unlink($tempFileName);
 
         self::assertNotNull($reloadedSpreadsheet);
+        $spreadsheet->disconnectWorksheets();
+        $reloadedSpreadsheet->disconnectWorksheets();
     }
 
     /**
@@ -174,6 +182,8 @@ class DrawingsTest extends AbstractFunctional
 
         unlink($tempFileName);
         self::assertNotNull($reloadedSpreadsheet);
+        $spreadsheet->disconnectWorksheets();
+        $reloadedSpreadsheet->disconnectWorksheets();
     }
 
     /**
@@ -428,6 +438,161 @@ class DrawingsTest extends AbstractFunctional
 
         unlink($tempFileName);
 
-        self::assertNotNull($reloadedSpreadsheet);
+        $spreadsheet->disconnectWorksheets();
+        $reloadedSpreadsheet->disconnectWorksheets();
+    }
+
+    /**
+     * Test save and load XLSX file with drawing image that coordinate is two cell anchor.
+     */
+    public function testTwoCellAnchorDrawing(): void
+    {
+        $reader = new Xlsx();
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        // Add gif image that coordinates is two cell anchor.
+        $drawing = new Drawing();
+        $drawing->setName('Green Square');
+        $drawing->setPath('tests/data/Writer/XLSX/green_square.gif');
+        self::assertEquals($drawing->getWidth(), 150);
+        self::assertEquals($drawing->getHeight(), 150);
+        $drawing->setCoordinates('A1');
+        $drawing->setOffsetX(30);
+        $drawing->setOffsetY(10);
+        $drawing->setCoordinates2('E8');
+        $drawing->setOffsetX2(-50);
+        $drawing->setOffsetY2(-20);
+        $drawing->setWorksheet($sheet);
+
+        // Write file
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Xlsx');
+        $spreadsheet->disconnectWorksheets();
+        $rsheet = $reloadedSpreadsheet->getActiveSheet();
+
+        // Check image coordinates.
+        $drawingCollection = $rsheet->getDrawingCollection();
+        $drawing = $drawingCollection[0];
+        self::assertNotNull($drawing);
+
+        self::assertSame(150, $drawing->getWidth());
+        self::assertSame(150, $drawing->getHeight());
+        self::assertSame('A1', $drawing->getCoordinates());
+        self::assertSame(30, $drawing->getOffsetX());
+        self::assertSame(10, $drawing->getOffsetY());
+        self::assertSame('E8', $drawing->getCoordinates2());
+        self::assertSame(-50, $drawing->getOffsetX2());
+        self::assertSame(-20, $drawing->getOffsetY2());
+        self::assertSame($rsheet, $drawing->getWorksheet());
+        $reloadedSpreadsheet->disconnectWorksheets();
+    }
+
+    /**
+     * Test editAs attribute for two-cell anchors.
+     *
+     * @dataProvider providerEditAs
+     */
+    public function testTwoCellEditAs(string $editAs, ?string $expectedResult = null): void
+    {
+        if ($expectedResult === null) {
+            $expectedResult = $editAs;
+        }
+        $reader = new Xlsx();
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        // Add gif image that coordinates is two cell anchor.
+        $drawing = new Drawing();
+        $drawing->setName('Green Square');
+        $drawing->setPath('tests/data/Writer/XLSX/green_square.gif');
+        self::assertEquals($drawing->getWidth(), 150);
+        self::assertEquals($drawing->getHeight(), 150);
+        $drawing->setCoordinates('A1');
+        $drawing->setOffsetX(30);
+        $drawing->setOffsetY(10);
+        $drawing->setCoordinates2('E8');
+        $drawing->setOffsetX2(-50);
+        $drawing->setOffsetY2(-20);
+        if ($editAs !== '') {
+            $drawing->setEditAs($editAs);
+        }
+        $drawing->setWorksheet($sheet);
+
+        // Write file
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Xlsx');
+        $spreadsheet->disconnectWorksheets();
+        $rsheet = $reloadedSpreadsheet->getActiveSheet();
+
+        // Check image coordinates.
+        $drawingCollection = $rsheet->getDrawingCollection();
+        $drawing = $drawingCollection[0];
+        self::assertNotNull($drawing);
+
+        self::assertSame(150, $drawing->getWidth());
+        self::assertSame(150, $drawing->getHeight());
+        self::assertSame('A1', $drawing->getCoordinates());
+        self::assertSame(30, $drawing->getOffsetX());
+        self::assertSame(10, $drawing->getOffsetY());
+        self::assertSame('E8', $drawing->getCoordinates2());
+        self::assertSame(-50, $drawing->getOffsetX2());
+        self::assertSame(-20, $drawing->getOffsetY2());
+        self::assertSame($rsheet, $drawing->getWorksheet());
+        self::assertSame($expectedResult, $drawing->getEditAs());
+        $reloadedSpreadsheet->disconnectWorksheets();
+    }
+
+    public function providerEditAs(): array
+    {
+        return [
+            'absolute' => ['absolute'],
+            'onecell' => ['onecell'],
+            'twocell' => ['twocell'],
+            'unset (will be treated as twocell)' => [''],
+            'unknown (will be treated as twocell)' => ['unknown', ''],
+        ];
+    }
+
+    public function testMemoryDrawingDuplicateResource(): void
+    {
+        $gdImage = imagecreatetruecolor(120, 20);
+        $textColor = ($gdImage === false) ? false : imagecolorallocate($gdImage, 255, 255, 255);
+        if ($gdImage === false || $textColor === false) {
+            self::fail('imagecreatetruecolor or imagecolorallocate failed');
+        } else {
+            $spreadsheet = new Spreadsheet();
+            $aSheet = $spreadsheet->getActiveSheet();
+            imagestring($gdImage, 1, 5, 5, 'Created with PhpSpreadsheet', $textColor);
+            $listOfModes = [
+                BaseDrawing::EDIT_AS_TWOCELL,
+                BaseDrawing::EDIT_AS_ABSOLUTE,
+                BaseDrawing::EDIT_AS_ONECELL,
+            ];
+
+            foreach ($listOfModes as $i => $mode) {
+                $drawing = new MemoryDrawing();
+                $drawing->setName('In-Memory image ' . $i);
+                $drawing->setDescription('In-Memory image ' . $i);
+
+                $drawing->setCoordinates('A' . ((4 * $i) + 1));
+                $drawing->setCoordinates2('D' . ((4 * $i) + 4));
+                $drawing->setEditAs($mode);
+
+                $drawing->setImageResource($gdImage);
+                $drawing->setRenderingFunction(
+                    MemoryDrawing::RENDERING_JPEG
+                );
+
+                $drawing->setMimeType(MemoryDrawing::MIMETYPE_DEFAULT);
+
+                $drawing->setWorksheet($aSheet);
+            }
+            $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Xlsx');
+            $spreadsheet->disconnectWorksheets();
+
+            foreach ($reloadedSpreadsheet->getActiveSheet()->getDrawingCollection() as $index => $pDrawing) {
+                self::assertEquals($listOfModes[$index], $pDrawing->getEditAs(), 'functional test drawing twoCellAnchor');
+            }
+            $reloadedSpreadsheet->disconnectWorksheets();
+        }
     }
 }


### PR DESCRIPTION
This change was introduced by @naotake51 as PR #2532, but it was closed before I had a chance to review it, and I have been unable to communicate with the author since. I will gladly defer to the original. Please see the original PR for details.

Similarly, PR #2237 (@AdamGaskins) is open, but with changes requested for several months. It covers a lot of the same ground as 2532. It makes sense to me to combine them.

To those changes I added support for the 'editAs' attribute - I imagine that there are instances of 'absolute' out in the wild.

There have been several other tickets referencing two cell anchors, including issue #1159 and PR #1160 (@sgarwood, who also added support for editAs), PR #643, and issue #126, all now closed but not necessarily entirely resolved. I will try to ensure that those tickets are addressed with this one.

And, in trying to make sure 1160 is covered, I stumbled upon a bug. If you use the same image resource to create two+ memory drawings, the MemoryDrawing destructor for the first will cause the rest to generate a very long warning message. This is not a problem for Php8+, only for Php7-. I have suppressed the message in the MemoryDrawing constructor. 1160 went stale due to an unresolved test error, but I don't think this was the problem. At any rate, its test works now.

This is:

```
- [x] a bugfix
- [x] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
