### PR TITLE
more minor tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Allow `INDIRECT()` to accept row/column ranges as well as cell ranges [PR #2687](https://github.com/PHPOffice/PhpSpreadsheet/pull/2687)
 - Fix bug when deleting cells with hyperlinks, where the hyperlink was then being "inherited" by whatever cell moved to that cell address.
 - Fix bug in Conditional Formatting in the Xls Writer that resulted in a broken file when there were multiple conditional ranges in a worksheet.
 - Fix Conditional Formatting in the Xls Writer to work with rules that contain string literals, cell references and formulae.

--- a/tests/data/Calculation/LookupRef/INDIRECT.php
+++ b/tests/data/Calculation/LookupRef/INDIRECT.php
@@ -34,4 +34,8 @@ return [
     'supply a1 argument as int' => [900, 'A2:A4', 1],
     'supply a1 argument as float' => [900, 'A2:A4', 7.3],
     'supply a1 argument as string not permitted' => ['#VALUE!', 'A2:A4', '1'],
+    'row range' => [600, '1:3'],
+    'column range' => [1500, 'A:C'],
+    'row range on different sheet' => [66, 'OtherSheet!1:3'],
+    'column range on different sheet' => [165, 'OtherSheet!A:C'],
 ];


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

`INDIRECT()` only worked with cell ranges, returning a `#REF!` for anything else. This change allows it to accept row or column ranges as well.