### PR TITLE
Option to specify a range of columns/rows for the Row/Column `isEmpty()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
+- Option to specify a range of columns/rows for the Row/Column `isEmpty()` methods [PR #3315](https://github.com/PHPOffice/PhpSpreadsheet/pull/3315)
 - Option for Cell Iterator to return a null value or create and return a new cell when accessing a cell that doesn't exist [PR #3314](https://github.com/PHPOffice/PhpSpreadsheet/pull/3314)
 - Support for Structured References in the Calculation Engine [PR #3261](https://github.com/PHPOffice/PhpSpreadsheet/pull/3261)
 - Limited Support for Form Controls [PR #3130](https://github.com/PHPOffice/PhpSpreadsheet/pull/3130) [Issue #2396](https://github.com/PHPOffice/PhpSpreadsheet/issues/2396) [Issue #1770](https://github.com/PHPOffice/PhpSpreadsheet/issues/1770) [Issue #2388](https://github.com/PHPOffice/PhpSpreadsheet/issues/2388) [Issue #2904](https://github.com/PHPOffice/PhpSpreadsheet/issues/2904) [Issue #2661](https://github.com/PHPOffice/PhpSpreadsheet/issues/2661)

--- a/src/PhpSpreadsheet/Worksheet/Column.php
+++ b/src/PhpSpreadsheet/Worksheet/Column.php
@@ -85,13 +85,15 @@ class Column
      *              Possible Flag Values are:
      *                  CellIterator::TREAT_NULL_VALUE_AS_EMPTY_CELL
      *                  CellIterator::TREAT_EMPTY_STRING_AS_EMPTY_CELL
+     * @param int $startRow The row number at which to start iterating
+     * @param int $endRow Optionally, the row number at which to stop iterating
      */
-    public function isEmpty(int $definitionOfEmptyFlags = 0): bool
+    public function isEmpty(int $definitionOfEmptyFlags = 0, $startRow = 1, $endRow = null): bool
     {
         $nullValueCellIsEmpty = (bool) ($definitionOfEmptyFlags & CellIterator::TREAT_NULL_VALUE_AS_EMPTY_CELL);
         $emptyStringCellIsEmpty = (bool) ($definitionOfEmptyFlags & CellIterator::TREAT_EMPTY_STRING_AS_EMPTY_CELL);
 
-        $cellIterator = $this->getCellIterator();
+        $cellIterator = $this->getCellIterator($startRow, $endRow);
         $cellIterator->setIterateOnlyExistingCells(true);
         foreach ($cellIterator as $cell) {
             /** @scrutinizer ignore-call */

--- a/src/PhpSpreadsheet/Worksheet/Row.php
+++ b/src/PhpSpreadsheet/Worksheet/Row.php
@@ -84,13 +84,15 @@ class Row
      *              Possible Flag Values are:
      *                  CellIterator::TREAT_NULL_VALUE_AS_EMPTY_CELL
      *                  CellIterator::TREAT_EMPTY_STRING_AS_EMPTY_CELL
+     * @param string $startColumn The column address at which to start iterating
+     * @param string $endColumn Optionally, the column address at which to stop iterating
      */
-    public function isEmpty(int $definitionOfEmptyFlags = 0): bool
+    public function isEmpty(int $definitionOfEmptyFlags = 0, $startColumn = 'A', $endColumn = null): bool
     {
         $nullValueCellIsEmpty = (bool) ($definitionOfEmptyFlags & CellIterator::TREAT_NULL_VALUE_AS_EMPTY_CELL);
         $emptyStringCellIsEmpty = (bool) ($definitionOfEmptyFlags & CellIterator::TREAT_EMPTY_STRING_AS_EMPTY_CELL);
 
-        $cellIterator = $this->getCellIterator();
+        $cellIterator = $this->getCellIterator($startColumn, $endColumn);
         $cellIterator->setIterateOnlyExistingCells(true);
         foreach ($cellIterator as $cell) {
             /** @scrutinizer ignore-call */

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnIteratorEmptyTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnIteratorEmptyTest.php
@@ -39,8 +39,8 @@ class ColumnIteratorEmptyTest extends TestCase
         $sheet = self::getPopulatedSheet($spreadsheet);
         $iterator = new ColumnIterator($sheet, 'A', 'I');
         $iterator->seek($columnId);
-        $row = $iterator->current();
-        $isEmpty = $row->isEmpty();
+        $column = $iterator->current();
+        $isEmpty = $column->isEmpty();
         self::assertSame($expectedEmpty, $isEmpty);
         $spreadsheet->disconnectWorksheets();
     }
@@ -69,8 +69,8 @@ class ColumnIteratorEmptyTest extends TestCase
         $sheet = self::getPopulatedSheet($spreadsheet);
         $iterator = new ColumnIterator($sheet, 'A', 'I');
         $iterator->seek($columnId);
-        $row = $iterator->current();
-        $isEmpty = $row->isEmpty(CellIterator::TREAT_NULL_VALUE_AS_EMPTY_CELL);
+        $column = $iterator->current();
+        $isEmpty = $column->isEmpty(CellIterator::TREAT_NULL_VALUE_AS_EMPTY_CELL);
         self::assertSame($expectedEmpty, $isEmpty);
         $spreadsheet->disconnectWorksheets();
     }
@@ -99,8 +99,8 @@ class ColumnIteratorEmptyTest extends TestCase
         $sheet = self::getPopulatedSheet($spreadsheet);
         $iterator = new ColumnIterator($sheet, 'A', 'I');
         $iterator->seek($columnId);
-        $row = $iterator->current();
-        $isEmpty = $row->isEmpty(CellIterator::TREAT_EMPTY_STRING_AS_EMPTY_CELL);
+        $column = $iterator->current();
+        $isEmpty = $column->isEmpty(CellIterator::TREAT_EMPTY_STRING_AS_EMPTY_CELL);
         self::assertSame($expectedEmpty, $isEmpty);
         $spreadsheet->disconnectWorksheets();
     }
@@ -129,8 +129,8 @@ class ColumnIteratorEmptyTest extends TestCase
         $sheet = self::getPopulatedSheet($spreadsheet);
         $iterator = new ColumnIterator($sheet, 'A', 'I');
         $iterator->seek($columnId);
-        $row = $iterator->current();
-        $isEmpty = $row->isEmpty(
+        $column = $iterator->current();
+        $isEmpty = $column->isEmpty(
             CellIterator::TREAT_EMPTY_STRING_AS_EMPTY_CELL | CellIterator::TREAT_NULL_VALUE_AS_EMPTY_CELL
         );
         self::assertSame($expectedEmpty, $isEmpty);
@@ -150,5 +150,22 @@ class ColumnIteratorEmptyTest extends TestCase
             ['H', false],
             ['I', true],
         ];
+    }
+
+    public function testIteratorEmptyColumnWithRowLimit(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = self::getPopulatedSheet($spreadsheet);
+        $sheet->setCellValue('A8', 'NO LONGER EMPTY');
+
+        $iterator = new ColumnIterator($sheet, 'A', 'A');
+        $column = $iterator->current();
+
+        $isEmpty = $column->isEmpty(CellIterator::TREAT_NULL_VALUE_AS_EMPTY_CELL);
+        self::assertFalse($isEmpty);
+        $isEmpty = $column->isEmpty(CellIterator::TREAT_NULL_VALUE_AS_EMPTY_CELL, 2, 7);
+        self::assertTrue($isEmpty);
+
+        $spreadsheet->disconnectWorksheets();
     }
 }

--- a/tests/PhpSpreadsheetTests/Worksheet/RowIteratorEmptyTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/RowIteratorEmptyTest.php
@@ -40,8 +40,10 @@ class RowIteratorEmptyTest extends TestCase
         $iterator = new RowIterator($sheet, 1, 9);
         $iterator->seek($rowId);
         $row = $iterator->current();
+
         $isEmpty = $row->isEmpty();
         self::assertSame($expectedEmpty, $isEmpty);
+
         $spreadsheet->disconnectWorksheets();
     }
 
@@ -150,5 +152,22 @@ class RowIteratorEmptyTest extends TestCase
             [8, false],
             [9, true],
         ];
+    }
+
+    public function testIteratorEmptyRowWithColumnLimit(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = self::getPopulatedSheet($spreadsheet);
+        $sheet->setCellValue('E3', 'NO LONGER EMPTY');
+
+        $iterator = new RowIterator($sheet, 3, 3);
+        $row = $iterator->current();
+
+        $isEmpty = $row->isEmpty(CellIterator::TREAT_NULL_VALUE_AS_EMPTY_CELL);
+        self::assertFalse($isEmpty);
+        $isEmpty = $row->isEmpty(CellIterator::TREAT_NULL_VALUE_AS_EMPTY_CELL, 'A', 'D');
+        self::assertTrue($isEmpty);
+
+        $spreadsheet->disconnectWorksheets();
     }
 }


### PR DESCRIPTION
This is:

```
- [ ] a bugfix
- [X] a new feature
- [ ] refactoring
- [ ] additional unit tests
```

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?

Option to specify a range of columns/rows for the Row/Column `isEmpty()` methods
