### PR TITLE
Validate that lookup arrays are actually arrays

### DIFF
--- a/src/PhpSpreadsheet/Calculation/LookupRef/HLookup.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/HLookup.php
@@ -32,9 +32,10 @@ class HLookup extends LookupBase
         }
 
         $notExactMatch = (bool) ($notExactMatch ?? true);
-        $lookupArray = self::convertLiteralArray($lookupArray);
 
         try {
+            self::validateLookupArray($lookupArray);
+            $lookupArray = self::convertLiteralArray($lookupArray);
             $indexNumber = self::validateIndexLookup($lookupArray, $indexNumber);
         } catch (Exception $e) {
             return $e->getMessage();

--- a/src/PhpSpreadsheet/Calculation/LookupRef/LookupBase.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/LookupBase.php
@@ -7,6 +7,16 @@ use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
 
 abstract class LookupBase
 {
+    /**
+     * @param mixed $lookup_array
+     */
+    protected static function validateLookupArray($lookup_array): void
+    {
+        if (!is_array($lookup_array)) {
+            throw new Exception(ExcelError::REF());
+        }
+    }
+
     protected static function validateIndexLookup(array $lookup_array, $index_number): int
     {
         // index_number must be a number greater than or equal to 1

--- a/src/PhpSpreadsheet/Calculation/LookupRef/VLookup.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/VLookup.php
@@ -33,6 +33,7 @@ class VLookup extends LookupBase
         $notExactMatch = (bool) ($notExactMatch ?? true);
 
         try {
+            self::validateLookupArray($lookupArray);
             $indexNumber = self::validateIndexLookup($lookupArray, $indexNumber);
         } catch (Exception $e) {
             return $e->getMessage();

--- a/tests/data/Calculation/LookupRef/VLOOKUP.php
+++ b/tests/data/Calculation/LookupRef/VLOOKUP.php
@@ -25,6 +25,13 @@ return [
         false,
     ],
     [
+        '#REF!',
+        1,
+        'HELLO WORLD',
+        2,
+        false,
+    ],
+    [
         100,
         1,
         densityGrid(),


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

If the lookup arrays passed to `HLOOKUP()` or `VLOOKUP()` aren't actually arrays, the function should return an Excel error, not terminate with a fatal PHP error