### PR TITLE
Fix issue with row height styles in Ods Writer

### DIFF
--- a/src/PhpSpreadsheet/Writer/Ods/Cell/Style.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Cell/Style.php
@@ -199,7 +199,7 @@ class Style
             'style:row-height',
             round($rowDimension->getRowHeight(Dimension::UOM_CENTIMETERS), 3) . 'cm'
         );
-        $this->writer->writeAttribute('style:use-optimal-row-height', 'true');
+        $this->writer->writeAttribute('style:use-optimal-row-height', 'false');
         $this->writer->writeAttribute('fo:break-before', 'auto');
 
         // End

--- a/src/PhpSpreadsheet/Writer/Ods/Content.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Content.php
@@ -151,25 +151,24 @@ class Content extends WriterPart
             $cellIterator = $row->getCellIterator();
             --$numberRowsRepeated;
             if ($cellIterator->valid()) {
+                $objWriter->startElement('table:table-row');
                 if ($span_row) {
-                    $objWriter->startElement('table:table-row');
                     if ($span_row > 1) {
                         $objWriter->writeAttribute('table:number-rows-repeated', $span_row);
-                    }
-                    if ($sheet->getRowDimension($row->getRowIndex())->getRowHeight() > 0) {
-                        $objWriter->writeAttribute(
-                            'table:style_name',
-                            sprintf('%s_%d_%d', Style::ROW_STYLE_PREFIX, $sheetIndex, $row->getRowIndex())
-                        );
                     }
                     $objWriter->startElement('table:table-cell');
                     $objWriter->writeAttribute('table:number-columns-repeated', (string) self::NUMBER_COLS_REPEATED_MAX);
                     $objWriter->endElement();
-                    $objWriter->endElement();
                     $span_row = 0;
+                } else {
+                    if ($sheet->getRowDimension($row->getRowIndex())->getRowHeight() > 0) {
+                        $objWriter->writeAttribute(
+                            'table:style-name',
+                            sprintf('%s_%d_%d', Style::ROW_STYLE_PREFIX, $sheetIndex, $row->getRowIndex())
+                        );
+                    }
+                    $this->writeCells($objWriter, $cellIterator);
                 }
-                $objWriter->startElement('table:table-row');
-                $this->writeCells($objWriter, $cellIterator);
                 $objWriter->endElement();
             } else {
                 ++$span_row;


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Row height not being written for all rows, and the style needed to be written with `use-optimal-row-height` set to false