### PR TITLE
Eliminate duplicate call to set Conditional Styles in the model when loading an Xls file

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -8089,7 +8089,6 @@ class Xls extends BaseReader
             $conditionalStyles[] = $conditional;
 
             $this->phpSheet->getStyle($cellRange)->setConditionalStyles($conditionalStyles);
-            $this->phpSheet->getStyle($cellRange)->setConditionalStyles($conditionalStyles);
         }
     }
 }


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Eliminate a redundant duplicate call