### PR TITLE
fix #2700 : set xaxis/yaxis and chart title color

### DIFF
--- a/src/PhpSpreadsheet/Chart/Title.php
+++ b/src/PhpSpreadsheet/Chart/Title.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheet\Chart;
 
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
+use PhpOffice\PhpSpreadsheet\Style\Font;
 
 class Title
 {
@@ -21,6 +22,12 @@ class Title
     private $layout;
 
     /**
+     * Title Font
+     * @var Font
+     */
+    private $font;
+
+    /**
      * Create a new Title.
      *
      * @param array|RichText|string $caption
@@ -29,6 +36,7 @@ class Title
     {
         $this->caption = $caption;
         $this->layout = $layout;
+        $this->font = new Font();
     }
 
     /**
@@ -86,5 +94,24 @@ class Title
     public function getLayout()
     {
         return $this->layout;
+    }
+    /**
+     * Get font
+     *
+     * @return Font
+     */
+    public function getFont() {
+        return $this->font;
+    }
+
+    /**
+     * Set font
+     *
+     * @param Font $font
+     * @return Title
+     */
+    public function setFont(Font $font = null)  {
+        $this->font = $font;
+        return $this;
     }
 }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
@@ -409,6 +409,15 @@ class Chart extends WriterPart
             if (is_array($caption)) {
                 $caption = $caption[0];
             }
+            if ($xAxisLabel->getFont()->getColor()->getRGB() !== null) {
+                $objWriter->startElement('a:rPr');
+                $objWriter->startElement('a:solidFill');
+                $objWriter->startElement("a:srgbClr");
+                $objWriter->writeAttribute('val', $xAxisLabel->getFont()->getColor()->getRGB());
+                $objWriter->endElement(); //end srgbClr
+                $objWriter->endElement(); //end solidFill
+                $objWriter->endElement(); //end rPr
+            }
             $objWriter->startElement('a:t');
             $objWriter->writeRawData(StringHelper::controlCharacterPHP2OOXML($caption));
             $objWriter->endElement();
@@ -751,6 +760,16 @@ class Chart extends WriterPart
             $caption = $yAxisLabel->getCaption();
             if (is_array($caption)) {
                 $caption = $caption[0];
+            }
+
+            if ($yAxisLabel->getFont()->getColor()->getRGB() !== null) {
+                $objWriter->startElement('a:rPr');
+                $objWriter->startElement('a:solidFill');
+                $objWriter->startElement("a:srgbClr");
+                $objWriter->writeAttribute('val', $yAxisLabel->getFont()->getColor()->getRGB());
+                $objWriter->endElement(); //end srgbClr
+                $objWriter->endElement(); //end solidFill
+                $objWriter->endElement(); //end rPr
             }
 
             $objWriter->startElement('a:t');

--- a/src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/StringTable.php
@@ -238,6 +238,13 @@ class StringTable extends WriterPart
             $objWriter->writeAttribute('strike', ($element->getFont()->getStrikethrough() ? 'sngStrike' : 'noStrike'));
 
             // rFont
+            if ($element->getFont()->getColor()->getRGB() !== null) {
+                $objWriter->startElement('a:solidFill');
+                $objWriter->startElement("a:srgbClr");
+                $objWriter->writeAttribute('val', $element->getFont()->getColor()->getRGB());
+                $objWriter->endElement(); //end srgbClr
+                $objWriter->endElement(); //end solidFill
+            }
             $objWriter->startElement($prefix . 'latin');
             $objWriter->writeAttribute('typeface', $element->getFont()->getName());
             $objWriter->endElement();


### PR DESCRIPTION
This PR is a partial solution (only excel export) for #2700 : now you can choose font color for xaxis/yaxis/title charts.
