### PR TITLE
Handle Currencies Stored as Strings in Formulas

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Engine/FormattedNumber.php
+++ b/src/PhpSpreadsheet/Calculation/Engine/FormattedNumber.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheet\Calculation\Engine;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 
 class FormattedNumber
 {
@@ -17,6 +18,7 @@ class FormattedNumber
         [self::class, 'convertToNumberIfNumeric'],
         [self::class, 'convertToNumberIfFraction'],
         [self::class, 'convertToNumberIfPercent'],
+        [self::class, 'convertToNumberIfCurrency'],
     ];
 
     /**
@@ -86,6 +88,30 @@ class FormattedNumber
             //Calculate the percentage
             $sign = ($match['PrefixedSign'] ?? $match['PrefixedSign2'] ?? $match['PostfixedSign']) ?? '';
             $operand = (float) ($sign . ($match['PostfixedValue'] ?? $match['PrefixedValue'])) / 100;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Identify whether a string contains a currency value, and if so,
+     * convert it to a numeric.
+     *
+     * @param string $operand string value to test
+     */
+    public static function convertToNumberIfCurrency(string &$operand): bool
+    {
+        $quotedCurrencyCode = preg_quote(StringHelper::getCurrencyCode());
+        $regExp = '~^(?:(?: *(?<PrefixedSign>[-+])? *' . $quotedCurrencyCode . ' *(?<PrefixedSign2>[-+])? *(?<PrefixedValue>[0-9]+\.?[0-9*]*(?:E[-+]?[0-9]*)?) *)|(?: *(?<PostfixedSign>[-+])? *(?<PostfixedValue>[0-9]+\.?[0-9]*(?:E[-+]?[0-9]*)?) *' . $quotedCurrencyCode . ' *))$~i';
+
+        $match = [];
+        if (preg_match($regExp, $operand, $match, PREG_UNMATCHED_AS_NULL)) {
+            //Determine the sign
+            $sign = ($match['PrefixedSign'] ?? $match['PrefixedSign2'] ?? $match['PostfixedSign']) ?? '';
+            //Cast to a float
+            $operand = (float) ($sign . ($match['PostfixedValue'] ?? $match['PrefixedValue']));
 
             return true;
         }

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit\Framework\TestCase;
 
@@ -214,6 +215,20 @@ class CalculationTest extends TestCase
         $cell2->setValue('=100*A1');
 
         self::assertSame(2.0, $cell2->getCalculatedValue());
+    }
+
+    public function testCellWithStringCurrency(): void
+    {
+        $currencyCode = StringHelper::getCurrencyCode();
+
+        $spreadsheet = new Spreadsheet();
+        $workSheet = $spreadsheet->getActiveSheet();
+        $cell1 = $workSheet->getCell('A1');
+        $cell1->setValue($currencyCode . '2');
+        $cell2 = $workSheet->getCell('B1');
+        $cell2->setValue('=100*A1');
+
+        self::assertSame(200.0, $cell2->getCalculatedValue());
     }
 
     public function testBranchPruningFormulaParsingSimpleCase(): void

--- a/tests/PhpSpreadsheetTests/Calculation/Engine/FormattedNumberTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Engine/FormattedNumberTest.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Engine;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Engine\FormattedNumber;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\TestCase;
 
 class FormattedNumberTest extends TestCase
@@ -181,6 +182,46 @@ class FormattedNumberTest extends TestCase
             'permutation_86' => ['-2.5E-8', ' - % 2.50e-06 '],
             'permutation_87' => [' - % 2.50e- 06 ', ' - % 2.50e- 06 '],
             'permutation_88' => [' - % 2.50e - 06 ', ' - % 2.50e - 06 '],
+        ];
+    }
+
+    /**
+     * @dataProvider providerCurrencies
+     */
+    public function testCurrencies(string $expected, string $value): void
+    {
+        $originalValue = $value;
+        $result = FormattedNumber::convertToNumberIfCurrency($value);
+        if ($result === false) {
+            self::assertSame($expected, $originalValue);
+            self::assertSame($expected, $value);
+        } else {
+            self::assertSame($expected, (string) $value);
+            self::assertNotEquals($value, $originalValue);
+        }
+    }
+
+    public function providerCurrencies(): array
+    {
+        $currencyCode = StringHelper::getCurrencyCode();
+        return [
+            'basic_prefix_currency'    => ['2.75', "{$currencyCode}2.75"],
+            'basic_postfix_currency'    => ['2.75', "2.75{$currencyCode}"],
+
+            'basic_prefix_currency_with_spaces'    => ['2.75', "{$currencyCode} 2.75"],
+            'basic_postfix_currency_with_spaces'    => ['2.75', "2.75 {$currencyCode}"],
+
+            'negative_basic_prefix_currency'    => ['-2.75', "-{$currencyCode}2.75"],
+            'negative_basic_postfix_currency'    => ['-2.75', "-2.75{$currencyCode}"],
+
+            'negative_basic_prefix_currency_with_spaces'    => ['-2.75', "-{$currencyCode} 2.75"],
+            'negative_basic_postfix_currency_with_spaces'    => ['-2.75', "-2.75 {$currencyCode}"],
+
+            'basic_prefix_scientific_currency'    => ['2000000', "{$currencyCode}2E6"],
+            'basic_postfix_scientific_currency'    => ['2000000', "2E6{$currencyCode}"],
+
+            'basic_prefix_scientific_currency_with_spaces'    => ['2000000', "{$currencyCode} 2E6"],
+            'basic_postfix_scientific_currency_with_spaces'    => ['2000000', "2E6 {$currencyCode}"],
         ];
     }
 }


### PR DESCRIPTION
Added a function to the new `FormattedNumber` helper that will use the currency code pulled from `localeconv` by `StringHelper::getCurrencyCode()`.  The currency code is `preg_quoted` and then dropped into a regexp that is modelled on the expression developed for `convertToNumberIfPercent`.  This will allow locale independent operation. Unfortunately `localeconv` only provides information about standard currency formats and not accounting formats.  This means that we can't say for sure whether or not a locale has an accounting format where the currency symbol shows up in a non-standard position (eg. left justified for some countries instead of appearing directly in front of the value).  The regexp should handle these cases.

The primary issue with this approach is that the regexp will incorrectly match invalid currency formats for some locals as it checks for the symbol before and after the value.

A possible improvement would be to pull `p_cs_precedes` and `n_cs_precedes` from `localeconv` and using them to determine if the currency symbol should appear before or after the value for the current locale.  Since white-space is ignored by the regexp, accounting formats should still work, as long as the accounting format doesn't involve moving the symbol to the opposite side of the value.

This is:

```
- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

See issue #3165 
