### PR TITLE
Failing Test Requiring Too Much Precision

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCscTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCscTest.php
@@ -52,6 +52,18 @@ class ImCscTest extends TestCase
 
         $formula = "=IMCSC({$complex})";
         $result = $calculation->_calculateFormulaValue($formula);
+        // Avoid testing for excess precision
+        foreach ($expectedResult as &$array) {
+            foreach ($array as &$string) {
+                $string = preg_replace('/(\\d{8})\\d+/', '$1', $string);
+            }
+        }
+        foreach ($result as &$array) {
+            foreach ($array as &$string) {
+                $string = preg_replace('/(\\d{8})\\d+/', '$1', $string);
+            }
+        }
+
         self::assertEquals($expectedResult, $result);
     }
 


### PR DESCRIPTION
The new array tests for IMCSC fail on my system because of a rounding error in the 14th (!) decimal position. This is not a real failure. Change the test to use only the first 8 decimal positions.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
