### PR TITLE
Fix `ezyang/htmlpurifier` caret version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "ext-xmlwriter": "*",
         "ext-zip": "*",
         "ext-zlib": "*",
-        "ezyang/htmlpurifier": "4.15",
+        "ezyang/htmlpurifier": "^4.15",
         "maennchen/zipstream-php": "^2.1",
         "markbaker/complex": "^3.0",
         "markbaker/matrix": "^3.0",


### PR DESCRIPTION
This is:

```
- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [x] Documentation is updated as necessary

### Why this change is needed?

This change is needed to fix the regression https://github.com/PHPOffice/PhpSpreadsheet/issues/3085 caused by https://github.com/PHPOffice/PhpSpreadsheet/commit/a3921d20bc5c9a2ba6add05ad96fb41f873e36bd.