### PR TITLE
Minor refactoring work

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2219,15 +2219,17 @@ class Worksheet implements IComparable
         $highestColumnIndex = Coordinate::columnIndexFromString($highestColumn);
         $pColumnIndex = Coordinate::columnIndexFromString($column);
 
-        if ($pColumnIndex > $highestColumnIndex) {
-            return $this;
-        }
-
         $holdColumnDimensions = $this->removeColumnDimensions($pColumnIndex, $numberOfColumns);
 
         $column = Coordinate::stringFromColumnIndex($pColumnIndex + $numberOfColumns);
         $objReferenceHelper = ReferenceHelper::getInstance();
         $objReferenceHelper->insertNewBefore($column . '1', -$numberOfColumns, 0, $this);
+
+        $this->columnDimensions = $holdColumnDimensions;
+
+        if ($pColumnIndex > $highestColumnIndex) {
+            return $this;
+        }
 
         $maxPossibleColumnsToBeRemoved = $highestColumnIndex - $pColumnIndex + 1;
 
@@ -2235,8 +2237,6 @@ class Worksheet implements IComparable
             $this->getCellCollection()->removeColumn($highestColumn);
             $highestColumn = Coordinate::stringFromColumnIndex(Coordinate::columnIndexFromString($highestColumn) - 1);
         }
-
-        $this->columnDimensions = $holdColumnDimensions;
 
         $this->garbageCollect();
 

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterTest.php
@@ -134,6 +134,64 @@ class AutoFilterTest extends SetupTeardown
         }
     }
 
+    public function testRemoveColumns(): void
+    {
+        $sheet = $this->getSheet();
+        $sheet->fromArray(range('H', 'O'), null, 'H2');
+        $autoFilter = $sheet->getAutoFilter();
+        $autoFilter->setRange(self::INITIAL_RANGE);
+        $autoFilter->getColumn('L')->addRule((new Column\Rule())->setValue(5));
+
+        $sheet->removeColumn('K', 2);
+        $result = $autoFilter->getRange();
+        self::assertEquals('H2:M256', $result);
+
+        // Check that the rule that was set for column L is no longer set
+        self::assertEmpty($autoFilter->getColumn('L')->getRule(0)->getValue());
+    }
+
+    public function testRemoveRows(): void
+    {
+        $sheet = $this->getSheet();
+        $sheet->fromArray(range('H', 'O'), null, 'H2');
+        $autoFilter = $sheet->getAutoFilter();
+        $autoFilter->setRange(self::INITIAL_RANGE);
+
+        $sheet->removeRow(42, 128);
+        $result = $autoFilter->getRange();
+        self::assertEquals('H2:O128', $result);
+    }
+
+    public function testInsertColumns(): void
+    {
+        $sheet = $this->getSheet();
+        $sheet->fromArray(range('H', 'O'), null, 'H2');
+        $autoFilter = $sheet->getAutoFilter();
+        $autoFilter->setRange(self::INITIAL_RANGE);
+        $autoFilter->getColumn('N')->addRule((new Column\Rule())->setValue(5));
+
+        $sheet->insertNewColumnBefore('N', 3);
+        $result = $autoFilter->getRange();
+        self::assertEquals('H2:R256', $result);
+
+        // Check that column N no longer has a rule set
+        self::assertEmpty($autoFilter->getColumn('N')->getRule(0)->getValue());
+        // Check that the rule originally set in column N has been moved to column Q
+        self::assertSame(5, $autoFilter->getColumn('Q')->getRule(0)->getValue());
+    }
+
+    public function testInsertRows(): void
+    {
+        $sheet = $this->getSheet();
+        $sheet->fromArray(range('H', 'O'), null, 'H2');
+        $autoFilter = $sheet->getAutoFilter();
+        $autoFilter->setRange(self::INITIAL_RANGE);
+
+        $sheet->insertNewRowBefore(3, 4);
+        $result = $autoFilter->getRange();
+        self::assertEquals('H2:O260', $result);
+    }
+
     public function testGetInvalidColumnOffset(): void
     {
         $this->expectException(PhpSpreadsheetException::class);


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] refactoring
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

General code improvements to the ReferenceHelper, including eliminating multiple duplicated calls to `Coordinate::columnIndexFromString()`