### PR TITLE
Additional exception handling to prevent an invalid formula from breaking `isDateTime()`

### DIFF
--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -375,13 +375,18 @@ class Date
         if ($worksheet !== null && $spreadsheet !== null) {
             $index = $spreadsheet->getActiveSheetIndex();
             $selected = $worksheet->getSelectedCells();
-            $result = is_numeric($value ?? $cell->getCalculatedValue()) &&
-                self::isDateTimeFormat(
-                    $worksheet->getStyle(
-                        $cell->getCoordinate()
-                    )->getNumberFormat(),
-                    $dateWithoutTimeOkay
-                );
+
+            try {
+                $result = is_numeric($value ?? $cell->getCalculatedValue()) &&
+                    self::isDateTimeFormat(
+                        $worksheet->getStyle(
+                            $cell->getCoordinate()
+                        )->getNumberFormat(),
+                        $dateWithoutTimeOkay
+                    );
+            } catch (Exception $e) {
+                // Result is already false, so no need to actually do anything here
+            }
             $worksheet->setSelectedCells($selected);
             $spreadsheet->setActiveSheetIndex($index);
         }

--- a/tests/PhpSpreadsheetTests/Shared/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/DateTest.php
@@ -262,5 +262,14 @@ class DateTest extends TestCase
             ->getNumberFormat()
             ->setFormatCode('0.00E+00');
         self::assertFalse(null !== $cella3 && Date::isDateTime($cella3));
+
+        $cella4 = $sheet->getCell('A4');
+        self::assertNotNull($cella4);
+
+        $cella4->setValue('= 44 7510557347');
+        $sheet->getStyle('A4')
+            ->getNumberFormat()
+            ->setFormatCode('yyyy-mm-dd');
+        self::assertFalse(Date::isDateTime($cella4));
     }
 }


### PR DESCRIPTION
This is:

- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [X] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Additional exception handling to prevent a cell containing an invalid formula from breaking `isDateTime()`

Linked to [PR #3329](https://github.com/PHPOffice/PhpSpreadsheet/pull/3329)