### PR TITLE
Use exception code rather than exception message for #Headers Structured Reference Exception

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -4740,7 +4740,7 @@ class Calculation
                         $this->debugLog->writeDebugLog('Evaluated Structured Reference %s as value %s', $token->value(), $this->showValue($cellValue));
                     }
                 } catch (Exception $e) {
-                    if ($e->getMessage() === 'Table Headers are Hidden, and should not be Referenced') {
+                    if ($e->getCode() === Exception::CALCULATION_ENGINE_PUSH_TO_STACK) {
                         $stack->push('Error', Information\ExcelError::REF(), null);
                         $this->debugLog->writeDebugLog('Evaluated Structured Reference %s as error value %s', $token->value(), Information\ExcelError::REF());
                     } else {

--- a/src/PhpSpreadsheet/Calculation/Engine/Operands/StructuredReference.php
+++ b/src/PhpSpreadsheet/Calculation/Engine/Operands/StructuredReference.php
@@ -288,7 +288,10 @@ final class StructuredReference implements Operand
             /** @var string $reference */
             if (preg_match($pattern, $reference) === 1) {
                 if (($rowReference === self::ITEM_SPECIFIER_HEADERS) && ($this->table->getShowHeaderRow() === false)) {
-                    throw new Exception('Table Headers are Hidden, and should not be Referenced');
+                    throw new Exception(
+                        'Table Headers are Hidden, and should not be Referenced',
+                        Exception::CALCULATION_ENGINE_PUSH_TO_STACK
+                    );
                 }
                 $rowsSelected = true;
                 $startRow = min($startRow, $this->getMinimumRow($rowReference));

--- a/src/PhpSpreadsheet/Calculation/Exception.php
+++ b/src/PhpSpreadsheet/Calculation/Exception.php
@@ -6,6 +6,8 @@ use PhpOffice\PhpSpreadsheet\Exception as PhpSpreadsheetException;
 
 class Exception extends PhpSpreadsheetException
 {
+    public const CALCULATION_ENGINE_PUSH_TO_STACK = 1;
+
     /**
      * Error handler callback.
      *

--- a/tests/PhpSpreadsheetTests/Calculation/Engine/StructuredReferenceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Engine/StructuredReferenceTest.php
@@ -104,6 +104,7 @@ class StructuredReferenceTest extends TestCase
         $table->setShowHeaderRow(false);
 
         self::expectException(Exception::class);
+        self::expectExceptionCode(1);
         self::expectExceptionMessage('Table Headers are Hidden, and should not be Referenced');
         $structuredReferenceObject = new StructuredReference('DeptSales[[#Headers],[% Commission]]');
         $cellRange = $structuredReferenceObject->parse($cell);


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Use exception code rather than exception message to identify whether the Calc Engine should throw an exception or push to stack for Structured Reference Exceptions
