### PR TITLE
Improve support for locale settings in the Calculation Engine formatted number matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Changed
 
 - Improved handling for @ in Number Format Masks [PR #3344](https://github.com/PHPOffice/PhpSpreadsheet/pull/3344)
+- Improved support for locale settings and currency codes when matching formatted strings to numerics in the Calculation Engine [PR #3373](https://github.com/PHPOffice/PhpSpreadsheet/pull/3373) and [PR #3374](https://github.com/PHPOffice/PhpSpreadsheet/pull/3374) 
 
 ### Deprecated
 

--- a/src/PhpSpreadsheet/Calculation/Engine/FormattedNumber.php
+++ b/src/PhpSpreadsheet/Calculation/Engine/FormattedNumber.php
@@ -48,7 +48,10 @@ class FormattedNumber
      */
     public static function convertToNumberIfNumeric(string &$operand): bool
     {
-        $value = preg_replace(['/(\d),(\d)/u', '/([+-])\s+(\d)/u'], ['$1$2', '$1$2'], trim($operand));
+        $thousandsSeparator = preg_quote(StringHelper::getThousandsSeparator());
+        $value = preg_replace(['/(\d)' . $thousandsSeparator . '(\d)/u', '/([+-])\s+(\d)/u'], ['$1$2', '$1$2'], trim($operand));
+        $decimalSeparator = preg_quote(StringHelper::getDecimalSeparator());
+        $value = preg_replace(['/(\d)' . $decimalSeparator . '(\d)/u', '/([+-])\s+(\d)/u'], ['$1.$2', '$1$2'], $value ?? '');
 
         if (is_numeric($value)) {
             $operand = (float) $value;
@@ -87,7 +90,10 @@ class FormattedNumber
      */
     public static function convertToNumberIfPercent(string &$operand): bool
     {
-        $value = preg_replace('/(\d),(\d)/u', '$1$2', $operand);
+        $thousandsSeparator = preg_quote(StringHelper::getThousandsSeparator());
+        $value = preg_replace('/(\d)' . $thousandsSeparator . '(\d)/u', '$1$2', trim($operand));
+        $decimalSeparator = preg_quote(StringHelper::getDecimalSeparator());
+        $value = preg_replace(['/(\d)' . $decimalSeparator . '(\d)/u', '/([+-])\s+(\d)/u'], ['$1.$2', '$1$2'], $value ?? '');
 
         $match = [];
         if ($value !== null && preg_match(self::STRING_REGEXP_PERCENT, $value, $match, PREG_UNMATCHED_AS_NULL)) {
@@ -110,7 +116,8 @@ class FormattedNumber
     public static function convertToNumberIfCurrency(string &$operand): bool
     {
         $currencyRegexp = self::currencyMatcherRegexp();
-        $value = preg_replace('/(\d),(\d)/u', '$1$2', $operand);
+        $thousandsSeparator = preg_quote(StringHelper::getThousandsSeparator());
+        $value = preg_replace('/(\d)' . $thousandsSeparator . '(\d)/u', '$1$2', $operand);
 
         $match = [];
         if ($value !== null && preg_match($currencyRegexp, $value, $match, PREG_UNMATCHED_AS_NULL)) {
@@ -127,8 +134,9 @@ class FormattedNumber
 
     public static function currencyMatcherRegexp(): string
     {
-        $quotedCurrencyCode = sprintf(self::CURRENCY_CONVERSION_LIST, preg_quote(StringHelper::getCurrencyCode()));
+        $currencyCodes = sprintf(self::CURRENCY_CONVERSION_LIST, preg_quote(StringHelper::getCurrencyCode()));
+        $decimalSeparator = preg_quote(StringHelper::getDecimalSeparator());
 
-        return '~^(?:(?: *(?<PrefixedSign>[-+])? *(?<PrefixedCurrency>[' . $quotedCurrencyCode . ']) *(?<PrefixedSign2>[-+])? *(?<PrefixedValue>[0-9]+\.?[0-9*]*(?:E[-+]?[0-9]*)?) *)|(?: *(?<PostfixedSign>[-+])? *(?<PostfixedValue>[0-9]+\.?[0-9]*(?:E[-+]?[0-9]*)?) *(?<PostCurrency>[' . $quotedCurrencyCode . ']) *))$~ui';
+        return '~^(?:(?: *(?<PrefixedSign>[-+])? *(?<PrefixedCurrency>[' . $currencyCodes . ']) *(?<PrefixedSign2>[-+])? *(?<PrefixedValue>[0-9]+[' . $decimalSeparator . ']?[0-9*]*(?:E[-+]?[0-9]*)?) *)|(?: *(?<PostfixedSign>[-+])? *(?<PostfixedValue>[0-9]+' . $decimalSeparator . '?[0-9]*(?:E[-+]?[0-9]*)?) *(?<PostCurrency>[' . $currencyCodes . ']) *))$~ui';
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Engine/FormattedNumberTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Engine/FormattedNumberTest.php
@@ -177,14 +177,14 @@ class FormattedNumberTest extends TestCase
             'permutation_77' => ['-2.5E-8', '-%2.50E-06'],
             'permutation_78' => [' - % 2.50 E -06 ', ' - % 2.50 E -06 '],
             'permutation_79' => ['-2.5E-8', ' - % 2.50E-06 '],
-            'permutation_80' => [' - % 2.50E- 06 ', ' - % 2.50E- 06 '],
+            'permutation_80' => ['-2.5E-8', ' - % 2.50E- 06 '],
             'permutation_81' => [' - % 2.50E - 06 ', ' - % 2.50E - 06 '],
             'permutation_82' => ['-2.5E-6', '-2.5e-4%'],
             'permutation_83' => ['200', '2e4%'],
             'permutation_84' => ['-2.5E-8', '-%2.50e-06'],
             'permutation_85' => [' - % 2.50 e -06 ', ' - % 2.50 e -06 '],
             'permutation_86' => ['-2.5E-8', ' - % 2.50e-06 '],
-            'permutation_87' => [' - % 2.50e- 06 ', ' - % 2.50e- 06 '],
+            'permutation_87' => ['-2.5E-8', ' - % 2.50e- 06 '],
             'permutation_88' => [' - % 2.50e - 06 ', ' - % 2.50e - 06 '],
         ];
     }


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [X] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Improve support for locale settings in the Calculation Engine formatted number matcher