### PR TITLE
Ensure that Full Table Structured References are correctly recognised

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -47,7 +47,7 @@ class Calculation
     //    Defined Names: Named Range of cells, or Named Formulae
     const CALCULATION_REGEXP_DEFINEDNAME = '((([^\s,!&%^\/\*\+<>=-]*)|(\'(?:[^\']|\'[^!])+?\')|(\"(?:[^\"]|\"[^!])+?\"))!)?([_\p{L}][_\p{L}\p{N}\.]*)';
     // Structured Reference (Fully Qualified and Unqualified)
-    const CALCULATION_REGEXP_STRUCTURED_REFERENCE = '([\p{L}_\\\\][\p{L}\p{N}\._]+)?(\[(?:[^\d\]+-]))';
+    const CALCULATION_REGEXP_STRUCTURED_REFERENCE = '([\p{L}_\\\\][\p{L}\p{N}\._]+)?(\[(?:[^\d\]+-])?)';
     //    Error
     const CALCULATION_REGEXP_ERROR = '\#[A-Z][A-Z0_\/]*[!\?]?';
 

--- a/tests/PhpSpreadsheetTests/Calculation/ParseFormulaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/ParseFormulaTest.php
@@ -303,6 +303,18 @@ class ParseFormulaTest extends TestCase
                 ],
                 '=[@[Unit Price]]',
             ],
+            'Fully Qualified Full Table Structured Reference' => [
+                [
+                    ['type' => 'Structured Reference', 'value' => new StructuredReference('DeptSales[]'), 'reference' => null],
+                ],
+                '=DeptSales[]',
+            ],
+            'Unqualified Full Table Structured Reference' => [
+                [
+                    ['type' => 'Structured Reference', 'value' => new StructuredReference('[]'), 'reference' => null],
+                ],
+                '=[]',
+            ],
             'Structured Reference Arithmetic' => [
                 [
                     ['type' => 'Structured Reference', 'value' => new StructuredReference('[@Quantity]'), 'reference' => null],


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Ensure that Full Table Structured References are correctly recognised, and don't throw an error
