### PR TITLE
Allow AutoFilter on single cell, or a single row

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/AutoFilter.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter.php
@@ -9,6 +9,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\Internal\WildcardMatch;
 use PhpOffice\PhpSpreadsheet\Cell\AddressRange;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\Exception as PhpSpreadsheetException;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column\Rule;
@@ -104,7 +105,7 @@ class AutoFilter
      * Set AutoFilter Cell Range.
      *
      * @param AddressRange|array<int>|string $range
-     *            A simple string containing a Cell range like 'A1:E10' is permitted
+     *            A simple string containing a Cell range like 'A1:E10' or a Cell address like 'A1' is permitted
      *              or passing in an array of [$fromColumnIndex, $fromRow, $toColumnIndex, $toRow] (e.g. [3, 5, 6, 8]),
      *              or an AddressRange object.
      */
@@ -115,6 +116,7 @@ class AutoFilter
         if ($range !== '') {
             [, $range] = Worksheet::extractSheetTitle(Validations::validateCellRange($range), true);
         }
+
         if (empty($range)) {
             //    Discard all column rules
             $this->columns = [];
@@ -123,8 +125,8 @@ class AutoFilter
             return $this;
         }
 
-        if (strpos($range, ':') === false) {
-            throw new PhpSpreadsheetException('Autofilter must be set on a range of cells.');
+        if (ctype_digit($range) || ctype_alpha($range)) {
+            throw new Exception("{$range} is an invalid range for AutoFilter");
         }
 
         $this->range = $range;

--- a/src/PhpSpreadsheet/Writer/Xlsx/DefinedNames.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/DefinedNames.php
@@ -115,7 +115,9 @@ class DefinedNames
             [, $range[0]] = Worksheet::extractSheetTitle($range[0], true);
 
             $range[0] = Coordinate::absoluteCoordinate($range[0]);
-            $range[1] = Coordinate::absoluteCoordinate($range[1]);
+            if (count($range) > 1) {
+                $range[1] = Coordinate::absoluteCoordinate($range[1]);
+            }
             $range = implode(':', $range);
 
             $this->objWriter->writeRawData('\'' . str_replace("'", "''", $worksheet->getTitle()) . '\'!' . $range);

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterTest.php
@@ -65,6 +65,7 @@ class AutoFilterTest extends SetupTeardown
         $ranges = [
             'G1:J512' => "$title!G1:J512",
             'K1:N20' => 'K1:N20',
+            'B10' => 'B10',
         ];
 
         foreach ($ranges as $actualRange => $fullRange) {
@@ -94,11 +95,22 @@ class AutoFilterTest extends SetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function testSetRangeInvalidRange(): void
+    public function testSetRangeInvalidRowRange(): void
     {
         $this->expectException(PhpSpreadsheetException::class);
 
-        $expectedResult = 'A1';
+        $expectedResult = '999';
+
+        $sheet = $this->getSheet();
+        $autoFilter = $sheet->getAutoFilter();
+        $autoFilter->setRange($expectedResult);
+    }
+
+    public function testSetRangeInvalidColumnRange(): void
+    {
+        $this->expectException(PhpSpreadsheetException::class);
+
+        $expectedResult = 'ABC';
 
         $sheet = $this->getSheet();
         $autoFilter = $sheet->getAutoFilter();

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterTest.php
@@ -510,4 +510,26 @@ class AutoFilterTest extends SetupTeardown
         self::assertArrayHasKey('K', $columns);
         self::assertArrayHasKey('M', $columns);
     }
+
+    public function testAutoExtendRange(): void
+    {
+        $spreadsheet = $this->getSpreadsheet();
+        $worksheet = $spreadsheet->addSheet(new Worksheet($spreadsheet, 'Autosized AutoFilter'));
+
+        $worksheet->getCell('A1')->setValue('Col 1');
+        $worksheet->getCell('B1')->setValue('Col 2');
+
+        $worksheet->setAutoFilter('A1:B1');
+        $lastRow = $worksheet->getAutoFilter()->autoExtendRange(1, 1);
+        self::assertSame(1, $lastRow, 'No data below AutoFilter, so there should ne no resize');
+
+        $lastRow = $worksheet->getAutoFilter()->autoExtendRange(1, 999);
+        self::assertSame(999, $lastRow, 'Filter range is already correctly sized');
+
+        $data = [['A', 'A'], ['B', 'A'], ['A', 'B'], ['C', 'B'], ['B', null], [null, null], ['D', 'D'], ['E', 'E']];
+        $worksheet->fromArray($data, null, 'A2', true);
+
+        $lastRow = $worksheet->getAutoFilter()->autoExtendRange(1, 1);
+        self::assertSame(6, $lastRow, 'Filter range has been re-sized incorrectly');
+    }
 }


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [X] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Fix for [Issue #3102 ](https://github.com/PHPOffice/PhpSpreadsheet/issues/3102)

Also modified the AutoFilter logic to automagically determine the rows to check when the AutoFilter `showHideRows()` is called on a single-row AutoFilter (using the same logic as MS Excel, extending the range until the first empty row).