### PR TITLE
Bugfix to returned column indexes for FILTER() by row

### DIFF
--- a/src/PhpSpreadsheet/Calculation/LookupRef/Filter.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Filter.php
@@ -29,7 +29,7 @@ class Filter
             return $ifEmpty ?? ExcelError::CALC();
         }
 
-        return array_values($result);
+        return array_values(array_map('array_values', $result));
     }
 
     private static function enumerateArrayKeys(array $sortArray): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/FilterTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/FilterTest.php
@@ -15,7 +15,7 @@ class FilterTest extends TestCase
             ['East', 'Tom', 'Apple', 6830],
             ['East', 'Fritz', 'Apple', 4394],
             ['South', 'Sal', 'Apple', 1310],
-            ['South', 'Hector', 'Apple', 98144],
+            ['South', 'Hector', 'Apple', 8144],
         ];
         $result = Filter::filter($this->sampleDataForRow(), $criteria);
         self::assertSame($expectedResult, $result);
@@ -70,7 +70,7 @@ class FilterTest extends TestCase
             ['East', 'Fritz', 'Banana', 6274],
             ['West', 'Sravan', 'Pear', 4894],
             ['North', 'Xi', 'Grape', 7580],
-            ['South', 'Hector', 'Apple', 98144],
+            ['South', 'Hector', 'Apple', 8144],
         ];
     }
 


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

FILTER() by row was returning column Ids in result; should be simple enumerated keys 