### PR TITLE
Allow multiple delimiters for `TEXTBEFORE()` and `TEXTAFTER()` functions

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextAfterTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextAfterTest.php
@@ -2,8 +2,6 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\TextData;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
-
 class TextAfterTest extends AllSetupTeardown
 {
     /**
@@ -14,14 +12,17 @@ class TextAfterTest extends AllSetupTeardown
         $text = $arguments[0];
         $delimiter = $arguments[1];
 
-        $args = 'A1, A2';
+        $args = (is_array($delimiter)) ? 'A1, {A2,A3}' : 'A1, A2';
         $args .= (isset($arguments[2])) ? ", {$arguments[2]}" : ',';
         $args .= (isset($arguments[3])) ? ", {$arguments[3]}" : ',';
         $args .= (isset($arguments[4])) ? ", {$arguments[4]}" : ',';
 
         $worksheet = $this->getSheet();
         $worksheet->getCell('A1')->setValue($text);
-        $worksheet->getCell('A2')->setValue($delimiter);
+        $worksheet->getCell('A2')->setValue((is_array($delimiter)) ? $delimiter[0] : $delimiter);
+        if (is_array($delimiter)) {
+            $worksheet->getCell('A3')->setValue($delimiter[1]);
+        }
         $worksheet->getCell('B1')->setValue("=TEXTAFTER({$args})");
 
         $result = $worksheet->getCell('B1')->getCalculatedValue();
@@ -31,19 +32,5 @@ class TextAfterTest extends AllSetupTeardown
     public function providerTEXTAFTER(): array
     {
         return require 'tests/data/Calculation/TextData/TEXTAFTER.php';
-    }
-
-    public function testTextAfterWithArray(): void
-    {
-        $calculation = Calculation::getInstance();
-
-        $text = "Red Riding Hood's red riding hood";
-        $delimiter = 'red';
-
-        $args = "\"{$text}\", \"{$delimiter}\", 1, {0;1}";
-
-        $formula = "=TEXTAFTER({$args})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals([[' riding hood'], [" Riding Hood's red riding hood"]], $result);
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextBeforeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextBeforeTest.php
@@ -12,14 +12,17 @@ class TextBeforeTest extends AllSetupTeardown
         $text = $arguments[0];
         $delimiter = $arguments[1];
 
-        $args = 'A1, A2';
+        $args = (is_array($delimiter)) ? 'A1, {A2,A3}' : 'A1, A2';
         $args .= (isset($arguments[2])) ? ", {$arguments[2]}" : ',';
         $args .= (isset($arguments[3])) ? ", {$arguments[3]}" : ',';
         $args .= (isset($arguments[4])) ? ", {$arguments[4]}" : ',';
 
         $worksheet = $this->getSheet();
         $worksheet->getCell('A1')->setValue($text);
-        $worksheet->getCell('A2')->setValue($delimiter);
+        $worksheet->getCell('A2')->setValue((is_array($delimiter)) ? $delimiter[0] : $delimiter);
+        if (is_array($delimiter)) {
+            $worksheet->getCell('A3')->setValue($delimiter[1]);
+        }
         $worksheet->getCell('B1')->setValue("=TEXTBEFORE({$args})");
 
         $result = $worksheet->getCell('B1')->getCalculatedValue();

--- a/tests/data/Calculation/TextData/TEXTAFTER.php
+++ b/tests/data/Calculation/TextData/TEXTAFTER.php
@@ -212,4 +212,40 @@ return [
             1,
         ],
     ],
+    'Multi-delimiter Case-Insensitive Offset 1' => [
+        " riding hood's red riding hood",
+        [
+            "Little Red riding hood's red riding hood",
+            ['HOOD', 'RED'],
+            1,
+            1,
+        ],
+    ],
+    'Multi-delimiter Case-Insensitive Offset 2' => [
+        "'s red riding hood",
+        [
+            "Little Red riding hood's red riding hood",
+            ['HOOD', 'RED'],
+            2,
+            1,
+        ],
+    ],
+    'Multi-delimiter Case-Insensitive Offset 3' => [
+        ' riding hood',
+        [
+            "Little Red riding hood's red riding hood",
+            ['HOOD', 'RED'],
+            3,
+            1,
+        ],
+    ],
+    'Multi-delimiter Case-Insensitive Offset -2' => [
+        ' riding hood',
+        [
+            "Little Red riding hood's red riding hood",
+            ['HOOD', 'RED'],
+            -2,
+            1,
+        ],
+    ],
 ];

--- a/tests/data/Calculation/TextData/TEXTBEFORE.php
+++ b/tests/data/Calculation/TextData/TEXTBEFORE.php
@@ -204,4 +204,40 @@ return [
             1,
         ],
     ],
+    'Multi-delimiter Case-Insensitive Offset 1' => [
+        'Little ',
+        [
+            "Little Red riding hood's red riding hood",
+            ['HOOD', 'RED'],
+            1,
+            1,
+        ],
+    ],
+    'Multi-delimiter Case-Insensitive Offset 2' => [
+        'Little Red riding ',
+        [
+            "Little Red riding hood's red riding hood",
+            ['HOOD', 'RED'],
+            2,
+            1,
+        ],
+    ],
+    'Multi-delimiter Case-Insensitive Offset 3' => [
+        "Little Red riding hood's ",
+        [
+            "Little Red riding hood's red riding hood",
+            ['HOOD', 'RED'],
+            3,
+            1,
+        ],
+    ],
+    'Multi-delimiter Case-Insensitive Offset -2' => [
+        "Little Red riding hood's ",
+        [
+            "Little Red riding hood's red riding hood",
+            ['HOOD', 'RED'],
+            -2,
+            1,
+        ],
+    ],
 ];


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [ ] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Undocumented feature in MS Excel: the delimiter argument can accept an array of values, and split on any of those values
