### PR TITLE
FIX #2868 PHP 8.1 Deprecation message when using cell->setValueExplicit()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3227,7 +3227,7 @@ parameters:
 
 		-
 			message: "#^Variable \\$textValue on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 3
+			count: 4
 			path: src/PhpSpreadsheet/Shared/StringHelper.php
 
 		-

--- a/src/PhpSpreadsheet/Shared/StringHelper.php
+++ b/src/PhpSpreadsheet/Shared/StringHelper.php
@@ -478,7 +478,7 @@ class StringHelper
      */
     public static function substring($textValue, $offset, $length = 0)
     {
-        return mb_substr($textValue, $offset, $length, 'UTF-8');
+        return mb_substr($textValue ?? '', $offset, $length, 'UTF-8');
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Shared/StringHelperTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/StringHelperTest.php
@@ -119,4 +119,21 @@ class StringHelperTest extends TestCase
 
         self::assertEquals($expectedResult, $result);
     }
+
+    public function testSubstringUTF8(): void
+    {
+        $expectedResult = '😀';
+        $result = StringHelper::substring('🙃😀🙃', 1, 1);
+
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public function testSubstringWithNull(): void
+    {
+        // Issue #2868 PHP 8.1 Deprecation message for null value
+        $expectedResult = '';
+        $result = StringHelper::substring(null, 1, 10);
+
+        self::assertEquals($expectedResult, $result);
+    }
 }


### PR DESCRIPTION
**FIX #2868** - deprecation message shown when using $cell->setValueExplicit() with a null string

This is:

```
- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [X] additional unit tests
- [X] my first PR here :)
```

Checklist:

- [X] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary
