### PR TITLE
Fix: SUBTOTAL to handle #REF! errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- #REF! value handling in the Excel Math/Trig SUBTOTAL() function [PR #2870](https://github.com/PHPOffice/PhpSpreadsheet/pull/2870)
 - Xls Reader resolving absolute named ranges to relative ranges [Issue #2826](https://github.com/PHPOffice/PhpSpreadsheet/issues/2826) [PR #2827](https://github.com/PHPOffice/PhpSpreadsheet/pull/2827)
 - Null value handling in the Excel Math/Trig PRODUCT() function [Issue #2833](https://github.com/PHPOffice/PhpSpreadsheet/issues/2833) [PR #2834](https://github.com/PHPOffice/PhpSpreadsheet/pull/2834)
 - Invalid Print Area defined in Xlsx corrupts internal storage of print area [Issue #2848](https://github.com/PHPOffice/PhpSpreadsheet/issues/2848) [PR #2849](https://github.com/PHPOffice/PhpSpreadsheet/pull/2849)

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Subtotal.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Subtotal.php
@@ -89,6 +89,10 @@ class Subtotal
         $cellReference = array_pop($args);
         $aArgs = Functions::flattenArrayIndexed($args);
 
+        if (in_array(ExcelError::REF(), $args)) {
+            return ExcelError::REF();
+        }
+
         try {
             $subtotal = (int) Helpers::validateNumericNullBool($functionType);
         } catch (Exception $e) {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SubTotalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SubTotalTest.php
@@ -141,4 +141,18 @@ class SubTotalTest extends AllSetupTeardown
         $sheet->getCell('A1')->setValue('=SUBTOTAL(9, B1:B9,#REF!,C1:C9)');
         self::assertEquals('#REF!', $sheet->getCell('A1')->getCalculatedValue());
     }
+
+    public function testNonStringSingleCellRefError(): void
+    {
+        $sheet = $this->getSheet();
+        $sheet->getCell('A1')->setValue('=SUBTOTAL(9, Sheet99!A1)');
+        self::assertEquals('#REF!', $sheet->getCell('A1')->getCalculatedValue());
+    }
+
+    public function testNonStringCellRangeRefError(): void
+    {
+        $sheet = $this->getSheet();
+        $sheet->getCell('A1')->setValue('=SUBTOTAL(9, Sheet99!A1)');
+        self::assertEquals('#REF!', $sheet->getCell('A1')->getCalculatedValue());
+    }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SubTotalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SubTotalTest.php
@@ -127,4 +127,18 @@ class SubTotalTest extends AllSetupTeardown
         $sheet->getCell('H1')->setValue("=SUBTOTAL(9, A1:$maxCol$maxRow)");
         self::assertEquals(362, $sheet->getCell('H1')->getCalculatedValue());
     }
+
+    public function testRefError(): void
+    {
+        $sheet = $this->getSheet();
+        $sheet->getCell('A1')->setValue("=SUBTOTAL(9, #REF!)");
+        self::assertEquals('#REF!', $sheet->getCell('A1')->getCalculatedValue());
+    }
+
+    public function testSecondaryRefError(): void
+    {
+        $sheet = $this->getSheet();
+        $sheet->getCell('A1')->setValue("=SUBTOTAL(9, B1:B9,#REF!,C1:C9)");
+        self::assertEquals('#REF!', $sheet->getCell('A1')->getCalculatedValue());
+    }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SubTotalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SubTotalTest.php
@@ -131,14 +131,14 @@ class SubTotalTest extends AllSetupTeardown
     public function testRefError(): void
     {
         $sheet = $this->getSheet();
-        $sheet->getCell('A1')->setValue("=SUBTOTAL(9, #REF!)");
+        $sheet->getCell('A1')->setValue('=SUBTOTAL(9, #REF!)');
         self::assertEquals('#REF!', $sheet->getCell('A1')->getCalculatedValue());
     }
 
     public function testSecondaryRefError(): void
     {
         $sheet = $this->getSheet();
-        $sheet->getCell('A1')->setValue("=SUBTOTAL(9, B1:B9,#REF!,C1:C9)");
+        $sheet->getCell('A1')->setValue('=SUBTOTAL(9, B1:B9,#REF!,C1:C9)');
         self::assertEquals('#REF!', $sheet->getCell('A1')->getCalculatedValue());
     }
 }


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

When Excel calculates a `SUBTOTAL` that contains `#REF!`, such as `=SUBTOTAL(9, #REF!)` it returns `#REF!`. PhpSpreadsheet causes a PHP warning to be raised due to an array unpacking in [Subtotal](https://github.com/hyraiq/PhpSpreadsheet/blob/d0ff3d9ca7fc1b44cc2136ec427ca219572215c6/src/PhpSpreadsheet/Calculation/MathTrig/Subtotal.php#L38).

The root cause is the call to [Functions::flattenArrayIndexed](https://github.com/hyraiq/PhpSpreadsheet/blob/d0ff3d9ca7fc1b44cc2136ec427ca219572215c6/src/PhpSpreadsheet/Calculation/MathTrig/Subtotal.php#L90) which returns something that looks like `[0 => '#REF!']` as opposed to `[0.W.29 => '#REF!']`. The `Subtotal.php` function then does an explode on the key to get the column and row values to check if they are hidden or contain other aggregate functions that the `SUBTOTAL` should ignore.

I'm unsure of the best way to handle this. 

1. Should the `FlattenArrayIndexed` be updated? 
    - I've steered clear of this because it's used in many places and I was unsure of flow on effects
2. Are there other `#REF!` calculation errors that should also be tracked down? 
    - A quick search shows that not many places use `explode` and then unpack the result immediately into more than property. So I think it's unlikely.
3. Can `Subtotal.php` handle other error type values?
    - There are already tests for the `#VALUE!` error. Excel won't let me write other errors into a column to see how it handles them with the SUBTOTAL function.

Submitting this PR to provide some failing test cases and my suggested solution (which has the fewest flow on effects possible).
Let me know if there's another way this should be handled.