### PR TITLE
Add setName Method for Chart

### DIFF
--- a/src/PhpSpreadsheet/Chart/Chart.php
+++ b/src/PhpSpreadsheet/Chart/Chart.php
@@ -188,6 +188,13 @@ class Chart
         return $this->name;
     }
 
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
     /**
      * Get Worksheet.
      */

--- a/tests/PhpSpreadsheetTests/Chart/ChartMethodTest.php
+++ b/tests/PhpSpreadsheetTests/Chart/ChartMethodTest.php
@@ -93,8 +93,9 @@ class ChartMethodTest extends TestCase
             $xAxis, // xAxis
             $yAxis // yAxis
         );
-        $chart2 = new Chart('chart1');
+        $chart2 = new Chart('xyz');
         $chart2
+            ->setName('chart1')
             ->setLegend($legend)
             ->setPlotArea($plotArea)
             ->setPlotVisibleOnly(true)


### PR DESCRIPTION
Addresses a problem identified in issue #2991. Chart name is set in constructor, but there is no method to subsequently change it. This PR adds a method to do so.

This is:

```
- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
