### PR TITLE
Decrease xlsx reader memory consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
   (i.e. `"Vrai"` wil be converted to a boolean `true` if the Locale is set to `fr`.)
 - Allow `psr/simple-cache` 2.x
+- Decrease xlsx reader memory consumption by using `XMLReader` to read each node in a loop instead of reading a whole sheet with `simplexml_load_string`. 
 
 ### Deprecated
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2486,11 +2486,6 @@ parameters:
 			path: src/PhpSpreadsheet/Reader/Xlsx.php
 
 		-
-			message: "#^Comparison operation \"\\>\" between SimpleXMLElement\\|null and 0 results in an error\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xlsx.php
-
-		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\:\\:boolean\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2691,7 +2686,7 @@ parameters:
 			path: src/PhpSpreadsheet/Reader/Xlsx/AutoFilter.php
 
 		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\AutoFilter\\:\\:readAutoFilter\\(\\) has parameter \\$xmlSheet with no type specified\\.$#"
+			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\AutoFilter\\:\\:readAutoFilter\\(\\) has parameter \\$xmlAutoFilter with no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Reader/Xlsx/AutoFilter.php
 
@@ -2706,7 +2701,7 @@ parameters:
 			path: src/PhpSpreadsheet/Reader/Xlsx/AutoFilter.php
 
 		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\AutoFilter\\:\\:\\$worksheetXml has no type specified\\.$#"
+			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\AutoFilter\\:\\:\\$autoFilter has no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Reader/Xlsx/AutoFilter.php
 
@@ -2976,14 +2971,14 @@ parameters:
 			path: src/PhpSpreadsheet/Reader/Xlsx/ColumnAndRowAttributes.php
 
 		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\ColumnAndRowAttributes\\:\\:\\$worksheetXml has no type specified\\.$#"
+			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\ColumnAndRowAttributes\\:\\:\\$xmlMap has no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Reader/Xlsx/ColumnAndRowAttributes.php
 
 		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\ConditionalStyles\\:\\:readConditionalStyles\\(\\) has parameter \\$xmlSheet with no type specified\\.$#"
+			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\ColumnAndRowAttributes\\:\\:\\$securityScanner has no type specified\\.$#"
 			count: 1
-			path: src/PhpSpreadsheet/Reader/Xlsx/ConditionalStyles.php
+			path: src/PhpSpreadsheet/Reader/Xlsx/ColumnAndRowAttributes.php
 
 		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\ConditionalStyles\\:\\:readDataBarExtLstOfConditionalRule\\(\\) has parameter \\$cfRule with no type specified\\.$#"
@@ -3016,16 +3011,6 @@ parameters:
 			path: src/PhpSpreadsheet/Reader/Xlsx/ConditionalStyles.php
 
 		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\ConditionalStyles\\:\\:readStyleRules\\(\\) has parameter \\$extLst with no type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xlsx/ConditionalStyles.php
-
-		-
-			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\ConditionalStyles\\:\\:setConditionalStyles\\(\\) has parameter \\$xmlExtLst with no type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xlsx/ConditionalStyles.php
-
-		-
 			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\ConditionalStyles\\:\\:\\$dxfs has no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Reader/Xlsx/ConditionalStyles.php
@@ -3036,7 +3021,7 @@ parameters:
 			path: src/PhpSpreadsheet/Reader/Xlsx/ConditionalStyles.php
 
 		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\ConditionalStyles\\:\\:\\$worksheetXml has no type specified\\.$#"
+			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\ConditionalStyles\\:\\:\\$securityScanner has no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Reader/Xlsx/ConditionalStyles.php
 
@@ -3046,12 +3031,22 @@ parameters:
 			path: src/PhpSpreadsheet/Reader/Xlsx/DataValidations.php
 
 		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\DataValidations\\:\\:\\$worksheetXml has no type specified\\.$#"
+			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\DataValidations\\:\\:\\$securityScanner has no type specified\\.$#"
+			count: 1
+			path: src/PhpSpreadsheet/Reader/Xlsx/DataValidations.php
+
+		-
+			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\DataValidations\\:\\:\\$dataValidations has no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Reader/Xlsx/DataValidations.php
 
 		-
 			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\Hyperlinks\\:\\:\\$hyperlinks has no type specified\\.$#"
+			count: 1
+			path: src/PhpSpreadsheet/Reader/Xlsx/Hyperlinks.php
+
+		-
+			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\Hyperlinks\\:\\:\\$securityScanner has no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Reader/Xlsx/Hyperlinks.php
 
@@ -3076,7 +3071,12 @@ parameters:
 			path: src/PhpSpreadsheet/Reader/Xlsx/PageSetup.php
 
 		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\PageSetup\\:\\:\\$worksheetXml has no type specified\\.$#"
+			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\PageSetup\\:\\:\\$xmlMap has no type specified\\.$#"
+			count: 1
+			path: src/PhpSpreadsheet/Reader/Xlsx/PageSetup.php
+
+		-
+			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\PageSetup\\:\\:\\$securityScanner has no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Reader/Xlsx/PageSetup.php
 
