### PR TITLE
Fix a TypeError on complex number format with small enough number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Allow setting AutoFilter range on a single cell or row [Issue #3102](https://github.com/PHPOffice/PhpSpreadsheet/issues/3102) [PR #3111](https://github.com/PHPOffice/PhpSpreadsheet/pull/3111)
 - Xlsx Reader External Data Validations Flag Missing [Issue #2677](https://github.com/PHPOffice/PhpSpreadsheet/issues/2677) [PR #3078](https://github.com/PHPOffice/PhpSpreadsheet/pull/3078)
 - Reduces extra memory usage on `__destruct()` calls
-
+- TypeError using small numbers along a complex number format [Issue #3128](https://github.com/PHPOffice/PhpSpreadsheet/issues/3128)
 
 ## 1.25.2 - 2022-09-25
 

--- a/src/PhpSpreadsheet/Style/NumberFormat/NumberFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/NumberFormatter.php
@@ -75,7 +75,7 @@ class NumberFormatter
 
         if ($splitOnPoint && strpos($mask, '.') !== false && strpos($number, '.') !== false) {
             if (strpos($number, 'E') !== false) {
-                $number = sprintf('%.'.PHP_FLOAT_DIG.'F', $number);
+                $number = sprintf('%.' . PHP_FLOAT_DIG . 'F', $number);
             }
             $numbers = explode('.', $number);
             $masks = explode('.', $mask);

--- a/src/PhpSpreadsheet/Style/NumberFormat/NumberFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/NumberFormatter.php
@@ -74,6 +74,9 @@ class NumberFormatter
         $number = (string) abs($numberFloat);
 
         if ($splitOnPoint && strpos($mask, '.') !== false && strpos($number, '.') !== false) {
+            if (strpos($number, 'E') !== false) {
+                $number = sprintf('%.'.PHP_FLOAT_DIG.'F', $number);
+            }
             $numbers = explode('.', $number);
             $masks = explode('.', $mask);
             if (count($masks) > 2) {

--- a/tests/PhpSpreadsheetTests/Style/NumberFormatTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormatTest.php
@@ -84,4 +84,11 @@ class NumberFormatTest extends TestCase
         self::assertEquals($rslt, '$ 12,345.679');
         StringHelper::setCurrencyCode($cur);
     }
+
+    public function testSmallValueWithComplexFormat(): void
+    {
+        $result = NumberFormat::toFormattedString(1E-17, '0 000.0');
+
+        self::assertEquals('0 000.0', $result);
+    }
 }


### PR DESCRIPTION
TypeError occurs with numbers that convert to scientific notation (ie small enough ones) when using number formats that require the complex algorithm of NumberFormatter.

This is:

```
- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

This fixes https://github.com/PHPOffice/PhpSpreadsheet/issues/3128
