### PR TITLE
Reconcile Differences between Css and Excel For Cell Alignment

### DIFF
--- a/samples/Basic/49_alignment.php
+++ b/samples/Basic/49_alignment.php
@@ -1,0 +1,80 @@
+<?php
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+
+require __DIR__ . '/../Header.php';
+
+$helper->log('Create new Spreadsheet object');
+$spreadsheet = new Spreadsheet();
+$spreadsheet->getProperties()->setTitle('Alignment');
+$sheet = $spreadsheet->getActiveSheet();
+$hi = 'Hi There';
+$ju = 'This is a longer than normal sentence';
+$sheet->fromArray([
+    ['', 'default', 'bottom', 'top', 'center', 'justify', 'distributed'],
+    ['default', $hi, $hi, $hi, $hi, $hi, $hi],
+    ['left', $hi, $hi, $hi, $hi, $hi, $hi],
+    ['right', $hi, $hi, $hi, $hi, $hi, $hi],
+    ['center', $hi, $hi, $hi, $hi, $hi, $hi],
+    ['justify', $ju, $ju, $ju, $ju, $ju, $ju],
+    ['distributed', $ju, $ju, $ju, $ju, $ju, $ju],
+]);
+$sheet->getColumnDimension('B')->setWidth(20);
+$sheet->getColumnDimension('C')->setWidth(20);
+$sheet->getColumnDimension('D')->setWidth(20);
+$sheet->getColumnDimension('E')->setWidth(20);
+$sheet->getColumnDimension('F')->setWidth(20);
+$sheet->getColumnDimension('G')->setWidth(20);
+$sheet->getRowDimension(2)->setRowHeight(30);
+$sheet->getRowDimension(3)->setRowHeight(30);
+$sheet->getRowDimension(4)->setRowHeight(30);
+$sheet->getRowDimension(5)->setRowHeight(30);
+$sheet->getRowDimension(6)->setRowHeight(40);
+$sheet->getRowDimension(7)->setRowHeight(40);
+$minRow = 2;
+$maxRow = 7;
+$minCol = 'B';
+$maxCol = 'g';
+$sheet->getStyle("C$minRow:C$maxRow")
+    ->getAlignment()
+    ->setVertical(Alignment::VERTICAL_BOTTOM);
+$sheet->getStyle("D$minRow:D$maxRow")
+    ->getAlignment()
+    ->setVertical(Alignment::VERTICAL_TOP);
+$sheet->getStyle("E$minRow:E$maxRow")
+    ->getAlignment()
+    ->setVertical(Alignment::VERTICAL_CENTER);
+$sheet->getStyle("F$minRow:F$maxRow")
+    ->getAlignment()
+    ->setVertical(Alignment::VERTICAL_JUSTIFY);
+$sheet->getStyle("G$minRow:G$maxRow")
+    ->getAlignment()
+    ->setVertical(Alignment::VERTICAL_DISTRIBUTED);
+$sheet->getStyle("{$minCol}3:{$maxCol}3")
+    ->getAlignment()
+    ->setHorizontal(Alignment::HORIZONTAL_LEFT);
+$sheet->getStyle("{$minCol}4:{$maxCol}4")
+    ->getAlignment()
+    ->setHorizontal(Alignment::HORIZONTAL_RIGHT);
+$sheet->getStyle("{$minCol}5:{$maxCol}5")
+    ->getAlignment()
+    ->setHorizontal(Alignment::HORIZONTAL_CENTER);
+$sheet->getStyle("{$minCol}6:{$maxCol}6")
+    ->getAlignment()
+    ->setHorizontal(Alignment::HORIZONTAL_JUSTIFY);
+$sheet->getStyle("{$minCol}7:{$maxCol}7")
+    ->getAlignment()
+    ->setHorizontal(Alignment::HORIZONTAL_DISTRIBUTED);
+
+$sheet->getCell('A9')->setValue('Center Continuous A9-C9');
+$sheet->getStyle('A9:C9')
+    ->getAlignment()
+    ->setHorizontal(Alignment::HORIZONTAL_CENTER_CONTINUOUS);
+$sheet->getCell('A10')->setValue('Fill');
+$sheet->getStyle('A10')
+    ->getAlignment()
+    ->setHorizontal(Alignment::HORIZONTAL_FILL);
+$sheet->setSelectedCells('A1');
+
+$helper->write($spreadsheet, __FILE__, ['Xlsx', 'Html', 'Xls']);

