### PR TITLE
Php stan cleanup regexp string casting

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -126,11 +126,6 @@ parameters:
 			path: src/PhpSpreadsheet/Calculation/Calculation.php
 
 		-
-			message: "#^Parameter \\#3 \\$formula of static method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\Calculation\\:\\:translateSeparator\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Calculation/Calculation.php
-
-		-
 			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\Calculation\\:\\:\\$cellStack has no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Calculation/Calculation.php
@@ -749,11 +744,6 @@ parameters:
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Calculation\\\\LookupRef\\\\Offset\\:\\:extractWorksheet\\(\\) has parameter \\$cellAddress with no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Calculation/LookupRef/Offset.php
-
-		-
-			message: "#^Parameter \\#1 \\$columnAddress of static method PhpOffice\\\\PhpSpreadsheet\\\\Cell\\\\Coordinate\\:\\:columnIndexFromString\\(\\) expects string, string\\|null given\\.$#"
-			count: 3
-			path: src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
 
 		-
 			message: "#^Binary operation \"/\" between array\\|float\\|int\\|string and array\\|float\\|int\\|string results in an error\\.$#"
@@ -1711,11 +1701,6 @@ parameters:
 			path: src/PhpSpreadsheet/Helper/Html.php
 
 		-
-			message: "#^Parameter \\#1 \\$text of method PhpOffice\\\\PhpSpreadsheet\\\\RichText\\\\ITextElement\\:\\:setText\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Helper/Html.php
-
-		-
 			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Helper\\\\Html\\:\\:\\$bold has no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Helper/Html.php
@@ -1812,11 +1797,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Helper/Sample.php
-
-		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Helper/Sample.php
 
@@ -2722,11 +2702,6 @@ parameters:
 
 		-
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/ReferenceHelper.php
-
-		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/ReferenceHelper.php
 
@@ -3726,22 +3701,7 @@ parameters:
 			path: src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
 
 		-
-			message: "#^Parameter \\#2 \\$subject of function preg_split expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
-
-		-
-			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
-
-		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Style\\\\NumberFormat\\\\PercentageFormatter\\:\\:format\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Style/NumberFormat/PercentageFormatter.php
-
-		-
-			message: "#^Parameter \\#1 \\$format of function sprintf expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Style/NumberFormat/PercentageFormatter.php
 
@@ -4181,11 +4141,6 @@ parameters:
 			path: src/PhpSpreadsheet/Writer/Html.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Html.php
-
-		-
 			message: "#^Parameter \\#1 \\$vAlign of method PhpOffice\\\\PhpSpreadsheet\\\\Writer\\\\Html\\:\\:mapVAlign\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Writer/Html.php
@@ -4381,16 +4336,6 @@ parameters:
 			path: src/PhpSpreadsheet/Writer/Xls/Parser.php
 
 		-
-			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xls/Parser.php
-
-		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xls/Parser.php
-
-		-
 			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Writer\\\\Xls\\\\Parser\\:\\:\\$spreadsheet has no type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Writer/Xls/Parser.php
@@ -4488,21 +4433,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$length of function fread expects int\\<0, max\\>, int\\<0, max\\>\\|false given\\.$#"
 			count: 1
