### PR TITLE
Add support for ignored errors for sheets to now display errors over selected ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Limited support for Xls Reader to handle Conditional Formatting:
 
   Ranges and Rules are read, but style is currently limited to font size, weight and color; and to fill style and color.
+- Added support for ignored errors for cell ranges.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Limited support for Xls Reader to handle Conditional Formatting:
 
   Ranges and Rules are read, but style is currently limited to font size, weight and color; and to fill style and color.
-- Added support for ignored errors for cell ranges.
+- Added support for ignored errors for cell ranges. [#2723](https://github.com/PHPOffice/PhpSpreadsheet/pull/2723)
 
 ### Changed
 

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -3228,7 +3228,7 @@ class Worksheet implements IComparable
     /**
      * Get Ignored Errors.
      *
-     * @return string[]
+     * @return array
      */
     public function getIgnoredErrors()
     {
@@ -3244,17 +3244,22 @@ class Worksheet implements IComparable
      */
     public function ignoreError(string $range, string $errorType)
     {
-        if (!in_array($errorType, [
-            'evalError',
-            'twoDigitTextYear',
-            'numberStoredAsText',
-            'formula',
-            'formulaRange',
-            'unlockedFormula',
-            'emptyCellReference',
-            'listDataValidation',
-            'calculatedColumn',
-        ])) {
+        if (
+            !in_array(
+                $errorType,
+                [
+                    'evalError',
+                    'twoDigitTextYear',
+                    'numberStoredAsText',
+                    'formula',
+                    'formulaRange',
+                    'unlockedFormula',
+                    'emptyCellReference',
+                    'listDataValidation',
+                    'calculatedColumn',
+                ]
+            )
+        ) {
             throw new Exception('Ignored errors must have a valid error type specified.');
         }
 

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -3271,7 +3271,7 @@ class Worksheet implements IComparable
         $range = self::pregReplace('/^(\\d+):(\\d+)$/', 'A${1}:XFD${2}', $range);
 
         if (preg_match('/^([A-Z]+)(\\d+):([A-Z]+)(\\d+)$/', $range, $matches) === 1) {
-            if (!\array_key_exists($errorType, $this->ignoredErrors)) {
+            if (!array_key_exists($errorType, $this->ignoredErrors)) {
                 $this->ignoredErrors[$errorType] = [];
             }
             $this->ignoredErrors[$errorType][$range] = $range;

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -3227,6 +3227,16 @@ class Worksheet implements IComparable
     }
 
     /**
+     * Get Ignored Errors.
+     *
+     * @return string[]
+     */
+    public function getIgnoredErrors()
+    {
+        return $this->ignoredErrors;
+    }
+
+    /**
      * Ignore Errors
      *
      * @param string $range Cell range (e.g. A1:E1)

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -338,7 +338,6 @@ class Worksheet implements IComparable
      */
     private $codeName;
 
-
     /**
      * Ignored Errors.
      *
@@ -3237,7 +3236,7 @@ class Worksheet implements IComparable
     }
 
     /**
-     * Ignore Errors
+     * Ignore Errors.
      *
      * @param string $range Cell range (e.g. A1:E1)
      *

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -218,7 +218,7 @@ class Worksheet extends WriterPart
 
         // Show zeros (Excel also writes this attribute only if set to false)
         if ($worksheet->getSheetView()->getShowZeros() === false) {
-            $objWriter->writeAttribute('showZeros', 0);
+            $objWriter->writeAttribute('showZeros', '0');
         }
 
         // View Layout Type

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -149,7 +149,7 @@ class Worksheet extends WriterPart
         }
         $autoFilterRange = $worksheet->getAutoFilter()->getRange();
         if (!empty($autoFilterRange)) {
-            $objWriter->writeAttribute('filterMode', 1);
+            $objWriter->writeAttribute('filterMode', '1');
             if (!$worksheet->getAutoFilter()->getEvaluated()) {
                 $worksheet->getAutoFilter()->showHideRows();
             }
@@ -1482,7 +1482,7 @@ class Worksheet extends WriterPart
                 // ignoredError
                 $objWriter->startElement('ignoredError');
                 $objWriter->writeAttribute('sqref', implode(' ', array_values($ignoreRange)));
-                $objWriter->writeAttribute($errorType, 1);
+                $objWriter->writeAttribute($errorType, '1');
                 $objWriter->endElement();
             }
 

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -120,6 +120,9 @@ class Worksheet extends WriterPart
         // AlternateContent
         $this->writeAlternateContent($objWriter, $worksheet);
 
+        // Ignore Errors
+        $this->writeIgnoredErrors($objWriter, $worksheet);
+
         // ConditionalFormattingRuleExtensionList
         // (Must be inserted last. Not insert last, an Excel parse error will occur)
         $this->writeExtLst($objWriter, $worksheet);
@@ -1439,6 +1442,51 @@ class Worksheet extends WriterPart
             $objWriter->endElement(); //end conditionalFormattings
             $objWriter->endElement(); //end ext
             $objWriter->endElement(); //end extLst
+        }
+    }
+
+    /**
+     * Write Ignored Errors
+     *
+     *  <xsd:complexType name="CT_IgnoredErrors">
+     *   <xsd:sequence>
+     *     <xsd:element name="ignoredError" type="CT_IgnoredError" minOccurs="0" maxOccurs="unbounded"/>
+     *     <xsd:element name="extLst" type="x:CT_ExtensionList" minOccurs="0" maxOccurs="1"/>
+     *   </xsd:sequence>
+     * </xsd:complexType>
+     * <xsd:complexType name="CT_IgnoredError">
+     *   <xsd:sequence>
+     *     <xsd:element ref="xm:sqref" minOccurs="1" maxOccurs="1"/>
+     *   </xsd:sequence>
+     *   <xsd:attribute name="evalError" type="xsd:boolean" use="optional" default="false"/>
+     *   <xsd:attribute name="twoDigitTextYear" type="xsd:boolean" use="optional" default="false"/>
+     *   <xsd:attribute name="numberStoredAsText" type="xsd:boolean" use="optional" default="false"/>
+     *   <xsd:attribute name="formula" type="xsd:boolean" use="optional" default="false"/>
+     *   <xsd:attribute name="formulaRange" type="xsd:boolean" use="optional" default="false"/>
+     *   <xsd:attribute name="unlockedFormula" type="xsd:boolean" use="optional" default="false"/>
+     *   <xsd:attribute name="emptyCellReference" type="xsd:boolean" use="optional" default="false"/>
+     *   <xsd:attribute name="listDataValidation" type="xsd:boolean" use="optional" default="false"/>
+     *   <xsd:attribute name="calculatedColumn" type="xsd:boolean" use="optional" default="false"/>
+     * </xsd:complexType>
+     *
+     * @see https://docs.microsoft.com/en-us/openspecs/office_standards/ms-xlsx/0a377581-c743-4ace-bfcd-22f359e70165
+     */
+    private function writeIgnoredErrors(XMLWriter $objWriter, PhpspreadsheetWorksheet $worksheet): void
+    {
+        if (count($worksheet->getIgnoreErrors()) > 0) {
+            // ignoredErrors
+            $objWriter->startElement('ignoredErrors');
+
+            // Loop ignoredErrors
+            foreach ($worksheet->getIgnoredErrors() as $errorType => $ignoreRange) {
+                // ignoredError
+                $objWriter->startElement('ignoreError');
+                $objWriter->writeAttribute('sref', $ignoreRange);
+                $objWriter->writeAttribute($errorType, 1);
+                $objWriter->endElement();
+            }
+
+            $objWriter->endElement();
         }
     }
 }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1473,15 +1473,15 @@ class Worksheet extends WriterPart
      */
     private function writeIgnoredErrors(XMLWriter $objWriter, PhpspreadsheetWorksheet $worksheet): void
     {
-        if (count($worksheet->getIgnoreErrors()) > 0) {
+        if (count($worksheet->getIgnoredErrors()) > 0) {
             // ignoredErrors
             $objWriter->startElement('ignoredErrors');
 
             // Loop ignoredErrors
             foreach ($worksheet->getIgnoredErrors() as $errorType => $ignoreRange) {
-                // ignoredError
-                $objWriter->startElement('ignoreError');
-                $objWriter->writeAttribute('sref', $ignoreRange);
+                // ignoreError
+                $objWriter->startElement('ignoredError');
+                $objWriter->writeAttribute('sqref', implode(" ", array_values($ignoreRange)));
                 $objWriter->writeAttribute($errorType, 1);
                 $objWriter->endElement();
             }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -108,6 +108,9 @@ class Worksheet extends WriterPart
         // Breaks
         $this->writeBreaks($objWriter, $worksheet);
 
+        // Ignore Errors
+        $this->writeIgnoredErrors($objWriter, $worksheet);
+
         // Drawings and/or Charts
         $this->writeDrawings($objWriter, $worksheet, $includeCharts);
 
@@ -119,9 +122,6 @@ class Worksheet extends WriterPart
 
         // AlternateContent
         $this->writeAlternateContent($objWriter, $worksheet);
-
-        // Ignore Errors
-        $this->writeIgnoredErrors($objWriter, $worksheet);
 
         // ConditionalFormattingRuleExtensionList
         // (Must be inserted last. Not insert last, an Excel parse error will occur)
@@ -1479,7 +1479,7 @@ class Worksheet extends WriterPart
 
             // Loop ignoredErrors
             foreach ($worksheet->getIgnoredErrors() as $errorType => $ignoreRange) {
-                // ignoreError
+                // ignoredError
                 $objWriter->startElement('ignoredError');
                 $objWriter->writeAttribute('sqref', implode(" ", array_values($ignoreRange)));
                 $objWriter->writeAttribute($errorType, 1);

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1446,7 +1446,7 @@ class Worksheet extends WriterPart
     }
 
     /**
-     * Write Ignored Errors
+     * Write Ignored Errors.
      *
      *  <xsd:complexType name="CT_IgnoredErrors">
      *   <xsd:sequence>
@@ -1481,7 +1481,7 @@ class Worksheet extends WriterPart
             foreach ($worksheet->getIgnoredErrors() as $errorType => $ignoreRange) {
                 // ignoredError
                 $objWriter->startElement('ignoredError');
-                $objWriter->writeAttribute('sqref', implode(" ", array_values($ignoreRange)));
+                $objWriter->writeAttribute('sqref', implode(' ', array_values($ignoreRange)));
                 $objWriter->writeAttribute($errorType, 1);
                 $objWriter->endElement();
             }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [x] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Adds the ability to specify that specific cell ranges should have errors ignored (i.e. when using formulas that reference cells and the formulas next door don't match the one to the left).  This removes the green triangles from being displayed as Excel ignores the error.