### PR TITLE
Resolve Conditional Formatting issues with Xls writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Fix bug in Conditional Formatting in the Xls Writer that resulted in a broken file when there were multiple conditional ranges in a worksheet.
+- Fix Conditional Formatting in the Xls Writer to work with rules that contain string literals, cell references and formulae.
 - Fix for setting Active Sheet to the first loaded worksheet when bookViews element isn't defined [Issue #2666](https://github.com/PHPOffice/PhpSpreadsheet/issues/2666) [PR #2669](https://github.com/PHPOffice/PhpSpreadsheet/pull/2669)
 - Fixed behaviour of XLSX font style vertical align settings.
 - Resolved formula translations to handle separators (row and column) for array functions as well as for function argument separators; and cleanly handle nesting levels.

--- a/samples/ConditionalFormatting/01_Basic_Comparisons.php
+++ b/samples/ConditionalFormatting/01_Basic_Comparisons.php
@@ -30,7 +30,8 @@ $spreadsheet->getActiveSheet()
     ->setCellValue('A1', 'Literal Value Comparison')
     ->setCellValue('A9', 'Value Comparison with Absolute Cell Reference $H$9')
     ->setCellValue('A17', 'Value Comparison with Relative Cell References')
-    ->setCellValue('A23', 'Value Comparison with Formula based on AVERAGE() ± STDEV()');
+    ->setCellValue('A23', 'Value Comparison with Formula based on AVERAGE() ± STDEV()')
+    ->setCellValue('A30', 'Literal String Value Comparison');
 
 $dataArray = [
     [-2, -1, 0, 1, 2],
@@ -45,11 +46,18 @@ $betweenDataArray = [
     [4, 3, 8],
 ];
 
+$stringArray = [
+    ['I'],
+    ['Love'],
+    ['PHP'],
+];
+
 $spreadsheet->getActiveSheet()
     ->fromArray($dataArray, null, 'A2', true)
     ->fromArray($dataArray, null, 'A10', true)
     ->fromArray($betweenDataArray, null, 'A18', true)
     ->fromArray($dataArray, null, 'A24', true)
+    ->fromArray($stringArray, null, 'A31', true)
     ->setCellValue('H9', 1);
 
 // Set title row bold
@@ -58,21 +66,31 @@ $spreadsheet->getActiveSheet()->getStyle('A1:E1')->getFont()->setBold(true);
 $spreadsheet->getActiveSheet()->getStyle('A9:E9')->getFont()->setBold(true);
 $spreadsheet->getActiveSheet()->getStyle('A17:E17')->getFont()->setBold(true);
 $spreadsheet->getActiveSheet()->getStyle('A23:E23')->getFont()->setBold(true);
+$spreadsheet->getActiveSheet()->getStyle('A30:E30')->getFont()->setBold(true);
 
 // Define some styles for our Conditionals
 $helper->log('Define some styles for our Conditionals');
 $yellowStyle = new Style(false, true);
 $yellowStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
+    ->getStartColor()->setARGB(Color::COLOR_YELLOW);
+$yellowStyle->getFill()
     ->getEndColor()->setARGB(Color::COLOR_YELLOW);
+$yellowStyle->getFont()->setColor(new Color(Color::COLOR_BLUE));
 $greenStyle = new Style(false, true);
 $greenStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
+    ->getStartColor()->setARGB(Color::COLOR_GREEN);
+$greenStyle->getFill()
     ->getEndColor()->setARGB(Color::COLOR_GREEN);
+$greenStyle->getFont()->setColor(new Color(Color::COLOR_DARKRED));
 $redStyle = new Style(false, true);
 $redStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
+    ->getStartColor()->setARGB(Color::COLOR_RED);
+$redStyle->getFill()
     ->getEndColor()->setARGB(Color::COLOR_RED);
+$redStyle->getFont()->setColor(new Color(Color::COLOR_GREEN));
 
 // Set conditional formatting rules and styles
 $helper->log('Define conditional formatting and set styles');
@@ -164,6 +182,32 @@ $conditionalStyles[] = $cellWizard->getConditional();
 
 $cellWizard->lessThan('AVERAGE(' . $formulaRange . ')-STDEV(' . $formulaRange . ')', Wizard::VALUE_TYPE_FORMULA)
     ->setStyle($redStyle);
+$conditionalStyles[] = $cellWizard->getConditional();
+
+$spreadsheet->getActiveSheet()
+    ->getStyle($cellWizard->getCellRange())
+    ->setConditionalStyles($conditionalStyles);
+
+// Set rules for Value Comparison with String Literal
+$cellRange = 'A31:A33';
+$formulaRange = implode(
+    ':',
+    array_map(
+        [Coordinate::class, 'absoluteCoordinate'],
+        Coordinate::splitRange($cellRange)[0]
+    )
+);
+$conditionalStyles = [];
+$wizardFactory = new Wizard($cellRange);
+/** @var Wizard\CellValue $cellWizard */
+$cellWizard = $wizardFactory->newRule(Wizard::CELL_VALUE);
+
+$cellWizard->equals('LOVE')
+    ->setStyle($redStyle);
+$conditionalStyles[] = $cellWizard->getConditional();
+
+$cellWizard->equals('PHP')
+    ->setStyle($greenStyle);
 $conditionalStyles[] = $cellWizard->getConditional();
 
 $spreadsheet->getActiveSheet()

--- a/samples/ConditionalFormatting/02_Text_Comparisons.php
+++ b/samples/ConditionalFormatting/02_Text_Comparisons.php
@@ -74,14 +74,17 @@ $yellowStyle = new Style(false, true);
 $yellowStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
     ->getEndColor()->setARGB(Color::COLOR_YELLOW);
+$yellowStyle->getFont()->setColor(new Color(Color::COLOR_BLUE));
 $greenStyle = new Style(false, true);
 $greenStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
     ->getEndColor()->setARGB(Color::COLOR_GREEN);
+$greenStyle->getFont()->setColor(new Color(Color::COLOR_DARKRED));
 $redStyle = new Style(false, true);
 $redStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
     ->getEndColor()->setARGB(Color::COLOR_RED);
+$redStyle->getFont()->setColor(new Color(Color::COLOR_GREEN));
 
 // Set conditional formatting rules and styles
 $helper->log('Define conditional formatting and set styles');

--- a/samples/ConditionalFormatting/03_Blank_Comparisons.php
+++ b/samples/ConditionalFormatting/03_Blank_Comparisons.php
@@ -46,10 +46,12 @@ $greenStyle = new Style(false, true);
 $greenStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
     ->getEndColor()->setARGB(Color::COLOR_GREEN);
+$greenStyle->getFont()->setColor(new Color(Color::COLOR_DARKRED));
 $redStyle = new Style(false, true);
 $redStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
     ->getEndColor()->setARGB(Color::COLOR_RED);
+$redStyle->getFont()->setColor(new Color(Color::COLOR_GREEN));
 
 // Set conditional formatting rules and styles
 $helper->log('Define conditional formatting and set styles');

--- a/samples/ConditionalFormatting/04_Error_Comparisons.php
+++ b/samples/ConditionalFormatting/04_Error_Comparisons.php
@@ -49,10 +49,12 @@ $greenStyle = new Style(false, true);
 $greenStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
     ->getEndColor()->setARGB(Color::COLOR_GREEN);
+$greenStyle->getFont()->setColor(new Color(Color::COLOR_DARKRED));
 $redStyle = new Style(false, true);
 $redStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
     ->getEndColor()->setARGB(Color::COLOR_RED);
+$redStyle->getFont()->setColor(new Color(Color::COLOR_GREEN));
 
 // Set conditional formatting rules and styles
 $helper->log('Define conditional formatting and set styles');

--- a/samples/ConditionalFormatting/05_Date_Comparisons.php
+++ b/samples/ConditionalFormatting/05_Date_Comparisons.php
@@ -108,12 +108,11 @@ $spreadsheet->getActiveSheet()->getStyle('B1:K1')->getAlignment()->setHorizontal
 
 // Define some styles for our Conditionals
 $helper->log('Define some styles for our Conditionals');
-
 $yellowStyle = new Style(false, true);
 $yellowStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
     ->getEndColor()->setARGB(Color::COLOR_YELLOW);
-$yellowStyle->getNumberFormat()->setFormatCode('ddd dd-mmm-yyyy');
+$yellowStyle->getFont()->setColor(new Color(Color::COLOR_BLUE));
 
 // Set conditional formatting rules and styles
 $helper->log('Define conditional formatting and set styles');

--- a/samples/ConditionalFormatting/06_Duplicate_Comparisons.php
+++ b/samples/ConditionalFormatting/06_Duplicate_Comparisons.php
@@ -51,14 +51,16 @@ $spreadsheet->getActiveSheet()->getStyle('A1:C1')->getFont()->setBold(true);
 
 // Define some styles for our Conditionals
 $helper->log('Define some styles for our Conditionals');
-$greenStyle = new Style(false, true);
-$greenStyle->getFill()
-    ->setFillType(Fill::FILL_SOLID)
-    ->getEndColor()->setARGB(Color::COLOR_GREEN);
 $yellowStyle = new Style(false, true);
 $yellowStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
     ->getEndColor()->setARGB(Color::COLOR_YELLOW);
+$yellowStyle->getFont()->setColor(new Color(Color::COLOR_BLUE));
+$greenStyle = new Style(false, true);
+$greenStyle->getFill()
+    ->setFillType(Fill::FILL_SOLID)
+    ->getEndColor()->setARGB(Color::COLOR_GREEN);
+$greenStyle->getFont()->setColor(new Color(Color::COLOR_DARKRED));
 
 // Set conditional formatting rules and styles
 $helper->log('Define conditional formatting and set styles');

--- a/samples/ConditionalFormatting/07_Expression_Comparisons.php
+++ b/samples/ConditionalFormatting/07_Expression_Comparisons.php
@@ -28,6 +28,7 @@ $helper->log('Add data');
 $spreadsheet->setActiveSheetIndex(0);
 $spreadsheet->getActiveSheet()
     ->setCellValue('A1', 'Odd/Even Expression Comparison')
+    ->setCellValue('A4', 'Note that these functions are not available for Xls files')
     ->setCellValue('A15', 'Sales Grid Expression Comparison')
     ->setCellValue('A25', 'Sales Grid Multiple Expression Comparison');
 
@@ -101,9 +102,9 @@ $expressionWizard->expression('ISEVEN(A1)')
     ->setStyle($yellowStyle);
 $conditionalStyles[] = $expressionWizard->getConditional();
 
-$spreadsheet->getActiveSheet()
-    ->getStyle($expressionWizard->getCellRange())
-    ->setConditionalStyles($conditionalStyles);
+//$spreadsheet->getActiveSheet()
+//    ->getStyle($expressionWizard->getCellRange())
+//    ->setConditionalStyles($conditionalStyles);
 
 // Set rules for Sales Grid Row match against Country Comparison
 $cellRange = 'A17:D22';

--- a/samples/ConditionalFormatting/07_Expression_Comparisons.php
+++ b/samples/ConditionalFormatting/07_Expression_Comparisons.php
@@ -69,14 +69,16 @@ $spreadsheet->getActiveSheet()->getStyle('A25:D26')->getFont()->setBold(true);
 
 // Define some styles for our Conditionals
 $helper->log('Define some styles for our Conditionals');
-$greenStyle = new Style(false, true);
-$greenStyle->getFill()
-    ->setFillType(Fill::FILL_SOLID)
-    ->getEndColor()->setARGB(Color::COLOR_GREEN);
 $yellowStyle = new Style(false, true);
 $yellowStyle->getFill()
     ->setFillType(Fill::FILL_SOLID)
     ->getEndColor()->setARGB(Color::COLOR_YELLOW);
+$yellowStyle->getFont()->setColor(new Color(Color::COLOR_BLUE));
+$greenStyle = new Style(false, true);
+$greenStyle->getFill()
+    ->setFillType(Fill::FILL_SOLID)
+    ->getEndColor()->setARGB(Color::COLOR_GREEN);
+$greenStyle->getFont()->setColor(new Color(Color::COLOR_DARKRED));
 
 $greenStyleMoney = clone $greenStyle;
 $greenStyleMoney->getNumberFormat()->setFormatCode(NumberFormat::FORMAT_ACCOUNTING_USD);

--- a/samples/ConditionalFormatting/07_Expression_Comparisons.php
+++ b/samples/ConditionalFormatting/07_Expression_Comparisons.php
@@ -102,9 +102,9 @@ $expressionWizard->expression('ISEVEN(A1)')
     ->setStyle($yellowStyle);
 $conditionalStyles[] = $expressionWizard->getConditional();
 
-//$spreadsheet->getActiveSheet()
-//    ->getStyle($expressionWizard->getCellRange())
-//    ->setConditionalStyles($conditionalStyles);
+$spreadsheet->getActiveSheet()
+    ->getStyle($expressionWizard->getCellRange())
+    ->setConditionalStyles($conditionalStyles);
 
 // Set rules for Sales Grid Row match against Country Comparison
 $cellRange = 'A17:D22';

--- a/src/PhpSpreadsheet/Style/ConditionalFormatting/Wizard/WizardAbstract.php
+++ b/src/PhpSpreadsheet/Style/ConditionalFormatting/Wizard/WizardAbstract.php
@@ -122,7 +122,7 @@ abstract class WizardAbstract
         return "{$worksheet}{$column}{$row}";
     }
 
