### PR TITLE
Add point size option for scatter charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
-- Nothing
+- Add point size option for scatter charts
 
 ### Changed
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4957,7 +4957,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$value of method XMLWriter\\:\\:writeAttribute\\(\\) expects string, int given\\.$#"
-			count: 45
+			count: 44
 			path: src/PhpSpreadsheet/Writer/Xlsx/Chart.php
 
 		-

--- a/src/PhpSpreadsheet/Chart/DataSeriesValues.php
+++ b/src/PhpSpreadsheet/Chart/DataSeriesValues.php
@@ -46,6 +46,13 @@ class DataSeriesValues
     private $pointMarker;
 
     /**
+     * Series Point Size.
+     *
+     * @var int
+     */
+    private $pointSize = 3;
+
+    /**
      * Point Count (The number of datapoints in the dataseries).
      *
      * @var int
@@ -171,6 +178,26 @@ class DataSeriesValues
     public function setPointMarker($marker)
     {
         $this->pointMarker = $marker;
+
+        return $this;
+    }
+
+    /**
+     * Get Point Size.
+     */
+    public function getPointSize(): int
+    {
+        return $this->pointSize;
+    }
+
+    /**
+     * Set Point Size.
+     *
+     * @return $this
+     */
+    public function setPointSize(int $size = 3)
+    {
+        $this->pointSize = $size;
 
         return $this;
     }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Chart.php
@@ -1140,7 +1140,7 @@ class Chart extends WriterPart
 
                     if ($plotSeriesMarker !== 'none') {
                         $objWriter->startElement('c:size');
-                        $objWriter->writeAttribute('val', 3);
+                        $objWriter->writeAttribute('val', (string) $plotSeriesValues->getPointSize());
                         $objWriter->endElement();
                     }
 


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Add point size option for scatter charts [Issue #2298](https://github.com/PHPOffice/PhpSpreadsheet/issues/2298)