### PR TITLE
Minor Fix for Percentage Formatting

### DIFF
--- a/src/PhpSpreadsheet/Style/NumberFormat/PercentageFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/PercentageFormatter.php
@@ -20,7 +20,8 @@ class PercentageFormatter extends BaseFormatter
 
         $format = str_replace('%', '%%', $format);
         $wholePartSize = strlen((string) floor($value));
-        $decimalPartSize = $placeHolders = 0;
+        $decimalPartSize = 0;
+        $placeHolders = '';
         // Number of decimals
         if (preg_match('/\.([?0]+)/u', $format, $matches)) {
             $decimalPartSize = strlen($matches[1]);
@@ -29,12 +30,13 @@ class PercentageFormatter extends BaseFormatter
             $placeHolders = str_repeat(' ', strlen($matches[1]) - $decimalPartSize);
         }
         // Number of digits to display before the decimal
-        if (preg_match('/([#0,]+)\./u', $format, $matches)) {
-            $wholePartSize = max($wholePartSize, strlen($matches[1]));
+        if (preg_match('/([#0,]+)\.?/u', $format, $matches)) {
+            $firstZero = preg_replace('/^[#,]*/', '', $matches[1]);
+            $wholePartSize = max($wholePartSize, strlen($firstZero));
         }
 
-        $wholePartSize += $decimalPartSize;
-        $replacement = "{$wholePartSize}.{$decimalPartSize}";
+        $wholePartSize += $decimalPartSize + (int) ($decimalPartSize > 0);
+        $replacement = "0{$wholePartSize}.{$decimalPartSize}";
         $mask = (string) preg_replace('/[#0,]+\.?[?#0,]*/ui', "%{$replacement}f{$placeHolders}", $format);
 
         /** @var float */

--- a/tests/PhpSpreadsheetTests/Style/NumberFormatTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormatTest.php
@@ -47,7 +47,7 @@ class NumberFormatTest extends TestCase
     public function testFormatValueWithMask($expectedResult, ...$args): void
     {
         $result = NumberFormat::toFormattedString(...$args);
-        self::assertEquals($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 
     public function providerNumberFormat(): array

--- a/tests/data/Style/NumberFormat.php
+++ b/tests/data/Style/NumberFormat.php
@@ -146,13 +146,13 @@ return [
         '#,###',
     ],
     [
-        12,
+        '12',
         12000,
         '#,',
     ],
     // Scaling test
     [
-        12.199999999999999,
+        '12.2',
         12200000,
         '0.0,,',
     ],
@@ -1486,4 +1486,9 @@ return [
         '-1111.119',
         NumberFormat::FORMAT_ACCOUNTING_EUR,
     ],
+    'issue 1929' => ['(79.3%)', -0.793, '#,##0.0%;(#,##0.0%)'],
+    'percent without leading 0' => ['6.2%', 0.062, '##.0%'],
+    'percent with leading 0' => ['06.2%', 0.062, '00.0%'],
+    'percent lead0 no decimal' => ['06%', 0.062, '00%'],
+    'percent nolead0 no decimal' => ['6%', 0.062, '##%'],
 ];


### PR DESCRIPTION
Fix #1929. This was already substantially fixed, but there was a lingering problem with an unexpected leading space. It turns out there was also a problem with leading zeros, also fixed. There are also problems involving commas; fixing those seems too complicated to delay these changes, but I will add it to my to-do list.

This is:

```
- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
