### PR TITLE
Fix handling for a # symbol in quotes inside a number format mask

### DIFF
--- a/src/PhpSpreadsheet/Style/NumberFormat/NumberFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/NumberFormatter.php
@@ -205,9 +205,6 @@ class NumberFormatter
         //    return 'EUR ' . sprintf('%1.2f', $value);
         //}
 
-        // Some non-number strings are quoted, so we'll get rid of the quotes, likewise any positional * symbols
-        $format = self::makeString(str_replace(['"', '*'], '', $format));
-
         // Find out if we need thousands separator
         // This is indicated by a comma enclosed by a digit placeholder:
         //        #,#   or   0,0
@@ -229,6 +226,7 @@ class NumberFormatter
             $format = self::pregReplace('/0,+/', '0', $format);
             $format = self::pregReplace('/#,+/', '#', $format);
         }
+
         if (preg_match('/#?.*\?\/(\?+|\d+)/', $format)) {
             $value = FractionFormatter::format($value, $format);
         } else {
@@ -236,13 +234,18 @@ class NumberFormatter
 
             // scale number
             $value = $value / $scale;
+
             // Strip #
-            $format = self::pregReplace('/\\#/', '0', $format);
+            $format = self::pregReplace('/\\#(?=(?:[^"]*"[^"]*")*[^"]*\Z)/', '0', $format);
             // Remove locale code [$-###]
             $format = self::pregReplace('/\[\$\-.*\]/', '', $format);
 
             $n = '/\\[[^\\]]+\\]/';
             $m = self::pregReplace($n, '', $format);
+
+            // Some non-number strings are quoted, so we'll get rid of the quotes, likewise any positional * symbols
+            $format = self::makeString(str_replace(['"', '*'], '', $format));
+
             if (preg_match(self::NUMBER_REGEX, $m, $matches)) {
                 // There are placeholders for digits, so inject digits from the value into the mask
                 $value = self::formatStraightNumericValue($value, $format, $matches, $useThousands);

--- a/tests/data/Style/NumberFormat.php
+++ b/tests/data/Style/NumberFormat.php
@@ -1494,4 +1494,19 @@ return [
         -12345.6789,
         '0.000E+00',
     ],
+    [
+        'Product SKU #12345',
+        12345,
+        '"Product SKU #"0',
+    ],
+    [
+        'Product SKU #12-345',
+        12345,
+        '"Product SKU #"00-000',
+    ],
+    [
+        '€12,345.74 Surplus for Product #12-345',
+        12345.74,
+        '[$€]#,##0.00" Surplus for Product #12-345";$-#,##0.00" Shortage for Product #12-345"',
+    ],
 ];


### PR DESCRIPTION
This is:

- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [X] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Fix handling for a # symbol in quotes inside a number format mask