--- a/src/PhpSpreadsheet/Style/Alignment.php
+++ b/src/PhpSpreadsheet/Style/Alignment.php
@@ -15,6 +15,27 @@ class Alignment extends Supervisor
     const HORIZONTAL_JUSTIFY = 'justify';
     const HORIZONTAL_FILL = 'fill';
     const HORIZONTAL_DISTRIBUTED = 'distributed'; // Excel2007 only
+    private const HORIZONTAL_CENTER_CONTINUOUS_LC = 'centercontinuous';
+    // Mapping for horizontal alignment
+    const HORIZONTAL_ALIGNMENT_FOR_XLSX = [
+        self::HORIZONTAL_LEFT => self::HORIZONTAL_LEFT,
+        self::HORIZONTAL_RIGHT => self::HORIZONTAL_RIGHT,
+        self::HORIZONTAL_CENTER => self::HORIZONTAL_CENTER,
+        self::HORIZONTAL_CENTER_CONTINUOUS => self::HORIZONTAL_CENTER_CONTINUOUS,
+        self::HORIZONTAL_JUSTIFY => self::HORIZONTAL_JUSTIFY,
+        self::HORIZONTAL_FILL => self::HORIZONTAL_FILL,
+        self::HORIZONTAL_DISTRIBUTED => self::HORIZONTAL_DISTRIBUTED,
+    ];
+    // Mapping for horizontal alignment CSS
+    const HORIZONTAL_ALIGNMENT_FOR_HTML = [
+        self::HORIZONTAL_LEFT => self::HORIZONTAL_LEFT,
+        self::HORIZONTAL_RIGHT => self::HORIZONTAL_RIGHT,
+        self::HORIZONTAL_CENTER => self::HORIZONTAL_CENTER,
+        self::HORIZONTAL_CENTER_CONTINUOUS => self::HORIZONTAL_CENTER,
+        self::HORIZONTAL_JUSTIFY => self::HORIZONTAL_JUSTIFY,
+        //self::HORIZONTAL_FILL => self::HORIZONTAL_FILL, // no reasonable equivalent for fill
+        self::HORIZONTAL_DISTRIBUTED => self::HORIZONTAL_JUSTIFY,
+    ];
 
     // Vertical alignment styles
     const VERTICAL_BOTTOM = 'bottom';
@@ -22,6 +43,45 @@ class Alignment extends Supervisor
     const VERTICAL_CENTER = 'center';
     const VERTICAL_JUSTIFY = 'justify';
     const VERTICAL_DISTRIBUTED = 'distributed'; // Excel2007 only
+    // Vertical alignment CSS
+    private const VERTICAL_BASELINE = 'baseline';
+    private const VERTICAL_MIDDLE = 'middle';
+    private const VERTICAL_SUB = 'sub';
+    private const VERTICAL_SUPER = 'super';
+    private const VERTICAL_TEXT_BOTTOM = 'text-bottom';
+    private const VERTICAL_TEXT_TOP = 'text-top';
+
+    // Mapping for vertical alignment
+    const VERTICAL_ALIGNMENT_FOR_XLSX = [
+        self::VERTICAL_BOTTOM => self::VERTICAL_BOTTOM,
+        self::VERTICAL_TOP => self::VERTICAL_TOP,
+        self::VERTICAL_CENTER => self::VERTICAL_CENTER,
+        self::VERTICAL_JUSTIFY => self::VERTICAL_JUSTIFY,
+        self::VERTICAL_DISTRIBUTED => self::VERTICAL_DISTRIBUTED,
+        // css settings that arent't in sync with Excel
+        self::VERTICAL_BASELINE => self::VERTICAL_BOTTOM,
+        self::VERTICAL_MIDDLE => self::VERTICAL_CENTER,
+        self::VERTICAL_SUB => self::VERTICAL_BOTTOM,
+        self::VERTICAL_SUPER => self::VERTICAL_TOP,
+        self::VERTICAL_TEXT_BOTTOM => self::VERTICAL_BOTTOM,
+        self::VERTICAL_TEXT_TOP => self::VERTICAL_TOP,
+    ];
+
+    // Mapping for vertical alignment for Html
+    const VERTICAL_ALIGNMENT_FOR_HTML = [
+        self::VERTICAL_BOTTOM => self::VERTICAL_BOTTOM,
+        self::VERTICAL_TOP => self::VERTICAL_TOP,
+        self::VERTICAL_CENTER => self::VERTICAL_MIDDLE,
+        self::VERTICAL_JUSTIFY => self::VERTICAL_MIDDLE,
+        self::VERTICAL_DISTRIBUTED => self::VERTICAL_MIDDLE,
+        // css settings that arent't in sync with Excel
+        self::VERTICAL_BASELINE => self::VERTICAL_BASELINE,
+        self::VERTICAL_MIDDLE => self::VERTICAL_MIDDLE,
+        self::VERTICAL_SUB => self::VERTICAL_SUB,
+        self::VERTICAL_SUPER => self::VERTICAL_SUPER,
+        self::VERTICAL_TEXT_BOTTOM => self::VERTICAL_TEXT_BOTTOM,
+        self::VERTICAL_TEXT_TOP => self::VERTICAL_TEXT_TOP,
+    ];
 
     // Read order
     const READORDER_CONTEXT = 0;