-			path: src/PhpSpreadsheet/Writer/Xls/Worksheet.php
-
-		-
-			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, string\\|null given\\.$#"
-			count: 2
-			path: src/PhpSpreadsheet/Writer/Xls/Worksheet.php
-
-		-
-			message: "#^Parameter \\#2 \\$subject of function preg_match_all expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Writer/Xls/Worksheet.php
-
-		-
-			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
-			count: 2
 			path: src/PhpSpreadsheet/Writer/Xls/Worksheet.php
 
 		-

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -3197,7 +3197,7 @@ class Calculation
         string $toSeparator
     ): string {
         // Function Names
-        $formula = preg_replace($from, $to, $formula);
+        $formula = (string) preg_replace($from, $to, $formula);
 
         // Temporarily adjust matrix separators so that they won't be confused with function arguments
         $formula = self::translateSeparator(';', '|', $formula, $inMatrixBracesLevel, self::FORMULA_OPEN_MATRIX_BRACE, self::FORMULA_CLOSE_MATRIX_BRACE);
@@ -4180,7 +4180,7 @@ class Calculation
                 $length = strlen($val);
 
                 if (preg_match('/^' . self::CALCULATION_REGEXP_FUNCTION . '$/miu', $val, $matches)) {
-                    $val = preg_replace('/\s/u', '', $val);
+                    $val = (string) preg_replace('/\s/u', '', $val);
                     if (isset(self::$phpSpreadsheetFunctions[strtoupper($matches[1])]) || isset(self::$controlFunctions[strtoupper($matches[1])])) {    // it's a function
                         $valToUpper = strtoupper($val);
                     } else {

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/DateValue.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/DateValue.php
@@ -49,7 +49,7 @@ class DateValue
         $baseYear = SharedDateHelper::getExcelCalendar();
         $dateValue = trim($dateValue ?? '', '"');
         //    Strip any ordinals because they're allowed in Excel (English only)
-        $dateValue = preg_replace('/(\d)(st|nd|rd|th)([ -\/])/Ui', '$1$3', $dateValue) ?? '';
+        $dateValue = (string) preg_replace('/(\d)(st|nd|rd|th)([ -\/])/Ui', '$1$3', $dateValue);
         //    Convert separators (/ . or space) to hyphens (should also handle dot used for ordinals in some countries, e.g. Denmark, Germany)
         $dateValue = str_replace(['/', '.', '-', '  '], ' ', $dateValue);
 

--- a/src/PhpSpreadsheet/Calculation/Functions.php
+++ b/src/PhpSpreadsheet/Calculation/Functions.php
@@ -159,7 +159,7 @@ class Functions
             } elseif (!is_numeric($condition)) {
                 if ($condition !== '""') { // Not an empty string
                     // Escape any quotes in the string value
-                    $condition = preg_replace('/"/ui', '""', $condition);
+                    $condition = (string) preg_replace('/"/ui', '""', $condition);
                 }
                 $condition = Calculation::wrapResult(strtoupper($condition));
             }

--- a/src/PhpSpreadsheet/Calculation/LookupRef/Helpers.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Helpers.php
@@ -43,7 +43,7 @@ class Helpers
         if ($namedRange !== null) {
             $workSheet = $namedRange->getWorkSheet();
             $sheetTitle = ($workSheet === null) ? '' : $workSheet->getTitle();
-            $value = preg_replace('/^=/', '', $namedRange->getValue());
+            $value = (string) preg_replace('/^=/', '', $namedRange->getValue());
             self::adjustSheetTitle($sheetTitle, $value);
             $cellAddress1 = $sheetTitle . $value;
             $cellAddress = $cellAddress1;

--- a/src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
@@ -50,7 +50,7 @@ class RowColumnInformation
 
         if (is_array($cellAddress)) {
             foreach ($cellAddress as $columnKey => $value) {
-                $columnKey = preg_replace('/[^a-z]/i', '', $columnKey);
+                $columnKey = (string) preg_replace('/[^a-z]/i', '', $columnKey);
 
                 return (int) Coordinate::columnIndexFromString($columnKey);
             }
@@ -66,8 +66,8 @@ class RowColumnInformation
         [, $cellAddress] = Worksheet::extractSheetTitle($cellAddress, true);
         if (strpos($cellAddress, ':') !== false) {
             [$startAddress, $endAddress] = explode(':', $cellAddress);
-            $startAddress = preg_replace('/[^a-z]/i', '', $startAddress);
-            $endAddress = preg_replace('/[^a-z]/i', '', $endAddress);
+            $startAddress = (string) preg_replace('/[^a-z]/i', '', $startAddress);
+            $endAddress = (string) preg_replace('/[^a-z]/i', '', $endAddress);
 
             return range(
                 (int) Coordinate::columnIndexFromString($startAddress),
@@ -75,7 +75,7 @@ class RowColumnInformation
             );
         }
 
-        $cellAddress = preg_replace('/[^a-z]/i', '', $cellAddress);
+        $cellAddress = (string) preg_replace('/[^a-z]/i', '', $cellAddress);
 
         return (int) Coordinate::columnIndexFromString($cellAddress);
     }
@@ -159,14 +159,13 @@ class RowColumnInformation
         [, $cellAddress] = Worksheet::extractSheetTitle($cellAddress, true);
         if (strpos($cellAddress, ':') !== false) {
             [$startAddress, $endAddress] = explode(':', $cellAddress);
-            $startAddress = preg_replace('/\D/', '', $startAddress);
-            $endAddress = preg_replace('/\D/', '', $endAddress);
+            $startAddress = (string) preg_replace('/\D/', '', $startAddress);
+            $endAddress = (string) preg_replace('/\D/', '', $endAddress);
 
             return array_map(
                 function ($value) {
                     return [$value];
                 },
-                // @phpstan-ignore-next-line
                 range($startAddress, $endAddress)
             );
         }

--- a/src/PhpSpreadsheet/Document/Properties.php
+++ b/src/PhpSpreadsheet/Document/Properties.php
@@ -171,9 +171,9 @@ class Properties
             if (is_numeric($timestamp)) {
                 $timestamp = (float) $timestamp;
             } else {
-                $timestamp = preg_replace('/[.][0-9]*$/', '', $timestamp) ?? '';
-                $timestamp = preg_replace('/^(\\d{4})- (\\d)/', '$1-0$2', $timestamp) ?? '';
-                $timestamp = preg_replace('/^(\\d{4}-\\d{2})- (\\d)/', '$1-0$2', $timestamp) ?? '';
+                $timestamp = (string) preg_replace('/[.][0-9]*$/', '', $timestamp);
+                $timestamp = (string) preg_replace('/^(\\d{4})- (\\d)/', '$1-0$2', $timestamp);
+                $timestamp = (string) preg_replace('/^(\\d{4}-\\d{2})- (\\d)/', '$1-0$2', $timestamp);
                 $timestamp = (float) (new DateTime($timestamp))->format('U');
             }
         }

--- a/src/PhpSpreadsheet/Helper/Html.php
+++ b/src/PhpSpreadsheet/Helper/Html.php
@@ -642,7 +642,7 @@ class Html
                 $text = ltrim($text);
             }
             // Trim any spaces immediately after a line break
-            $text = preg_replace('/\n */mu', "\n", $text);
+            $text = (string) preg_replace('/\n */mu', "\n", $text);
             $element->setText($text);
         }
     }
