### PR TITLE
Disable URLImageTest

### DIFF
--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
@@ -11,9 +11,12 @@ class URLImageTest extends TestCase
 {
     public function testURLImageSource(): void
     {
-        if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
-            self::markTestSkipped('Skipped due to setting of environment variable');
+        if (getenv('RUN_URL_IMAGE_TEST') !== '1') {
+            self::markTestSkipped('Skipped due to no longer bein able to access external URL');
         }
+        //if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
+        //    self::markTestSkipped('Skipped due to setting of environment variable');
+        //}
         $filename = realpath(__DIR__ . '/../../../data/Reader/XLSX/urlImage.xlsx');
         self::assertNotFalse($filename);
         $reader = IOFactory::createReader('Xlsx');


### PR DESCRIPTION
This test has always been problematic in that it depends on an external site not under the control of PhpSpreadsheet, and can therefore break at any time. As it has done this morning. Disable it until a better test is available.

This is:

```
- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
