### PR TITLE
Add Condition When Read Property On Null

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -898,8 +898,8 @@ class Xlsx extends BaseReader
                                     foreach ($item->attributes() ?? [] as $attr) {
                                         $node->addAttribute($attr->getName(), $attr);
                                     }
-                                    $node->addAttribute('sqref', $item->children('xm', true)->sqref);
-                                    $node->addChild('formula1', $item->formula1->children('xm', true)->f);
+                                    $node->addAttribute('sqref', $item->children('xm', true)->sqref ?? '');
+                                    $node->addChild('formula1', $item->formula1->children('xm', true)->f ?? '');
                                 }
                             }
 


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
Add Condition When Read Property On Null
Related issue: https://github.com/PHPOffice/PhpSpreadsheet/issues/2677