### PR TITLE
Adjust regexp for an explicit 0 for a decimals value when using Currency and Accounting locale masks

### DIFF
--- a/src/PhpSpreadsheet/Style/NumberFormat/Wizard/Accounting.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Wizard/Accounting.php
@@ -55,7 +55,7 @@ class Accounting extends Currency
         $formatter = new Locale($this->fullLocale, NumberFormatter::CURRENCY_ACCOUNTING);
         $mask = $formatter->format();
         if ($this->decimals === 0) {
-            $mask = (string) preg_replace('/\.0*/', '', $mask);
+            $mask = (string) preg_replace('/\.0+/miu', '', $mask);
         }
 
         return str_replace('¤', $this->formatCurrencyCode(), $mask);

--- a/src/PhpSpreadsheet/Style/NumberFormat/Wizard/Currency.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Wizard/Currency.php
@@ -72,7 +72,7 @@ class Currency extends Number
         $formatter = new Locale($this->fullLocale, NumberFormatter::CURRENCY);
         $mask = $formatter->format();
         if ($this->decimals === 0) {
-            $mask = (string) preg_replace('/\.0*/', '', $mask);
+            $mask = (string) preg_replace('/\.0+/miu', '', $mask);
         }
 
         return str_replace('¤', $this->formatCurrencyCode(), $mask);


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [X] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Adjust regexp for an explicit 0 for a decimals value when using Currency and Accounting Number Format Wizards with a locale, to require at least one digit after a dot to ensure this is a decimal and not a text literal