-    protected static function reverseAdjustCellRef(string $condition, string $cellRange): string
+    public static function reverseAdjustCellRef(string $condition, string $cellRange): string
     {
         $conditionalRange = Coordinate::splitRange(str_replace('$', '', strtoupper($cellRange)));
         [$referenceCell] = $conditionalRange[0];

--- a/src/PhpSpreadsheet/Writer/Xls/ConditionalHelper.php
+++ b/src/PhpSpreadsheet/Writer/Xls/ConditionalHelper.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Writer\Xls;
+
+use PhpOffice\PhpSpreadsheet\Exception as PhpSpreadsheetException;
+use PhpOffice\PhpSpreadsheet\Style\ConditionalFormatting\Wizard;
+
+class ConditionalHelper
+{
+    /**
+     * Formula parser.
+     *
+     * @var Parser
+     */
+    protected $parser;
+
+    /**
+     * @var mixed
+     */
+    protected $condition;
+
+    /**
+     * @var string
+     */
+    protected $cellRange;
+
+    /**
+     * @var null|string
+     */
+    protected $tokens;
+
+    /**
+     * @var int
+     */
+    protected $size;
+
+    public function __construct(Parser $parser)
+    {
+        $this->parser = $parser;
+    }
+
+    /**
+     * @param mixed $condition
+     */
+    public function processCondition($condition, string $cellRange): void
+    {
+        $this->condition = $condition;
+        $this->cellRange = $cellRange;
+
+        if (is_int($condition) || is_float($condition)) {
+            $this->size = ($condition <= 65535 ? 3 : 0x0000);
+            $this->tokens = pack('Cv', 0x1E, $condition);
+        } else {
+            try {
+                $formula = Wizard\WizardAbstract::reverseAdjustCellRef((string) $condition, $cellRange);
+                $this->parser->parse($formula);
+                $this->tokens = $this->parser->toReversePolish();
+                $this->size = strlen($this->tokens);
+            } catch (PhpSpreadsheetException $e) {
+                var_dump("PARSER EXCEPTION: {$e->getMessage()}");
+                $this->tokens = null;
+                $this->size = 0;
+            }
+        }
+    }
+
+    public function tokens(): ?string
+    {
+        return $this->tokens;
+    }
+
+    public function size(): int
+    {
+        return $this->size;
+    }
+}

--- a/src/PhpSpreadsheet/Writer/Xls/ConditionalHelper.php
+++ b/src/PhpSpreadsheet/Writer/Xls/ConditionalHelper.php
@@ -55,11 +55,11 @@ class ConditionalHelper
                 $formula = Wizard\WizardAbstract::reverseAdjustCellRef((string) $condition, $cellRange);
                 $this->parser->parse($formula);
                 $this->tokens = $this->parser->toReversePolish();
-                $this->size = strlen($this->tokens);
+                $this->size = strlen($this->tokens ?? '');
             } catch (PhpSpreadsheetException $e) {
-                var_dump("PARSER EXCEPTION: {$e->getMessage()}");
-                $this->tokens = null;
-                $this->size = 0;
+                // In the event of a parser error with a formula value, we set the expression to ptgInt + 0
+                $this->tokens = pack('Cv', 0x1E, 0);
+                $this->size = 3;
             }
         }
     }

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -2787,8 +2787,8 @@ class Worksheet extends BIFFwriter
         string $cellRange
     ): void {
         $record = 0x01B1; // Record identifier
-        $type = null;  //  Type of the CF
-        $operatorType = null;   //  Comparison operator
+        $type = null; // Type of the CF
+        $operatorType = null; // Comparison operator
 
         if ($conditional->getConditionType() == Conditional::CONDITION_EXPRESSION) {
             $type = 0x02;

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -13,6 +13,7 @@ use PhpOffice\PhpSpreadsheet\Shared\Xls;
 use PhpOffice\PhpSpreadsheet\Style\Border;
 use PhpOffice\PhpSpreadsheet\Style\Color;
 use PhpOffice\PhpSpreadsheet\Style\Conditional;
+use PhpOffice\PhpSpreadsheet\Style\ConditionalFormatting\Wizard;
 use PhpOffice\PhpSpreadsheet\Style\Protection;
 use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 use PhpOffice\PhpSpreadsheet\Worksheet\SheetView;
@@ -569,7 +570,7 @@ class Worksheet extends BIFFwriter
                             $arrConditional[$conditional->getHashCode()] = true;
 
                             // Write CFRULE record
-                            $this->writeCFRule($conditional);
+                            $this->writeCFRule($conditional, $cellCoordinate);
                         }
                     }
                 }
