### PR TITLE
Minor Changes for Mpdf, Dompdf

### DIFF
--- a/samples/Pdf/21a_Pdf.php
+++ b/samples/Pdf/21a_Pdf.php
@@ -12,6 +12,8 @@ $spreadsheet->getActiveSheet()->setShowGridLines(false);
 $helper->log('Set orientation to landscape');
 $spreadsheet->getActiveSheet()->getPageSetup()->setOrientation(PageSetup::ORIENTATION_LANDSCAPE);
 $spreadsheet->setActiveSheetIndex(0)->setPrintGridlines(true);
+// Issue 2299 - mpdf can't handle hide rows without kludge
+$spreadsheet->getActiveSheet()->getRowDimension(2)->setVisible(false);
 
 function changeGridlines(string $html): string
 {

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -54,7 +54,7 @@ class Html extends BaseWriter
      *
      * @var bool
      */
-    private $embedImages = false;
+    protected $embedImages = false;
 
     /**
      * Use inline CSS?
@@ -635,11 +635,12 @@ class Html extends BaseWriter
      *
      * @return string
      */
-    public static function winFileToUrl($filename)
+    public static function winFileToUrl($filename, bool $mpdf = false)
     {
         // Windows filename
         if (substr($filename, 1, 2) === ':\\') {
-            $filename = 'file:///' . str_replace('\\', '/', $filename);
+            $protocol = $mpdf ? '' : 'file:///';
+            $filename = $protocol . str_replace('\\', '/', $filename);
         }
 
         return $filename;
@@ -681,9 +682,9 @@ class Html extends BaseWriter
                 $filename = htmlspecialchars($filename, Settings::htmlEntityFlags());
 
                 $html .= PHP_EOL;
-                $imageData = self::winFileToUrl($filename);
+                $imageData = self::winFileToUrl($filename, $this->isMPdf);
 
-                if (($this->embedImages && !$this->isPdf) || substr($imageData, 0, 6) === 'zip://') {
+                if ($this->embedImages || substr($imageData, 0, 6) === 'zip://') {
                     $picture = @file_get_contents($filename);
                     if ($picture !== false) {
                         $imageDetails = getimagesize($filename);
@@ -1170,9 +1171,9 @@ class Html extends BaseWriter
         $html = '';
         $id = $showid ? "id='sheet$sheetIndex'" : '';
         if ($showid) {
-            $html .= "<div style='page: page$sheetIndex'>\n";
+            $html .= "<div style='page: page$sheetIndex'>" . PHP_EOL;
         } else {
-            $html .= "<div style='page: page$sheetIndex' class='scrpgbrk'>\n";
+            $html .= "<div style='page: page$sheetIndex' class='scrpgbrk'>" . PHP_EOL;
         }
 
         $this->generateTableTag($worksheet, $id, $html, $sheetIndex);
@@ -1467,6 +1468,10 @@ class Html extends BaseWriter
         // Sheet index
         $sheetIndex = $worksheet->getParent()->getIndex($worksheet);
         $html = $this->generateRowStart($worksheet, $sheetIndex, $row);
+        $generateDiv = $this->isMPdf && $worksheet->getRowDimension($row + 1)->getVisible() === false;
+        if ($generateDiv) {
+            $html .= '<div style="visibility:hidden; display:none;">' . PHP_EOL;
+        }
 
         // Write cells
         $colNum = 0;
@@ -1514,6 +1519,9 @@ class Html extends BaseWriter
         }
 
         // Write row end
+        if ($generateDiv) {
+            $html .= '</div>' . PHP_EOL;
+        }
         $html .= '          </tr>' . PHP_EOL;
 
         // Return
@@ -1844,26 +1852,26 @@ class Html extends BaseWriter
             } elseif ($orientation === \PhpOffice\PhpSpreadsheet\Worksheet\PageSetup::ORIENTATION_PORTRAIT) {
                 $htmlPage .= 'size: portrait; ';
             }
-            $htmlPage .= "}\n";
+            $htmlPage .= '}' . PHP_EOL;
             ++$sheetId;
         }
-        $htmlPage .= <<<EOF
-.navigation {page-break-after: always;}
-.scrpgbrk, div + div {page-break-before: always;}
-@media screen {
-  .gridlines td {border: 1px solid black;}
-  .gridlines th {border: 1px solid black;}
-  body>div {margin-top: 5px;}
-  body>div:first-child {margin-top: 0;}
-  .scrpgbrk {margin-top: 1px;}
-}
-@media print {
-  .gridlinesp td {border: 1px solid black;}
-  .gridlinesp th {border: 1px solid black;}
-  .navigation {display: none;}
-}
-
-EOF;
+        $htmlPage .= implode(PHP_EOL, [
+            '.navigation {page-break-after: always;}',
+            '.scrpgbrk, div + div {page-break-before: always;}',
+            '@media screen {',
+            '  .gridlines td {border: 1px solid black;}',
+            '  .gridlines th {border: 1px solid black;}',
+            '  body>div {margin-top: 5px;}',
+            '  body>div:first-child {margin-top: 0;}',
+            '  .scrpgbrk {margin-top: 1px;}',
+            '}',
+            '@media print {',
+            '  .gridlinesp td {border: 1px solid black;}',
+            '  .gridlinesp th {border: 1px solid black;}',
+            '  .navigation {display: none;}',
+            '}',
+            '',
+        ]);
         $htmlPage .= $generateSurroundingHTML ? ('</style>' . PHP_EOL) : '';
 
         return $htmlPage;

--- a/src/PhpSpreadsheet/Writer/Pdf/Dompdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Dompdf.php
@@ -8,6 +8,13 @@ use PhpOffice\PhpSpreadsheet\Writer\Pdf;
 class Dompdf extends Pdf
 {
     /**
+     * embed images, or link to images.
+     *
+     * @var bool
+     */
+    protected $embedImages = true;
+
+    /**
      * Gets the implementation of external PDF library that should be used.
      *
      * @return \Dompdf\Dompdf implementation


### PR DESCRIPTION
See discussion in #2999. Mpdf is not acknowledging the styling that we're using to hide table rows. I have opened an issue with them, but enclosing the cells in the hidden row inside a div with appropriate css does seem to be a workaround, and that can be incorporated into PhpSpreadsheet. It's kludgey, and it isn't even valid HTML, but ...

Mpdf also doesn't like the addition of the ```file:///``` prefix when using local images from Windows (sample 21). Results are better when that prefix is not added.

Dompdf seemed to have problems with sample 21 images on both Windows and Unix, with or without the file prefix. It does, however, support data urls for both, so is changed to embed images. It's still not perfect - the image seems truncated to the row height - but the results are better. I will continue to research, but may proceed as-is if I don't find anything better to do.

Html Writer was producing a file with mixed line endings on Windows. This didn't cause any harm, but it seems a bit sloppy. It is changed to always use PHP_EOL as a line ending.

This is:

```
- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
