### PR TITLE
Establish boundary for function prefix regexp to prevent over-aggressive prefixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Updates Cell formula absolute ranges/references, and Defined Name absolute ranges/references when inserting/deleting rows/columns [Issue #3368](https://github.com/PHPOffice/PhpSpreadsheet/issues/3368) [PR #3402](https://github.com/PHPOffice/PhpSpreadsheet/pull/3402)
 - EOMONTH() and EDATE() Functions should round date value before evaluation [Issue #3436](https://github.com/PHPOffice/PhpSpreadsheet/issues/3436) [PR #3437](https://github.com/PHPOffice/PhpSpreadsheet/pull/3437)
+- NETWORKDAYS function erroneously being converted to NETWORK_xlfn.DAYS in Xlsx Writer [Issue #3461](https://github.com/PHPOffice/PhpSpreadsheet/issues/3461) [PR #3463](https://github.com/PHPOffice/PhpSpreadsheet/pull/3463)
 
 
 ## 1.28.0 - 2023-02-25

--- a/src/PhpSpreadsheet/Writer/Xlsx/FunctionPrefix.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/FunctionPrefix.php
@@ -4,7 +4,7 @@ namespace PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
 class FunctionPrefix
 {
-    const XLFNREGEXP = '/(?:_xlfn\.)?((?:_xlws\.)?('
+    const XLFNREGEXP = '/(?:_xlfn\.)?((?:_xlws\.)?\b('
             // functions added with Excel 2010
         . 'beta[.]dist'
         . '|beta[.]inv'

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/FunctionPrefixTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/FunctionPrefixTest.php
@@ -27,6 +27,11 @@ class FunctionPrefixTest extends TestCase
             'New Function requiring Double-Prefix already partially Prefixed #2' => ['_xlfn._xlws.FILTER()', '_xlws.FILTER()'],
             'New Function requiring Double-Prefix already Fully Prefixed' => ['_xlfn._xlws.FILTER()', '_xlfn._xlws.FILTER()'],
             'Multiple Functions' => ['_xlfn._xlws.SORT(_xlfn._xlws.FILTER(A:A, A:A<>""))', 'SORT(FILTER(A:A, A:A<>""))'],
+            'DAYS/NETWORKDAYS 1' => ['_xlfn.DAYS(DATE(2023,1,1),TODAY())', 'DAYS(DATE(2023,1,1),TODAY())'],
+            'DAYS/NETWORKDAYS 2' => ['_xlfn.DAYS(DATE(2023,1,1),TODAY())', '_xlfn.DAYS(DATE(2023,1,1),TODAY())'],
+            'DAYS/NETWORKDAYS 3' => ['ABS(_xlfn.DAYS(DATE(2023,1,1),TODAY()))', 'ABS(DAYS(DATE(2023,1,1),TODAY()))'],
+            'DAYS/NETWORKDAYS 4' => ['ABS(_xlfn.DAYS(DATE(2023,1,1),TODAY()))', 'ABS(_xlfn.DAYS(DATE(2023,1,1),TODAY()))'],
+            'DAYS/NETWORKDAYS 5' => ['NETWORKDAYS(DATE(2023,1,1),TODAY(), C:C)', 'NETWORKDAYS(DATE(2023,1,1),TODAY(), C:C)'],
         ];
     }
 


### PR DESCRIPTION
This is:

- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [X] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [X] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [X] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

See [Issue #3461](https://github.com/PHPOffice/PhpSpreadsheet/issues/3461)

Establish boundary for function prefix regexp to prevent NETWORKDAYS being picked up by DAYS entry in function list
