### PR TITLE
Floating-point Equality in Two Tests

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ConvertUoMTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ConvertUoMTest.php
@@ -4,15 +4,11 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PHPUnit\Framework\TestCase;
 
 class ConvertUoMTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-    }
+    const UOM_PRECISION = 1E-12;
 
     public function testGetConversionGroups(): void
     {
@@ -52,7 +48,7 @@ class ConvertUoMTest extends TestCase
     public function testCONVERTUOM($expectedResult, ...$args): void
     {
         $result = Engineering::CONVERTUOM(...$args);
-        self::assertEquals($expectedResult, $result);
+        self::assertEqualsWithDelta($expectedResult, $result, self::UOM_PRECISION);
     }
 
     public function providerCONVERTUOM(): array
@@ -69,7 +65,7 @@ class ConvertUoMTest extends TestCase
 
         $formula = "=CONVERT({$value}, {$fromUoM}, {$toUoM})";
         $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        self::assertEqualsWithDelta($expectedResult, $result, self::UOM_PRECISION);
     }
 
     public function providerConvertUoMArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfCTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfCTest.php
@@ -4,17 +4,11 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PHPUnit\Framework\TestCase;
 
 class ErfCTest extends TestCase
 {
     const ERF_PRECISION = 1E-12;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-    }
 
     /**
      * @dataProvider providerERFC
@@ -25,7 +19,6 @@ class ErfCTest extends TestCase
     public function testERFC($expectedResult, $lower): void
     {
         $result = Engineering::ERFC($lower);
-        self::assertEquals($expectedResult, $result);
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
@@ -43,7 +36,7 @@ class ErfCTest extends TestCase
 
         $formula = "=ERFC({$lower})";
         $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
     public function providerErfCArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfPreciseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfPreciseTest.php
@@ -4,17 +4,11 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PHPUnit\Framework\TestCase;
 
 class ErfPreciseTest extends TestCase
 {
     const ERF_PRECISION = 1E-12;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-    }
 
     /**
      * @dataProvider providerERFPRECISE
@@ -25,7 +19,6 @@ class ErfPreciseTest extends TestCase
     public function testERFPRECISE($expectedResult, $limit): void
     {
         $result = Engineering::ERFPRECISE($limit);
-        self::assertEquals($expectedResult, $result);
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
@@ -43,7 +36,7 @@ class ErfPreciseTest extends TestCase
 
         $formula = "=ERF.PRECISE({$limit})";
         $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
     public function providerErfPreciseArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfTest.php
@@ -4,17 +4,11 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PHPUnit\Framework\TestCase;
 
 class ErfTest extends TestCase
 {
     const ERF_PRECISION = 1E-12;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-    }
 
     /**
      * @dataProvider providerERF
@@ -26,7 +20,6 @@ class ErfTest extends TestCase
     public function testERF($expectedResult, $lower, $upper = null): void
     {
         $result = Engineering::ERF($lower, $upper);
-        self::assertEquals($expectedResult, $result);
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
@@ -44,7 +37,7 @@ class ErfTest extends TestCase
 
         $formula = "=ERF({$lower}, {$upper})";
         $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
     public function providerErfArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FactTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FactTest.php
@@ -6,6 +6,8 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 
 class FactTest extends AllSetupTeardown
 {
+    const FACT_PRECISION = 1E-12;
+
     /**
      * @dataProvider providerFACT
      *
@@ -53,7 +55,7 @@ class FactTest extends AllSetupTeardown
             $sheet->getCell('B1')->setValue('=FACT(A1)');
         }
         $result = $sheet->getCell('B1')->getCalculatedValue();
-        self::assertEquals($expectedResult, $result);
+        self::assertEqualsWithDelta($expectedResult, $result, self::FACT_PRECISION);
     }
 
     public function providerFACTGnumeric(): array
@@ -70,7 +72,7 @@ class FactTest extends AllSetupTeardown
 
         $formula = "=FACT({$array})";
         $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        self::assertEqualsWithDelta($expectedResult, $result, self::FACT_PRECISION);
     }
 
     public function providerFactArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MUnitTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MUnitTest.php
@@ -6,6 +6,8 @@ use PhpOffice\PhpSpreadsheet\Calculation\MathTrig\MatrixFunctions;
 
 class MUnitTest extends AllSetupTeardown
 {
+    const MU_PRECISION = 1.0E-12;
+
     public function testMUNIT(): void
     {
         $identity = MatrixFunctions::identity(3);
@@ -15,7 +17,7 @@ class MUnitTest extends AllSetupTeardown
         self::assertEquals($startArray, $resultArray);
         $inverseArray = MatrixFunctions::inverse($startArray);
         $resultArray = MatrixFunctions::multiply($startArray, $inverseArray);
-        self::assertEquals($identity, $resultArray);
+        self::assertEqualsWithDelta($identity, $resultArray, self::MU_PRECISION);
         self::assertEquals('#VALUE!', MatrixFunctions::identity(0));
         self::assertEquals('#VALUE!', MatrixFunctions::identity(-1));
         self::assertEquals('#VALUE!', MatrixFunctions::identity('X'));

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/NumberValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/NumberValueTest.php
@@ -6,6 +6,8 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 
 class NumberValueTest extends AllSetupTeardown
 {
+    const NV_PRECISION = 1.0E-8;
+
     /**
      * @dataProvider providerNUMBERVALUE
      *
@@ -34,7 +36,7 @@ class NumberValueTest extends AllSetupTeardown
             $sheet->getCell('B1')->setValue('=NUMBERVALUE(A1, A2, A3)');
         }
         $result = $sheet->getCell('B1')->getCalculatedValue();
-        self::assertEquals($expectedResult, $result);
+        self::assertEqualsWithDelta($expectedResult, $result, self::NV_PRECISION);
     }
 
     public function providerNUMBERVALUE(): array
@@ -51,7 +53,7 @@ class NumberValueTest extends AllSetupTeardown
 
         $formula = "=NumberValue({$argument1}, {$argument2}, {$argument3})";
         $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        self::assertEqualsWithDelta($expectedResult, $result, self::NV_PRECISION);
     }
 
     public function providerNumberValueArray(): array

--- a/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
@@ -11,6 +11,8 @@ use PHPUnit\Framework\TestCase;
 
 class AdvancedValueBinderTest extends TestCase
 {
+    const AVB_PRECISION = 1.0E-8;
+
     /**
      * @var string
      */
