### PR TITLE
Apply strict type checking to Complex suffix

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Engineering/Complex.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/Complex.php
@@ -49,7 +49,7 @@ class Complex
             return $e->getMessage();
         }
 
-        if (($suffix == 'i') || ($suffix == 'j') || ($suffix == '')) {
+        if (($suffix === 'i') || ($suffix === 'j') || ($suffix === '')) {
             $complex = new ComplexObject($realNumber, $imaginary, $suffix);
 
             return (string) $complex;


### PR DESCRIPTION
This is:

- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Passing a true/false value to the Complex function as a suffix results in a 0 or 1 being appended to the value, and no suffix applied

So `COMPLEX(1.5, 3.5, true)` will result in `1.5+3.51`, a totally erroneous value.