@@ -792,7 +792,7 @@ class Html
 
     protected function parseTextNode(DOMText $textNode): void
     {
-        $domText = preg_replace(
+        $domText = (string) preg_replace(
             '/\s+/u',
             ' ',
             str_replace(["\r", "\n"], ' ', $textNode->nodeValue ?? '')

--- a/src/PhpSpreadsheet/Helper/Sample.php
+++ b/src/PhpSpreadsheet/Helper/Sample.php
@@ -85,7 +85,7 @@ class Sample
             $file = str_replace(str_replace('\\', '/', $baseDir) . '/', '', str_replace('\\', '/', $file[0]));
             $info = pathinfo($file);
             $category = str_replace('_', ' ', $info['dirname']);
-            $name = str_replace('_', ' ', preg_replace('/(|\.php)/', '', $info['filename']));
+            $name = str_replace('_', ' ', (string) preg_replace('/(|\.php)/', '', $info['filename']));
             if (!in_array($category, ['.', 'boostrap', 'templates'])) {
                 if (!isset($files[$category])) {
                     $files[$category] = [];

--- a/src/PhpSpreadsheet/Reader/Csv/Delimiter.php
+++ b/src/PhpSpreadsheet/Reader/Csv/Delimiter.php
@@ -140,12 +140,12 @@ class Delimiter
             $line = $line . $newLine;
 
             // Drop everything that is enclosed to avoid counting false positives in enclosures
-            $line = preg_replace('/(' . $enclosure . '.*' . $enclosure . ')/Us', '', $line);
+            $line = (string) preg_replace('/(' . $enclosure . '.*' . $enclosure . ')/Us', '', $line);
 
             // See if we have any enclosures left in the line
             // if we still have an enclosure then we need to read the next line as well
-        } while (preg_match('/(' . $enclosure . ')/', $line ?? '') > 0);
+        } while (preg_match('/(' . $enclosure . ')/', $line) > 0);
 
-        return $line ?? false;
+        return ($line !== '') ? $line : false;
     }
 }

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -619,7 +619,7 @@ class Html extends BaseReader
     {
         foreach ($element->childNodes as $child) {
             if ($child instanceof DOMText) {
-                $domText = preg_replace('/\s+/u', ' ', trim($child->nodeValue ?? ''));
+                $domText = (string) preg_replace('/\s+/u', ' ', trim($child->nodeValue ?? ''));
                 if (is_string($cellContent)) {
                     //    simply append the text if the cell content is a plain text string
                     $cellContent .= $domText;

--- a/src/PhpSpreadsheet/Reader/Ods/FormulaTranslator.php
+++ b/src/PhpSpreadsheet/Reader/Ods/FormulaTranslator.php
@@ -13,15 +13,23 @@ class FormulaTranslator
         // Cell range 3-d reference
         // As we don't support 3-d ranges, we're just going to take a quick and dirty approach
         //  and assume that the second worksheet reference is the same as the first
-        $excelAddress = (string) preg_replace('/\$?([^\.]+)\.([^\.]+):\$?([^\.]+)\.([^\.]+)/miu', '$1!$2:$4', $excelAddress);
-        // Cell range reference in another sheet
-        $excelAddress = (string) preg_replace('/\$?([^\.]+)\.([^\.]+):\.([^\.]+)/miu', '$1!$2:$3', $excelAddress);
-        // Cell reference in another sheet
-        $excelAddress = (string) preg_replace('/\$?([^\.]+)\.([^\.]+)/miu', '$1!$2', $excelAddress);
-        // Cell range reference
-        $excelAddress = (string) preg_replace('/\.([^\.]+):\.([^\.]+)/miu', '$1:$2', $excelAddress);
-        // Simple cell reference
-        $excelAddress = (string) preg_replace('/\.([^\.]+)/miu', '$1', $excelAddress);
+        $excelAddress = (string) preg_replace(
+            [
+                '/\$?([^\.]+)\.([^\.]+):\$?([^\.]+)\.([^\.]+)/miu',
+                '/\$?([^\.]+)\.([^\.]+):\.([^\.]+)/miu', // Cell range reference in another sheet
+                '/\$?([^\.]+)\.([^\.]+)/miu', // Cell reference in another sheet
+                '/\.([^\.]+):\.([^\.]+)/miu', // Cell range reference
+                '/\.([^\.]+)/miu', // Simple cell reference
+            ],
+            [
+                '$1!$2:$4',
+                '$1!$2:$3',
+                '$1!$2',
+                '$1:$2',
+                '$1',
+            ],
+            $excelAddress
+        );
 
         return $excelAddress;
     }
@@ -37,14 +45,21 @@ class FormulaTranslator
             // Only replace in alternate array entries (i.e. non-quoted blocks)
             //      so that conversion isn't done in string values
             if ($tKey = !$tKey) {
-                // Cell range reference in another sheet
-                $value = (string) preg_replace('/\[\$?([^\.]+)\.([^\.]+):\.([^\.]+)\]/miu', '$1!$2:$3', $value);
-                // Cell reference in another sheet
-                $value = (string) preg_replace('/\[\$?([^\.]+)\.([^\.]+)\]/miu', '$1!$2', $value);
-                // Cell range reference
-                $value = (string) preg_replace('/\[\.([^\.]+):\.([^\.]+)\]/miu', '$1:$2', $value);
-                // Simple cell reference
-                $value = (string) preg_replace('/\[\.([^\.]+)\]/miu', '$1', $value);
+                $value = (string) preg_replace(
+                    [
+                        '/\[\$?([^\.]+)\.([^\.]+):\.([^\.]+)\]/miu', // Cell range reference in another sheet
+                        '/\[\$?([^\.]+)\.([^\.]+)\]/miu', // Cell reference in another sheet
+                        '/\[\.([^\.]+):\.([^\.]+)\]/miu', // Cell range reference
+                        '/\[\.([^\.]+)\]/miu', // Simple cell reference
+                    ],
+                    [
+                        '$1!$2:$3',
+                        '$1!$2',
+                        '$1:$2',
+                        '$1',
+                    ],
+                    $value
+                );
                 // Convert references to defined names/formulae
                 $value = str_replace('$$', '', $value);
 

--- a/src/PhpSpreadsheet/Reader/Ods/FormulaTranslator.php
+++ b/src/PhpSpreadsheet/Reader/Ods/FormulaTranslator.php
@@ -13,17 +13,17 @@ class FormulaTranslator
         // Cell range 3-d reference
         // As we don't support 3-d ranges, we're just going to take a quick and dirty approach
         //  and assume that the second worksheet reference is the same as the first
-        $excelAddress = preg_replace('/\$?([^\.]+)\.([^\.]+):\$?([^\.]+)\.([^\.]+)/miu', '$1!$2:$4', $excelAddress);
+        $excelAddress = (string) preg_replace('/\$?([^\.]+)\.([^\.]+):\$?([^\.]+)\.([^\.]+)/miu', '$1!$2:$4', $excelAddress);
         // Cell range reference in another sheet
-        $excelAddress = preg_replace('/\$?([^\.]+)\.([^\.]+):\.([^\.]+)/miu', '$1!$2:$3', $excelAddress ?? '');
+        $excelAddress = (string) preg_replace('/\$?([^\.]+)\.([^\.]+):\.([^\.]+)/miu', '$1!$2:$3', $excelAddress);
         // Cell reference in another sheet
-        $excelAddress = preg_replace('/\$?([^\.]+)\.([^\.]+)/miu', '$1!$2', $excelAddress ?? '');
+        $excelAddress = (string) preg_replace('/\$?([^\.]+)\.([^\.]+)/miu', '$1!$2', $excelAddress);
         // Cell range reference
-        $excelAddress = preg_replace('/\.([^\.]+):\.([^\.]+)/miu', '$1:$2', $excelAddress ?? '');
+        $excelAddress = (string) preg_replace('/\.([^\.]+):\.([^\.]+)/miu', '$1:$2', $excelAddress);
         // Simple cell reference
-        $excelAddress = preg_replace('/\.([^\.]+)/miu', '$1', $excelAddress ?? '');
+        $excelAddress = (string) preg_replace('/\.([^\.]+)/miu', '$1', $excelAddress);
 
-        return $excelAddress ?? '';
+        return $excelAddress;
     }
 
     public static function convertToExcelFormulaValue(string $openOfficeFormula): string
@@ -38,15 +38,15 @@ class FormulaTranslator
             //      so that conversion isn't done in string values
             if ($tKey = !$tKey) {
                 // Cell range reference in another sheet
-                $value = preg_replace('/\[\$?([^\.]+)\.([^\.]+):\.([^\.]+)\]/miu', '$1!$2:$3', $value);
+                $value = (string) preg_replace('/\[\$?([^\.]+)\.([^\.]+):\.([^\.]+)\]/miu', '$1!$2:$3', $value);
                 // Cell reference in another sheet
-                $value = preg_replace('/\[\$?([^\.]+)\.([^\.]+)\]/miu', '$1!$2', $value ?? '');
+                $value = (string) preg_replace('/\[\$?([^\.]+)\.([^\.]+)\]/miu', '$1!$2', $value);
                 // Cell range reference
-                $value = preg_replace('/\[\.([^\.]+):\.([^\.]+)\]/miu', '$1:$2', $value ?? '');
+                $value = (string) preg_replace('/\[\.([^\.]+):\.([^\.]+)\]/miu', '$1:$2', $value);
                 // Simple cell reference
-                $value = preg_replace('/\[\.([^\.]+)\]/miu', '$1', $value ?? '');
+                $value = (string) preg_replace('/\[\.([^\.]+)\]/miu', '$1', $value);
                 // Convert references to defined names/formulae
-                $value = str_replace('$$', '', $value ?? '');
+                $value = str_replace('$$', '', $value);
 
                 // Convert ODS function argument separators to Excel function argument separators
                 $value = Calculation::translateSeparator(';', ',', $value, $inFunctionBracesLevel);
@@ -69,7 +69,7 @@ class FormulaTranslator
                     Calculation::FORMULA_CLOSE_MATRIX_BRACE
                 );
 
-                $value = preg_replace('/COM\.MICROSOFT\./ui', '', $value);
+                $value = (string) preg_replace('/COM\.MICROSOFT\./ui', '', $value);
             }
         }
 

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -4521,17 +4521,17 @@ class Xls extends BaseReader
 
             // first row '1' + last row '16384' indicates that full column is selected (apparently also in BIFF8!)
             if (preg_match('/^([A-Z]+1\:[A-Z]+)16384$/', $selectedCells)) {
-                $selectedCells = preg_replace('/^([A-Z]+1\:[A-Z]+)16384$/', '${1}1048576', $selectedCells);
+                $selectedCells = (string) preg_replace('/^([A-Z]+1\:[A-Z]+)16384$/', '${1}1048576', $selectedCells);
             }
 
             // first row '1' + last row '65536' indicates that full column is selected
             if (preg_match('/^([A-Z]+1\:[A-Z]+)65536$/', $selectedCells)) {
-                $selectedCells = preg_replace('/^([A-Z]+1\:[A-Z]+)65536$/', '${1}1048576', $selectedCells);
+                $selectedCells = (string) preg_replace('/^([A-Z]+1\:[A-Z]+)65536$/', '${1}1048576', $selectedCells);
             }
 
             // first column 'A' + last column 'IV' indicates that full row is selected
             if (preg_match('/^(A\d+\:)IV(\d+)$/', $selectedCells)) {
-                $selectedCells = preg_replace('/^(A\d+\:)IV(\d+)$/', '${1}XFD${2}', $selectedCells);
+                $selectedCells = (string) preg_replace('/^(A\d+\:)IV(\d+)$/', '${1}XFD${2}', $selectedCells);
             }
 
             $this->phpSheet->setSelectedCells($selectedCells);

--- a/src/PhpSpreadsheet/Reader/Xlsx/AutoFilter.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/AutoFilter.php
@@ -22,7 +22,7 @@ class AutoFilter
     public function load(): void
     {
         // Remove all "$" in the auto filter range
-        $autoFilterRange = preg_replace('/\$/', '', $this->worksheetXml->autoFilter['ref'] ?? '');
+        $autoFilterRange = (string) preg_replace('/\$/', '', $this->worksheetXml->autoFilter['ref'] ?? '');
         if (strpos($autoFilterRange, ':') !== false) {
             $this->readAutoFilter($autoFilterRange, $this->worksheetXml);
         }

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -90,9 +90,9 @@ class Xml extends BaseReader
         //    Retrieve charset encoding
         if (preg_match('/<?xml.*encoding=[\'"](.*?)[\'"].*?>/m', $data, $matches)) {
             $charSet = strtoupper($matches[1]);
-            if (1 == preg_match('/^ISO-8859-\d[\dL]?$/i', $charSet)) {
+            if (preg_match('/^ISO-8859-\d[\dL]?$/i', $charSet) === 1) {
                 $data = StringHelper::convertEncoding($data, 'UTF-8', $charSet);
-                $data = preg_replace('/(<?xml.*encoding=[\'"]).*?([\'"].*?>)/um', '$1' . 'UTF-8' . '$2', $data, 1);
+                $data = (string) preg_replace('/(<?xml.*encoding=[\'"]).*?([\'"].*?>)/um', '$1' . 'UTF-8' . '$2', $data, 1);
             }
         }
         $this->fileContents = $data;

--- a/src/PhpSpreadsheet/Reader/Xml/Properties.php
+++ b/src/PhpSpreadsheet/Reader/Xml/Properties.php
@@ -44,7 +44,7 @@ class Properties
 
             foreach ($xml->CustomDocumentProperties[0] as $propertyName => $propertyValue) {
                 $propertyAttributes = self::getAttributes($propertyValue, $namespaces['dt']);
-                $propertyName = preg_replace_callback('/_x([0-9a-f]{4})_/i', [$this, 'hex2str'], $propertyName);
+                $propertyName = (string) preg_replace_callback('/_x([0-9a-f]{4})_/i', [$this, 'hex2str'], $propertyName);
 
                 $this->processCustomProperty($docProps, $propertyName, $propertyValue, $propertyAttributes);
             }

--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -687,7 +687,7 @@ class ReferenceHelper
                         ksort($cellTokens);
                         ksort($newCellTokens);
                     }   //  Update cell references in the formula
-                    $formulaBlock = str_replace('\\', '', preg_replace($cellTokens, $newCellTokens, $formulaBlock));
+                    $formulaBlock = str_replace('\\', '', (string) preg_replace($cellTokens, $newCellTokens, $formulaBlock));
                 }
             }
         }

