### PR TITLE
Phpstan Differences from Php7 to Php8, Again

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -151,16 +151,6 @@ parameters:
 			path: src/PhpSpreadsheet/Calculation/Calculation.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function trim expects string, int\\|string given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/Calculation.php
-
-		-
-			message: "#^Parameter \\#1 \\$str of function trim expects string, null given\\.$#"
-			count: 2
-			path: src/PhpSpreadsheet/Calculation/Calculation.php
-
-		-
 			message: "#^Parameter \\#2 \\$worksheet of static method PhpOffice\\\\PhpSpreadsheet\\\\DefinedName\\:\\:resolveName\\(\\) expects PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\Worksheet, PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\Worksheet\\|null given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Calculation/Calculation.php
@@ -354,21 +344,6 @@ parameters:
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\Engineering\\\\BesselK\\:\\:besselK2\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Calculation/Engineering/BesselK.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\Engineering\\\\BitWise\\:\\:validateBitwiseArgument\\(\\) never returns int so it can be removed from the return type\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/Engineering/BitWise.php
-
-		-
-			message: "#^Parameter \\#1 \\$number of function floor expects float, float\\|int\\<0, 281474976710655\\>\\|string given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/Engineering/BitWise.php
-
-		-
-			message: "#^Parameter \\#1 \\$number of function floor expects float, float\\|int\\|string given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/Engineering/BitWise.php
 
 		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\Engineering\\\\ConvertBase\\:\\:validatePlaces\\(\\) has parameter \\$places with no type specified\\.$#"
@@ -821,16 +796,6 @@ parameters:
 			path: src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
 
 		-
-			message: "#^Parameter \\#1 \\$low of function range expects float\\|int\\|string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
-
-		-
-			message: "#^Parameter \\#2 \\$high of function range expects float\\|int\\|string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
-
-		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\VLookup\\:\\:vlookupSort\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Calculation/LookupRef/VLookup.php
@@ -1217,16 +1182,6 @@ parameters:
 
 		-
 			message: "#^Cannot use array destructuring on array\\|null\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Cell/Coordinate.php
-
-		-
-			message: "#^Parameter \\#1 \\$input of function array_chunk expects array, array\\<int, string\\>\\|false given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Cell/Coordinate.php
-
-		-
-			message: "#^Parameter \\#2 \\$str of function explode expects string, array\\<int, string\\>\\|string given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Cell/Coordinate.php
 
@@ -1911,11 +1866,6 @@ parameters:
 			path: src/PhpSpreadsheet/Helper/Html.php
 
 		-
-			message: "#^Parameter \\#1 \\$function of function call_user_func expects callable\\(\\)\\: mixed, array\\{\\$this\\(PhpOffice\\\\PhpSpreadsheet\\\\Helper\\\\Html\\), mixed\\} given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Helper/Html.php
-
-		-
 			message: "#^Parameter \\#1 \\$text of method PhpOffice\\\\PhpSpreadsheet\\\\RichText\\\\ITextElement\\:\\:setText\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Helper/Html.php
@@ -2482,11 +2432,6 @@ parameters:
 
 		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xls\\\\MD5\\:\\:step\\(\\) has parameter \\$func with no type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xls/MD5.php
-
-		-
-			message: "#^Parameter \\#1 \\$input of function array_values expects array, array\\|false given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Reader/Xls/MD5.php
 
@@ -3301,71 +3246,6 @@ parameters:
 			path: src/PhpSpreadsheet/Shared/Drawing.php
 
 		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Shared\\\\Drawing\\:\\:imagecreatefrombmp\\(\\) should return GdImage\\|resource but returns resource\\|false\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
-			message: "#^Parameter \\#1 \\$fp of function feof expects resource, resource\\|false given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
-			message: "#^Parameter \\#1 \\$fp of function fread expects resource, resource\\|false given\\.$#"
-			count: 2
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
-			message: "#^Parameter \\#1 \\$im of function imagecolorallocate expects resource, resource\\|false given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
-			message: "#^Parameter \\#1 \\$im of function imagesetpixel expects resource, resource\\|false given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
-			message: "#^Parameter \\#1 \\$x_size of function imagecreatetruecolor expects int, float\\|int given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
-			message: "#^Parameter \\#2 \\$data of function unpack expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
-			message: "#^Parameter \\#2 \\$red of function imagecolorallocate expects int, float\\|int given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
-			message: "#^Parameter \\#2 \\$y_size of function imagecreatetruecolor expects int, float\\|int given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
-			message: "#^Parameter \\#3 \\$green of function imagecolorallocate expects int, float\\|int given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
-			message: "#^Parameter \\#3 \\$y of function imagesetpixel expects int, float\\|int given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
-			message: "#^Parameter \\#4 \\$blue of function imagecolorallocate expects int, float\\|int given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
-			message: "#^Parameter \\#4 \\$col of function imagesetpixel expects int, int\\|false given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Drawing.php
-
-		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Shared\\\\Escher\\\\DgContainer\\:\\:getDgId\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Shared/Escher/DgContainer.php
@@ -3561,11 +3441,6 @@ parameters:
 			path: src/PhpSpreadsheet/Shared/JAMA/Matrix.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function trim expects string, float\\|int given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/JAMA/Matrix.php
-
-		-
 			message: "#^Parameter \\#3 \\$c of method PhpOffice\\\\PhpSpreadsheet\\\\Shared\\\\JAMA\\\\Matrix\\:\\:set\\(\\) expects float\\|int\\|null, string given\\.$#"
 			count: 2
 			path: src/PhpSpreadsheet/Shared/JAMA/Matrix.php
@@ -3611,11 +3486,6 @@ parameters:
 			path: src/PhpSpreadsheet/Shared/OLE.php
 
 		-
-			message: "#^Cannot use array destructuring on array\\|false\\.$#"
-			count: 3
-			path: src/PhpSpreadsheet/Shared/OLE.php
-
-		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Shared\\\\OLE\\:\\:getData\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Shared/OLE.php
@@ -3638,11 +3508,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
 			count: 1
-			path: src/PhpSpreadsheet/Shared/OLE.php
-
-		-
-			message: "#^Parameter \\#2 \\$data of function unpack expects string, string\\|false given\\.$#"
-			count: 3
 			path: src/PhpSpreadsheet/Shared/OLE.php
 
 		-
