### PR TITLE
Memory Leak in Sample35

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
         "dompdf/dompdf": "^1.0 || ^2.0",
         "friendsofphp/php-cs-fixer": "^3.2",
-        "mitoteam/jpgraph": "10.2.2",
+        "mitoteam/jpgraph": "10.2.3",
         "mpdf/mpdf": "8.1.1",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpstan/phpstan": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8512207f173cb137bc2085b7fdf698bc",
+    "content-hash": "b5bdb9f96d18ce59557436521053fdd9",
     "packages": [
         {
             "name": "ezyang/htmlpurifier",
@@ -1342,16 +1342,16 @@
         },
         {
             "name": "mitoteam/jpgraph",
-            "version": "10.2.2",
+            "version": "10.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mitoteam/jpgraph.git",
-                "reference": "6d87fc342afaf8a9a898a3122b5f0f34fc82c4cf"
+                "reference": "21121535537e05c32e7964327b80746462a6057d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mitoteam/jpgraph/zipball/6d87fc342afaf8a9a898a3122b5f0f34fc82c4cf",
-                "reference": "6d87fc342afaf8a9a898a3122b5f0f34fc82c4cf",
+                "url": "https://api.github.com/repos/mitoteam/jpgraph/zipball/21121535537e05c32e7964327b80746462a6057d",
+                "reference": "21121535537e05c32e7964327b80746462a6057d",
                 "shasum": ""
             },
             "require": {
@@ -1375,16 +1375,16 @@
                     "name": "JpGraph team"
                 }
             ],
-            "description": "Composer compatible version of JpGraph library with PHP 8.2 support",
+            "description": "JpGraph library composer package with PHP 8.2 support",
             "homepage": "https://github.com/mitoteam/jpgraph",
             "keywords": [
                 "jpgraph"
             ],
             "support": {
                 "issues": "https://github.com/mitoteam/jpgraph/issues",
-                "source": "https://github.com/mitoteam/jpgraph/tree/10.2.2"
+                "source": "https://github.com/mitoteam/jpgraph/tree/10.2.3"
             },
