### PR TITLE
Fix for setting Active Sheet to the first loaded worksheet when `bookViews` element isn't defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Fix for setting Active Sheet to the first loaded worksheet when bookViews element isn't defined [Issue #2666](https://github.com/PHPOffice/PhpSpreadsheet/issues/2666) [PR #2669](https://github.com/PHPOffice/PhpSpreadsheet/pull/2669)
 - Fixed behaviour of XLSX font style vertical align settings.
 - Resolved formula translations to handle separators (row and column) for array functions as well as for function argument separators; and cleanly handle nesting levels.
 

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -20,6 +20,7 @@ use PhpOffice\PhpSpreadsheet\Reader\Xlsx\SheetViewOptions;
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx\SheetViews;
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx\Styles;
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx\Theme;
+use PhpOffice\PhpSpreadsheet\Reader\Xlsx\WorkbookView;
 use PhpOffice\PhpSpreadsheet\ReferenceHelper;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Settings;
@@ -1564,62 +1565,7 @@ class Xlsx extends BaseReader
                         }
                     }
 
-                    $workbookView = $xmlWorkbook->children($mainNS)->bookViews->workbookView;
-                    if ((!$this->readDataOnly || !empty($this->loadSheetsOnly)) && !empty($workbookView)) {
-                        $workbookViewAttributes = self::testSimpleXml(self::getAttributes($workbookView));
-                        // active sheet index
-                        $activeTab = (int) $workbookViewAttributes->activeTab; // refers to old sheet index
-
-                        // keep active sheet index if sheet is still loaded, else first sheet is set as the active
-                        if (isset($mapSheetId[$activeTab]) && $mapSheetId[$activeTab] !== null) {
-                            $excel->setActiveSheetIndex($mapSheetId[$activeTab]);
-                        } else {
-                            if ($excel->getSheetCount() == 0) {
-                                $excel->createSheet();
-                            }
-                            $excel->setActiveSheetIndex(0);
-                        }
-
-                        if (isset($workbookViewAttributes->showHorizontalScroll)) {
-                            $showHorizontalScroll = (string) $workbookViewAttributes->showHorizontalScroll;
-                            $excel->setShowHorizontalScroll($this->castXsdBooleanToBool($showHorizontalScroll));
-                        }
-
-                        if (isset($workbookViewAttributes->showVerticalScroll)) {
-                            $showVerticalScroll = (string) $workbookViewAttributes->showVerticalScroll;
-                            $excel->setShowVerticalScroll($this->castXsdBooleanToBool($showVerticalScroll));
-                        }
-
-                        if (isset($workbookViewAttributes->showSheetTabs)) {
-                            $showSheetTabs = (string) $workbookViewAttributes->showSheetTabs;
-                            $excel->setShowSheetTabs($this->castXsdBooleanToBool($showSheetTabs));
-                        }
-
-                        if (isset($workbookViewAttributes->minimized)) {
-                            $minimized = (string) $workbookViewAttributes->minimized;
-                            $excel->setMinimized($this->castXsdBooleanToBool($minimized));
-                        }
-
-                        if (isset($workbookViewAttributes->autoFilterDateGrouping)) {
-                            $autoFilterDateGrouping = (string) $workbookViewAttributes->autoFilterDateGrouping;
-                            $excel->setAutoFilterDateGrouping($this->castXsdBooleanToBool($autoFilterDateGrouping));
-                        }
-
-                        if (isset($workbookViewAttributes->firstSheet)) {
-                            $firstSheet = (string) $workbookViewAttributes->firstSheet;
-                            $excel->setFirstSheetIndex((int) $firstSheet);
-                        }
-
-                        if (isset($workbookViewAttributes->visibility)) {
-                            $visibility = (string) $workbookViewAttributes->visibility;
-                            $excel->setVisibility($visibility);
-                        }
-
-                        if (isset($workbookViewAttributes->tabRatio)) {
-                            $tabRatio = (string) $workbookViewAttributes->tabRatio;
-                            $excel->setTabRatio((int) $tabRatio);
-                        }
-                    }
+                    (new WorkbookView($excel))->viewSettings($xmlWorkbook, $mainNS, $mapSheetId, $this->readDataOnly);
 
                     break;
             }
