### PR TITLE
Xls Reader Conditional Styles

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -7921,7 +7921,7 @@ class Xls extends BaseReader
         // offset: 6; size: 4; Options
         $options = self::getInt4d($recordData, 6);
 
-        $style = new Style();
+        $style = new Style(false, true); // non-supervisor, conditional
         $this->getCFStyleOptions($options, $style);
 
         $hasFontRecord = (bool) ((0x04000000 & $options) >> 26);

--- a/tests/PhpSpreadsheetTests/Reader/Xls/ConditionalFormattingBasicTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xls/ConditionalFormattingBasicTest.php
@@ -3,6 +3,7 @@
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Xls;
 
 use PhpOffice\PhpSpreadsheet\Reader\Xls;
+use PhpOffice\PhpSpreadsheet\Style\Border;
 use PhpOffice\PhpSpreadsheet\Style\Conditional;
 use PHPUnit\Framework\TestCase;
 
@@ -145,5 +146,60 @@ class ConditionalFormattingBasicTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    public function testReadConditionalFormattingStyles(): void
+    {
+        $filename = 'tests/data/Reader/XLS/CF_Basic_Comparisons.xls';
+        $reader = new Xls();
+        $spreadsheet = $reader->load($filename);
+        $sheet = $spreadsheet->getActiveSheet();
+        $expectedRange = 'A2:E5';
+        $hasConditionalStyles = $sheet->conditionalStylesExists($expectedRange);
+        self::assertTrue($hasConditionalStyles);
+
+        $conditionalStyles = $sheet->getConditionalStyles($expectedRange);
+        self::assertCount(3, $conditionalStyles);
+
+        $style = $conditionalStyles[0]->getStyle();
+        $font = $style->getFont();
+        self::assertSame('FF0000FF', $font->getColor()->getArgb());
+        self::assertNull($font->getItalic());
+        self::assertNull($font->getStrikethrough());
+        // Fill not handled correctly - forget for now
+        $borders = $style->getBorders();
+        self::assertSame(Border::BORDER_OMIT, $borders->getLeft()->getBorderStyle());
+        self::assertSame(Border::BORDER_OMIT, $borders->getRight()->getBorderStyle());
+        self::assertSame(Border::BORDER_OMIT, $borders->getTop()->getBorderStyle());
+        self::assertSame(Border::BORDER_OMIT, $borders->getBottom()->getBorderStyle());
+        self::assertNull($style->getNumberFormat()->getFormatCode());
+
+        $style = $conditionalStyles[1]->getStyle();
+        $font = $style->getFont();
+        self::assertSame('FF800000', $font->getColor()->getArgb());
+        self::assertNull($font->getItalic());
+        self::assertNull($font->getStrikethrough());
+        // Fill not handled correctly - forget for now
+        $borders = $style->getBorders();
+        self::assertSame(Border::BORDER_OMIT, $borders->getLeft()->getBorderStyle());
+        self::assertSame(Border::BORDER_OMIT, $borders->getRight()->getBorderStyle());
+        self::assertSame(Border::BORDER_OMIT, $borders->getTop()->getBorderStyle());
+        self::assertSame(Border::BORDER_OMIT, $borders->getBottom()->getBorderStyle());
+        self::assertNull($style->getNumberFormat()->getFormatCode());
+
+        $style = $conditionalStyles[2]->getStyle();
+        $font = $style->getFont();
+        self::assertSame('FF00FF00', $font->getColor()->getArgb());
+        self::assertNull($font->getItalic());
+        self::assertNull($font->getStrikethrough());
+        // Fill not handled correctly - forget for now
+        $borders = $style->getBorders();
+        self::assertSame(Border::BORDER_OMIT, $borders->getLeft()->getBorderStyle());
+        self::assertSame(Border::BORDER_OMIT, $borders->getRight()->getBorderStyle());
+        self::assertSame(Border::BORDER_OMIT, $borders->getTop()->getBorderStyle());
+        self::assertSame(Border::BORDER_OMIT, $borders->getBottom()->getBorderStyle());
+        self::assertNull($style->getNumberFormat()->getFormatCode());
+
+        $spreadsheet->disconnectWorksheets();
     }
 }


### PR DESCRIPTION
The code currently allocates the style object as a non-conditional style, leading to corruption when the spreadsheet is written out.

That being said, Font Color is the only Conditional Formatting I have gotten to work for Xls for read or write. Use of other styles will essentially continue to be ignored, but will at least no longer result in corrupt spreadsheets.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
