### PR TITLE
Update excel migration with sets() method

### DIFF
--- a/docs/topics/migration-from-PHPExcel.md
+++ b/docs/topics/migration-from-PHPExcel.md
@@ -14,8 +14,30 @@ in `src/`, you can run the migration like so:
 
 ```sh
 composer require rector/rector --dev
-vendor/bin/rector process src --set phpexcel-to-phpspreadsheet
-composer remove rector/rector
+
+# this creates rector.php config
+vendor/bin/rector init 
+```
+
+Add `PHPOfficeSetList` set to `rector.php`
+
+```php
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPOffice\Set\PHPOfficeSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([
+        PHPOfficeSetList::PHPEXCEL_TO_PHPSPREADSHEET
+    ]);
+};
+```
+
+And run Rector on your code:
+
+```sh
+vendor/bin/rector process src
 ```
 
 For more details, see


### PR DESCRIPTION
Hi, 
I'm here to update old information about the migration with Rector :)
The `--set` is no longer used. We have people comming to Rector to report it, as the docs here is still old:
https://github.com/PHPOffice/PhpSpreadsheet/issues/1445

This PR solves it and shows the new way to use Rector configuration :+1: 