### PR TITLE
Eliminate call to getFormattedValue() when not required

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1822,7 +1822,9 @@ class Worksheet implements IComparable
 
     private function clearMergeCellsByColumn(string $firstColumn, string $lastColumn, int $firstRow, int $lastRow, string $upperLeft, string $behaviour): void
     {
-        $leftCellValue = [$this->getCell($upperLeft)->getFormattedValue()];
+        $leftCellValue = ($behaviour === self::MERGE_CELL_CONTENT_MERGE)
+            ? [$this->getCell($upperLeft)->getFormattedValue()]
+            : [];
 
         foreach ($this->getColumnIterator($firstColumn, $lastColumn) as $column) {
             $iterator = $column->getCellIterator($firstRow);
@@ -1838,15 +1840,16 @@ class Worksheet implements IComparable
             }
         }
 
-        $leftCellValue = implode(' ', $leftCellValue);
         if ($behaviour === self::MERGE_CELL_CONTENT_MERGE) {
-            $this->getCell($upperLeft)->setValueExplicit($leftCellValue, DataType::TYPE_STRING);
+            $this->getCell($upperLeft)->setValueExplicit(implode(' ', $leftCellValue), DataType::TYPE_STRING);
         }
     }
 
     private function clearMergeCellsByRow(string $firstColumn, int $lastColumnIndex, int $firstRow, int $lastRow, string $upperLeft, string $behaviour): void
     {
-        $leftCellValue = [$this->getCell($upperLeft)->getFormattedValue()];
+        $leftCellValue = ($behaviour === self::MERGE_CELL_CONTENT_MERGE)
+            ? [$this->getCell($upperLeft)->getFormattedValue()]
+            : [];
 
         foreach ($this->getRowIterator($firstRow, $lastRow) as $row) {
             $iterator = $row->getCellIterator($firstColumn);
@@ -1863,9 +1866,8 @@ class Worksheet implements IComparable
             }
         }
 
-        $leftCellValue = implode(' ', $leftCellValue);
         if ($behaviour === self::MERGE_CELL_CONTENT_MERGE) {
-            $this->getCell($upperLeft)->setValueExplicit($leftCellValue, DataType::TYPE_STRING);
+            $this->getCell($upperLeft)->setValueExplicit(implode(' ', $leftCellValue), DataType::TYPE_STRING);
         }
     }
 


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

BUGFIX: Formatted value should only be used for `Worksheet::MERGE_CELL_CONTENT_MERGE`, otherwise the top-left cell and its datatype should be left unchanged.
PERFORMANCE: Because only `Worksheet::MERGE_CELL_CONTENT_MERGE` requires cell formatted values, we can eliminate any other calls to `getFormattedValue()` for other merge modes, eliminating the calculation and formatting overhead 