### PR TITLE
Support for SimpleCache Interface versions 1.0, 2.0 and 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
+- Support for SimpleCache Interface versions 1.0, 2.0 and 3.0
 - Add Chart Axis Option textRotation [Issue #2705](https://github.com/PHPOffice/PhpSpreadsheet/issues/2705) [PR #2940](https://github.com/PHPOffice/PhpSpreadsheet/pull/2940)
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "markbaker/matrix": "^3.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/simple-cache": "^1.0 || ^2.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "dev-master",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1101,11 +1101,6 @@ parameters:
 			path: src/PhpSpreadsheet/Cell/Coordinate.php
 
 		-
-			message: "#^Property PhpOffice\\\\PhpSpreadsheet\\\\Collection\\\\Memory\\:\\:\\$cache has no type specified\\.$#"
-			count: 1
-			path: src/PhpSpreadsheet/Collection/Memory.php
-
-		-
 			message: "#^Parameter \\#1 \\$namedRange of method PhpOffice\\\\PhpSpreadsheet\\\\Spreadsheet\\:\\:addNamedRange\\(\\) expects PhpOffice\\\\PhpSpreadsheet\\\\NamedRange, \\$this\\(PhpOffice\\\\PhpSpreadsheet\\\\DefinedName\\) given\\.$#"
 			count: 1
 			path: src/PhpSpreadsheet/DefinedName.php

--- a/src/PhpSpreadsheet/Collection/Cells.php
+++ b/src/PhpSpreadsheet/Collection/Cells.php
@@ -268,7 +268,9 @@ class Cells
      */
     private function getUniqueID()
     {
-        return Settings::getCache() instanceof Memory
+        $cacheType = Settings::getCache();
+
+        return ($cacheType instanceof Memory\SimpleCache1 || $cacheType instanceof Memory\SimpleCache3)
             ? random_bytes(7) . ':'
             : uniqid('phpspreadsheet.', true) . '.';
     }

--- a/src/PhpSpreadsheet/Collection/Memory/SimpleCache1.php
+++ b/src/PhpSpreadsheet/Collection/Memory/SimpleCache1.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Collection\Memory;
+
+use DateInterval;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * This is the default implementation for in-memory cell collection.
+ *
+ * Alternatives implementation should leverage off-memory, non-volatile storage
+ * to reduce overall memory usage.
+ */
+class SimpleCache1 implements CacheInterface
+{
+    /**
+     * @var array Cell Cache
+     */
+    private $cache = [];
+
+    /**
+     * @return bool
+     */
+    public function clear()
+    {
+        $this->cache = [];
+
+        return true;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function delete($key)
+    {
+        unset($this->cache[$key]);
+
+        return true;
+    }
+
+    /**
+     * @param iterable $keys
+     *
+     * @return bool
+     */
+    public function deleteMultiple($keys)
+    {
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        if ($this->has($key)) {
+            return $this->cache[$key];
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param iterable $keys
+     * @param mixed    $default
+     *
+     * @return iterable
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $results = [];
+        foreach ($keys as $key) {
+            $results[$key] = $this->get($key, $default);
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function has($key)
+    {
+        return array_key_exists($key, $this->cache);
+    }
+
+    /**
+     * @param string                 $key
+     * @param mixed                  $value
+     * @param null|DateInterval|int $ttl
+     *
+     * @return bool
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        $this->cache[$key] = $value;
+
+        return true;
+    }
+
+    /**
+     * @param iterable               $values
+     * @param null|DateInterval|int $ttl
+     *
+     * @return bool
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value);
+        }
+
+        return true;
+    }
+}

--- a/src/PhpSpreadsheet/Collection/Memory/SimpleCache3.php
+++ b/src/PhpSpreadsheet/Collection/Memory/SimpleCache3.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpOffice\PhpSpreadsheet\Collection;
+namespace PhpOffice\PhpSpreadsheet\Collection\Memory;
 
 use DateInterval;
 use Psr\SimpleCache\CacheInterface;
@@ -11,14 +11,14 @@ use Psr\SimpleCache\CacheInterface;
  * Alternatives implementation should leverage off-memory, non-volatile storage
  * to reduce overall memory usage.
  */
-class Memory implements CacheInterface
+class SimpleCache3 implements CacheInterface
 {
+    /**
+     * @var array Cell Cache
+     */
     private $cache = [];
 
-    /**
-     * @return bool
-     */
-    public function clear()
+    public function clear(): bool
     {
         $this->cache = [];
 
@@ -27,10 +27,8 @@ class Memory implements CacheInterface
 
     /**
      * @param string $key
-     *
-     * @return bool
      */
-    public function delete($key)
+    public function delete($key): bool
     {
         unset($this->cache[$key]);
 
@@ -39,10 +37,8 @@ class Memory implements CacheInterface
 
     /**
      * @param iterable $keys
-     *
-     * @return bool
      */
-    public function deleteMultiple($keys)
+    public function deleteMultiple($keys): bool
     {
         foreach ($keys as $key) {
             $this->delete($key);
@@ -54,10 +50,8 @@ class Memory implements CacheInterface
     /**
      * @param string $key
      * @param mixed  $default
-     *
-     * @return mixed
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
         if ($this->has($key)) {
             return $this->cache[$key];
@@ -69,10 +63,8 @@ class Memory implements CacheInterface
     /**
      * @param iterable $keys
      * @param mixed    $default
-     *
-     * @return iterable
      */
-    public function getMultiple($keys, $default = null)
+    public function getMultiple($keys, $default = null): iterable
     {
         $results = [];
         foreach ($keys as $key) {
@@ -84,10 +76,8 @@ class Memory implements CacheInterface
 
     /**
      * @param string $key
-     *
-     * @return bool
      */
-    public function has($key)
+    public function has($key): bool
     {
         return array_key_exists($key, $this->cache);
     }
@@ -96,10 +86,8 @@ class Memory implements CacheInterface
      * @param string                 $key
      * @param mixed                  $value
      * @param null|DateInterval|int $ttl
-     *
-     * @return bool
      */
-    public function set($key, $value, $ttl = null)
+    public function set($key, $value, $ttl = null): bool
     {
         $this->cache[$key] = $value;
 
@@ -109,10 +97,8 @@ class Memory implements CacheInterface
     /**
      * @param iterable               $values
      * @param null|DateInterval|int $ttl
-     *
-     * @return bool
      */
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple($values, $ttl = null): bool
     {
         foreach ($values as $key => $value) {
             $this->set($key, $value);

--- a/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
+++ b/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
@@ -52,7 +52,7 @@ class XmlScanner
 
     public static function threadSafeLibxmlDisableEntityLoaderAvailability()
     {
-        if (PHP_MAJOR_VERSION == 7) {
+        if (PHP_MAJOR_VERSION === 7) {
             switch (PHP_MINOR_VERSION) {
                 case 2:
                     return PHP_RELEASE_VERSION >= 1;

--- a/src/PhpSpreadsheet/Settings.php
+++ b/src/PhpSpreadsheet/Settings.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpSpreadsheet\Collection\Memory;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\SimpleCache\CacheInterface;
+use ReflectionClass;
 
 class Settings
 {
@@ -161,10 +162,17 @@ class Settings
     public static function getCache(): CacheInterface
     {
         if (!self::$cache) {
-            self::$cache = new Memory();
+            self::$cache = self::useSimpleCacheVersion3() ? new Memory\SimpleCache3() : new Memory\SimpleCache1();
         }
 
         return self::$cache;
+    }
+
+    public static function useSimpleCacheVersion3(): bool
+    {
+        return
+            PHP_MAJOR_VERSION === 8 &&
+            (new ReflectionClass(CacheInterface::class))->getMethod('get')->getReturnType() !== null;
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Collection/CellsTest.php
+++ b/tests/PhpSpreadsheetTests/Collection/CellsTest.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Collection;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Collection\Cells;
 use PhpOffice\PhpSpreadsheet\Collection\Memory;
+use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PHPUnit\Framework\TestCase;
@@ -107,7 +108,10 @@ class CellsTest extends TestCase
         $this->expectException(\PhpOffice\PhpSpreadsheet\Exception::class);
 
         $collection = $this->getMockBuilder(Cells::class)
-            ->setConstructorArgs([new Worksheet(), new Memory()])
+            ->setConstructorArgs([
+                new Worksheet(),
+                Settings::useSimpleCacheVersion3() ? new Memory\SimpleCache3() : new Memory\SimpleCache1(),
+            ])
             ->onlyMethods(['has'])
             ->getMock();
 
@@ -121,7 +125,9 @@ class CellsTest extends TestCase
     {
         $this->expectException(\PhpOffice\PhpSpreadsheet\Exception::class);
 
-        $cache = $this->createMock(Memory::class);
+        $cache = $this->createMock(
+            Settings::useSimpleCacheVersion3() ? Memory\SimpleCache3::class : Memory\SimpleCache1::class
+        );
         $cell = $this->createMock(Cell::class);
         $cache->method('set')
             ->willReturn(false);


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Support for SimpleCache Interface versions 1.0, 2.0 and 3.0; to stop people moaning; even though it requires a second implementation of the Memory cache for Cells