--- a/src/PhpSpreadsheet/Style/ConditionalFormatting/CellMatcher.php
+++ b/src/PhpSpreadsheet/Style/ConditionalFormatting/CellMatcher.php
@@ -219,7 +219,7 @@ class CellMatcher
         foreach ($splitCondition as &$value) {
             //    Only count/replace in alternating array entries (ie. not in quoted strings)
             if ($i = !$i) {
-                $value = preg_replace_callback(
+                $value = (string) preg_replace_callback(
                     '/' . Calculation::CALCULATION_REGEXP_CELLREF_RELATIVE . '/i',
                     [$this, 'conditionCellAdjustment'],
                     $value
@@ -287,7 +287,7 @@ class CellMatcher
         $conditions = $this->adjustConditionsForCellReferences($conditional->getConditions());
         $expression = array_pop($conditions);
 
-        $expression = preg_replace(
+        $expression = (string) preg_replace(
             '/\b' . $this->referenceCell . '\b/i',
             (string) $this->wrapCellValue(),
             $expression

--- a/src/PhpSpreadsheet/Style/ConditionalFormatting/Wizard/WizardAbstract.php
+++ b/src/PhpSpreadsheet/Style/ConditionalFormatting/Wizard/WizardAbstract.php
@@ -133,7 +133,7 @@ abstract class WizardAbstract
         foreach ($splitCondition as &$value) {
             //    Only count/replace in alternating array entries (ie. not in quoted strings)
             if ($i = !$i) {
-                $value = preg_replace_callback(
+                $value = (string) preg_replace_callback(
                     '/' . Calculation::CALCULATION_REGEXP_CELLREF_RELATIVE . '/i',
                     function ($matches) use ($referenceColumnIndex, $referenceRow) {
                         return self::reverseCellAdjustment($matches, $referenceColumnIndex, $referenceRow);
@@ -174,7 +174,7 @@ abstract class WizardAbstract
         foreach ($splitCondition as &$value) {
             //    Only count/replace in alternating array entries (ie. not in quoted strings)
             if ($i = !$i) {
-                $value = preg_replace_callback(
+                $value = (string) preg_replace_callback(
                     '/' . Calculation::CALCULATION_REGEXP_CELLREF_RELATIVE . '/i',
                     [$this, 'conditionCellAdjustment'],
                     $value

--- a/src/PhpSpreadsheet/Style/NumberFormat/DateFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/DateFormatter.php
@@ -129,11 +129,10 @@ class DateFormatter
         //    but we don't want to change any quoted strings
         /** @var callable */
         $callable = [self::class, 'setLowercaseCallback'];
-        $format = preg_replace_callback('/(?:^|")([^"]*)(?:$|")/', $callable, $format);
+        $format = (string) preg_replace_callback('/(?:^|")([^"]*)(?:$|")/', $callable, $format);
 
         // Only process the non-quoted blocks for date format characters
 
-        /** @phpstan-ignore-next-line */
         $blocks = explode('"', $format);
         foreach ($blocks as $key => &$block) {
             if ($key % 2 == 0) {

--- a/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
@@ -51,12 +51,12 @@ class Formatter
         for ($idx = 0; $idx < $cnt; ++$idx) {
             if (preg_match($color_regex, $sections[$idx], $matches)) {
                 $colors[$idx] = $matches[0];
-                $sections[$idx] = preg_replace($color_regex, '', $sections[$idx]);
+                $sections[$idx] = (string) preg_replace($color_regex, '', $sections[$idx]);
             }
             if (preg_match($cond_regex, $sections[$idx], $matches)) {
                 $condops[$idx] = $matches[1];
                 $condvals[$idx] = $matches[2];
-                $sections[$idx] = preg_replace($cond_regex, '', $sections[$idx]);
+                $sections[$idx] = (string) preg_replace($cond_regex, '', $sections[$idx]);
             }
         }
         $color = $colors[0];
@@ -112,7 +112,7 @@ class Formatter
             return $value;
         }
 
-        $format = preg_replace_callback(
+        $format = (string) preg_replace_callback(
             '/(["])(?:(?=(\\\\?))\\2.)*?\\1/u',
             function ($matches) {
                 return str_replace('.', chr(0x00), $matches[0]);
@@ -121,7 +121,7 @@ class Formatter
         );
 
         // Convert any other escaped characters to quoted strings, e.g. (\T to "T")
-        $format = preg_replace('/(\\\(((.)(?!((AM\/PM)|(A\/P))))|([^ ])))(?=(?:[^"]|"[^"]*")*$)/ui', '"${2}"', $format);
+        $format = (string) preg_replace('/(\\\(((.)(?!((AM\/PM)|(A\/P))))|([^ ])))(?=(?:[^"]|"[^"]*")*$)/ui', '"${2}"', $format);
 
         // Get the sections, there can be up to four sections, separated with a semi-colon (but only if not a quoted literal)
         $sections = preg_split('/(;)(?=(?:[^"]|"[^"]*")*$)/u', $format);
@@ -130,7 +130,7 @@ class Formatter
 
         // In Excel formats, "_" is used to add spacing,
         //    The following character indicates the size of the spacing, which we can't do in HTML, so we just use a standard space
-        $format = preg_replace('/_.?/ui', ' ', $format);
+        $format = (string) preg_replace('/_.?/ui', ' ', $format);
 
         // Let's begin inspecting the format and converting the value to a formatted string
 

--- a/src/PhpSpreadsheet/Style/NumberFormat/PercentageFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/PercentageFormatter.php
@@ -35,7 +35,7 @@ class PercentageFormatter extends BaseFormatter
 
         $wholePartSize += $decimalPartSize;
         $replacement = "{$wholePartSize}.{$decimalPartSize}";
-        $mask = preg_replace('/[#0,]+\.?[?#0,]*/ui', "%{$replacement}f{$placeHolders}", $format);
+        $mask = (string) preg_replace('/[#0,]+\.?[?#0,]*/ui', "%{$replacement}f{$placeHolders}", $format);
 
         /** @var float */
         $valueFloat = $value;

--- a/src/PhpSpreadsheet/Worksheet/AutoFilter.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter.php
@@ -145,7 +145,7 @@ class AutoFilter
         $this->evaluated = false;
         if ($this->workSheet !== null) {
             $thisrange = $this->range;
-            $range = preg_replace('/\\d+$/', (string) $this->workSheet->getHighestRow(), $thisrange) ?? '';
+            $range = (string) preg_replace('/\\d+$/', (string) $this->workSheet->getHighestRow(), $thisrange);
             if ($range !== $thisrange) {
                 $this->setRange($range);
             }

--- a/src/PhpSpreadsheet/Worksheet/Table.php
+++ b/src/PhpSpreadsheet/Worksheet/Table.php
@@ -212,7 +212,7 @@ class Table
     {
         if ($this->workSheet !== null) {
             $thisrange = $this->range;
-            $range = preg_replace('/\\d+$/', (string) $this->workSheet->getHighestRow(), $thisrange) ?? '';
+            $range = (string) preg_replace('/\\d+$/', (string) $this->workSheet->getHighestRow(), $thisrange);
             if ($range !== $thisrange) {
                 $this->setRange($range);
             }

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -662,13 +662,13 @@ class Html extends BaseWriter
                 $filename = $drawing->getPath();
 
                 // Strip off eventual '.'
-                $filename = preg_replace('/^[.]/', '', $filename);
+                $filename = (string) preg_replace('/^[.]/', '', $filename);
 
                 // Prepend images root
                 $filename = $this->getImagesRoot() . $filename;
 
                 // Strip off eventual '.' if followed by non-/
-                $filename = preg_replace('@^[.]([^/])@', '$1', $filename);
+                $filename = (string) preg_replace('@^[.]([^/])@', '$1', $filename);
 
                 // Convert UTF8 data to PCDATA
                 $filename = htmlspecialchars($filename, Settings::htmlEntityFlags());
@@ -1326,7 +1326,7 @@ class Html extends BaseWriter
 
             // Converts the cell content so that spaces occuring at beginning of each new line are replaced by &nbsp;
             // Example: "  Hello\n to the world" is converted to "&nbsp;&nbsp;Hello\n&nbsp;to the world"
-            $cellData = preg_replace('/(?m)(?:^|\\G) /', '&nbsp;', $cellData);
+            $cellData = (string) preg_replace('/(?m)(?:^|\\G) /', '&nbsp;', $cellData);
 
             // convert newline "\n" to '<br>'
             $cellData = nl2br($cellData);

--- a/src/PhpSpreadsheet/Writer/Xls/Parser.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Parser.php
@@ -778,8 +778,8 @@ class Parser
      */
     private function getRefIndex($ext_ref)
     {
-        $ext_ref = preg_replace("/^'/", '', $ext_ref); // Remove leading  ' if any.
-        $ext_ref = preg_replace("/'$/", '', $ext_ref); // Remove trailing ' if any.
+        $ext_ref = (string) preg_replace("/^'/", '', $ext_ref); // Remove leading  ' if any.
+        $ext_ref = (string) preg_replace("/'$/", '', $ext_ref); // Remove trailing ' if any.
         $ext_ref = str_replace('\'\'', '\'', $ext_ref); // Replace escaped '' with '
 
         // Check if there is a sheet range eg., Sheet1:Sheet2.

--- a/src/PhpSpreadsheet/Writer/Xls/Parser.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Parser.php
@@ -778,8 +778,7 @@ class Parser
      */
     private function getRefIndex($ext_ref)
     {
-        $ext_ref = (string) preg_replace("/^'/", '', $ext_ref); // Remove leading  ' if any.
-        $ext_ref = (string) preg_replace("/'$/", '', $ext_ref); // Remove trailing ' if any.
+        $ext_ref = (string) preg_replace(["/^'/", "/'$/"], ['', ''], $ext_ref); // Remove leading and trailing ' if any.
         $ext_ref = str_replace('\'\'', '\'', $ext_ref); // Replace escaped '' with '
 
         // Check if there is a sheet range eg., Sheet1:Sheet2.

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -1095,8 +1095,7 @@ class Worksheet extends BIFFwriter
 
         // Strip URL type and change Unix dir separator to Dos style (if needed)
         //
-        $url = (string) preg_replace('/^external:/', '', $url);
-        $url = (string) preg_replace('/\//', '\\', $url);
+        $url = (string) preg_replace(['/^external:/', '/\//'], ['', '\\'], $url);
 
         // Determine if the link is relative or absolute:
         //   relative if link contains no dir separator, "somefile.xls"

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -1039,7 +1039,7 @@ class Worksheet extends BIFFwriter
         $record = 0x01B8; // Record identifier
 
         // Strip URL type
-        $url = preg_replace('/^internal:/', '', $url);
+        $url = (string) preg_replace('/^internal:/', '', $url);
 
         // Pack the undocumented parts of the hyperlink stream
         $unknown1 = pack('H*', 'D0C9EA79F9BACE118C8200AA004BA90B02000000');
@@ -1095,8 +1095,8 @@ class Worksheet extends BIFFwriter
 
         // Strip URL type and change Unix dir separator to Dos style (if needed)
         //
-        $url = preg_replace('/^external:/', '', $url);
-        $url = preg_replace('/\//', '\\', $url);
+        $url = (string) preg_replace('/^external:/', '', $url);
+        $url = (string) preg_replace('/\//', '\\', $url);
 
         // Determine if the link is relative or absolute:
         //   relative if link contains no dir separator, "somefile.xls"
@@ -1125,7 +1125,7 @@ class Worksheet extends BIFFwriter
         $up_count = pack('v', $up_count);
 
         // Store the short dos dir name (null terminated)
-        $dir_short = preg_replace('/\\.\\.\\\\/', '', $dir_long) . "\0";
+        $dir_short = (string) preg_replace('/\\.\\.\\\\/', '', $dir_long) . "\0";
 
         // Store the long dir name as a wchar string (non-null terminated)
         $dir_long = $dir_long . "\0";


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

- Ensure response from `preg_replace()` is cast to a string wherever appropriate to avoid string/null warnings in phpstan
- When calling `preg_replace()`, several times in a row, use array arguments as that's more efficient 