### PR TITLE
Modify Date/Time check in the NumberFormatter for decimal/fractional times

### DIFF
--- a/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
@@ -170,10 +170,11 @@ class Formatter
         $format = (string) preg_replace('/_.?/ui', ' ', $format);
 
         // Let's begin inspecting the format and converting the value to a formatted string
-        //  Check for date/time characters (not inside quotes)
         if (
-            (preg_match('/(\[\$[A-Z]*-[0-9A-F]*\])*[hmsdy](?=(?:[^"]|"[^"]*")*$)/miu', $format)) &&
-            (preg_match('/0(?![^\[]*\])/miu', $format) === 0)
+            //  Check for date/time characters (not inside quotes)
+            (preg_match('/(\[\$[A-Z]*-[0-9A-F]*\])*[hmsdy](?=(?:[^"]|"[^"]*")*$)/miu', $format))
+            // A date/time with a decimal time shouldn't have a digit placeholder before the decimal point
+            && (preg_match('/[0\?#]\.(?![^\[]*\])/miu', $format) === 0)
         ) {
             // datetime format
             $value = DateFormatter::format($value, $format);
@@ -194,8 +195,6 @@ class Formatter
             $value = $writerInstance->$function($value, $colors);
         }
 
-        $value = str_replace(chr(0x00), '.', $value);
-
-        return $value;
+        return str_replace(chr(0x00), '.', $value);
     }
 }

--- a/tests/data/Style/NumberFormatDates.php
+++ b/tests/data/Style/NumberFormatDates.php
@@ -36,6 +36,17 @@ return [
         22269.0625,
         '"y-m-d "yyyy-mm-dd" h:m:s "hh:mm:ss',
     ],
+    // Date with fractional/decimal time
+    [
+        '2023/02/28 0:00:00.000',
+        44985,
+        'yyyy/mm/dd\ h:mm:ss.000',
+    ],
+    [
+        '2023/02/28 07:35:02.000',
+        44985.316,
+        'yyyy/mm/dd\ hh:mm:ss.000',
+    ],
     [
         '07:35:00 AM',
         43270.315972222,


### PR DESCRIPTION
This is:

- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [X] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

[Issue #3412](https://github.com/PHPOffice/PhpSpreadsheet/issues/3412)

Modify Date/Time check in the NumberFormatter so that masks with a decimal/fractional time aren't misinterpreted as number masks, while still ensuring that durations are interpreted as date/time masks, and locale currency masks are still treated as numbers

A date/time with a decimal time shouldn't have a digit placeholder **_before_** the decimal point, only after