@@ -2779,7 +2780,7 @@ class Worksheet extends BIFFwriter
     /**
      * Write CFRule Record.
      */
-    private function writeCFRule(Conditional $conditional): void
+    private function writeCFRule(Conditional $conditional, string $cellRange): void
     {
         $record = 0x01B1; // Record identifier
         $type = null;  //  Type of the CF
@@ -2832,21 +2833,59 @@ class Worksheet extends BIFFwriter
         // $szValue2 : size of the formula data for second value or formula
         $arrConditions = $conditional->getConditions();
         $numConditions = count($arrConditions);
+
+        $szValue1 = 0x0000;
+        $szValue2 = 0x0000;
+        $operand1 = null;
+        $operand2 = null;
+
         if ($numConditions == 1) {
-            $szValue1 = ($arrConditions[0] <= 65535 ? 3 : 0x0000);
-            $szValue2 = 0x0000;
-            $operand1 = pack('Cv', 0x1E, $arrConditions[0]);
-            $operand2 = null;
+            if (is_int($arrConditions[0]) || is_float($arrConditions[0])) {
+                $szValue1 = ($arrConditions[0] <= 65535 ? 3 : 0x0000);
+                $operand1 = pack('Cv', 0x1E, $arrConditions[0]);
+            } else {
+                try {
+                    $formula1 = Wizard\WizardAbstract::reverseAdjustCellRef((string) $arrConditions[0], $cellRange);
+                    $this->parser->parse($formula1);
+                    $formula1 = $this->parser->toReversePolish();
+                    $szValue1 = strlen($formula1);
+                } catch (PhpSpreadsheetException $e) {
+                    var_dump("PARSER EXCEPTION: {$e->getMessage()}");
+                    $formula1 = null;
+                }
+                $operand1 = $formula1;
+            }
         } elseif ($numConditions == 2 && ($conditional->getOperatorType() == Conditional::OPERATOR_BETWEEN)) {
-            $szValue1 = ($arrConditions[0] <= 65535 ? 3 : 0x0000);
-            $szValue2 = ($arrConditions[1] <= 65535 ? 3 : 0x0000);
-            $operand1 = pack('Cv', 0x1E, $arrConditions[0]);
-            $operand2 = pack('Cv', 0x1E, $arrConditions[1]);
-        } else {
-            $szValue1 = 0x0000;
-            $szValue2 = 0x0000;
-            $operand1 = null;
-            $operand2 = null;
+            if (is_int($arrConditions[0]) || is_float($arrConditions[0])) {
+                $szValue1 = ($arrConditions[0] <= 65535 ? 3 : 0x0000);
+                $operand1 = pack('Cv', 0x1E, $arrConditions[0]);
+            } else {
+                try {
+                    $formula1 = Wizard\WizardAbstract::reverseAdjustCellRef((string) $arrConditions[0], $cellRange);
+                    $this->parser->parse($formula1);
+                    $formula1 = $this->parser->toReversePolish();
+                    $szValue1 = strlen($formula1);
+                } catch (PhpSpreadsheetException $e) {
+                    var_dump("PARSER EXCEPTION: {$e->getMessage()}");
+                    $formula1 = null;
+                }
+                $operand1 = $formula1;
+            }
+            if (is_int($arrConditions[1]) || is_float($arrConditions[1])) {
+                $szValue2 = ($arrConditions[1] <= 65535 ? 3 : 0x0000);
+                $operand2 = pack('Cv', 0x1E, $arrConditions[1]);
+            } else {
+                try {
+                    $formula2 = Wizard\WizardAbstract::reverseAdjustCellRef((string) $arrConditions[1], $cellRange);
+                    $this->parser->parse($formula2);
+                    $formula2 = $this->parser->toReversePolish();
+                    $szValue2 = strlen($formula2);
+                } catch (PhpSpreadsheetException $e) {
+                    var_dump("PARSER EXCEPTION: {$e->getMessage()}");
+                    $formula2 = null;
+                }
+                $operand2 = $formula2;
+            }
         }
 
         // $flags : Option flags


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

This PR resolves the problem with writing a CF Header for each CF range, no matter how many rules there are for that range, rather than writing a single header for all ranges.

It does not appear that this has ever worked correctly, and that only writing a single CF range was supported before, but recent changes to provide examples of multiple CF ranges in a single worksheet have highlighted the problem, while a modification to the Xls Writer to support multiple ranges actually broke the CF Writer so that Excel issues a warning when the file is opened.

Now the code can also handle:
 - Using cell references for the rule value
 - Using string literals for the rule value
 - Using formula expressions for the rule value
 
None of these previously worked. All cell reference, string literal or formula expressions used as rule values were silently converted to integer 0

In the event of s formula expressions that Xls itself doesn't support (e.g. when they use an Excel function that isn't known to the BIFF format), the code defaults the condition to `ptgInt` +0 (`=0`) to avoid breaking the structure of the file.