### PR TITLE
docs: Typo in Reader/Writer Flags section

### DIFF
--- a/docs/topics/reading-and-writing-to-file.md
+++ b/docs/topics/reading-and-writing-to-file.md
@@ -1099,7 +1099,7 @@ Flags that are available that can be passed to the Reader in this way include:
 | Slk      | N/A              | NO             | NO               |
 | Csv      | N/A              | NO             | NO               |
 
-Likewise, when saving a file using a Writer, loaded charts wil not be saved unless you explicitly tell the Writer to include them:
+Likewise, when saving a file using a Writer, loaded charts will not be saved unless you explicitly tell the Writer to include them:
 
 ```php
 $writer = IOFactory::createWriter($spreadsheet, 'Xlsx');


### PR DESCRIPTION
This is:

```
- [x] a typo
```

At the end of section https://phpspreadsheet.readthedocs.io/en/latest/topics/reading-and-writing-to-file/#readerwriter-flags there is a typo "wil" instead of "will".