@@ -1976,29 +1922,6 @@ class Xlsx extends BaseReader
             $unparsedPrinterSettings[$rId]['content'] = $this->securityScanner->scan($this->getFromZipArchive($zip, $unparsedPrinterSettings[$rId]['filePath']));
         }
         unset($unparsedPrinterSettings);
-    }
-
-    /**
-     * Convert an 'xsd:boolean' XML value to a PHP boolean value.
-     * A valid 'xsd:boolean' XML value can be one of the following
-     * four values: 'true', 'false', '1', '0'.  It is case sensitive.
-     *
-     * Note that just doing '(bool) $xsdBoolean' is not safe,
-     * since '(bool) "false"' returns true.
-     *
-     * @see https://www.w3.org/TR/xmlschema11-2/#boolean
-     *
-     * @param string $xsdBoolean An XML string value of type 'xsd:boolean'
-     *
-     * @return bool  Boolean value
-     */
-    private function castXsdBooleanToBool($xsdBoolean)
-    {
-        if ($xsdBoolean === 'false') {
-            return false;
-        }
-
-        return (bool) $xsdBoolean;
     }
 
     private function getWorkbookBaseName(): array

--- a/src/PhpSpreadsheet/Reader/Xlsx/WorkbookView.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/WorkbookView.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Reader\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use SimpleXMLElement;
+
+class WorkbookView
+{
+    /**
+     * @var Spreadsheet
+     */
+    private $spreadsheet;
+
+    public function __construct(Spreadsheet $spreadsheet)
+    {
+        $this->spreadsheet = $spreadsheet;
+    }
+
+    /**
+     * @param mixed $mainNS
+     */
+    public function viewSettings(SimpleXMLElement $xmlWorkbook, $mainNS, array $mapSheetId, bool $readDataOnly): void
+    {
+        if ($this->spreadsheet->getSheetCount() == 0) {
+            $this->spreadsheet->createSheet();
+        }
+        // Default active sheet index to the first loaded worksheet from the file
+        $this->spreadsheet->setActiveSheetIndex(0);
+
+        $workbookView = $xmlWorkbook->children($mainNS)->bookViews->workbookView;
+        if (($readDataOnly !== true || !empty($this->loadSheetsOnly)) && !empty($workbookView)) {
+            $workbookViewAttributes = self::testSimpleXml(self::getAttributes($workbookView));
+            // active sheet index
+            $activeTab = (int) $workbookViewAttributes->activeTab; // refers to old sheet index
+            // keep active sheet index if sheet is still loaded, else first sheet is set as the active worksheet
+            if (isset($mapSheetId[$activeTab]) && $mapSheetId[$activeTab] !== null) {
+                $this->spreadsheet->setActiveSheetIndex($mapSheetId[$activeTab]);
+            }
+
+            $this->horizontalScroll($workbookViewAttributes);
+            $this->verticalScroll($workbookViewAttributes);
+            $this->sheetTabs($workbookViewAttributes);
+            $this->minimized($workbookViewAttributes);
+            $this->autoFilterDateGrouping($workbookViewAttributes);
+            $this->firstSheet($workbookViewAttributes);
+            $this->visibility($workbookViewAttributes);
+            $this->tabRatio($workbookViewAttributes);
+        }
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function testSimpleXml($value): SimpleXMLElement
+    {
+        return ($value instanceof SimpleXMLElement)
+            ? $value
+            : new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><root></root>');
+    }
+
+    public static function getAttributes(?SimpleXMLElement $value, string $ns = ''): SimpleXMLElement
+    {
+        return self::testSimpleXml($value === null ? $value : $value->attributes($ns));
+    }
+
+    /**
+     * Convert an 'xsd:boolean' XML value to a PHP boolean value.
+     * A valid 'xsd:boolean' XML value can be one of the following
+     * four values: 'true', 'false', '1', '0'.  It is case sensitive.
+     *
+     * Note that just doing '(bool) $xsdBoolean' is not safe,
+     * since '(bool) "false"' returns true.
+     *
+     * @see https://www.w3.org/TR/xmlschema11-2/#boolean
+     *
+     * @param string $xsdBoolean An XML string value of type 'xsd:boolean'
+     *
+     * @return bool  Boolean value
+     */
+    private function castXsdBooleanToBool(string $xsdBoolean): bool
+    {
+        if ($xsdBoolean === 'false') {
+            return false;
+        }
+
+        return (bool) $xsdBoolean;
+    }
+
+    private function horizontalScroll(SimpleXMLElement $workbookViewAttributes): void
+    {
+        if (isset($workbookViewAttributes->showHorizontalScroll)) {
+            $showHorizontalScroll = (string) $workbookViewAttributes->showHorizontalScroll;
+            $this->spreadsheet->setShowHorizontalScroll($this->castXsdBooleanToBool($showHorizontalScroll));
+        }
+    }
+
+    private function verticalScroll(SimpleXMLElement $workbookViewAttributes): void
+    {
+        if (isset($workbookViewAttributes->showVerticalScroll)) {
+            $showVerticalScroll = (string) $workbookViewAttributes->showVerticalScroll;
+            $this->spreadsheet->setShowVerticalScroll($this->castXsdBooleanToBool($showVerticalScroll));
+        }
+    }
+
+    private function sheetTabs(SimpleXMLElement $workbookViewAttributes): void
+    {
+        if (isset($workbookViewAttributes->showSheetTabs)) {
+            $showSheetTabs = (string) $workbookViewAttributes->showSheetTabs;
+            $this->spreadsheet->setShowSheetTabs($this->castXsdBooleanToBool($showSheetTabs));
+        }
+    }
+
+    private function minimized(SimpleXMLElement $workbookViewAttributes): void
+    {
+        if (isset($workbookViewAttributes->minimized)) {
+            $minimized = (string) $workbookViewAttributes->minimized;
+            $this->spreadsheet->setMinimized($this->castXsdBooleanToBool($minimized));
+        }
+    }
+
+    private function autoFilterDateGrouping(SimpleXMLElement $workbookViewAttributes): void
+    {
+        if (isset($workbookViewAttributes->autoFilterDateGrouping)) {
+            $autoFilterDateGrouping = (string) $workbookViewAttributes->autoFilterDateGrouping;
+            $this->spreadsheet->setAutoFilterDateGrouping($this->castXsdBooleanToBool($autoFilterDateGrouping));
+        }
+    }
+
+    private function firstSheet(SimpleXMLElement $workbookViewAttributes): void
+    {
+        if (isset($workbookViewAttributes->firstSheet)) {
+            $firstSheet = (string) $workbookViewAttributes->firstSheet;
+            $this->spreadsheet->setFirstSheetIndex((int) $firstSheet);
+        }
+    }
+
+    private function visibility(SimpleXMLElement $workbookViewAttributes): void
+    {
+        if (isset($workbookViewAttributes->visibility)) {
+            $visibility = (string) $workbookViewAttributes->visibility;
+            $this->spreadsheet->setVisibility($visibility);
+        }
+    }
+
+    private function tabRatio(SimpleXMLElement $workbookViewAttributes): void
+    {
+        if (isset($workbookViewAttributes->tabRatio)) {
+            $tabRatio = (string) $workbookViewAttributes->tabRatio;
+            $this->spreadsheet->setTabRatio((int) $tabRatio);
+        }
+    }
+}


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Fix for setting Active Sheet to the first loaded worksheet when `bookViews` element isn't defined

See [Issue #2666](https://github.com/PHPOffice/PhpSpreadsheet/issues/2666)