### PR TITLE
Adjust `extractAllCellReferencesInRange()` method to allow a worksheet in the reference

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1061,11 +1061,6 @@ parameters:
 			path: src/PhpSpreadsheet/Calculation/TextData/Text.php
 
 		-
-			message: "#^Elseif branch is unreachable because previous condition is always true\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Cell/Cell.php
-
-		-
 			message: "#^Method PhpOffice\\\\PhpSpreadsheet\\\\Cell\\\\Cell\\:\\:getFormulaAttributes\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/Cell/Cell.php

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -32,14 +32,16 @@ use PhpOffice\PhpSpreadsheet\Style\Style;
 class Worksheet implements IComparable
 {
     // Break types
-    const BREAK_NONE = 0;
-    const BREAK_ROW = 1;
-    const BREAK_COLUMN = 2;
+    public const BREAK_NONE = 0;
+    public const BREAK_ROW = 1;
+    public const BREAK_COLUMN = 2;
 
     // Sheet state
-    const SHEETSTATE_VISIBLE = 'visible';
-    const SHEETSTATE_HIDDEN = 'hidden';
-    const SHEETSTATE_VERYHIDDEN = 'veryHidden';
+    public const SHEETSTATE_VISIBLE = 'visible';
+    public const SHEETSTATE_HIDDEN = 'hidden';
+    public const SHEETSTATE_VERYHIDDEN = 'veryHidden';
+
+    protected const SHEET_NAME_REQUIRES_NO_QUOTES = '/^[_\p{L}][_\p{L}\p{N}]*$/mui';
 
     /**
      * Maximum 31 characters allowed for sheet title.
@@ -3051,7 +3053,11 @@ class Worksheet implements IComparable
      * Extract worksheet title from range.
      *
      * Example: extractSheetTitle("testSheet!A1") ==> 'A1'
+     * Example: extractSheetTitle("testSheet!A1:C3") ==> 'A1:C3'
      * Example: extractSheetTitle("'testSheet 1'!A1", true) ==> ['testSheet 1', 'A1'];
+     * Example: extractSheetTitle("'testSheet 1'!A1:C3", true) ==> ['testSheet 1', 'A1:C3'];
+     * Example: extractSheetTitle("A1", true) ==> ['', 'A1'];
+     * Example: extractSheetTitle("A1:C3", true) ==> ['', 'A1:C3']
      *
      * @param string $range Range to extract title from
      * @param bool $returnRange Return range? (see example)
@@ -3449,5 +3455,10 @@ class Worksheet implements IComparable
     public function hasCodeName()
     {
         return $this->codeName !== null;
+    }
+
+    public static function nameRequiresQuotes(string $sheetName): bool
+    {
+        return preg_match(self::SHEET_NAME_REQUIRES_NO_QUOTES, $sheetName) !== 1;
     }
 }

--- a/testing/cellReferenceTest.php
+++ b/testing/cellReferenceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+
+error_reporting(E_ALL);
+set_time_limit(0);
+
+date_default_timezone_set('UTC');
+
+// Adjust the path as required to reference the PHPSpreadsheet Bootstrap file
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$cellRange1 = Coordinate::extractAllCellReferencesInRange('D3');
+var_dump($cellRange1);
+$cellRange2 = Coordinate::extractAllCellReferencesInRange('D3:E4');
+var_dump($cellRange2);
+$cellRange3 = Coordinate::extractAllCellReferencesInRange('Sheet1!D3');
+var_dump($cellRange3);
+$cellRange4 = Coordinate::extractAllCellReferencesInRange('Sheet1!D3:E4');
+var_dump($cellRange4);
+
+$cellRange11 = Coordinate::extractAllCellReferencesInRange('D3:E4 D4:F6');
+var_dump($cellRange11);
+$cellRange12 = Coordinate::extractAllCellReferencesInRange('D3:E4,D4:F6');
+var_dump($cellRange12);
+
+$cellRange5 = Coordinate::extractAllCellReferencesInRange('Sheet1!D3:Sheet2!E4');
+var_dump($cellRange5);

--- a/tests/data/CellExtractAllCellReferencesInRange.php
+++ b/tests/data/CellExtractAllCellReferencesInRange.php
@@ -130,4 +130,37 @@ return [
         ],
         'Z2:AA3',
     ],
+    [
+        [
+            'Sheet1!D3',
+        ],
+        'Sheet1!D3',
+    ],
+    [
+        [
+            'Sheet1!D3',
+            'Sheet1!E3',
+            'Sheet1!D4',
+            'Sheet1!E4',
+        ],
+        'Sheet1!D3:E4',
+    ],
+    [
+        [
+            "'Sheet 1'!D3",
+            "'Sheet 1'!E3",
+            "'Sheet 1'!D4",
+            "'Sheet 1'!E4",
+        ],
+        "'Sheet 1'!D3:E4",
+    ],
+    [
+        [
+            "'Mark''s Sheet'!D3",
+            "'Mark''s Sheet'!E3",
+            "'Mark''s Sheet'!D4",
+            "'Mark''s Sheet'!E4",
+        ],
+        "'Mark's Sheet'!D3:E4",
+    ],
 ];


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Reference [Issue #3005](https://github.com/PHPOffice/PhpSpreadsheet/issues/3005)