### PR TITLE
Set Selected Cells for Worksheets in Gnumeric Loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Changed
 
 - Gnumeric Reader now loads number formatting for cells.
-- Gnumeric Reader now correctly identifies selected worksheet.
+- Gnumeric Reader now correctly identifies selected worksheet and selected cells in a worksheet.
 - Some Refactoring of the Ods Reader, moving all formula and address translation from Ods to Excel into a separate class to eliminate code duplication and ensure consistency.
 - Make Boolean Conversion in Csv Reader locale-aware when using the String Value Binder.
 
-  This is determined b the Calculation Engine locale setting.
+  This is determined by the Calculation Engine locale setting.
 
   (i.e. `"Vrai"` wil be converted to a boolean `true` if the Locale is set to `fr`.)
 

--- a/tests/PhpSpreadsheetTests/Reader/Gnumeric/GnumericLoadTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Gnumeric/GnumericLoadTest.php
@@ -125,6 +125,8 @@ class GnumericLoadTest extends TestCase
         self::assertTrue($sheet->getCell('B24')->getStyle()->getFont()->getSuperScript());
         $rowDimension = $sheet->getRowDimension(30);
         self::assertFalse($rowDimension->getVisible());
+
+        self::assertSame('B24', $sheet->getSelectedCells());
     }
 
     public function testLoadFilter(): void
@@ -167,5 +169,7 @@ class GnumericLoadTest extends TestCase
         $sheet = $spreadsheet->getSheet(0);
         self::assertEquals('Report Data', $sheet->getTitle());
         self::assertEquals('Third Heading', $sheet->getCell('C2')->getValue());
+
+        self::assertSame('A1', $sheet->getSelectedCells());
     }
 }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Set Selected Cells for Worksheet in Gnumeric Reader