@@ -161,7 +163,7 @@ class AdvancedValueBinderTest extends TestCase
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
         $sheet->getCell('A1')->setValue($value);
-        self::assertEquals($valueBinded, $sheet->getCell('A1')->getValue());
+        self::assertEqualsWithDelta($valueBinded, $sheet->getCell('A1')->getValue(), self::AVB_PRECISION);
         $spreadsheet->disconnectWorksheets();
     }
 

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 
 class XlsxTest extends TestCase
 {
+    const XLSX_PRECISION = 1.0E-8;
+
     public function testLoadXlsxRowColumnAttributes(): void
     {
         $filename = 'tests/data/Reader/XLSX/rowColumnAttributeTest.xlsx';
@@ -133,10 +135,10 @@ class XlsxTest extends TestCase
 
         $pageMargins = $worksheet->getPageMargins();
         // Convert from inches to cm for testing
-        self::assertEquals(2.5, $pageMargins->getTop() * 2.54);
-        self::assertEquals(3.3, $pageMargins->getLeft() * 2.54);
-        self::assertEquals(3.3, $pageMargins->getRight() * 2.54);
-        self::assertEquals(1.3, $pageMargins->getHeader() * 2.54);
+        self::assertEqualsWithDelta(2.5, $pageMargins->getTop() * 2.54, self::XLSX_PRECISION);
+        self::assertEqualsWithDelta(3.3, $pageMargins->getLeft() * 2.54, self::XLSX_PRECISION);
+        self::assertEqualsWithDelta(3.3, $pageMargins->getRight() * 2.54, self::XLSX_PRECISION);
+        self::assertEqualsWithDelta(1.3, $pageMargins->getHeader() * 2.54, self::XLSX_PRECISION);
 
         self::assertEquals(PageSetup::PAPERSIZE_A4, $worksheet->getPageSetup()->getPaperSize());
         self::assertEquals(['A10', 'A20', 'A30', 'A40', 'A50'], array_keys($worksheet->getBreaks()));

--- a/tests/PhpSpreadsheetTests/Shared/FontTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/FontTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 
 class FontTest extends TestCase
 {
+    const FONT_PRECISION = 1.0E-12;
+
     public function testGetAutoSizeMethod(): void
     {
         $expectedResult = Font::AUTOSIZE_METHOD_APPROX;
@@ -63,7 +65,7 @@ class FontTest extends TestCase
     public function testInchSizeToPixels($expectedResult, $size): void
     {
         $result = Font::inchSizeToPixels($size);
-        self::assertEquals($expectedResult, $result);
+        self::assertEqualsWithDelta($expectedResult, $result, self::FONT_PRECISION);
     }
 
     public function providerInchSizeToPixels(): array
@@ -80,7 +82,7 @@ class FontTest extends TestCase
     public function testCentimeterSizeToPixels($expectedResult, $size): void
     {
         $result = Font::centimeterSizeToPixels($size);
-        self::assertEquals($expectedResult, $result);
+        self::assertEqualsWithDelta($expectedResult, $result, self::FONT_PRECISION);
     }
 
     public function providerCentimeterSizeToPixels(): array

--- a/tests/PhpSpreadsheetTests/Shared/Trend/LinearBestFitTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/Trend/LinearBestFitTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 class LinearBestFitTest extends TestCase
 {
+    const LBF_PRECISION = 1.0E-8;
+
     /**
      * @dataProvider providerLinearBestFit
      *
@@ -27,13 +29,13 @@ class LinearBestFitTest extends TestCase
     ): void {
         $bestFit = new LinearBestFit($yValues, $xValues);
         $slope = $bestFit->getSlope(1);
-        self::assertEquals($expectedSlope[0], $slope);
+        self::assertEqualsWithDelta($expectedSlope[0], $slope, self::LBF_PRECISION);
         $slope = $bestFit->getSlope();
-        self::assertEquals($expectedSlope[1], $slope);
+        self::assertEqualsWithDelta($expectedSlope[1], $slope, self::LBF_PRECISION);
         $intersect = $bestFit->getIntersect(1);
-        self::assertEquals($expectedIntersect[0], $intersect);
+        self::assertEqualsWithDelta($expectedIntersect[0], $intersect, self::LBF_PRECISION);
         $intersect = $bestFit->getIntersect();
-        self::assertEquals($expectedIntersect[1], $intersect);
+        self::assertEqualsWithDelta($expectedIntersect[1], $intersect, self::LBF_PRECISION);
 
         $equation = $bestFit->getEquation(2);
         self::assertEquals($expectedEquation, $equation);


### PR DESCRIPTION
Merging a change today, Git reported failures that did not occur during "normal" unit testing. The merge still succeeded, but ... The problem was an error comparing float values for equal, and the inequality occurred beyond the 14th decimal digit. Change the tests in question, which incidentally were not part of the merged changed, to use assertEqualsWithDelta.

This is:

```
- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
