### PR TITLE
Add destructor for RowIterator to ensure disconnection from worksheet

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/CellIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/CellIterator.php
@@ -56,7 +56,7 @@ abstract class CellIterator implements NativeIterator
     }
 
     /**
-     * Validate start/end values for "IterateOnlyExistingCells" mode, and adjust if necessary.
+     * Validate start/end values for 'IterateOnlyExistingCells' mode, and adjust if necessary.
      */
     abstract protected function adjustForExistingOnlyRange(): void;
 

--- a/src/PhpSpreadsheet/Worksheet/RowIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/RowIterator.php
@@ -53,6 +53,11 @@ class RowIterator implements NativeIterator
         $this->resetStart($startRow);
     }
 
+    public function __destruct()
+    {
+        $this->subject = null; // @phpstan-ignore-line
+    }
+
     /**
      * (Re)Set the start row and the current row pointer.
      *


### PR DESCRIPTION
This is:

```
- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Ensure memory cleanup for RowIterator with disconnect from worksheet on destruct