@@ -3679,11 +3544,6 @@ parameters:
 			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Shared\\\\OLE\\:\\:\\$root \\(PhpOffice\\\\PhpSpreadsheet\\\\Shared\\\\OLE\\\\PPS\\\\Root\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Shared/OLE.php
-
-		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, string given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/OLE/ChainedBlockStream.php
 
 		-
 			message: "#^Parameter \\#2 \\$offset of function array_slice expects int, float given\\.$#"
@@ -4026,11 +3886,6 @@ parameters:
 			path: src/PhpSpreadsheet/Shared/Trend/PolynomialBestFit.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function array_merge expects array, float given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Shared/Trend/PolynomialBestFit.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:getGoodnessOfFit\\(\\)\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Shared/Trend/Trend.php
@@ -4311,11 +4166,6 @@ parameters:
 			path: src/PhpSpreadsheet/Style/NumberFormat/DateFormatter.php
 
 		-
-			message: "#^Parameter \\#2 \\$str of function explode expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Style/NumberFormat/DateFormatter.php
-
-		-
 			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Style/NumberFormat/DateFormatter.php
@@ -4436,11 +4286,6 @@ parameters:
 			path: src/PhpSpreadsheet/Worksheet/PageSetup.php
 
 		-
-			message: "#^Parameter \\#2 \\$str of function explode expects string, string\\|null given\\.$#"
-			count: 5
-			path: src/PhpSpreadsheet/Worksheet/PageSetup.php
-
-		-
 			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\PageSetup\\:\\:\\$pageOrder has no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Worksheet/PageSetup.php
@@ -4486,11 +4331,6 @@ parameters:
 			path: src/PhpSpreadsheet/Worksheet/Worksheet.php
 
 		-
-			message: "#^Cannot call method getValue\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\DefinedName\\|null\\.$#"
-			count: 2
-			path: src/PhpSpreadsheet/Worksheet/Worksheet.php
-
-		-
 			message: "#^Cannot call method getWorksheet\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\DefinedName\\|null\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -4531,11 +4371,6 @@ parameters:
 			path: src/PhpSpreadsheet/Worksheet/Worksheet.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function array_splice expects array, ArrayObject\\<int, PhpOffice\\\\PhpSpreadsheet\\\\Chart\\\\Chart\\> given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Worksheet/Worksheet.php
-
-		-
 			message: "#^Parameter \\#1 \\$range of static method PhpOffice\\\\PhpSpreadsheet\\\\Cell\\\\Coordinate\\:\\:rangeDimension\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -4552,11 +4387,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$format of static method PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\NumberFormat\\:\\:toFormattedString\\(\\) expects string, string\\|null given\\.$#"
-			count: 2
-			path: src/PhpSpreadsheet/Worksheet/Worksheet.php
-
-		-
-			message: "#^Parameter \\#2 \\$start of function substr expects int, int\\<0, max\\>\\|false given\\.$#"
 			count: 2
 			path: src/PhpSpreadsheet/Worksheet/Worksheet.php
 
@@ -4881,16 +4711,6 @@ parameters:
 			path: src/PhpSpreadsheet/Writer/Html.php
 
 		-
-			message: "#^Parameter \\#1 \\$im of function imagepng expects resource, GdImage\\|resource given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Html.php
-
-		-
-			message: "#^Parameter \\#1 \\$str of function base64_encode expects string, string\\|false given\\.$#"
-			count: 2
-			path: src/PhpSpreadsheet/Writer/Html.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Writer/Html.php
@@ -5012,16 +4832,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$font of method PhpOffice\\\\PhpSpreadsheet\\\\Writer\\\\Xls\\\\Workbook\\:\\:addFont\\(\\) expects PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\Font, PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\Font\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xls.php
-
-		-
-			message: "#^Parameter \\#1 \\$im of function imagepng expects resource, GdImage\\|resource given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xls.php
-
-		-
-			message: "#^Parameter \\#1 \\$im of function imagepng expects resource, resource\\|false given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Writer/Xls.php
 
@@ -5206,11 +5016,6 @@ parameters:
 			path: src/PhpSpreadsheet/Writer/Xls/Worksheet.php
 
 		-
-			message: "#^Parameter \\#1 \\$im of function imagecolorat expects resource, GdImage\\|resource given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xls/Worksheet.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -5221,22 +5026,7 @@ parameters:
 			path: src/PhpSpreadsheet/Writer/Xls/Worksheet.php
 
 		-
-			message: "#^Parameter \\#2 \\$col of function imagecolorsforindex expects int, int\\|false given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xls/Worksheet.php
-
-		-
-			message: "#^Parameter \\#2 \\$data of function unpack expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xls/Worksheet.php
-
-		-
 			message: "#^Parameter \\#2 \\$length of function fread expects int\\<0, max\\>, int\\<0, max\\>\\|false given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xls/Worksheet.php
-
-		-
-			message: "#^Parameter \\#2 \\$pieces of function implode expects array, array\\<int, string\\>\\|false given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Writer/Xls/Worksheet.php
 
@@ -5317,11 +5107,6 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type array\\|null supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xlsx.php
-
-		-
-			message: "#^Parameter \\#1 \\$function of function call_user_func expects callable\\(\\)\\: mixed, string given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Writer/Xlsx.php
 
@@ -5769,248 +5554,3 @@ parameters:
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Writer\\\\Xlsx\\\\Xlfn\\:\\:addXlfn\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Writer/Xlsx/Xlfn.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Calculation/Engine/RangeTest.php
-
-		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with arguments PhpOffice\\\\PhpSpreadsheet\\\\Cell\\\\Cell, null and 'should get exact…' will always evaluate to false\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Collection/CellsTest.php
-
-		-
-			message: "#^Cannot call method getCoordinate\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Cell\\\\Cell\\|null\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Collection/CellsTest.php
-
-		-
-			message: "#^Cannot call method getParent\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Cell\\\\Cell\\|null\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Collection/CellsTest.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\Functional\\\\ColumnWidthTest\\:\\:testReadColumnWidth\\(\\) has parameter \\$format with no type specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Functional/ColumnWidthTest.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\Functional\\\\CommentsTest\\:\\:testComments\\(\\) has parameter \\$format with no type specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Functional/CommentsTest.php
-
-		-
-			message: "#^Cannot call method getPageSetup\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\Worksheet\\|null\\.$#"
-			count: 5
-			path: tests/PhpSpreadsheetTests/Functional/PrintAreaTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$expected of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) expects class\\-string\\<object\\>, string given\\.$#"
-			count: 3
-			path: tests/PhpSpreadsheetTests/IOFactoryTest.php
-
-		-
-			message: "#^Cannot call method getValue\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\NamedFormula\\|null\\.$#"
-			count: 5
-			path: tests/PhpSpreadsheetTests/NamedFormulaTest.php
-
-		-
-			message: "#^Cannot call method getValue\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\NamedRange\\|null\\.$#"
-			count: 5
-			path: tests/PhpSpreadsheetTests/NamedRangeTest.php
-
-		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\Ods\\\\OdsTest\\:\\:\\$spreadsheetData \\(PhpOffice\\\\PhpSpreadsheet\\\\Spreadsheet\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Ods/OdsTest.php
-
-		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\Ods\\\\OdsTest\\:\\:\\$spreadsheetOdsTest \\(PhpOffice\\\\PhpSpreadsheet\\\\Spreadsheet\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Ods/OdsTest.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Ods/OdsTest.php
-
-		-
-			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 3
-			path: tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\Security\\\\XmlScannerTest\\:\\:testInvalidXML\\(\\) has parameter \\$libxmlDisableEntityLoader with no type specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\Security\\\\XmlScannerTest\\:\\:testValidXML\\(\\) has parameter \\$libxmlDisableEntityLoader with no type specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\Xlsx\\\\AutoFilterTest\\:\\:getAutoFilterInstance\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/AutoFilterTest.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\Xlsx\\\\AutoFilterTest\\:\\:getWorksheetInstance\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/AutoFilterTest.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\Xlsx\\\\AutoFilterTest\\:\\:getXMLInstance\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/AutoFilterTest.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\Xlsx\\\\AutoFilterTest\\:\\:getXMLInstance\\(\\) has parameter \\$ref with no type specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/AutoFilterTest.php
-
-		-
-			message: "#^Cannot call method getTitle\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Chart\\\\Chart\\|null\\.$#"
-			count: 5
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ChartsTitleTest.php
-
-		-
-			message: "#^Cannot call method getXAxisLabel\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Chart\\\\Chart\\|null\\.$#"
-			count: 5
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ChartsTitleTest.php
-
-		-
-			message: "#^Cannot call method getYAxisLabel\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Chart\\\\Chart\\|null\\.$#"
-			count: 5
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ChartsTitleTest.php
-
-		-
-			message: "#^Cannot call method getColor\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\ConditionalFormatting\\\\ConditionalDataBar\\|null\\.$#"
-			count: 5
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalFormattingDataBarXlsxTest.php
-
-		-
-			message: "#^Cannot call method getConditionalFormattingRuleExt\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\ConditionalFormatting\\\\ConditionalDataBar\\|null\\.$#"
-			count: 8
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalFormattingDataBarXlsxTest.php
-
-		-
-			message: "#^Cannot call method getMaximumConditionalFormatValueObject\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\ConditionalFormatting\\\\ConditionalDataBar\\|null\\.$#"
-			count: 13
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalFormattingDataBarXlsxTest.php
-
-		-
-			message: "#^Cannot call method getMinimumConditionalFormatValueObject\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\ConditionalFormatting\\\\ConditionalDataBar\\|null\\.$#"
-			count: 13
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalFormattingDataBarXlsxTest.php
-
-		-
-			message: "#^Cannot call method getShowValue\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\ConditionalFormatting\\\\ConditionalDataBar\\|null\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalFormattingDataBarXlsxTest.php
-
-		-
-			message: "#^Cannot call method setMinimumConditionalFormatValueObject\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\ConditionalFormatting\\\\ConditionalDataBar\\|null\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalFormattingDataBarXlsxTest.php
-
-		-
-			message: "#^Cannot call method getPlotArea\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Chart\\\\Chart\\|null\\.$#"
-			count: 2
-			path: tests/PhpSpreadsheetTests/Reader/Xlsx/SheetsXlsxChartTest.php
-
-		-
-			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xml/XmlTest.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\Reader\\\\Xml\\\\XmlTest\\:\\:testInvalidSimpleXML\\(\\) has parameter \\$filename with no type specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Reader/Xml/XmlTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$currencyCode of static method PhpOffice\\\\PhpSpreadsheet\\\\Shared\\\\StringHelper\\:\\:setCurrencyCode\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Shared/StringHelperTest.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\SpreadsheetTest\\:\\:testGetSheetByName\\(\\) has parameter \\$index with no type specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/SpreadsheetTest.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\SpreadsheetTest\\:\\:testGetSheetByName\\(\\) has parameter \\$sheetName with no type specified\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/SpreadsheetTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\AutoFilter\\\\Column\\:\\:setAttribute\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Worksheet/AutoFilter/ColumnTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$rowIndex of class PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\RowCellIterator constructor expects int, string given\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Worksheet/RowCellIterator2Test.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheetTests\\\\Writer\\\\Html\\\\CallbackTest\\:\\:yellowBody\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Writer/Html/CallbackTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Writer/Html/CallbackTest.php
-
-		-
-			message: "#^Cannot call method getColor\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\Font\\|null\\.$#"
-			count: 3
-			path: tests/PhpSpreadsheetTests/Writer/Html/GridlinesTest.php
-
-		-
-			message: "#^Cannot call method setSubScript\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\Font\\|null\\.$#"
-			count: 3
-			path: tests/PhpSpreadsheetTests/Writer/Html/GridlinesTest.php
-
-		-
-			message: "#^Cannot call method setSuperScript\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\Font\\|null\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Writer/Html/GridlinesTest.php
-
-		-
-			message: "#^Cannot call method setBold\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\Font\\|null\\.$#"
-			count: 3
-			path: tests/PhpSpreadsheetTests/Writer/Html/HtmlCommentsTest.php
-
-		-
-			message: "#^Cannot call method getCell\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\Worksheet\\|null\\.$#"
-			count: 4
-			path: tests/PhpSpreadsheetTests/Writer/Xlsx/UnparsedDataCloneTest.php
-
-		-
-			message: "#^Cannot call method getDrawingCollection\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\Worksheet\\|null\\.$#"
-			count: 4
-			path: tests/PhpSpreadsheetTests/Writer/Xlsx/UnparsedDataCloneTest.php
-
-		-
-			message: "#^Cannot access property \\$pageSetup on SimpleXMLElement\\|false\\.$#"
-			count: 1
-			path: tests/PhpSpreadsheetTests/Writer/Xlsx/UnparsedDataTest.php
-
-		-
-			message: "#^Cannot access property \\$sheetProtection on SimpleXMLElement\\|false\\.$#"
-			count: 5
-			path: tests/PhpSpreadsheetTests/Writer/Xlsx/UnparsedDataTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$data of function simplexml_load_string expects string, string\\|false given\\.$#"
-			count: 2
-			path: tests/PhpSpreadsheetTests/Writer/Xlsx/UnparsedDataTest.php
-
-		-
-			message: "#^Cannot call method getExtension\\(\\) on PhpOffice\\\\PhpSpreadsheet\\\\Worksheet\\\\BaseDrawing\\|null\\.$#"
-			count: 2
-			path: tests/PhpSpreadsheetTests/Writer/Xlsx/WmfTest.php

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -3226,6 +3226,7 @@ class Calculation
         if (self::$functionReplaceToExcel === null) {
             self::$functionReplaceToExcel = [];
             foreach (array_keys(self::$localeFunctions) as $excelFunctionName) {
+                // @phpstan-ignore-next-line
                 self::$functionReplaceToExcel[] = '$1' . trim($excelFunctionName) . '$2';
             }
             foreach (array_keys(self::$localeBoolean) as $excelBoolean) {
@@ -4490,6 +4491,7 @@ class Calculation
                             if ($operand1Data['reference'] === null) {
                                 if ((trim($operand1Data['value']) != '') && (is_numeric($operand1Data['value']))) {
                                     $operand1Data['reference'] = $cell->getColumn() . $operand1Data['value'];
+                                // @phpstan-ignore-next-line
                                 } elseif (trim($operand1Data['reference']) == '') {
                                     $operand1Data['reference'] = $cell->getCoordinate();
                                 } else {
@@ -4499,6 +4501,7 @@ class Calculation
                             if ($operand2Data['reference'] === null) {
                                 if ((trim($operand2Data['value']) != '') && (is_numeric($operand2Data['value']))) {
                                     $operand2Data['reference'] = $cell->getColumn() . $operand2Data['value'];
+                                // @phpstan-ignore-next-line
                                 } elseif (trim($operand2Data['reference']) == '') {
                                     $operand2Data['reference'] = $cell->getCoordinate();
                                 } else {

--- a/src/PhpSpreadsheet/Calculation/Engineering/BitWise.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/BitWise.php
@@ -211,13 +211,14 @@ class BitWise
      *
      * @param mixed $value
      *
-     * @return float|int
+     * @return float
      */
     private static function validateBitwiseArgument($value)
     {
         $value = self::nullFalseTrueToNumber($value);
 
         if (is_numeric($value)) {
+            $value = (float) $value;
             if ($value == floor($value)) {
                 if (($value > 2 ** 48 - 1) || ($value < 0)) {
                     throw new Exception(ExcelError::NAN());

--- a/src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
@@ -166,6 +166,7 @@ class RowColumnInformation
                 function ($value) {
                     return [$value];
                 },
+                // @phpstan-ignore-next-line
                 range($startAddress, $endAddress)
             );
         }

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -148,6 +148,7 @@ abstract class Coordinate
         $exploded = explode(',', $range);
         $counter = count($exploded);
         for ($i = 0; $i < $counter; ++$i) {
+            // @phpstan-ignore-next-line
             $exploded[$i] = explode(':', $exploded[$i]);
         }
 
@@ -544,7 +545,7 @@ abstract class Coordinate
 
         // split range sets on intersection (space) or union (,) operators
         $tokens = preg_split('/([ ,])/', $rangeString, -1, PREG_SPLIT_DELIM_CAPTURE);
-        // separate the range sets and the operators into arrays
+        /** @phpstan-ignore-next-line */
         $split = array_chunk($tokens, 2);
         $ranges = array_column($split, 0);
         $operators = array_column($split, 1);

--- a/src/PhpSpreadsheet/Helper/Html.php
+++ b/src/PhpSpreadsheet/Helper/Html.php
@@ -808,6 +808,7 @@ class Html
         if (isset($callbacks[$callbackTag])) {
             $elementHandler = $callbacks[$callbackTag];
             if (method_exists($this, $elementHandler)) {
+                // @phpstan-ignore-next-line
                 call_user_func([$this, $elementHandler], $element);
             }
         }

--- a/src/PhpSpreadsheet/Reader/Xls/MD5.php
+++ b/src/PhpSpreadsheet/Reader/Xls/MD5.php
@@ -71,6 +71,7 @@ class MD5
      */
     public function add(string $data): void
     {
+        /** @phpstan-ignore-next-line */
         $words = array_values(unpack('V16', $data));
 
         $A = $this->a;

--- a/src/PhpSpreadsheet/Shared/Drawing.php
+++ b/src/PhpSpreadsheet/Shared/Drawing.php
@@ -164,11 +164,15 @@ class Drawing
     {
         //    Load the image into a string
         $file = fopen($bmpFilename, 'rb');
+        /** @phpstan-ignore-next-line */
         $read = fread($file, 10);
+        // @phpstan-ignore-next-line
         while (!feof($file) && ($read != '')) {
+            // @phpstan-ignore-next-line
             $read .= fread($file, 1024);
         }
 
+        /** @phpstan-ignore-next-line */
         $temp = unpack('H*', $read);
         $hex = $temp[1];
         $header = substr($hex, 0, 108);
@@ -196,6 +200,8 @@ class Drawing
         $y = 1;
 
         //    Create newimage
+
+        /** @phpstan-ignore-next-line */
         $image = imagecreatetruecolor($width, $height);
 
         //    Grab the body from the image
@@ -241,7 +247,10 @@ class Drawing
             $b = hexdec($body[$i_pos] . $body[$i_pos + 1]);
 
             // Calculate and draw the pixel
+
+            /** @phpstan-ignore-next-line */
             $color = imagecolorallocate($image, $r, $g, $b);
+            // @phpstan-ignore-next-line
             imagesetpixel($image, $x, $height - $y, $color);
 
             // Raise the horizontal position
@@ -252,6 +261,7 @@ class Drawing
         unset($body);
 
         //    Return image-object
+        // @phpstan-ignore-next-line
         return $image;
     }
 }

--- a/src/PhpSpreadsheet/Shared/JAMA/Matrix.php
+++ b/src/PhpSpreadsheet/Shared/JAMA/Matrix.php
@@ -1134,6 +1134,7 @@ class Matrix
             $this->checkMatrixDimensions($M);
             for ($i = 0; $i < $this->m; ++$i) {
                 for ($j = 0; $j < $this->n; ++$j) {
+                    // @phpstan-ignore-next-line
                     $this->A[$i][$j] = trim($this->A[$i][$j], '"') . trim($M->get($i, $j), '"');
                 }
             }

--- a/src/PhpSpreadsheet/Shared/OLE.php
+++ b/src/PhpSpreadsheet/Shared/OLE.php
@@ -251,6 +251,7 @@ class OLE
      */
     private static function readInt1($fileHandle)
     {
+        // @phpstan-ignore-next-line
         [, $tmp] = unpack('c', fread($fileHandle, 1));
 
         return $tmp;
@@ -265,6 +266,7 @@ class OLE
      */
     private static function readInt2($fileHandle)
     {
+        // @phpstan-ignore-next-line
         [, $tmp] = unpack('v', fread($fileHandle, 2));
 
         return $tmp;
@@ -279,6 +281,7 @@ class OLE
      */
     private static function readInt4($fileHandle)
     {
+        // @phpstan-ignore-next-line
         [, $tmp] = unpack('V', fread($fileHandle, 4));
 
         return $tmp;

--- a/src/PhpSpreadsheet/Shared/OLE/ChainedBlockStream.php
+++ b/src/PhpSpreadsheet/Shared/OLE/ChainedBlockStream.php
@@ -160,6 +160,7 @@ class ChainedBlockStream
             $this->pos = $offset;
         } elseif ($whence == SEEK_CUR && -$offset <= $this->pos) {
             $this->pos += $offset;
+        // @phpstan-ignore-next-line
         } elseif ($whence == SEEK_END && -$offset <= count($this->data)) {
             $this->pos = strlen($this->data) + $offset;
         } else {

--- a/src/PhpSpreadsheet/Shared/Trend/PolynomialBestFit.php
+++ b/src/PhpSpreadsheet/Shared/Trend/PolynomialBestFit.php
@@ -114,6 +114,7 @@ class PolynomialBestFit extends BestFit
 
     public function getCoefficients($dp = 0)
     {
+        // @phpstan-ignore-next-line
         return array_merge([$this->getIntersect($dp)], $this->getSlope($dp));
     }
 

--- a/src/PhpSpreadsheet/Style/NumberFormat/DateFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/DateFormatter.php
@@ -85,6 +85,8 @@ class DateFormatter
         $format = preg_replace_callback('/(?:^|")([^"]*)(?:$|")/', $callable, $format);
 
         // Only process the non-quoted blocks for date format characters
+
+        /** @phpstan-ignore-next-line */
         $blocks = explode('"', $format);
         foreach ($blocks as $key => &$block) {
             if ($key % 2 == 0) {

--- a/src/PhpSpreadsheet/Worksheet/AutoFilter/Column.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter/Column.php
@@ -243,7 +243,7 @@ class Column
      * Set An AutoFilter Attribute.
      *
      * @param string $name Attribute Name
-     * @param string $value Attribute Value
+     * @param int|string $value Attribute Value
      *
      * @return $this
      */

--- a/src/PhpSpreadsheet/Worksheet/PageSetup.php
+++ b/src/PhpSpreadsheet/Worksheet/PageSetup.php
@@ -640,6 +640,7 @@ class PageSetup
         if ($index == 0) {
             return $this->printArea;
         }
+        /** @phpstan-ignore-next-line */
         $printAreas = explode(',', $this->printArea);
         if (isset($printAreas[$index - 1])) {
             return $printAreas[$index - 1];
@@ -663,6 +664,7 @@ class PageSetup
         if ($index == 0) {
             return $this->printArea !== null;
         }
+        /** @phpstan-ignore-next-line */
         $printAreas = explode(',', $this->printArea);
 
         return isset($printAreas[$index - 1]);
@@ -683,6 +685,7 @@ class PageSetup
         if ($index == 0) {
             $this->printArea = null;
         } else {
+            /** @phpstan-ignore-next-line */
             $printAreas = explode(',', $this->printArea);
             if (isset($printAreas[$index - 1])) {
                 unset($printAreas[$index - 1]);
@@ -731,6 +734,7 @@ class PageSetup
             if ($index == 0) {
                 $this->printArea = $value;
             } else {
+                /** @phpstan-ignore-next-line */
                 $printAreas = explode(',', $this->printArea);
                 if ($index < 0) {
                     $index = count($printAreas) - abs($index) + 1;
@@ -745,6 +749,7 @@ class PageSetup
             if ($index == 0) {
                 $this->printArea = $this->printArea ? ($this->printArea . ',' . $value) : $value;
             } else {
+                /** @phpstan-ignore-next-line */
                 $printAreas = explode(',', $this->printArea);
                 if ($index < 0) {
                     $index = abs($index) - 1;

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -567,6 +567,7 @@ class Worksheet implements IComparable
             $this->chartCollection[] = $chart;
         } else {
             // Insert the chart at the requested index
+            // @phpstan-ignore-next-line
             array_splice($this->chartCollection, $chartIndex, 0, [$chart]);
         }
 
@@ -1224,6 +1225,7 @@ class Worksheet implements IComparable
                     throw new Exception('Sheet not found for named range: ' . $namedRange->getName());
                 }
 
+                /** @phpstan-ignore-next-line */
                 $cellCoordinate = ltrim(substr($namedRange->getValue(), strrpos($namedRange->getValue(), '!')), '!');
                 $finalCoordinate = str_replace('$', '', $cellCoordinate);
             }
@@ -2767,6 +2769,7 @@ class Worksheet implements IComparable
     {
         $namedRange = $this->validateNamedRange($definedName);
         $workSheet = $namedRange->getWorksheet();
+        /** @phpstan-ignore-next-line */
         $cellRange = ltrim(substr($namedRange->getValue(), strrpos($namedRange->getValue(), '!')), '!');
         $cellRange = str_replace('$', '', $cellRange);
 

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -697,10 +697,12 @@ class Html extends BaseWriter
                 $imageResource = $drawing->getImageResource();
                 if ($imageResource) {
                     ob_start(); //  Let's start output buffering.
+                    // @phpstan-ignore-next-line
                     imagepng($imageResource); //  This will normally output the image, but because of ob_start(), it won't.
                     $contents = ob_get_contents(); //  Instead, output above is saved to $contents
                     ob_end_clean(); //  End the output buffer.
 
+                    /** @phpstan-ignore-next-line */
                     $dataUri = 'data:image/jpeg;base64,' . base64_encode($contents);
 
                     //  Because of the nature of tables, width is more important than height.
@@ -748,7 +750,7 @@ class Html extends BaseWriter
                     if ($fp = fopen($chartFileName, 'rb', 0)) {
                         $picture = fread($fp, filesize($chartFileName));
                         fclose($fp);
-                        // base64 encode the binary data
+                        /** @phpstan-ignore-next-line */
                         $base64 = base64_encode($picture);
                         $imageData = 'data:' . $imageDetails['mime'] . ';base64,' . $base64;
 

--- a/src/PhpSpreadsheet/Writer/Xls.php
+++ b/src/PhpSpreadsheet/Writer/Xls.php
@@ -434,6 +434,7 @@ class Xls extends BaseWriter
             case 1: // GIF, not supported by BIFF8, we convert to PNG
                 $blipType = BSE::BLIPTYPE_PNG;
                 ob_start();
+                // @phpstan-ignore-next-line
                 imagepng(imagecreatefromgif($filename));
                 $blipData = ob_get_contents();
                 ob_end_clean();
@@ -452,6 +453,7 @@ class Xls extends BaseWriter
             case 6: // Windows DIB (BMP), we convert to PNG
                 $blipType = BSE::BLIPTYPE_PNG;
                 ob_start();
+                // @phpstan-ignore-next-line
                 imagepng(SharedDrawing::imagecreatefrombmp($filename));
                 $blipData = ob_get_contents();
                 ob_end_clean();

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -989,6 +989,8 @@ class Worksheet extends BIFFwriter
         $options = pack('V', 0x03);
 
         // Convert URL to a null terminated wchar string
+
+        /** @phpstan-ignore-next-line */
         $url = implode("\0", preg_split("''", $url, -1, PREG_SPLIT_NO_EMPTY));
         $url = $url . "\0\0\0";
 
@@ -2387,6 +2389,7 @@ class Worksheet extends BIFFwriter
         $data = pack('Vvvvv', 0x000c, $width, $height, 0x01, 0x18);
         for ($j = $height; --$j;) {
             for ($i = 0; $i < $width; ++$i) {
+                /** @phpstan-ignore-next-line */
                 $color = imagecolorsforindex($image, imagecolorat($image, $i, $j));
                 foreach (['red', 'green', 'blue'] as $key) {
                     $color[$key] = $color[$key] + (int) round((255 - $color[$key]) * $color['alpha'] / 127);
@@ -2427,6 +2430,8 @@ class Worksheet extends BIFFwriter
         }
 
         // The first 2 bytes are used to identify the bitmap.
+
+        /** @phpstan-ignore-next-line */
         $identity = unpack('A2ident', $data);
         if ($identity['ident'] != 'BM') {
             throw new WriterException("$bitmap doesn't appear to be a valid bitmap image.\n");

--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -501,8 +501,10 @@ class Xlsx extends BaseWriter
                 $zipContent['xl/media/' . $this->getDrawingHashTable()->getByIndex($i)->getIndexedFilename()] = $imageContents;
             } elseif ($this->getDrawingHashTable()->getByIndex($i) instanceof MemoryDrawing) {
                 ob_start();
+                /** @var callable */
+                $callable = $this->getDrawingHashTable()->getByIndex($i)->getRenderingFunction();
                 call_user_func(
-                    $this->getDrawingHashTable()->getByIndex($i)->getRenderingFunction(),
+                    $callable,
                     $this->getDrawingHashTable()->getByIndex($i)->getImageResource()
                 );
                 $imageContents = ob_get_contents();

--- a/tests/PhpSpreadsheetTests/Calculation/Engine/RangeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Engine/RangeTest.php
@@ -9,6 +9,9 @@ use PHPUnit\Framework\TestCase;
 
 class RangeTest extends TestCase
 {
+    /** @var string */
+    private $incompleteMessage = 'Must be revisited';
+
     /**
      * @var Spreadsheet
      */
@@ -140,7 +143,9 @@ class RangeTest extends TestCase
      */
     public function testCompositeNamedRangeEvaluation(string $composite, int $expectedSum, int $expectedCount): void
     {
-        self::markTestSkipped('must be revisited.');
+        if ($this->incompleteMessage !== '') {
+            self::markTestIncomplete($this->incompleteMessage);
+        }
 
         $workSheet = $this->spreadSheet->getActiveSheet();
         $this->spreadSheet->addNamedRange(new NamedRange('COMPOSITE', $workSheet, $composite));

--- a/tests/PhpSpreadsheetTests/Collection/CellsTest.php
+++ b/tests/PhpSpreadsheetTests/Collection/CellsTest.php
@@ -20,7 +20,8 @@ class CellsTest extends TestCase
         // Assert empty state
         self::assertEquals([], $collection->getCoordinates(), 'cell list should be empty');
         self::assertEquals([], $collection->getSortedCoordinates(), 'sorted cell list should be empty');
-        self::assertNull($collection->get('B2'), 'getting non-existing cell must return null');
+        $getB2 = $collection->get('B2');
+        self::assertNull($getB2, 'getting non-existing cell must return null');
         self::assertFalse($collection->has('B2'), 'non-existing cell should be non-existent');
 
         // Add one cell
@@ -44,6 +45,7 @@ class CellsTest extends TestCase
         $collection2 = $collection->cloneCellCollection($sheet2);
         self::assertTrue($collection2->has('A1'));
         $copiedCell2 = $collection2->get('A1');
+        self::assertNotNull($copiedCell2);
         self::assertNotSame($cell2, $copiedCell2, 'copied cell should not be the same object any more');
         self::assertSame($collection2, $copiedCell2->getParent(), 'copied cell should be owned by the copied collection');
         self::assertSame('A1', $copiedCell2->getCoordinate(), 'copied cell should keep attributes');

--- a/tests/PhpSpreadsheetTests/Functional/ColumnWidthTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/ColumnWidthTest.php
@@ -17,7 +17,7 @@ class ColumnWidthTest extends AbstractFunctional
     /**
      * @dataProvider providerFormats
      */
-    public function testReadColumnWidth($format): void
+    public function testReadColumnWidth(string $format): void
     {
         // create new sheet with column width
         $spreadsheet = new Spreadsheet();

--- a/tests/PhpSpreadsheetTests/Functional/CommentsTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/CommentsTest.php
@@ -22,7 +22,7 @@ class CommentsTest extends AbstractFunctional
      *
      * @dataProvider providerFormats
      */
-    public function testComments($format): void
+    public function testComments(string $format): void
     {
         $spreadsheet = new Spreadsheet();
 

--- a/tests/PhpSpreadsheetTests/Functional/PrintAreaTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/PrintAreaTest.php
@@ -44,15 +44,23 @@ class PrintAreaTest extends AbstractFunctional
             $reader->setLoadSheetsOnly(['Sheet 1', 'Sheet 3', 'Sheet 4', 'Sheet 5', 'Sheet 6']);
         });
 
-        $actual1 = $reloadedSpreadsheet->getSheetByName('Sheet 1')->getPageSetup()->getPrintArea();
-        $actual3 = $reloadedSpreadsheet->getSheetByName('Sheet 3')->getPageSetup()->getPrintArea();
-        $actual4 = $reloadedSpreadsheet->getSheetByName('Sheet 4')->getPageSetup()->getPrintArea();
-        $actual5 = $reloadedSpreadsheet->getSheetByName('Sheet 5')->getPageSetup()->getPrintArea();
-        $actual6 = $reloadedSpreadsheet->getSheetByName('Sheet 6')->getPageSetup()->getPrintArea();
+        $actual1 = self::getPrintArea($reloadedSpreadsheet, 'Sheet 1');
+        $actual3 = self::getPrintArea($reloadedSpreadsheet, 'Sheet 3');
+        $actual4 = self::getPrintArea($reloadedSpreadsheet, 'Sheet 4');
+        $actual5 = self::getPrintArea($reloadedSpreadsheet, 'Sheet 5');
+        $actual6 = self::getPrintArea($reloadedSpreadsheet, 'Sheet 6');
         self::assertSame('A1:B1', $actual1, 'should be able to write and read normal page setup');
         self::assertSame('A3:B3', $actual3, 'should be able to write and read page setup even when skipping sheets');
         self::assertSame('A4:B4,D1:E4', $actual4, 'should be able to write and read page setup with multiple print areas');
         self::assertSame('A1:J10', $actual5, 'add by column and row');
         self::assertSame('A1:J10,L1:L10', $actual6, 'multiple add by column and row');
+    }
+
+    private static function getPrintArea(Spreadsheet $spreadsheet, string $name): string
+    {
+        $sheet = $spreadsheet->getSheetByName($name);
+        self::assertNotNull($sheet, "Unable to get sheet $name");
+
+        return $sheet->getPageSetup()->getPrintArea();
     }
 }

--- a/tests/PhpSpreadsheetTests/IOFactoryTest.php
+++ b/tests/PhpSpreadsheetTests/IOFactoryTest.php
@@ -21,7 +21,7 @@ class IOFactoryTest extends TestCase
     {
         $spreadsheet = new Spreadsheet();
         $actual = IOFactory::createWriter($spreadsheet, $name);
-        self::assertInstanceOf($expected, $actual);
+        self::assertSame($expected, get_class($actual));
     }
 
     public function providerCreateWriter(): array
@@ -55,7 +55,7 @@ class IOFactoryTest extends TestCase
     public function testCreateReader($name, $expected): void
     {
         $actual = IOFactory::createReader($name);
-        self::assertInstanceOf($expected, $actual);
+        self::assertSame($expected, get_class($actual));
     }
 
     public function providerCreateReader(): array
@@ -102,7 +102,7 @@ class IOFactoryTest extends TestCase
     public function testCreateReaderForFile($file, $expectedName, $expectedClass): void
     {
         $actual = IOFactory::createReaderForFile($file);
-        self::assertInstanceOf($expectedClass, $actual);
+        self::assertSame($expectedClass, get_class($actual));
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/NamedFormulaTest.php
+++ b/tests/PhpSpreadsheetTests/NamedFormulaTest.php
@@ -48,9 +48,11 @@ class NamedFormulaTest extends TestCase
         );
 
         self::assertCount(1, $this->spreadsheet->getNamedFormulae());
+        $formula = $this->spreadsheet->getNamedFormula('foo', $this->spreadsheet->getActiveSheet());
+        self::assertNotNull($formula);
         self::assertSame(
             '=16%',
-            $this->spreadsheet->getNamedFormula('foo', $this->spreadsheet->getActiveSheet())->getValue()
+            $formula->getValue()
         );
     }
 
@@ -64,13 +66,17 @@ class NamedFormulaTest extends TestCase
         );
 
         self::assertCount(2, $this->spreadsheet->getNamedFormulae());
+        $formula = $this->spreadsheet->getNamedFormula('foo', $this->spreadsheet->getActiveSheet());
+        self::assertNotNull($formula);
         self::assertSame(
             '=19%',
-            $this->spreadsheet->getNamedFormula('foo', $this->spreadsheet->getActiveSheet())->getValue()
+            $formula->getValue()
         );
+        $formula = $this->spreadsheet->getNamedFormula('foo', $this->spreadsheet->getSheetByName('Sheet #2'));
+        self::assertNotNull($formula);
         self::assertSame(
             '=16%',
-            $this->spreadsheet->getNamedFormula('foo', $this->spreadsheet->getSheetByName('Sheet #2'))->getValue()
+            $formula->getValue()
         );
     }
 
@@ -100,9 +106,11 @@ class NamedFormulaTest extends TestCase
         $this->spreadsheet->removeNamedFormula('Foo', $this->spreadsheet->getActiveSheet());
 
         self::assertCount(1, $this->spreadsheet->getNamedFormulae());
+        $formula = $this->spreadsheet->getNamedFormula('foo', $this->spreadsheet->getSheetByName('Sheet #2'));
+        self::assertNotNull($formula);
         self::assertSame(
             '=16%',
-            $this->spreadsheet->getNamedFormula('foo', $this->spreadsheet->getSheetByName('Sheet #2'))->getValue()
+            $formula->getValue()
         );
     }
 
@@ -118,9 +126,11 @@ class NamedFormulaTest extends TestCase
         $this->spreadsheet->removeNamedFormula('Foo', $this->spreadsheet->getSheetByName('Sheet #2'));
 
         self::assertCount(1, $this->spreadsheet->getNamedFormulae());
+        $formula = $this->spreadsheet->getNamedFormula('foo');
+        self::assertNotNull($formula);
         self::assertSame(
             '=19%',
-            $this->spreadsheet->getNamedFormula('foo')->getValue()
+            $formula->getValue()
         );
     }
 }

--- a/tests/PhpSpreadsheetTests/NamedRangeTest.php
+++ b/tests/PhpSpreadsheetTests/NamedRangeTest.php
@@ -48,9 +48,11 @@ class NamedRangeTest extends TestCase
         );
 
         self::assertCount(1, $this->spreadsheet->getNamedRanges());
+        $range = $this->spreadsheet->getNamedRange('foo', $this->spreadsheet->getActiveSheet());
+        self::assertNotNull($range);
         self::assertSame(
             '=B1',
-            $this->spreadsheet->getNamedRange('foo', $this->spreadsheet->getActiveSheet())->getValue()
+            $range->getValue()
         );
     }
 
@@ -64,13 +66,17 @@ class NamedRangeTest extends TestCase
         );
 
         self::assertCount(2, $this->spreadsheet->getNamedRanges());
+        $range = $this->spreadsheet->getNamedRange('foo', $this->spreadsheet->getActiveSheet());
+        self::assertNotNull($range);
         self::assertSame(
             '=A1',
-            $this->spreadsheet->getNamedRange('foo', $this->spreadsheet->getActiveSheet())->getValue()
+            $range->getValue()
         );
+        $range = $this->spreadsheet->getNamedRange('foo', $this->spreadsheet->getSheetByName('Sheet #2'));
+        self::assertNotNull($range);
         self::assertSame(
             '=B1',
-            $this->spreadsheet->getNamedRange('foo', $this->spreadsheet->getSheetByName('Sheet #2'))->getValue()
+            $range->getValue()
         );
     }
 
@@ -100,9 +106,11 @@ class NamedRangeTest extends TestCase
         $this->spreadsheet->removeNamedRange('Foo', $this->spreadsheet->getActiveSheet());
 
         self::assertCount(1, $this->spreadsheet->getNamedRanges());
+        $sheet = $this->spreadsheet->getNamedRange('foo', $this->spreadsheet->getSheetByName('Sheet #2'));
+        self::assertNotNull($sheet);
         self::assertSame(
             '=B1',
-            $this->spreadsheet->getNamedRange('foo', $this->spreadsheet->getSheetByName('Sheet #2'))->getValue()
+            $sheet->getValue()
         );
     }
 
@@ -118,9 +126,11 @@ class NamedRangeTest extends TestCase
         $this->spreadsheet->removeNamedRange('Foo', $this->spreadsheet->getSheetByName('Sheet #2'));
 
         self::assertCount(1, $this->spreadsheet->getNamedRanges());
+        $range = $this->spreadsheet->getNamedRange('foo');
+        self::AssertNotNull($range);
         self::assertSame(
             '=A1',
-            $this->spreadsheet->getNamedRange('foo')->getValue()
+            $range->getValue()
         );
     }
 }

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvNumberFormatLocaleTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvNumberFormatLocaleTest.php
@@ -96,6 +96,8 @@ class CsvNumberFormatLocaleTest extends TestCase
      * @dataProvider providerNumberValueConversionTest
      *
      * @param mixed $expectedValue
+     *
+     * @runInSeparateProcess
      */
     public function testNumberValueConversion($expectedValue, string $cellAddress): void
     {

--- a/tests/PhpSpreadsheetTests/Reader/Ods/OdsTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Ods/OdsTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
  */
 class OdsTest extends TestCase
 {
+    /** @var string */
+    private $incompleteMessage = 'Features not implemented yet';
+
     /**
      * @var string
      */
@@ -32,12 +35,12 @@ class OdsTest extends TestCase
     }
 
     /**
-     * @var Spreadsheet
+     * @var ?Spreadsheet
      */
     private $spreadsheetOdsTest;
 
     /**
-     * @var Spreadsheet
+     * @var ?Spreadsheet
      */
     private $spreadsheetData;
 
@@ -46,13 +49,13 @@ class OdsTest extends TestCase
      */
     private function loadOdsTestFile()
     {
-        if (!isset($this->spreadsheetOdsTest)) {
-            $filename = 'samples/templates/OOCalcTest.ods';
-
-            // Load into this instance
-            $reader = new Ods();
-            $this->spreadsheetOdsTest = $reader->loadIntoExisting($filename, new Spreadsheet());
+        if (isset($this->spreadsheetOdsTest)) {
+            return $this->spreadsheetOdsTest;
         }
+        $filename = 'samples/templates/OOCalcTest.ods';
+        // Load into this instance
+        $reader = new Ods();
+        $this->spreadsheetOdsTest = $reader->loadIntoExisting($filename, new Spreadsheet());
 
         return $this->spreadsheetOdsTest;
     }
@@ -62,13 +65,13 @@ class OdsTest extends TestCase
      */
     protected function loadDataFile()
     {
-        if (!isset($this->spreadsheetData)) {
-            $filename = 'tests/data/Reader/Ods/data.ods';
-
-            // Load into this instance
-            $reader = new Ods();
-            $this->spreadsheetData = $reader->load($filename);
+        if (isset($this->spreadsheetData)) {
+            return $this->spreadsheetData;
         }
+        $filename = 'tests/data/Reader/Ods/data.ods';
+        // Load into this instance
+        $reader = new Ods();
+        $this->spreadsheetData = $reader->load($filename);
 
         return $this->spreadsheetData;
     }
@@ -271,8 +274,9 @@ class OdsTest extends TestCase
 
     public function testReadBoldItalicUnderline(): void
     {
-        self::markTestIncomplete('Features not implemented yet');
-
+        if ($this->incompleteMessage !== '') {
+            self::markTestIncomplete($this->incompleteMessage);
+        }
         $spreadsheet = $this->loadOdsTestFile();
         $firstSheet = $spreadsheet->getSheet(0);
 

--- a/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
@@ -24,7 +24,7 @@ class XmlScannerTest extends TestCase
      * @param mixed $filename
      * @param mixed $expectedResult
      */
-    public function testValidXML($filename, $expectedResult, $libxmlDisableEntityLoader): void
+    public function testValidXML($filename, $expectedResult, bool $libxmlDisableEntityLoader): void
     {
         // php 8.+ deprecated libxml_disable_entity_loader() - It's on by default
         if (\PHP_VERSION_ID < 80000) {
@@ -44,7 +44,9 @@ class XmlScannerTest extends TestCase
     public function providerValidXML(): array
     {
         $tests = [];
-        foreach (glob('tests/data/Reader/Xml/XEETestValid*.xml') as $file) {
+        $glob = glob('tests/data/Reader/Xml/XEETestValid*.xml');
+        self::assertNotFalse($glob);
+        foreach ($glob as $file) {
             $filename = realpath($file);
             $expectedResult = file_get_contents($file);
             $tests[basename($file) . '_libxml_entity_loader_disabled'] = [$filename, $expectedResult, true];
@@ -59,7 +61,7 @@ class XmlScannerTest extends TestCase
      *
      * @param mixed $filename
      */
-    public function testInvalidXML($filename, $libxmlDisableEntityLoader): void
+    public function testInvalidXML($filename, bool $libxmlDisableEntityLoader): void
     {
         $this->expectException(\PhpOffice\PhpSpreadsheet\Reader\Exception::class);
 
@@ -81,7 +83,9 @@ class XmlScannerTest extends TestCase
     public function providerInvalidXML(): array
     {
         $tests = [];
-        foreach (glob('tests/data/Reader/Xml/XEETestInvalidUTF*.xml') as $file) {
+        $glob = glob('tests/data/Reader/Xml/XEETestInvalidUTF*.xml');
+        self::assertNotFalse($glob);
+        foreach ($glob as $file) {
             $filename = realpath($file);
             $tests[basename($file) . '_libxml_entity_loader_disabled'] = [$filename, true];
             $tests[basename($file) . '_libxml_entity_loader_enabled'] = [$filename, false];
@@ -128,7 +132,9 @@ class XmlScannerTest extends TestCase
     public function providerValidXMLForCallback(): array
     {
         $tests = [];
-        foreach (glob('tests/data/Reader/Xml/SecurityScannerWithCallback*.xml') as $file) {
+        $glob = glob('tests/data/Reader/Xml/SecurityScannerWithCallback*.xml');
+        self::assertNotFalse($glob);
+        foreach ($glob as $file) {
             $tests[basename($file)] = [realpath($file), file_get_contents($file)];
         }
 

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/AutoFilterTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/AutoFilterTest.php
@@ -10,14 +10,7 @@ use SimpleXMLElement;
 
 class AutoFilterTest extends TestCase
 {
-    private function getWorksheetInstance()
-    {
-        return $this->getMockBuilder(Worksheet::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
-
-    private function getXMLInstance($ref)
+    private function getXMLInstance(string $ref): SimpleXMLElement
     {
         return new SimpleXMLElement(
             '<?xml version="1.0" encoding="UTF-8"?>' .
@@ -25,15 +18,6 @@ class AutoFilterTest extends TestCase
                 '<autoFilter ref="' . $ref . '"></autoFilter>' .
             '</root>'
         );
-    }
-
-    private function getAutoFilterInstance()
-    {
-        $instance = $this->getMockBuilder(WorksheetAutoFilter::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        return $instance;
     }
 
     public function loadDataProvider(): array
@@ -53,12 +37,16 @@ class AutoFilterTest extends TestCase
      */
     public function testLoad($ref, $expectedReadAutoFilterCalled, $expectedRef): void
     {
-        $worksheetAutoFilter = $this->getAutoFilterInstance();
+        $worksheetAutoFilter = $this->getMockBuilder(WorksheetAutoFilter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $worksheetAutoFilter->expects(self::exactly($expectedReadAutoFilterCalled ? 1 : 0))
             ->method('setRange')
             ->with($expectedRef);
 
-        $worksheet = $this->getWorksheetInstance();
+        $worksheet = $this->getMockBuilder(Worksheet::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $worksheet->expects(self::exactly($expectedReadAutoFilterCalled ? 1 : 0))
             ->method('getAutoFilter')
             ->willReturn($worksheetAutoFilter);

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/ChartsTitleTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/ChartsTitleTest.php
@@ -26,6 +26,7 @@ class ChartsTitleTest extends TestCase
 
         // No title or axis labels
         $chart1 = $charts[0];
+        self::assertNotNull($chart1);
         $title = self::getTitleText($chart1->getTitle());
         self::assertEmpty($title);
         self::assertEmpty(self::getTitleText($chart1->getXAxisLabel()));
@@ -33,6 +34,7 @@ class ChartsTitleTest extends TestCase
 
         // Title, no axis labels
         $chart2 = $charts[1];
+        self::assertNotNull($chart2);
 
         self::assertEquals('Chart with Title and no Axis Labels', self::getTitleText($chart2->getTitle()));
         self::assertEmpty(self::getTitleText($chart2->getXAxisLabel()));
@@ -40,18 +42,21 @@ class ChartsTitleTest extends TestCase
 
         // No title, only horizontal axis label
         $chart3 = $charts[2];
+        self::assertNotNull($chart3);
         self::assertEmpty(self::getTitleText($chart3->getTitle()));
         self::assertEquals('Horizontal Axis Title Only', self::getTitleText($chart3->getXAxisLabel()));
         self::assertEmpty(self::getTitleText($chart3->getYAxisLabel()));
 
         // No title, only vertical axis label
         $chart4 = $charts[3];
+        self::assertNotNull($chart4);
         self::assertEmpty(self::getTitleText($chart4->getTitle()));
         self::assertEquals('Vertical Axis Title Only', self::getTitleText($chart4->getYAxisLabel()));
         self::assertEmpty(self::getTitleText($chart4->getXAxisLabel()));
 
         // Title and both axis labels
         $chart5 = $charts[4];
+        self::assertNotNull($chart5);
         self::assertEquals('Complete Annotations', self::getTitleText($chart5->getTitle()));
         self::assertEquals('Horizontal Axis Title', self::getTitleText($chart5->getXAxisLabel()));
         self::assertEquals('Vertical Axis Title', self::getTitleText($chart5->getYAxisLabel()));

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalFormattingDataBarXlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalFormattingDataBarXlsxTest.php
@@ -60,7 +60,9 @@ class ConditionalFormattingDataBarXlsxTest extends TestCase
         $cond1 = new Conditional();
         $cond1->setConditionType(Conditional::CONDITION_DATABAR);
         $cond1->setDataBar(new ConditionalDataBar());
-        $cond1->getDataBar()
+        $dataBar = $cond1->getDataBar();
+        self::assertNotNull($dataBar);
+        $dataBar
             ->setMinimumConditionalFormatValueObject(new ConditionalFormatValueObject('min'))
             ->setMaximumConditionalFormatValueObject(new ConditionalFormatValueObject('max'))
             ->setColor(Color::COLOR_GREEN);
@@ -83,6 +85,7 @@ class ConditionalFormattingDataBarXlsxTest extends TestCase
         self::assertNotEmpty($conditionalRule->getDataBar());
 
         $dataBar = $conditionalRule->getDataBar();
+        self::assertNotNull($dataBar);
         self::assertNotEmpty($dataBar->getMinimumConditionalFormatValueObject());
         self::assertNotEmpty($dataBar->getMaximumConditionalFormatValueObject());
         self::assertEquals('min', $dataBar->getMinimumConditionalFormatValueObject()->getType());
@@ -105,6 +108,7 @@ class ConditionalFormattingDataBarXlsxTest extends TestCase
 
         self::assertNotEmpty($dataBar);
         self::assertEquals(Conditional::CONDITION_DATABAR, $conditionalRule->getConditionType());
+        self::assertNotNull($dataBar);
         self::assertNotEmpty($dataBar->getMinimumConditionalFormatValueObject());
         self::assertNotEmpty($dataBar->getMaximumConditionalFormatValueObject());
         self::assertEquals('min', $dataBar->getMinimumConditionalFormatValueObject()->getType());
@@ -160,6 +164,7 @@ class ConditionalFormattingDataBarXlsxTest extends TestCase
 
         self::assertNotEmpty($dataBar);
         self::assertEquals(Conditional::CONDITION_DATABAR, $conditionalRule->getConditionType());
+        self::assertNotNull($dataBar);
         self::assertNotEmpty($dataBar->getMinimumConditionalFormatValueObject());
         self::assertNotEmpty($dataBar->getMaximumConditionalFormatValueObject());
         self::assertEquals('num', $dataBar->getMinimumConditionalFormatValueObject()->getType());
@@ -218,6 +223,7 @@ class ConditionalFormattingDataBarXlsxTest extends TestCase
 
         self::assertNotEmpty($dataBar);
         self::assertEquals(Conditional::CONDITION_DATABAR, $conditionalRule->getConditionType());
+        self::assertNotNull($dataBar);
         self::assertNotEmpty($dataBar->getMinimumConditionalFormatValueObject());
         self::assertNotEmpty($dataBar->getMaximumConditionalFormatValueObject());
         self::assertEquals('min', $dataBar->getMinimumConditionalFormatValueObject()->getType());
@@ -278,6 +284,7 @@ class ConditionalFormattingDataBarXlsxTest extends TestCase
         self::assertNotEmpty($dataBar);
         self::assertEquals(Conditional::CONDITION_DATABAR, $conditionalRule->getConditionType());
 
+        self::assertNotNull($dataBar);
         self::assertTrue($dataBar->getShowValue());
         self::assertNotEmpty($dataBar->getMinimumConditionalFormatValueObject());
         self::assertNotEmpty($dataBar->getMaximumConditionalFormatValueObject());

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/SheetsXlsxChartTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/SheetsXlsxChartTest.php
@@ -21,6 +21,7 @@ class SheetsXlsxChartTest extends TestCase
         self::assertCount(2, $charts);
 
         $chart1 = $charts[0];
+        self::assertNotNull($chart1);
         $pa1 = $chart1->getPlotArea();
         self::assertEquals(2, $pa1->getPlotSeriesCount());
 
@@ -32,6 +33,7 @@ class SheetsXlsxChartTest extends TestCase
         self::assertCount(2, $pg1->getPlotCategories());
 
         $chart2 = $charts[1];
+        self::assertNotNull($chart2);
         $pa1 = $chart2->getPlotArea();
         self::assertEquals(2, $pa1->getPlotSeriesCount());
 

--- a/tests/PhpSpreadsheetTests/Reader/Xml/XmlTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/XmlTest.php
@@ -11,7 +11,7 @@ class XmlTest extends TestCase
     /**
      * @dataProvider providerInvalidSimpleXML
      */
-    public function testInvalidSimpleXML($filename): void
+    public function testInvalidSimpleXML(string $filename): void
     {
         $this->expectException(\PhpOffice\PhpSpreadsheet\Reader\Exception::class);
 
@@ -22,7 +22,9 @@ class XmlTest extends TestCase
     public function providerInvalidSimpleXML(): array
     {
         $tests = [];
-        foreach (glob('tests/data/Reader/Xml/XEETestInvalidSimpleXML*.xml') as $file) {
+        $glob = glob('tests/data/Reader/Xml/XEETestInvalidSimpleXML*.xml');
+        self::assertNotFalse($glob);
+        foreach ($glob as $file) {
             $tests[basename($file)] = [realpath($file)];
         }
 

--- a/tests/PhpSpreadsheetTests/Shared/StringHelperTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/StringHelperTest.php
@@ -28,9 +28,6 @@ class StringHelperTest extends TestCase
         $this->currencyCode = StringHelper::getCurrencyCode();
         $this->decimalSeparator = StringHelper::getDecimalSeparator();
         $this->thousandsSeparator = StringHelper::getThousandsSeparator();
-
-        // Reset Currency Code
-        StringHelper::setCurrencyCode(null);
     }
 
     protected function tearDown(): void

--- a/tests/PhpSpreadsheetTests/SpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/SpreadsheetTest.php
@@ -43,7 +43,7 @@ class SpreadsheetTest extends TestCase
     /**
      * @dataProvider dataProviderForSheetNames
      */
-    public function testGetSheetByName($index, $sheetName): void
+    public function testGetSheetByName(int $index, string $sheetName): void
     {
         self::assertSame($this->object->getSheet($index), $this->object->getSheetByName($sheetName));
     }

--- a/tests/PhpSpreadsheetTests/Worksheet/RowCellIterator2Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/RowCellIterator2Test.php
@@ -55,7 +55,7 @@ class RowCellIterator2Test extends TestCase
         $sheet->getCell('B2')->setValue('cellb2');
         $sheet->getCell('F2')->setValue('cellf2');
 
-        $iterator = new RowCellIterator($sheet, '3');
+        $iterator = new RowCellIterator($sheet, 3);
         if (isset($existing)) {
             $iterator->setIterateOnlyExistingCells($existing);
         }

--- a/tests/PhpSpreadsheetTests/Writer/Html/CallbackTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/CallbackTest.php
@@ -20,7 +20,7 @@ body {
 
 EOF;
 
-        return preg_replace('~</head>~', "$newstyle</head>", $html);
+        return preg_replace('~</head>~', "$newstyle</head>", $html) ?? '';
     }
 
     public function testSetAndReset(): void
@@ -46,6 +46,7 @@ EOF;
         $writer->save($oufil);
         $html4 = file_get_contents($oufil);
         unlink($oufil);
+        self::assertNotFalse($html4);
         self::assertNotFalse(strpos($html4, 'background-color: yellow'));
 
         $this->writeAndReload($spreadsheet, 'Html');

--- a/tests/PhpSpreadsheetTests/Writer/Html/GridlinesTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/GridlinesTest.php
@@ -101,9 +101,12 @@ class GridlinesTest extends Functional\AbstractFunctional
         $sheet = $spreadsheet->getActiveSheet();
         $emc2 = new \PhpOffice\PhpSpreadsheet\RichText\RichText();
         $part1 = $emc2->createTextRun('e=mc');
-        $part1->getFont()->getColor()->setARGB(Color::COLOR_BLUE);
+        $font = $part1->getFont();
+        self::assertNotNull($font);
+        $font->getColor()->setARGB(Color::COLOR_BLUE);
         $part2 = $emc2->createTextRun('2');
         $font = $part2->getFont();
+        self::assertNotNull($font);
         $font->getColor()->setARGB(Color::COLOR_DARKGREEN);
         $font->setSuperScript(true);
         $sheet->setCellValue('A1', $emc2);
@@ -111,6 +114,7 @@ class GridlinesTest extends Functional\AbstractFunctional
         $h2o->createTextRun('H');
         $part2 = $h2o->createTextRun('2');
         $font = $part2->getFont();
+        self::assertNotNull($font);
         $font->setSubScript(true);
         $font->getColor()->setARGB(Color::COLOR_RED);
         $h2o->createTextRun('O');
@@ -119,10 +123,13 @@ class GridlinesTest extends Functional\AbstractFunctional
         $h2so4->createTextRun('H');
         $part2 = $h2so4->createTextRun('2');
         $font = $part2->getFont();
+        self::assertNotNull($font);
         $font->setSubScript(true);
         $h2so4->createTextRun('SO');
         $part4 = $h2so4->createTextRun('4');
-        $part4->getFont()->setSubScript(true);
+        $font = $part4->getFont();
+        self::assertNotNull($font);
+        $font->setSubScript(true);
         $sheet->setCellValue('A3', $h2so4);
         $sheet->setCellValue('A4', '5');
         $sheet->getCell('A4')->getStyle()->getFont()->setSuperScript(true);

--- a/tests/PhpSpreadsheetTests/Writer/Html/HtmlCommentsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/HtmlCommentsTest.php
@@ -25,14 +25,20 @@ class HtmlCommentsTest extends Functional\AbstractFunctional
         $plainMulti->createText($valueMulti);
 
         $richSingle = new RichText();
-        $richSingle->createTextRun($valueSingle)->getFont()->setBold(true);
+        $font = $richSingle->createTextRun($valueSingle)->getFont();
+        self::assertNotNull($font);
+        $font->setBold(true);
 
         $richMultiSimple = new RichText();
-        $richMultiSimple->createTextRun($valueMulti)->getFont()->setBold(true);
+        $font = $richMultiSimple->createTextRun($valueMulti)->getFont();
+        self::assertNotNull($font);
+        $font->setBold(true);
 
         $richMultiMixed = new RichText();
         $richMultiMixed->createText('I am' . PHP_EOL);
-        $richMultiMixed->createTextRun('multi-line')->getFont()->setBold(true);
+        $font = $richMultiMixed->createTextRun('multi-line')->getFont();
+        self::assertNotNull($font);
+        $font->setBold(true);
         $richMultiMixed->createText(PHP_EOL . 'comment!');
 
         return [

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/UnparsedDataCloneTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/UnparsedDataCloneTest.php
@@ -78,14 +78,18 @@ class UnparsedDataCloneTest extends TestCase
         $spreadsheet1 = $reader1->load($resultFilename1);
         unlink($resultFilename1);
         $sheet1c = $spreadsheet1->getSheetByName('Clone');
+        self::assertNotNull($sheet1c);
         $sheet1o = $spreadsheet1->getSheetByName('Original');
+        self::assertNotNull($sheet1o);
 
         $writer->save($resultFilename2);
         $reader2 = new \PhpOffice\PhpSpreadsheet\Reader\Xlsx();
         $spreadsheet2 = $reader2->load($resultFilename2);
         unlink($resultFilename2);
         $sheet2c = $spreadsheet2->getSheetByName('Clone');
+        self::assertNotNull($sheet2c);
         $sheet2o = $spreadsheet2->getSheetByName('Original');
+        self::assertNotNull($sheet2o);
 
         self::assertEquals($spreadsheet1->getSheetCount(), $spreadsheet2->getSheetCount());
         self::assertCount(1, $sheet1c->getDrawingCollection());

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/UnparsedDataTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/UnparsedDataTest.php
@@ -64,7 +64,7 @@ class UnparsedDataTest extends TestCase
         self::assertNotEmpty($resultVbaProjectRaw, 'vbaProject.bin not found!');
 
         // xl/workbook.xml
-        $xmlWorkbook = simplexml_load_string($resultWorkbookRaw, 'SimpleXMLElement', Settings::getLibXmlLoaderOptions());
+        $xmlWorkbook = simplexml_load_string($resultWorkbookRaw ?: '', 'SimpleXMLElement', Settings::getLibXmlLoaderOptions());
         self::assertNotFalse($xmlWorkbook);
         if (!$xmlWorkbook->workbookProtection) {
             self::fail('workbook.xml/workbookProtection not found!');
@@ -86,7 +86,8 @@ class UnparsedDataTest extends TestCase
 
         // xl/worksheets/sheet1.xml
         self::assertStringContainsString('<mc:AlternateContent', $resultSheet1Raw, 'AlternateContent at sheet1.xml not found!');
-        $xmlWorksheet = simplexml_load_string($resultSheet1Raw, 'SimpleXMLElement', Settings::getLibXmlLoaderOptions());
+        $xmlWorksheet = simplexml_load_string($resultSheet1Raw ?: '', 'SimpleXMLElement', Settings::getLibXmlLoaderOptions());
+        self::assertNotFalse($xmlWorksheet);
         $pageSetupAttributes = $xmlWorksheet->pageSetup->attributes('http://schemas.openxmlformats.org/officeDocument/2006/relationships');
         self::assertTrue(isset($pageSetupAttributes->id), 'sheet1.xml/pageSetup[r:id] not found!');
         if (!$xmlWorksheet->sheetProtection) {

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/WmfTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/WmfTest.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
+use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
 use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
 class WmfTest extends AbstractFunctional
@@ -19,6 +20,7 @@ class WmfTest extends AbstractFunctional
         $drawings = $spreadsheet->getActiveSheet()->getDrawingCollection();
         self::assertCount(1, $drawings);
         $drawing = $drawings[0];
+        self::assertInstanceOf(Drawing::class, $drawing);
         self::assertSame('wmf', $drawing->getExtension());
 
         // Save spreadsheet to file and read it back
@@ -26,6 +28,7 @@ class WmfTest extends AbstractFunctional
         $drawings = $reloadedSpreadsheet->getActiveSheet()->getDrawingCollection();
         self::assertCount(1, $drawings);
         $drawing = $drawings[0];
+        self::assertInstanceOf(Drawing::class, $drawing);
         self::assertSame('wmf', $drawing->getExtension());
 
         $spreadsheet->disconnectWorksheets();

--- a/tests/data/Calculation/MathTrig/SUMIF.php
+++ b/tests/data/Calculation/MathTrig/SUMIF.php
@@ -23,7 +23,7 @@ return [
         ],
     ],
     [
-        'incomplete', // 10,
+        10, // fixed by PR #2561
         [
             ['"text with quotes"'],
             [2],


### PR DESCRIPTION
These changes have already been implemented twice, and been regressed twice. I'll try once more (with a different approach), then give up ...

As configured, Phpstan running under Php7 reports no errors. However, running under Php8, it reports 100 (!) errors. The vast majority of these are due to two reasons:
- renaming parameters in Php builtin functions in preparation for named parameters.
- using the new class GdImage rather than type resource as the argument type for many image-based functions.

Regardless of the cause, this will be a problem sooner or later. This PR is an attempt to get ahead of that problem. For source members, it mostly adds annotations or updates doc-blocks. Only 2 members have changes to executable code, and these are very minor - BitWise and Writer/Xlsx. For test members, all baseline errors are deleted and the code is fixed. Php7 and Php8 both report no errors with this configuration.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
