### PR TITLE
Allow thousands separator in percentage formatted strings in formulae

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Engine/FormattedNumber.php
+++ b/src/PhpSpreadsheet/Calculation/Engine/FormattedNumber.php
@@ -83,8 +83,10 @@ class FormattedNumber
      */
     public static function convertToNumberIfPercent(string &$operand): bool
     {
+        $value = preg_replace('/(\d),(\d)/u', '$1$2', $operand);
+
         $match = [];
-        if (preg_match(self::STRING_REGEXP_PERCENT, $operand, $match, PREG_UNMATCHED_AS_NULL)) {
+        if ($value !== null && preg_match(self::STRING_REGEXP_PERCENT, $value, $match, PREG_UNMATCHED_AS_NULL)) {
             //Calculate the percentage
             $sign = ($match['PrefixedSign'] ?? $match['PrefixedSign2'] ?? $match['PostfixedSign']) ?? '';
             $operand = (float) ($sign . ($match['PostfixedValue'] ?? $match['PrefixedValue'])) / 100;

--- a/tests/PhpSpreadsheetTests/Calculation/Engine/FormattedNumberTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Engine/FormattedNumberTest.php
@@ -87,6 +87,7 @@ class FormattedNumberTest extends TestCase
             'trailing percent with space' => ['0.02', '2 %'],
             'trailing percent with leading and trailing space' => ['0.02', ' 2 % '],
             'leading percent with decimals' => ['0.025', ' % 2.5'],
+            'Percentage with thousands separator' => ['12.345', ' % 1,234.5'],
 
             //These should all fail
             'percent only' => ['%', '%'],


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Allow thousands separator in percentage formatted strings used as numbers by the Calculation Engine in binary math operations

