### PR TITLE
Performance tweaks to cell collection

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1176,11 +1176,6 @@ parameters:
 			path: src/PhpSpreadsheet/Cell/Coordinate.php
 
 		-
-			message: "#^Cannot use array destructuring on array\\|null\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Cell/Coordinate.php
-
-		-
 			message: "#^Parameter \\#4 \\$currentRow of static method PhpOffice\\\\PhpSpreadsheet\\\\Cell\\\\Coordinate\\:\\:validateRange\\(\\) expects int, string given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Cell/Coordinate.php
@@ -3119,11 +3114,6 @@ parameters:
 			message: "#^Argument of an invalid type SimpleXMLElement\\|null supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Reader/Xml/Style.php
-
-		-
-			message: "#^Cannot use array destructuring on array\\|null\\.$#"
-			count: 4
-			path: src/PhpSpreadsheet/ReferenceHelper.php
 
 		-
 			message: "#^Elseif condition is always true\\.$#"

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -383,7 +383,7 @@ abstract class Coordinate
         //    Sort the result by column and row
         $sortKeys = [];
         foreach ($cellList as $coord) {
-            [$column, $row] = sscanf($coord, '%[A-Z]%d');
+            sscanf($coord, '%[A-Z]%d', $column, $row);
             $sortKeys[sprintf('%3s%09d', $column, $row)] = $coord;
         }
         ksort($sortKeys);

--- a/src/PhpSpreadsheet/Collection/Cells.php
+++ b/src/PhpSpreadsheet/Collection/Cells.php
@@ -4,7 +4,6 @@ namespace PhpOffice\PhpSpreadsheet\Collection;
 
 use Generator;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
-use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Exception as PhpSpreadsheetException;
 use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
@@ -152,8 +151,6 @@ class Cells
     {
         $sortKeys = [];
         foreach ($this->getCoordinates() as $coord) {
-            $column = '';
-            $row = 0;
             sscanf($coord, '%[A-Z]%d', $column, $row);
             $sortKeys[sprintf('%09d%3s', $row, $column)] = $coord;
         }
@@ -172,8 +169,6 @@ class Cells
         // Lookup highest column and highest row
         $col = ['A' => '1A'];
         $row = [1];
-        $c = '';
-        $r = 0;
         foreach ($this->getCoordinates() as $coord) {
             sscanf($coord, '%[A-Z]%d', $c, $r);
             $row[$r] = $r;
@@ -207,9 +202,6 @@ class Cells
      */
     public function getCurrentColumn()
     {
-        $column = '';
-        $row = 0;
-
         sscanf($this->currentCoordinate ?? '', '%[A-Z]%d', $column, $row);
 
         return $column;
@@ -222,9 +214,6 @@ class Cells
      */
     public function getCurrentRow()
     {
-        $column = '';
-        $row = 0;
-
         sscanf($this->currentCoordinate ?? '', '%[A-Z]%d', $column, $row);
 
         return (int) $row;
@@ -245,8 +234,6 @@ class Cells
         }
 
         $maxColumn = '1A';
-        $c = '';
-        $r = 0;
         foreach ($this->getCoordinates() as $coord) {
             sscanf($coord, '%[A-Z]%d', $c, $r);
             if ($r != $row) {
@@ -273,8 +260,6 @@ class Cells
         }
 
         $maxRow = 1;
-        $c = '';
-        $r = 0;
         foreach ($this->getCoordinates() as $coord) {
             sscanf($coord, '%[A-Z]%d', $c, $r);
             if ($c != $column) {
@@ -341,8 +326,6 @@ class Cells
      */
     public function removeRow($row): void
     {
-        $c = '';
-        $r = 0;
         foreach ($this->getCoordinates() as $coord) {
             sscanf($coord, '%[A-Z]%d', $c, $r);
             if ($r == $row) {
@@ -358,8 +341,6 @@ class Cells
      */
     public function removeColumn($column): void
     {
-        $c = '';
-        $r = 0;
         foreach ($this->getCoordinates() as $coord) {
             sscanf($coord, '%[A-Z]%d', $c, $r);
             if ($c == $column) {

--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -90,8 +90,8 @@ class ReferenceHelper
      */
     public static function cellSort($a, $b)
     {
-        [$ac, $ar] = sscanf($a, '%[A-Z]%d');
-        [$bc, $br] = sscanf($b, '%[A-Z]%d');
+        sscanf($a, '%[A-Z]%d', $ac, $ar);
+        sscanf($b, '%[A-Z]%d', $bc, $br);
 
         if ($ar === $br) {
             return strcasecmp(strlen($ac) . $ac, strlen($bc) . $bc);
@@ -111,8 +111,8 @@ class ReferenceHelper
      */
     public static function cellReverseSort($a, $b)
     {
-        [$ac, $ar] = sscanf($a, '%[A-Z]%d');
-        [$bc, $br] = sscanf($b, '%[A-Z]%d');
+        sscanf($a, '%[A-Z]%d', $ac, $ar);
+        sscanf($b, '%[A-Z]%d', $bc, $br);
 
         if ($ar === $br) {
             return -strcasecmp(strlen($ac) . $ac, strlen($bc) . $bc);


### PR DESCRIPTION
I suspect that scrutiniser may complain that the pass-by-reference values in an expression like `sscanf($coord, '%[A-Z]%d', $column, $row)` don't exist; but PHP handles that without issue, creating the variables as needed, and phpstan has no problems with that, so scrutiniser shouldn't treat it as an issue. There's no point in adding code (even if it's just pre-defining call-by-reference arguments) when it's unnecessary overhead.

This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] performance
```

Checklist:

- [ ] Changes are covered by unit tests
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Improved performance by 10-15% for a couple of the more expensive methods in the cell collection, such as sorting