### PR TITLE
See if reintroducing PHP 7.3 in the matrix fixes the CI Workflow issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Delete composer lock file
         id: composer-lock
-        if: ${{ matrix.php-version == '8.1' || matrix.php-version == '8.2' || matrix.php-version == 'nightly' }}
+        if: ${{ matrix.php-version == '8.1' || matrix.php-version == '8.2' || matrix.php-version == '7.3' || matrix.php-version == 'nightly' }}
         run: |
           rm composer.lock
           echo "::set-output name=flags::--ignore-platform-reqs"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
         include:
           - php-version: 'nightly'
             experimental: true
+          - php-version: '7.3'
+            experimental: true
 
     name: PHP ${{ matrix.php-version }}
 


### PR DESCRIPTION
Heaven only knows why the CI pipelines are complaining about a PHP 7.3 issue; all references to PHP 7.3 should have been removed from the workflows

Re-introducing 7.3 now, just to try and ensure that all checks pass, so that the 7.3 weirdness won't be a blocker for merging

This is:

```
- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
