### PR TITLE
Read with generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
+- Changed Worksheet::rangeToArray() and Worksheet::rangeToRowGenerator() to add a map parameter letting user personalize keys instead of the 0-x or A-Z.
 - Changed if/else in Worksheet->rangeToArray() to clean up the code and make it more readable.
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
+- Added a new function to read a spreadsheet using generator syntax (https://www.php.net/manual/en/language.generators.syntax.php) to save memory which allow to read much more information than to put all data in a single array.
 - Allow the creation of In-Memory Drawings from a string of binary image data, or from a stream. [PR #3157](https://github.com/PHPOffice/PhpSpreadsheet/pull/3157)
 - Xlsx Reader support for Pivot Tables [PR #2829](https://github.com/PHPOffice/PhpSpreadsheet/pull/2829)
 - Permit Date/Time Entered on Spreadsheet to be calculated as Float [Issue #1416](https://github.com/PHPOffice/PhpSpreadsheet/issues/1416) [PR #3121](https://github.com/PHPOffice/PhpSpreadsheet/pull/3121)
 
 ### Changed
 
-- Nothing
+- Changed if/else in Worksheet->rangeToArray() to clean up the code and make it more readable.
 
 ### Deprecated
 

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2864,10 +2864,12 @@ class Worksheet implements IComparable
      * @param bool $formatData Should formatting be applied to cell values?
      * @param bool $returnCellRef False - Return a simple array of rows and columns indexed by number counting from zero
      *                            True - Return rows and columns indexed by their actual row and column IDs
+     * @param array $map an array to use for keys instead of column ID or column count
+     *                  Format should be [0=>'id', 1=>'name'] or ['A'=>'id', 'B'=>'name'] if $returnCellRef=true
      *
      * @return Generator|array
      */
-    public function rangeToRowGenerator($range, $nullValue = null, $calculateFormulas = true, $formatData = true, $returnCellRef = false)
+    public function rangeToRowGenerator($range, $nullValue = null, $calculateFormulas = true, $formatData = true, $returnCellRef = false, array $map = [])
     {
         // Returnvalue
         $returnValue = [];
@@ -2887,6 +2889,9 @@ class Worksheet implements IComparable
             // Loop through columns in the current row
             for ($col = $minCol; $col != $maxCol; ++$col) {
                 $cRef = $returnCellRef ? $col : ++$c;
+                if (isset($map[$cRef])) {
+                    $cRef = $map[$cRef];
+                }
 
                 //    Using getCell() will create a new cell if it doesn't already exist. We don't want that to happen
                 //        so we test and retrieve directly against cellCollection
@@ -2938,10 +2943,12 @@ class Worksheet implements IComparable
      * @param bool $formatData Should formatting be applied to cell values?
      * @param bool $returnCellRef False - Return a simple array of rows and columns indexed by number counting from zero
      *                               True - Return rows and columns indexed by their actual row and column IDs
+     * @param array $map an array to use for keys instead of column ID or column count.
+     *                  Format should be [0=>'id', 1=>'name'] or ['A'=>'id', 'B'=>'name'] if $returnCellRef=true
      *
      * @return array
      */
-    public function rangeToArray($range, $nullValue = null, $calculateFormulas = true, $formatData = true, $returnCellRef = false)
+    public function rangeToArray($range, $nullValue = null, $calculateFormulas = true, $formatData = true, $returnCellRef = false, array $map = [])
     {
         // Returnvalue
         $returnValue = [];
@@ -2961,6 +2968,9 @@ class Worksheet implements IComparable
             // Loop through columns in the current row
             for ($col = $minCol; $col != $maxCol; ++$col) {
                 $cRef = $returnCellRef ? $col : ++$c;
+                if (isset($map[$cRef])) {
+                    $cRef = $map[$cRef];
+                }
 
                 //    Using getCell() will create a new cell if it doesn't already exist. We don't want that to happen
                 //        so we test and retrieve directly against cellCollection


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
I added the function Worksheet::rangeToRowGenerator() to be able to load larger spreadsheet by using generators syntax instead of loading the data in array/memory. This is in relation to #3186 (Need a way to load larger spreadsheet using less memory).

This also add a $map argument to Worksheet::rangeToArray() (and Worksheet::rangeToRowGenerator()) to provide a way for users to set their own keys/indexes for the returned array/generator. This is in relation to #3187 (Can we add a argument to set keys to custom value instead of A-Z or 0-x).

p.s. This is my first pull request, hopefully I did it well.