### PR TITLE
Support null and empty values in TEXTJOIN()

### DIFF
--- a/src/PhpSpreadsheet/Calculation/TextData/Concatenate.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Concatenate.php
@@ -56,7 +56,7 @@ class Concatenate
      *         If an array of values is passed for the $delimiter or $ignoreEmpty arguments, then the returned result
      *            will also be an array with matching dimensions
      */
-    public static function TEXTJOIN($delimiter, $ignoreEmpty, ...$args)
+    public static function TEXTJOIN($delimiter = '', $ignoreEmpty = true, ...$args)
     {
         if (is_array($delimiter) || is_array($ignoreEmpty)) {
             return self::evaluateArrayArgumentsSubset(
@@ -68,29 +68,35 @@ class Concatenate
             );
         }
 
-        // Loop through arguments
+        $delimiter ??= '';
+        $ignoreEmpty ??= true;
         $aArgs = Functions::flattenArray($args);
-        $returnValue = '';
+        $returnValue = self::evaluateTextJoinArray($ignoreEmpty, $aArgs);
+
+        $returnValue ??= implode($delimiter, $aArgs);
+        if (StringHelper::countCharacters($returnValue) > DataType::MAX_STRING_LENGTH) {
+            $returnValue = ExcelError::CALC();
+        }
+
+        return $returnValue;
+    }
+
+    private static function evaluateTextJoinArray(bool $ignoreEmpty, array &$aArgs): ?string
+    {
         foreach ($aArgs as $key => &$arg) {
             $value = Helpers::extractString($arg);
             if (ErrorValue::isError($value)) {
-                $returnValue = $value;
-
-                break;
+                return $value;
             }
-            if ($ignoreEmpty === true && is_string($arg) && trim($arg) === '') {
+
+            if ($ignoreEmpty === true && ((is_string($arg) && trim($arg) === '') || $arg === null)) {
                 unset($aArgs[$key]);
             } elseif (is_bool($arg)) {
                 $arg = Helpers::convertBooleanValue($arg);
             }
         }
 
-        $returnValue = ($returnValue !== '') ? $returnValue : implode($delimiter, $aArgs);
-        if (StringHelper::countCharacters($returnValue) > DataType::MAX_STRING_LENGTH) {
-            $returnValue = ExcelError::CALC();
-        }
-
-        return $returnValue;
+        return null;
     }
 
     /**

--- a/tests/data/Calculation/TextData/TEXTJOIN.php
+++ b/tests/data/Calculation/TextData/TEXTJOIN.php
@@ -16,6 +16,22 @@ return [
         ['-', true, 1, 2, 3],
     ],
     [
+        'A-B-C-E',
+        ['-', true, 'A', 'B', 'C', null, 'E'],
+    ],
+    [
+        'A-B-C--E',
+        ['-', false, 'A', 'B', 'C', null, 'E'],
+    ],
+    [
+        'A-B-C-',
+        ['-', false, 'A', 'B', 'C', null],
+    ],
+    [
+        'A-B-C--',
+        ['-', false, 'A', 'B', 'C', null, null],
+    ],
+    [
         '<<::>>',
         ['::', true, '<<', '>>'],
     ],
@@ -64,4 +80,5 @@ return [
     ],
     'propagate REF' => ['#REF!', [',', true, '1', '=sheet99!A1', '3']],
     'propagate NUM' => ['#NUM!', [',', true, '1', '=SQRT(-1)', '3']],
+    'propagate DIV0' => ['#DIV/0!', [',', true, '1', '=12/0', '3']],
 ];


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

BugFix - Support null values in TEXTJOIN() text values as well as empty strings

Allow default values for TEXTJOIN() delimiter and ignore_empty... even though the official MS documentation lists them as required arguments, they are actually optional

