### PR TITLE
Reduce size of Unique ID Prefix used for the Cell Collection

### DIFF
--- a/src/PhpSpreadsheet/Collection/Cells.php
+++ b/src/PhpSpreadsheet/Collection/Cells.php
@@ -6,6 +6,7 @@ use Generator;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Exception as PhpSpreadsheetException;
+use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Psr\SimpleCache\CacheInterface;
 
@@ -298,7 +299,9 @@ class Cells
      */
     private function getUniqueID()
     {
-        return uniqid('phpspreadsheet.', true) . '.';
+        return Settings::getCache() instanceof Memory
+            ? random_bytes(7) . ':'
+            : uniqid('phpspreadsheet.', true) . '.';
     }
 
     /**


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] memory reduction
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Reduce size of Unique ID Prefix used for the Cell Collection when "in memory" (reduces the per-cell memory overhead, while still retaining a unique prefix to ensure no clash between worksheet collections).

External cache (where multiple threads may be accessing the same cache with different worksheets) still uses the same length and entropy in the prefix as before.
