### PR TITLE
Cast Cell value to float in processDomElementDataFormat function

### DIFF
--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -560,6 +560,8 @@ class Html extends BaseReader
     private function processDomElementDataFormat(Worksheet $sheet, int $row, string $column, array $attributeArray): void
     {
         if (isset($attributeArray['data-format'])) {
+            $value = $sheet->getCell($column . $row)->getValue();
+            $sheet->setCellValue($column . $row,(float) $value);
             $sheet->getStyle($column . $row)->getNumberFormat()->setFormatCode($attributeArray['data-format']);
         }
     }


### PR DESCRIPTION
If we want to use data-format attribute in html, we have to cast cell value to float (number). because format not applied to string values. We should know excel put Leading apostrophes " ' " to numeric string values. Leading apostrophes force excel to treat the cell's contents as a text value.


