### PR TITLE
Improved handling of @ format mask

### DIFF
--- a/tests/data/Style/NumberFormat.php
+++ b/tests/data/Style/NumberFormat.php
@@ -373,6 +373,27 @@ return [
         'test',
         '_-€* #,##0.00_-;"-€"* #,##0.00_-;_-€* -??_-;_-@_-',
     ],
+    // String masks (ie. @)
+    [
+        'World',
+        'World',
+        '@',
+    ],
+    [
+        'Hello World',
+        'World',
+        'Hello @',
+    ],
+    [
+        'Hello World',
+        'World',
+        '"Hello "@',
+    ],
+    [
+        'Meet me @ The Boathouse @ 16:30',
+        'The Boathouse',
+        '"Meet me @ "@" @ 16:30"',
+    ],
     // Named colours
     // Simple color
     [


### PR DESCRIPTION
This is:

- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Improved handling of @ format mask

With some limitations remaining:
 - Still doesn't work in section 4
 - Doesn't work correctly if there is an @ in quotes, not recognised as a literal