### PR TITLE
Fix issues with updating Conditional Formatting when inserting/deleting rows/columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Update Conditional Formatting ranges and rule conditions when inserting/deleting rows/columns [Issue #2678](https://github.com/PHPOffice/PhpSpreadsheet/issues/2678) [PR #2689](https://github.com/PHPOffice/PhpSpreadsheet/pull/2689)
 - Allow `INDIRECT()` to accept row/column ranges as well as cell ranges [PR #2687](https://github.com/PHPOffice/PhpSpreadsheet/pull/2687)
 - Fix bug when deleting cells with hyperlinks, where the hyperlink was then being "inherited" by whatever cell moved to that cell address.
 - Fix bug in Conditional Formatting in the Xls Writer that resulted in a broken file when there were multiple conditional ranges in a worksheet.

--- a/src/PhpSpreadsheet/CellReferenceHelper.php
+++ b/src/PhpSpreadsheet/CellReferenceHelper.php
@@ -43,6 +43,11 @@ class CellReferenceHelper
         $this->beforeRow = (int) $beforeRow;
     }
 
+    public function beforeCellAddress(): string
+    {
+        return $this->beforeCellAddress;
+    }
+
     public function refreshRequired(string $beforeCellAddress, int $numberOfColumns, int $numberOfRows): bool
     {
         return $this->beforeCellAddress !== $beforeCellAddress ||


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [X] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Fix issues with updating Conditional Formatting when inserting/deleting rows/columns
 - Update existing ranges, expanding or reducing if necessary, rather than trying to clone the CF for each individual cell.

    This is also better for memory usage, with fewer CF rules and styles being maintained
 - Update conditions, so that cell references and formulae are maintained correctly.

Note that absolute as well as relative cell references should be updated in conditions

---

This is a the third and final step toward allowing updates to absolute cell references, required to update Conditional Formatting rules when columns/rows are inserted/deleted as highlighted by [Issue #2678](https://github.com/PHPOffice/PhpSpreadsheet/issues/2678); the final step in a multi-step process.

Step 1
Refactor the cell reference update logic to make it easier to modify, and to test the planned modifications
This may also make the code more performant, as it allows elimination of a lot of code duplication in the different methods to update different components of the worksheet. [PR #2682](https://github.com/PHPOffice/PhpSpreadsheet/pull/2682)

Step 2
Modify the cell reference update logic to accept a flag indicating whether it should update absolute as well as relative cell references [PR #2685](https://github.com/PHPOffice/PhpSpreadsheet/pull/2685)

Step 3
Add the logic to update Conditional Formatting ranges and rules when inserting/deleting rows/columns
