### PR TITLE
Update cells that use structured references in formula, and defined names, when a table column heading is changed

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Table/Column.php
+++ b/src/PhpSpreadsheet/Worksheet/Table/Column.php
@@ -2,7 +2,11 @@
 
 namespace PhpOffice\PhpSpreadsheet\Worksheet\Table;
 
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Table;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class Column
 {
@@ -199,5 +203,52 @@ class Column
         $this->table = $table;
 
         return $this;
+    }
+
+    public static function updateStructuredReferences(?Worksheet $workSheet, ?string $oldTitle, string $newTitle): void
+    {
+        if ($workSheet === null || $oldTitle === null || $oldTitle === '') {
+            return;
+        }
+
+        // Remember that table headings are case-insensitive
+        if (StringHelper::strToLower($oldTitle) !== StringHelper::strToLower($newTitle)) {
+            // We need to check all formula cells that might contain Structured References that refer
+            //    to this column, and update those formulae to reference the new column text
+            $spreadsheet = $workSheet->getParent();
+            foreach ($spreadsheet->getWorksheetIterator() as $sheet) {
+                self::updateStructuredReferencesInCells($sheet, $oldTitle, $newTitle);
+            }
+            self::updateStructuredReferencesInNamedFormulae($spreadsheet, $oldTitle, $newTitle);
+        }
+    }
+
+    private static function updateStructuredReferencesInCells(Worksheet $worksheet, string $oldTitle, string $newTitle): void
+    {
+        $pattern = '/\[(@?)' . preg_quote($oldTitle) . '\]/mui';
+
+        foreach ($worksheet->getCoordinates(false) as $coordinate) {
+            $cell = $worksheet->getCell($coordinate);
+            if ($cell->getDataType() === DataType::TYPE_FORMULA) {
+                $formula = $cell->getValue();
+                if (preg_match($pattern, $formula) === 1) {
+                    $formula = preg_replace($pattern, "[$1{$newTitle}]", $formula);
+                    $cell->setValueExplicit($formula, DataType::TYPE_FORMULA);
+                }
+            }
+        }
+    }
+
+    private static function updateStructuredReferencesInNamedFormulae(Spreadsheet $spreadsheet, string $oldTitle, string $newTitle): void
+    {
+        $pattern = '/\[(@?)' . preg_quote($oldTitle) . '\]/mui';
+
+        foreach ($spreadsheet->getNamedFormulae() as $namedFormula) {
+            $formula = $namedFormula->getValue();
+            if (preg_match($pattern, $formula) === 1) {
+                $formula = preg_replace($pattern, "[$1{$newTitle}]", $formula);
+                $namedFormula->setValue($formula); // @phpstan-ignore-line
+            }
+        }
     }
 }

--- a/tests/PhpSpreadsheetTests/Worksheet/Table/FormulaTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/Table/FormulaTest.php
@@ -59,4 +59,55 @@ class FormulaTest extends TestCase
 
         $spreadsheet->disconnectWorksheets();
     }
+
+    public function testCellFormulaUpdateOnHeadingColumnChange(): void
+    {
+        $reader = new Xlsx();
+        $filename = 'tests/data/Worksheet/Table/TableFormulae.xlsx';
+        $spreadsheet = $reader->load($filename);
+        $worksheet = $spreadsheet->getActiveSheet();
+
+        // Verify original formulae
+        // Row Formula
+        self::assertSame("=DeptSales[[#This Row],[Sales\u{a0}Amount]]*DeptSales[[#This Row],[% Commission]]", $worksheet->getCell('E2')->getValue());
+        // Totals Formula
+        self::assertSame('=SUBTOTAL(109,DeptSales[Commission Amount])', $worksheet->getCell('E8')->getValue());
+
+        $worksheet->getCell('D1')->setValue('Commission %age');
+        $worksheet->getCell('E1')->setValue('Commission');
+
+        // Verify modified formulae
+        // Row Formula
+        self::assertSame("=DeptSales[[#This Row],[Sales\u{a0}Amount]]*DeptSales[[#This Row],[Commission %age]]", $worksheet->getCell('E2')->getValue());
+        // Totals Formula
+        self::assertSame('=SUBTOTAL(109,DeptSales[Commission])', $worksheet->getCell('E8')->getValue());
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testNamedFormulaUpdateOnHeadingColumnChange(): void
+    {
+        $reader = new Xlsx();
+        $filename = 'tests/data/Worksheet/Table/TableFormulae.xlsx';
+        $spreadsheet = $reader->load($filename);
+        $worksheet = $spreadsheet->getActiveSheet();
+
+        $table = $spreadsheet->getActiveSheet()->getTableCollection()[0];
+        if ($table === null) {
+            self::markTestSkipped('Unable to read table for testing.');
+        }
+        $namedFormula = $spreadsheet->getNamedFormula('CommissionTotal');
+        if ($namedFormula === null) {
+            self::markTestSkipped('Unable to read named formula for testing.');
+        }
+
+        // Verify original formula
+        self::assertSame('SUBTOTAL(109,DeptSales[Commission Amount])', $namedFormula->getFormula());
+
+        $worksheet->getCell('E1')->setValue('Commission');
+        // Verify modified formula
+        self::assertSame('SUBTOTAL(109,DeptSales[Commission])', $namedFormula->getFormula());
+
+        $spreadsheet->disconnectWorksheets();
+    }
 }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Essential to update structured references to the column names when that column heading is changed in the cell