@@ -202,8 +262,9 @@ class Alignment extends Supervisor
      */
     public function setHorizontal(string $horizontalAlignment)
     {
-        if ($horizontalAlignment == '') {
-            $horizontalAlignment = self::HORIZONTAL_GENERAL;
+        $horizontalAlignment = strtolower($horizontalAlignment);
+        if ($horizontalAlignment === self::HORIZONTAL_CENTER_CONTINUOUS_LC) {
+            $horizontalAlignment = self::HORIZONTAL_CENTER_CONTINUOUS;
         }
 
         if ($this->isSupervisor) {
@@ -239,9 +300,7 @@ class Alignment extends Supervisor
      */
     public function setVertical($verticalAlignment)
     {
-        if ($verticalAlignment == '') {
-            $verticalAlignment = self::VERTICAL_BOTTOM;
-        }
+        $verticalAlignment = strtolower($verticalAlignment);
 
         if ($this->isSupervisor) {
             $styleArray = $this->getStyleArray(['vertical' => $verticalAlignment]);

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -230,13 +230,6 @@ class Html extends BaseWriter
         $this->editHtmlCallback = $callback;
     }
 
-    const VALIGN_ARR = [
-        Alignment::VERTICAL_BOTTOM => 'bottom',
-        Alignment::VERTICAL_TOP => 'top',
-        Alignment::VERTICAL_CENTER => 'middle',
-        Alignment::VERTICAL_JUSTIFY => 'middle',
-    ];
-
     /**
      * Map VAlign.
      *
@@ -246,16 +239,8 @@ class Html extends BaseWriter
      */
     private function mapVAlign($vAlign)
     {
-        return array_key_exists($vAlign, self::VALIGN_ARR) ? self::VALIGN_ARR[$vAlign] : 'baseline';
+        return Alignment::VERTICAL_ALIGNMENT_FOR_HTML[$vAlign] ?? '';
     }
-
-    const HALIGN_ARR = [
-        Alignment::HORIZONTAL_LEFT => 'left',
-        Alignment::HORIZONTAL_RIGHT => 'right',
-        Alignment::HORIZONTAL_CENTER => 'center',
-        Alignment::HORIZONTAL_CENTER_CONTINUOUS => 'center',
-        Alignment::HORIZONTAL_JUSTIFY => 'justify',
-    ];
 
     /**
      * Map HAlign.
@@ -266,7 +251,7 @@ class Html extends BaseWriter
      */
     private function mapHAlign($hAlign)
     {
-        return array_key_exists($hAlign, self::HALIGN_ARR) ? self::HALIGN_ARR[$hAlign] : '';
+        return Alignment::HORIZONTAL_ALIGNMENT_FOR_HTML[$hAlign] ?? '';
     }
 
     const BORDER_ARR = [
@@ -988,7 +973,10 @@ class Html extends BaseWriter
         $css = [];
 
         // Create CSS
-        $css['vertical-align'] = $this->mapVAlign($alignment->getVertical() ?? '');
+        $verticalAlign = $this->mapVAlign($alignment->getVertical() ?? '');
+        if ($verticalAlign) {
+            $css['vertical-align'] = $verticalAlign;
+        }
         $textAlign = $this->mapHAlign($alignment->getHorizontal() ?? '');
         if ($textAlign) {
             $css['text-align'] = $textAlign;

--- a/src/PhpSpreadsheet/Writer/Xlsx/Style.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Style.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Shared\XMLWriter;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Style\Border;
 use PhpOffice\PhpSpreadsheet\Style\Borders;
 use PhpOffice\PhpSpreadsheet\Style\Conditional;
@@ -403,8 +404,14 @@ class Style extends WriterPart
 
         // alignment
         $objWriter->startElement('alignment');
-        $objWriter->writeAttribute('horizontal', (string) $style->getAlignment()->getHorizontal());
-        $objWriter->writeAttribute('vertical', (string) $style->getAlignment()->getVertical());
+        $vertical = Alignment::VERTICAL_ALIGNMENT_FOR_XLSX[$style->getAlignment()->getVertical()] ?? '';
+        $horizontal = Alignment::HORIZONTAL_ALIGNMENT_FOR_XLSX[$style->getAlignment()->getHorizontal()] ?? '';
+        if ($horizontal !== '') {
+            $objWriter->writeAttribute('horizontal', $horizontal);
+        }
+        if ($vertical !== '') {
+            $objWriter->writeAttribute('vertical', $vertical);
+        }
 
         $textRotation = 0;
         if ($style->getAlignment()->getTextRotation() >= 0) {
@@ -459,11 +466,13 @@ class Style extends WriterPart
 
         // alignment
         $objWriter->startElement('alignment');
-        if ($style->getAlignment()->getHorizontal() !== null) {
-            $objWriter->writeAttribute('horizontal', $style->getAlignment()->getHorizontal());
+        $horizontal = Alignment::HORIZONTAL_ALIGNMENT_FOR_XLSX[$style->getAlignment()->getHorizontal()] ?? '';
+        if ($horizontal) {
+            $objWriter->writeAttribute('horizontal', $horizontal);
         }
-        if ($style->getAlignment()->getVertical() !== null) {
-            $objWriter->writeAttribute('vertical', $style->getAlignment()->getVertical());
+        $vertical = Alignment::VERTICAL_ALIGNMENT_FOR_XLSX[$style->getAlignment()->getVertical()] ?? '';
+        if ($vertical) {
+            $objWriter->writeAttribute('vertical', $vertical);
         }
 
         if ($style->getAlignment()->getTextRotation() !== null) {

--- a/tests/PhpSpreadsheetTests/Style/AlignmentMiddleTest.php
+++ b/tests/PhpSpreadsheetTests/Style/AlignmentMiddleTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Style;
+
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Writer\Html;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+class AlignmentMiddleTest extends TestCase
+{
+    /** @var ?Spreadsheet */
+    private $spreadsheet;
+
+    /** @var string */
+    private $outputFileName = '';
+
+    protected function tearDown(): void
+    {
+        if ($this->spreadsheet !== null) {
+            $this->spreadsheet->disconnectWorksheets();
+            $this->spreadsheet = null;
+        }
+        if ($this->outputFileName !== '') {
+            unlink($this->outputFileName);
+            $this->outputFileName = '';
+        }
+    }
+
+    public function testCenterWriteHtml(): void
+    {
+        // Html Writer changes vertical align center to middle
+        $this->spreadsheet = new Spreadsheet();
+        $sheet = $this->spreadsheet->getActiveSheet();
+        $sheet->getCell('A1')->setValue('Cell1');
+        $sheet->getStyle('A1')
+            ->getAlignment()
+            ->setVertical(Alignment::VERTICAL_CENTER);
+        $writer = new HTML($this->spreadsheet);
+        $html = $writer->generateHtmlAll();
+        self::assertStringContainsString('vertical-align:middle', $html);
+        self::assertStringNotContainsString('vertical-align:center', $html);
+    }
+
+    public function testCenterWriteXlsx(): void
+    {
+        // Xlsx Writer uses vertical align center unchanged
+        $this->spreadsheet = new Spreadsheet();
+        $sheet = $this->spreadsheet->getActiveSheet();
+        $sheet->getCell('A1')->setValue('Cell1');
+        $sheet->getStyle('A1')
+            ->getAlignment()
+            ->setVertical(Alignment::VERTICAL_CENTER);
+        $this->outputFileName = File::temporaryFilename();
+        $writer = new Xlsx($this->spreadsheet);
+        $writer->save($this->outputFileName);
+        $zip = new ZipArchive();
+        $zip->open($this->outputFileName);
+        $html = $zip->getFromName('xl/styles.xml');
+        $zip->close();
+        self::assertStringContainsString('vertical="center"', $html);
+        self::assertStringNotContainsString('vertical="middle"', $html);
+    }
+
+    public function testCenterWriteXlsx2(): void
+    {
+        // Xlsx Writer changes vertical align middle to center
+        $this->spreadsheet = new Spreadsheet();
+        $sheet = $this->spreadsheet->getActiveSheet();
+        $sheet->getCell('A1')->setValue('Cell1');
+        $sheet->getStyle('A1')
+            ->getAlignment()
+            ->setVertical('middle');
+        $this->outputFileName = File::temporaryFilename();
+        $writer = new Xlsx($this->spreadsheet);
+        $writer->save($this->outputFileName);
+        $zip = new ZipArchive();
+        $zip->open($this->outputFileName);
+        $html = $zip->getFromName('xl/styles.xml');
+        $zip->close();
+        self::assertStringContainsString('vertical="center"', $html);
+        self::assertStringNotContainsString('vertical="middle"', $html);
+    }
+}

--- a/tests/PhpSpreadsheetTests/Style/AlignmentTest.php
+++ b/tests/PhpSpreadsheetTests/Style/AlignmentTest.php
@@ -9,10 +9,21 @@ use PHPUnit\Framework\TestCase;
 
 class AlignmentTest extends TestCase
 {
+    /** @var ?Spreadsheet */
+    private $spreadsheet;
+
+    protected function tearDown(): void
+    {
+        if ($this->spreadsheet !== null) {
+            $this->spreadsheet->disconnectWorksheets();
+            $this->spreadsheet = null;
+        }
+    }
+
     public function testAlignment(): void
     {
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
+        $this->spreadsheet = new Spreadsheet();
+        $sheet = $this->spreadsheet->getActiveSheet();
         $cell1 = $sheet->getCell('A1');
         $cell1->setValue('Cell1');
         $cell1->getStyle()->getAlignment()->setTextRotation(45);
@@ -31,8 +42,8 @@ class AlignmentTest extends TestCase
     public function testRotationTooHigh(): void
     {
         $this->expectException(PhpSpreadsheetException::class);
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
+        $this->spreadsheet = new Spreadsheet();
+        $sheet = $this->spreadsheet->getActiveSheet();
         $cell1 = $sheet->getCell('A1');
         $cell1->setValue('Cell1');
         $cell1->getStyle()->getAlignment()->setTextRotation(91);
@@ -42,8 +53,8 @@ class AlignmentTest extends TestCase
     public function testRotationTooLow(): void
     {
         $this->expectException(PhpSpreadsheetException::class);
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
+        $this->spreadsheet = new Spreadsheet();
+        $sheet = $this->spreadsheet->getActiveSheet();
         $cell1 = $sheet->getCell('A1');
         $cell1->setValue('Cell1');
         $cell1->getStyle()->getAlignment()->setTextRotation(-91);
@@ -52,8 +63,8 @@ class AlignmentTest extends TestCase
 
     public function testHorizontal(): void
     {
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
+        $this->spreadsheet = new Spreadsheet();
+        $sheet = $this->spreadsheet->getActiveSheet();
         $cell1 = $sheet->getCell('A1');
         $cell1->setValue('X');
         $cell1->getStyle()->getAlignment()->setHorizontal(Alignment::HORIZONTAL_LEFT)->setIndent(1);
@@ -74,8 +85,8 @@ class AlignmentTest extends TestCase
 
     public function testReadOrder(): void
     {
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
+        $this->spreadsheet = new Spreadsheet();
+        $sheet = $this->spreadsheet->getActiveSheet();
         $cell1 = $sheet->getCell('A1');
         $cell1->setValue('ABC');
         $cell1->getStyle()->getAlignment()->setReadOrder(0);


### PR DESCRIPTION
This PR expands on PR #2195 from @nkjackzhang. That PR has been stalled for some time awaiting requested fixes. Those fixes are part of this PR, and additional tests and samples are added. The original request was to handle `vertical-align:middle` in Css (Excel uses `center`). This PR does its best to also handle vertical alignment Excel values not found in Css - `justify` (as `middle`) and `distributed` (as `middle`). It likewises handles valid Css values not found in Excel (`baseline`, `sub`, and `text-bottom` as `bottom`; `super` and `text-top` as `top`; `middle` as `center`).

It also handles horizontal alignment Excel values not found in Css - `center-continuous` as `center` and `distributed` as `justify`; I couldn't think of a reasonable equivalent for `fill`, so it is ignored.

The values assigned for vertical and horizontal alignment are now lower-cased (special handling required for `centerContinuous`).

This is:

```
- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
