### PR TITLE
Relax validation on merge cells to allow input of a single cell

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/MergedCellTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/MergedCellTest.php
@@ -100,7 +100,7 @@ class MergedCellTest extends TestCase
             $sheet->mergeCells($range);
             self::fail("Expected invalid merge range $range");
         } catch (SpreadException $e) {
-            self::assertSame('Merge must be set on a range of cells.', $e->getMessage());
+            self::assertSame('Merge must be on a valid range of cells.', $e->getMessage());
         }
     }
 
@@ -109,7 +109,8 @@ class MergedCellTest extends TestCase
         $spreadSheet = new Spreadsheet();
 
         $dataSheet = $spreadSheet->getActiveSheet();
-        $this->setBadRange($dataSheet, 'B1');
+        // TODO - Reinstate full validation and disallow single cell merging for version 2.0
+//        $this->setBadRange($dataSheet, 'B1');
         $this->setBadRange($dataSheet, 'Invalid');
         $this->setBadRange($dataSheet, '1');
         $this->setBadRange($dataSheet, 'C');


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Relaxation of validation rules for [Issue #2776](https://github.com/PHPOffice/PhpSpreadsheet/issues/2776)