@@ -3086,7 +3086,12 @@ parameters:
 			path: src/PhpSpreadsheet/Reader/Xlsx/SheetViewOptions.php
 
 		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\SheetViewOptions\\:\\:\\$worksheetXml has no type specified\\.$#"
+			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\SheetViewOptions\\:\\:\\$xmlMap has no type specified\\.$#"
+			count: 1
+			path: src/PhpSpreadsheet/Reader/Xlsx/SheetViewOptions.php
+
+		-
+			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Reader\\\\Xlsx\\\\SheetViewOptions\\:\\:\\$securityScanner has no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Reader/Xlsx/SheetViewOptions.php
 

--- a/src/PhpSpreadsheet/Reader/Xlsx/AutoFilter.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/AutoFilter.php
@@ -11,29 +11,29 @@ class AutoFilter
 {
     private $worksheet;
 
-    private $worksheetXml;
+    private $autoFilter;
 
-    public function __construct(Worksheet $workSheet, SimpleXMLElement $worksheetXml)
+    public function __construct(Worksheet $workSheet, SimpleXMLElement $autoFilter)
     {
         $this->worksheet = $workSheet;
-        $this->worksheetXml = $worksheetXml;
+        $this->autoFilter = $autoFilter;
     }
 
     public function load(): void
     {
         // Remove all "$" in the auto filter range
-        $autoFilterRange = preg_replace('/\$/', '', $this->worksheetXml->autoFilter['ref'] ?? '');
+        $autoFilterRange = preg_replace('/\$/', '', $this->autoFilter['ref'] ?? '');
         if (strpos($autoFilterRange, ':') !== false) {
-            $this->readAutoFilter($autoFilterRange, $this->worksheetXml);
+            $this->readAutoFilter($autoFilterRange, $this->autoFilter);
         }
     }
 
-    private function readAutoFilter($autoFilterRange, $xmlSheet): void
+    private function readAutoFilter($autoFilterRange, $xmlAutoFilter): void
     {
         $autoFilter = $this->worksheet->getAutoFilter();
         $autoFilter->setRange($autoFilterRange);
 
-        foreach ($xmlSheet->autoFilter->filterColumn as $filterColumn) {
+        foreach ($xmlAutoFilter->filterColumn as $filterColumn) {
             $column = $autoFilter->getColumnByOffset((int) $filterColumn['colId']);
             //    Check for standard filters
             if ($filterColumn->filters) {

--- a/src/PhpSpreadsheet/Reader/Xlsx/DataValidations.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/DataValidations.php
@@ -3,26 +3,30 @@
 namespace PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Reader\Security\XmlScanner;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use SimpleXMLElement;
 
 class DataValidations
 {
     private $worksheet;
 
-    private $worksheetXml;
+    private $securityScanner;
 
-    public function __construct(Worksheet $workSheet, SimpleXMLElement $worksheetXml)
+    private $dataValidations;
+
+    public function __construct(Worksheet $workSheet, array $dataValidations, XmlScanner $securityScanner)
     {
         $this->worksheet = $workSheet;
-        $this->worksheetXml = $worksheetXml;
+        $this->dataValidations = $dataValidations;
+        $this->securityScanner = $securityScanner;
     }
 
     public function load(): void
     {
-        foreach ($this->worksheetXml->dataValidations->dataValidation as $dataValidation) {
+        foreach ($this->dataValidations as $stringDataValidation) {
+            $dataValidation = XmlParser::loadXml($this->securityScanner, $stringDataValidation);
             // Uppercase coordinate
-            $range = strtoupper($dataValidation['sqref']);
+            $range = strtoupper((string) $dataValidation['sqref']);
             $rangeSet = explode(' ', $range);
             foreach ($rangeSet as $range) {
                 $stRange = $this->worksheet->shrinkRangeToFit($range);

--- a/src/PhpSpreadsheet/Reader/Xlsx/Hyperlinks.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Hyperlinks.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Reader\Security\XmlScanner;
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use SimpleXMLElement;
@@ -13,9 +14,12 @@ class Hyperlinks
 
     private $hyperlinks = [];
 
-    public function __construct(Worksheet $workSheet)
+    private $securityScanner;
+
+    public function __construct(Worksheet $workSheet, XmlScanner $securityScanner)
     {
         $this->worksheet = $workSheet;
+        $this->securityScanner = $securityScanner;
     }
 
     public function readHyperlinks(SimpleXMLElement $relsWorksheet): void
@@ -28,12 +32,13 @@ class Hyperlinks
         }
     }
 
-    public function setHyperlinks(SimpleXMLElement $worksheetXml): void
+    /**
+     * @param string[] $hyperlinks
+     */
+    public function setHyperlinks(array $hyperlinks): void
     {
-        foreach ($worksheetXml->children(Namespaces::MAIN)->hyperlink as $hyperlink) {
-            if ($hyperlink !== null) {
-                $this->setHyperlink($hyperlink, $this->worksheet);
-            }
+        foreach ($hyperlinks as $hyperlink) {
+            $this->setHyperlink(XmlParser::loadXml($this->securityScanner, $hyperlink), $this->worksheet);
         }
     }
 

--- a/src/PhpSpreadsheet/Reader/Xlsx/SheetStructure.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/SheetStructure.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Reader\Xlsx;
+
+class SheetStructure
+{
+    public const CONDITIONAL_FORMATTING = 'conditionalFormatting';
+    public const SHEET_PROTECTION = 'sheetProtection';
+    public const SHEET_VIEW = 'sheetView';
+    public const MERGE_CELL = 'mergeCell';
+    public const EXT_LST = 'extLst';
+    public const DATA_VALIDATION = 'dataValidation';
+    public const LEGACY_DRAWING_HF = 'legacyDrawingHF';
+    public const DRAWING = 'drawing';
+    public const AUTO_FILTER = 'autoFilter';
+    public const TABLE_PART = 'tablePart';
+    public const HYPERLINK = 'hyperlink';
+    public const ROW = 'row';
+    public const COL = 'col';
+    public const PROTECTED_RANGE = 'protectedRange';
+    public const SHEET_PR = 'sheetPr';
+    public const SHEET_FORMAT_PR = 'sheetFormatPr';
+    public const PRINT_OPTIONS = 'printOptions';
+    public const PAGE_MARGINS = 'pageMargins';
+    public const PAGE_SETUP = 'pageSetup';
+    public const HEADER_FOOTER = 'headerFooter';
+    public const ROW_BREAKS = 'rowBreaks';
+    public const COL_BREAKS = 'colBreaks';
+    public const ALTERNATE_CONTENT = 'AlternateContent';
+}

--- a/src/PhpSpreadsheet/Reader/Xlsx/XmlParser.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/XmlParser.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Reader\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Reader\Security\XmlScanner;
+use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
+use PhpOffice\PhpSpreadsheet\Settings;
+use SimpleXMLElement;
+
+class XmlParser
+{
+    /**
+     * @param string[] $values
+     *
+     * @return SimpleXMLElement[]
+     */
+    public static function loadXmlArray(XmlScanner $securityScanner, array $values, string $ns = ''): array
+    {
+        $xmlArray = [];
+        foreach ($values as $stringXml) {
+            $xmlArray[] = self::loadXml($securityScanner, $stringXml, $ns);
+        }
+
+        return $xmlArray;
+    }
+
+    public static function loadXml(XmlScanner $securityScanner, string $contents, string $ns = ''): SimpleXMLElement
+    {
+        $rels = simplexml_load_string(
+            $securityScanner->scan($contents),
+            SimpleXMLElement::class,
+            Settings::getLibXmlLoaderOptions(),
+            $ns
+        );
+
+        return Xlsx::testSimpleXml($rels);
+    }
+}

--- a/src/PhpSpreadsheet/Style/ConditionalFormatting/ConditionalFormattingRuleExtension.php
+++ b/src/PhpSpreadsheet/Style/ConditionalFormatting/ConditionalFormattingRuleExtension.php
@@ -55,7 +55,7 @@ class ConditionalFormattingRuleExtension
     {
         $conditionalFormattingRuleExtensions = [];
         $conditionalFormattingRuleExtensionXml = null;
-        if ($extLstXml instanceof SimpleXMLElement) {
+        if (!empty($extLstXml)) {
             foreach ((count($extLstXml) > 0 ? $extLstXml : [$extLstXml]) as $extLst) {
                 //this uri is conditionalFormattings
                 //https://docs.microsoft.com/en-us/openspecs/office_standards/ms-xlsx/07d607af-5618-4ca2-b683-6a78dc0d9627

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/AutoFilterTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/AutoFilterTest.php
@@ -14,9 +14,7 @@ class AutoFilterTest extends TestCase
     {
         return new SimpleXMLElement(
             '<?xml version="1.0" encoding="UTF-8"?>' .
-            '<root>' .
-                '<autoFilter ref="' . $ref . '"></autoFilter>' .
-            '</root>'
+            '<autoFilter ref="' . $ref . '"></autoFilter>'
         );
     }
 


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [x] refactoring
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
While reading big xlsx file like 400k rows [test.xlsx](https://github.com/PHPOffice/PhpSpreadsheet/files/8464853/test.xlsx) `simplexml_load_string()` uses almost 6 GB of memory.
After changing it to `XMLReader` each node is reading separately and xml string is added to "map". Each map's element is parsed with `simplexml_load_string()` separately which dramatically decreases memory usage (~1,2 GB for the mentioned earlier file).

### How to check

XlsxTest.php
```php
<?php
require 'vendor/autoload.php';

use PhpOffice\PhpSpreadsheet\IOFactory;

$file = './test.xlsx';

$inputFileType = IOFactory::identify($file);
$objReader = IOFactory::createReader($inputFileType);
$excel = $objReader->load($file);

echo 'Done';
```

```
/usr/bin/time -l php XlsxTest.php
```
(cannot use `memory_get_usage()` because of https://bugs.php.net/bug.php?id=62467)
