### PR TITLE
getColumnIterator() and getRowIterator() synonyms for getCellIterator() methods

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Column.php
+++ b/src/PhpSpreadsheet/Worksheet/Column.php
@@ -52,12 +52,21 @@ class Column
      *
      * @param int $startRow The row number at which to start iterating
      * @param int $endRow Optionally, the row number at which to stop iterating
-     *
-     * @return ColumnCellIterator
      */
-    public function getCellIterator($startRow = 1, $endRow = null)
+    public function getCellIterator($startRow = 1, $endRow = null): ColumnCellIterator
     {
         return new ColumnCellIterator($this->worksheet, $this->columnIndex, $startRow, $endRow);
+    }
+
+    /**
+     * Get row iterator. Synonym for getCellIterator().
+     *
+     * @param int $startRow The row number at which to start iterating
+     * @param int $endRow Optionally, the row number at which to stop iterating
+     */
+    public function getRowIterator($startRow = 1, $endRow = null): ColumnCellIterator
+    {
+        return $this->getCellIterator($startRow, $endRow);
     }
 
     /**

--- a/src/PhpSpreadsheet/Worksheet/Row.php
+++ b/src/PhpSpreadsheet/Worksheet/Row.php
@@ -51,12 +51,21 @@ class Row
      *
      * @param string $startColumn The column address at which to start iterating
      * @param string $endColumn Optionally, the column address at which to stop iterating
-     *
-     * @return RowCellIterator
      */
-    public function getCellIterator($startColumn = 'A', $endColumn = null)
+    public function getCellIterator($startColumn = 'A', $endColumn = null): RowCellIterator
     {
         return new RowCellIterator($this->worksheet, $this->rowIndex, $startColumn, $endColumn);
+    }
+
+    /**
+     * Get column iterator. Synonym for getCellIterator().
+     *
+     * @param string $startColumn The column address at which to start iterating
+     * @param string $endColumn Optionally, the column address at which to stop iterating
+     */
+    public function getColumnIterator($startColumn = 'A', $endColumn = null): RowCellIterator
+    {
+        return $this->getCellIterator($startColumn, $endColumn);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnTest.php
@@ -40,4 +40,14 @@ class ColumnTest extends TestCase
         self::assertInstanceOf(ColumnCellIterator::class, $cellIterator);
         $spreadsheet->disconnectWorksheets();
     }
+
+    public function testGetRowIterator(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $column = new Column($sheet);
+        $cellIterator = $column->getRowIterator();
+        self::assertInstanceOf(ColumnCellIterator::class, $cellIterator);
+        $spreadsheet->disconnectWorksheets();
+    }
 }

--- a/tests/PhpSpreadsheetTests/Worksheet/RowTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/RowTest.php
@@ -40,4 +40,14 @@ class RowTest extends TestCase
         self::assertInstanceOf(RowCellIterator::class, $cellIterator);
         $spreadsheet->disconnectWorksheets();
     }
+
+    public function testGetColumnIterator(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $row = new Row($sheet);
+        $cellIterator = $row->getColumnIterator();
+        self::assertInstanceOf(RowCellIterator::class, $cellIterator);
+        $spreadsheet->disconnectWorksheets();
+    }
 }


### PR DESCRIPTION
…ethods in Row and Column objects

This is:

```
- [ ] a bugfix
- [ ] a new feature
- [X] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

`getColumnIterator()` and `getRowIterator()` synonyms for `getCellIterator()` methods in `Row` and `Column` objects