### PR TITLE
Provide $includeAbsoluteReferences option for the CellReferenceHelper when updating cell addresses

### DIFF
--- a/tests/PhpSpreadsheetTests/CellReferenceHelperTest.php
+++ b/tests/PhpSpreadsheetTests/CellReferenceHelperTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests;
+
+use PhpOffice\PhpSpreadsheet\CellReferenceHelper;
+use PHPUnit\Framework\TestCase;
+
+class CellReferenceHelperTest extends TestCase
+{
+    /**
+     * @dataProvider cellReferenceHelperInsertColumnsProvider
+     */
+    public function testCellReferenceHelperInsertColumns(string $expectedResult, string $cellAddress): void
+    {
+        $cellReferenceHelper = new CellReferenceHelper('E5', 2, 0);
+        $result = $cellReferenceHelper->updateCellReference($cellAddress);
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function cellReferenceHelperInsertColumnsProvider(): array
+    {
+        return [
+            ['A1', 'A1'],
+            ['D5', 'D5'],
+            ['G5', 'E5'],
+            ['$E5', '$E5'],
+            ['G$5', 'E$5'],
+            ['I5', 'G5'],
+            ['$G$5', '$G$5'],
+        ];
+    }
+
+    /**
+     * @dataProvider cellReferenceHelperDeleteColumnsProvider
+     */
+    public function testCellReferenceHelperDeleteColumns(string $expectedResult, string $cellAddress): void
+    {
+        $cellReferenceHelper = new CellReferenceHelper('E5', -2, 0);
+        $result = $cellReferenceHelper->updateCellReference($cellAddress);
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function cellReferenceHelperDeleteColumnsProvider(): array
+    {
+        return [
+            ['A1', 'A1'],
+            ['D5', 'D5'],
+            ['C5', 'E5'],
+            ['$E5', '$E5'],
+            ['C$5', 'E$5'],
+            ['E5', 'G5'],
+            ['$G$5', '$G$5'],
+        ];
+    }
+
+    /**
+     * @dataProvider cellReferenceHelperInsertRowsProvider
+     */
+    public function testCellReferenceHelperInsertRows(string $expectedResult, string $cellAddress): void
+    {
+        $cellReferenceHelper = new CellReferenceHelper('E5', 0, 2);
+        $result = $cellReferenceHelper->updateCellReference($cellAddress);
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function cellReferenceHelperInsertRowsProvider(): array
+    {
+        return [
+            ['A1', 'A1'],
+            ['E4', 'E4'],
+            ['E7', 'E5'],
+            ['E$5', 'E$5'],
+            ['$E7', '$E5'],
+            ['E11', 'E9'],
+            ['$E$9', '$E$9'],
+        ];
+    }
+
+    /**
+     * @dataProvider cellReferenceHelperDeleteRowsProvider
+     */
+    public function testCellReferenceHelperDeleteRows(string $expectedResult, string $cellAddress): void
+    {
+        $cellReferenceHelper = new CellReferenceHelper('E5', 0, -2);
+        $result = $cellReferenceHelper->updateCellReference($cellAddress);
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function cellReferenceHelperDeleteRowsProvider(): array
+    {
+        return [
+            ['A1', 'A1'],
+            ['E4', 'E4'],
+            ['E3', 'E5'],
+            ['E$5', 'E$5'],
+            ['$E3', '$E5'],
+            ['E7', 'E9'],
+            ['$E$9', '$E$9'],
+        ];
+    }
+
+    /**
+     * @dataProvider cellReferenceHelperInsertColumnsAbsoluteProvider
+     */
+    public function testCellReferenceHelperInsertColumnsAbsolute(string $expectedResult, string $cellAddress): void
+    {
+        $cellReferenceHelper = new CellReferenceHelper('E5', 2, 0);
+        $result = $cellReferenceHelper->updateCellReference($cellAddress, true);
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function cellReferenceHelperInsertColumnsAbsoluteProvider(): array
+    {
+        return [
+            ['A1', 'A1'],
+            ['D5', 'D5'],
+            ['G5', 'E5'],
+            ['$G5', '$E5'],
+            ['G$5', 'E$5'],
+            ['I5', 'G5'],
+            ['$I$5', '$G$5'],
+        ];
+    }
+
+    /**
+     * @dataProvider cellReferenceHelperDeleteColumnsAbsoluteProvider
+     */
+    public function testCellReferenceHelperDeleteColumnsAbsolute(string $expectedResult, string $cellAddress): void
+    {
+        $cellReferenceHelper = new CellReferenceHelper('E5', -2, 0);
+        $result = $cellReferenceHelper->updateCellReference($cellAddress, true);
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function cellReferenceHelperDeleteColumnsAbsoluteProvider(): array
+    {
+        return [
+            ['A1', 'A1'],
+            ['D5', 'D5'],
+            ['C5', 'E5'],
+            ['$C5', '$E5'],
+            ['C$5', 'E$5'],
+            ['E5', 'G5'],
+            ['$E$5', '$G$5'],
+        ];
+    }
+
+    /**
+     * @dataProvider cellReferenceHelperInsertRowsAbsoluteProvider
+     */
+    public function testCellReferenceHelperInsertRowsAbsolute(string $expectedResult, string $cellAddress): void
+    {
+        $cellReferenceHelper = new CellReferenceHelper('E5', 0, 2);
+        $result = $cellReferenceHelper->updateCellReference($cellAddress, true);
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function cellReferenceHelperInsertRowsAbsoluteProvider(): array
+    {
+        return [
+            ['A1', 'A1'],
+            ['E4', 'E4'],
+            ['E7', 'E5'],
+            ['E$7', 'E$5'],
+            ['$E7', '$E5'],
+            ['E11', 'E9'],
+            ['$E$11', '$E$9'],
+        ];
+    }
+
+    /**
+     * @dataProvider cellReferenceHelperDeleteRowsAbsoluteProvider
+     */
+    public function testCellReferenceHelperDeleteRowsAbsolute(string $expectedResult, string $cellAddress): void
+    {
+        $cellReferenceHelper = new CellReferenceHelper('E5', 0, -2);
+        $result = $cellReferenceHelper->updateCellReference($cellAddress, true);
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function cellReferenceHelperDeleteRowsAbsoluteProvider(): array
+    {
+        return [
+            ['A1', 'A1'],
+            ['E4', 'E4'],
+            ['E3', 'E5'],
+            ['E$3', 'E$5'],
+            ['$E3', '$E5'],
+            ['E7', 'E9'],
+            ['$E$7', '$E$9'],
+        ];
+    }
+}


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Even absolute cell references ned updating in Conditional Formatting rules when new rows/columns are inserted; and the ReferenceHelper currently only updates relative references.

This is a preliminary step toward allowing updates to absolute cell references, required to update Conditional Formatting rules when columns/rows are inserted/deleted as highlighted by [Issue 2678](https://github.com/PHPOffice/PhpSpreadsheet/issues/2678); the first step in a multi-step process.

Step 1
Refactor the cell reference update logic to make it easier to modify, and to test the planned modifications
This may also make the code more performant, as it allows elimination of a lot of code duplication in the different methods to update different components of the worksheet.

Step 2
Modify the cell reference update logic to accept a flag indicating whether it should update absolute as well as relative cell references

Step 3
Add the logic to update Conditional Formatting ranges and rules when inserting/deleting rows/columns


This is step 2:

