### PR TITLE
Modify Autosize calculation to make allowance for the filter dropdown icon in the first row of an AutoFilter range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Make allowance for the AutoFilter dropdown icon in the first row of an Autofilter range when using Autosize columns. [Issue #2413](https://github.com/PHPOffice/PhpSpreadsheet/issues/2413) [PR #2754](https://github.com/PHPOffice/PhpSpreadsheet/pull/2754)
 - Support for "chained" ranges (e.g. `A5:C10:C20:F1`) in the Calculation Engine; and also support for using named ranges with the Range operator (e.g. `NamedRange1:NamedRange2`) [Issue #2730](https://github.com/PHPOffice/PhpSpreadsheet/issues/2730) [PR #2746](https://github.com/PHPOffice/PhpSpreadsheet/pull/2746)
 - Update Conditional Formatting ranges and rule conditions when inserting/deleting rows/columns [Issue #2678](https://github.com/PHPOffice/PhpSpreadsheet/issues/2678) [PR #2689](https://github.com/PHPOffice/PhpSpreadsheet/pull/2689)
 - Allow `INDIRECT()` to accept row/column ranges as well as cell ranges [PR #2687](https://github.com/PHPOffice/PhpSpreadsheet/pull/2687)

--- a/src/PhpSpreadsheet/Shared/Font.php
+++ b/src/PhpSpreadsheet/Shared/Font.php
@@ -222,11 +222,15 @@ class Font
      * @param RichText|string $cellText Text to calculate width
      * @param int $rotation Rotation angle
      * @param null|FontStyle $defaultFont Font object
-     *
-     * @return int Column width
+     * @param bool $filterAdjustment Add space for Autofilter or Table dropdown
      */
-    public static function calculateColumnWidth(FontStyle $font, $cellText = '', $rotation = 0, ?FontStyle $defaultFont = null)
-    {
+    public static function calculateColumnWidth(
+        FontStyle $font,
+        $cellText = '',
+        $rotation = 0,
+        ?FontStyle $defaultFont = null,
+        bool $filterAdjustment = false
+    ): int {
         // If it is rich text, use plain text
         if ($cellText instanceof RichText) {
             $cellText = $cellText->getPlainText();
@@ -237,7 +241,7 @@ class Font
             $lineTexts = explode("\n", $cellText);
             $lineWidths = [];
             foreach ($lineTexts as $lineText) {
-                $lineWidths[] = self::calculateColumnWidth($font, $lineText, $rotation = 0, $defaultFont);
+                $lineWidths[] = self::calculateColumnWidth($font, $lineText, $rotation = 0, $defaultFont, $filterAdjustment);
             }
 
             return max($lineWidths); // width of longest line in cell
@@ -247,7 +251,13 @@ class Font
         $approximate = self::$autoSizeMethod == self::AUTOSIZE_METHOD_APPROX;
         $columnWidth = 0;
         if (!$approximate) {
-            $columnWidthAdjust = ceil(self::getTextWidthPixelsExact('n', $font, 0) * 1.07);
+            $columnWidthAdjust = ceil(
+                self::getTextWidthPixelsExact(
+                    str_repeat('n', 1 * ($filterAdjustment ? 3 : 1)),
+                    $font,
+                    0
+                ) * 1.07
+            );
 
             try {
                 // Width of text in pixels excl. padding
@@ -259,7 +269,11 @@ class Font
         }
 
         if ($approximate) {
-            $columnWidthAdjust = self::getTextWidthPixelsApprox('n', $font, 0);
+            $columnWidthAdjust = self::getTextWidthPixelsApprox(
+                str_repeat('n', 1 * ($filterAdjustment ? 3 : 1)),
+                $font,
+                0
+            );
             // Width of text in pixels excl. padding, approximation
             // and addition because Excel adds some padding, just use approx width of 'n' glyph
             $columnWidth = self::getTextWidthPixelsApprox($cellText, $font, $rotation) + $columnWidthAdjust;


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Reference [Issue #2413](https://github.com/PHPOffice/PhpSpreadsheet/issues/2413)

Modify Autosize calculation to make allowance for the filter dropdown icon in the first row of an AutoFilter range