-            "time": "2022-09-09T08:16:10+00:00"
+            "time": "2022-09-14T04:02:09+00:00"
         },
         {
             "name": "mpdf/mpdf",

--- a/samples/Chart/35_Chart_render.php
+++ b/samples/Chart/35_Chart_render.php
@@ -25,12 +25,10 @@ if (count($inputFileNames) === 1) {
     $unresolvedErrors = [];
 } else {
     $unresolvedErrors = [
+        // The following spreadsheet was created by 3rd party software,
+        // and doesn't include the data that usually accompanies a chart.
+        // That is good enough for Excel, but not for JpGraph.
         '32readwriteBubbleChart2.xlsx',
-        //'32readwritePieChart3.xlsx',
-        //'32readwritePieChart4.xlsx',
-        '32readwritePieChart3D1.xlsx',
-        //'32readwritePieChartExploded1.xlsx',
-        '32readwritePieChartExploded3D1.xlsx',
     ];
 }
 foreach ($inputFileNames as $inputFileName) {
@@ -42,7 +40,9 @@ foreach ($inputFileNames as $inputFileName) {
         continue;
     }
     if (in_array($inputFileNameShort, $unresolvedErrors, true)) {
-        $helper->log('File ' . $inputFileNameShort . ' does not yet work with this script');
+        $helper->log('*****');
+        $helper->log('***** File ' . $inputFileNameShort . ' does not yet work with this script');
+        $helper->log('*****');
 
         continue;
     }

--- a/samples/Chart/35_Chart_render.php
+++ b/samples/Chart/35_Chart_render.php
@@ -26,10 +26,10 @@ if (count($inputFileNames) === 1) {
 } else {
     $unresolvedErrors = [
         '32readwriteBubbleChart2.xlsx',
-        '32readwritePieChart3.xlsx',
-        '32readwritePieChart4.xlsx',
+        //'32readwritePieChart3.xlsx',
+        //'32readwritePieChart4.xlsx',
         '32readwritePieChart3D1.xlsx',
-        '32readwritePieChartExploded1.xlsx',
+        //'32readwritePieChartExploded1.xlsx',
         '32readwritePieChartExploded3D1.xlsx',
     ];
 }
@@ -92,6 +92,7 @@ foreach ($inputFileNames as $inputFileName) {
 
     $spreadsheet->disconnectWorksheets();
     unset($spreadsheet);
+    gc_collect_cycles();
 }
 
 $helper->log('Done rendering charts as images');

--- a/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
@@ -104,7 +104,7 @@ abstract class JpGraphRendererBase implements IRenderer
 
     private function formatDataSetLabels($groupID, $datasetLabels, $rotation = '')
     {
-        $datasetLabelFormatCode = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotCategoryByIndex(0)->getFormatCode();
+        $datasetLabelFormatCode = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotCategoryByIndex(0)->getFormatCode() ?? '';
         //    Retrieve any label formatting code
         $datasetLabelFormatCode = stripslashes($datasetLabelFormatCode);
 

--- a/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
@@ -102,13 +102,11 @@ abstract class JpGraphRendererBase implements IRenderer
         return $seriesPlot;
     }
 
-    private function formatDataSetLabels($groupID, $datasetLabels, $labelCount, $rotation = '')
+    private function formatDataSetLabels($groupID, $datasetLabels, $rotation = '')
     {
         $datasetLabelFormatCode = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotCategoryByIndex(0)->getFormatCode();
-        if ($datasetLabelFormatCode !== null) {
-            //    Retrieve any label formatting code
-            $datasetLabelFormatCode = stripslashes($datasetLabelFormatCode);
-        }
+        //    Retrieve any label formatting code
+        $datasetLabelFormatCode = stripslashes($datasetLabelFormatCode);
 
         $testCurrentIndex = 0;
         foreach ($datasetLabels as $i => $datasetLabel) {
@@ -273,7 +271,7 @@ abstract class JpGraphRendererBase implements IRenderer
         $this->renderTitle();
     }
 
-    private function renderPlotLine($groupID, $filled = false, $combination = false, $dimensions = '2d'): void
+    private function renderPlotLine($groupID, $filled = false, $combination = false): void
     {
         $grouping = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotGrouping();
 
@@ -281,7 +279,7 @@ abstract class JpGraphRendererBase implements IRenderer
         $labelCount = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotValuesByIndex($index)->getPointCount();
         if ($labelCount > 0) {
             $datasetLabels = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotCategoryByIndex(0)->getDataValues();
-            $datasetLabels = $this->formatDataSetLabels($groupID, $datasetLabels, $labelCount);
+            $datasetLabels = $this->formatDataSetLabels($groupID, $datasetLabels);
             $this->graph->xaxis->SetTickLabels($datasetLabels);
         }
 
@@ -353,7 +351,7 @@ abstract class JpGraphRendererBase implements IRenderer
         $labelCount = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotValuesByIndex($index)->getPointCount();
         if ($labelCount > 0) {
             $datasetLabels = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotCategoryByIndex(0)->getDataValues();
-            $datasetLabels = $this->formatDataSetLabels($groupID, $datasetLabels, $labelCount, $rotation);
+            $datasetLabels = $this->formatDataSetLabels($groupID, $datasetLabels, $rotation);
             //    Rotate for bar rather than column chart
             if ($rotation == 'bar') {
                 $datasetLabels = array_reverse($datasetLabels);
@@ -430,11 +428,9 @@ abstract class JpGraphRendererBase implements IRenderer
 
     private function renderPlotScatter($groupID, $bubble): void
     {
-        $grouping = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotGrouping();
         $scatterStyle = $bubbleSize = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotStyle();
 
         $seriesCount = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotSeriesCount();
-        $seriesPlots = [];
 
         //    Loop through each data series in turn
         for ($i = 0; $i < $seriesCount; ++$i) {
@@ -478,7 +474,6 @@ abstract class JpGraphRendererBase implements IRenderer
         $radarStyle = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotStyle();
 
         $seriesCount = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotSeriesCount();
-        $seriesPlots = [];
 
         //    Loop through each data series in turn
         for ($i = 0; $i < $seriesCount; ++$i) {
@@ -513,15 +508,11 @@ abstract class JpGraphRendererBase implements IRenderer
 
     private function renderPlotContour($groupID): void
     {
-        $contourStyle = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotStyle();
-
         $seriesCount = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotSeriesCount();
-        $seriesPlots = [];
 
         $dataValues = [];
         //    Loop through each data series in turn
         for ($i = 0; $i < $seriesCount; ++$i) {
-            $dataValuesY = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotCategoryByIndex($i)->getDataValues();
             $dataValuesX = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotValuesByIndex($i)->getDataValues();
 
             $dataValues[$i] = $dataValuesX;
@@ -565,7 +556,7 @@ abstract class JpGraphRendererBase implements IRenderer
         $labelCount = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotValuesByIndex(0)->getPointCount();
         if ($labelCount > 0) {
             $datasetLabels = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotCategoryByIndex(0)->getDataValues();
-            $datasetLabels = $this->formatDataSetLabels($groupID, $datasetLabels, $labelCount);
+            $datasetLabels = $this->formatDataSetLabels($groupID, $datasetLabels);
             $this->graph->xaxis->SetTickLabels($datasetLabels);
         }
 
@@ -575,21 +566,21 @@ abstract class JpGraphRendererBase implements IRenderer
         $this->graph->Add($seriesPlot);
     }
 
-    private function renderAreaChart($groupCount, $dimensions = '2d'): void
+    private function renderAreaChart($groupCount): void
     {
         $this->renderCartesianPlotArea();
 
         for ($i = 0; $i < $groupCount; ++$i) {
-            $this->renderPlotLine($i, true, false, $dimensions);
+            $this->renderPlotLine($i, true, false);
         }
     }
 
-    private function renderLineChart($groupCount, $dimensions = '2d'): void
+    private function renderLineChart($groupCount): void
     {
         $this->renderCartesianPlotArea();
 
         for ($i = 0; $i < $groupCount; ++$i) {
-            $this->renderPlotLine($i, false, false, $dimensions);
+            $this->renderPlotLine($i, false, false);
         }
     }
 
@@ -626,19 +617,17 @@ abstract class JpGraphRendererBase implements IRenderer
 
         $iLimit = ($multiplePlots) ? $groupCount : 1;
         for ($groupID = 0; $groupID < $iLimit; ++$groupID) {
-            $grouping = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotGrouping();
             $exploded = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotStyle();
             $datasetLabels = [];
             if ($groupID == 0) {
                 $labelCount = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotValuesByIndex(0)->getPointCount();
                 if ($labelCount > 0) {
                     $datasetLabels = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotCategoryByIndex(0)->getDataValues();
-                    $datasetLabels = $this->formatDataSetLabels($groupID, $datasetLabels, $labelCount);
+                    $datasetLabels = $this->formatDataSetLabels($groupID, $datasetLabels);
                 }
             }
 
             $seriesCount = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotSeriesCount();
-            $seriesPlots = [];
             //    For pie charts, we only display the first series: doughnut charts generally display all series
             $jLimit = ($multiplePlots) ? $seriesCount : 1;
             //    Loop through each data series in turn
@@ -669,7 +658,7 @@ abstract class JpGraphRendererBase implements IRenderer
                     $seriesPlot->SetSize(($jLimit - $j) / ($jLimit * 4));
                 }
 
-                if ($doughnut) {
+                if ($doughnut && method_exists($seriesPlot, 'SetMidColor')) {
                     $seriesPlot->SetMidColor('white');
                 }
 
@@ -710,7 +699,7 @@ abstract class JpGraphRendererBase implements IRenderer
         }
     }
 
-    private function renderContourChart($groupCount, $dimensions): void
+    private function renderContourChart($groupCount): void
     {
         $this->renderCartesianPlotArea('intint');
 
@@ -719,7 +708,7 @@ abstract class JpGraphRendererBase implements IRenderer
         }
     }
 
-    private function renderCombinationChart($groupCount, $dimensions, $outputDestination)
+    private function renderCombinationChart($groupCount, $outputDestination)
     {
         $this->renderCartesianPlotArea();
 
@@ -728,10 +717,8 @@ abstract class JpGraphRendererBase implements IRenderer
             $chartType = $this->chart->getPlotArea()->getPlotGroupByIndex($i)->getPlotType();
             switch ($chartType) {
                 case 'area3DChart':
-                    $dimensions = '3d';
-                    // no break
                 case 'areaChart':
-                    $this->renderPlotLine($i, true, true, $dimensions);
+                    $this->renderPlotLine($i, true, true);
 
                     break;
                 case 'bar3DChart':
@@ -742,10 +729,8 @@ abstract class JpGraphRendererBase implements IRenderer
 
                     break;
                 case 'line3DChart':
-                    $dimensions = '3d';
-                    // no break
                 case 'lineChart':
-                    $this->renderPlotLine($i, false, true, $dimensions);
+                    $this->renderPlotLine($i, false, true);
 
                     break;
                 case 'scatterChart':
@@ -792,7 +777,7 @@ abstract class JpGraphRendererBase implements IRenderer
 
                 return false;
             } else {
-                return $this->renderCombinationChart($groupCount, $dimensions, $outputDestination);
+                return $this->renderCombinationChart($groupCount, $outputDestination);
             }
         }
 
@@ -801,7 +786,7 @@ abstract class JpGraphRendererBase implements IRenderer
                 $dimensions = '3d';
                 // no break
             case 'areaChart':
-                $this->renderAreaChart($groupCount, $dimensions);
+                $this->renderAreaChart($groupCount);
 
                 break;
             case 'bar3DChart':
@@ -815,7 +800,7 @@ abstract class JpGraphRendererBase implements IRenderer
                 $dimensions = '3d';
                 // no break
             case 'lineChart':
-                $this->renderLineChart($groupCount, $dimensions);
+                $this->renderLineChart($groupCount);
 
                 break;
             case 'pie3DChart':
@@ -845,10 +830,8 @@ abstract class JpGraphRendererBase implements IRenderer
 
                 break;
             case 'surface3DChart':
-                $dimensions = '3d';
-                // no break
             case 'surfaceChart':
-                $this->renderContourChart($groupCount, $dimensions);
+                $this->renderContourChart($groupCount);
 
                 break;
             case 'stockChart':

--- a/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
@@ -664,11 +664,7 @@ abstract class JpGraphRendererBase implements IRenderer
 
                 $seriesPlot->SetColor(self::$colourSet[self::$plotColour++]);
                 if (count($datasetLabels) > 0) {
-                    if ($seriesPlot instanceof PiePlot3D) {
-                        $seriesPlot->SetLabels(array_fill(0, count($datasetLabels), ''), 1);
-                    } else {
-                        $seriesPlot->SetLabels(array_fill(0, count($datasetLabels), ''));
-                    }
+                    $seriesPlot->SetLabels(array_fill(0, count($datasetLabels), ''));
                 }
                 if ($dimensions != '3d') {
                     $seriesPlot->SetGuideLines(false);

--- a/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
@@ -664,7 +664,11 @@ abstract class JpGraphRendererBase implements IRenderer
 
                 $seriesPlot->SetColor(self::$colourSet[self::$plotColour++]);
                 if (count($datasetLabels) > 0) {
-                    $seriesPlot->SetLabels(array_fill(0, count($datasetLabels), ''));
+                    if ($seriesPlot instanceof PiePlot3D) {
+                        $seriesPlot->SetLabels(array_fill(0, count($datasetLabels), ''), 1);
+                    } else {
+                        $seriesPlot->SetLabels(array_fill(0, count($datasetLabels), ''));
+                    }
                 }
                 if ($dimensions != '3d') {
                     $seriesPlot->SetGuideLines(false);


### PR DESCRIPTION
All but 6 chart samples can be rendered by Sample35. Of those 6, 3 of the problems are because the script runs out of memory processing them. Adopting a suggestion from @MAKS-dev in issue #2092, adding a call to gc_collect_cycles after the charts from each spreadsheet is rendered appears to make it possible to include those 3 spreadsheets in Sample35 after all.

PR now includes a fix for the 2 Pie 3D charts. There is now only one unsupported, and the reasons for that are documented in the code.

Also take advantage of this opportunity to correct a number (hopefully all) of Scrutinizer problems with JpgraphRendererBases.

This is:

```
- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
