### PR TITLE
docs: fix typo on formula wizard example

### DIFF
--- a/docs/topics/conditional-formatting.md
+++ b/docs/topics/conditional-formatting.md
@@ -653,11 +653,11 @@ $wizardFactory = new Wizard($cellRange);
 /** @var Wizard\Expression $expressionWizard */
 $expressionWizard = $wizardFactory->newRule(Wizard::EXPRESSION);
 
-$expressionWizard->expression('ISODD(A1)')
+$expressionWizard->expression('ISODD(A2)')
     ->setStyle($greenStyle);
 $conditionalStyles[] = $expressionWizard->getConditional();
 
-$expressionWizard->expression('ISEVEN(A1)')
+$expressionWizard->expression('ISEVEN(A2)')
     ->setStyle($yellowStyle);
 $conditionalStyles[] = $expressionWizard->getConditional();
 


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?
Just a simple typo fix on the documentation for the expression wizard. I was really confused until I realized it was a typo because on the image below you can see the formula.