### PR TITLE
Shared Formulae outside the filter range when reading with a filter are not always being identified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - EOMONTH() and EDATE() Functions should round date value before evaluation [Issue #3436](https://github.com/PHPOffice/PhpSpreadsheet/issues/3436) [PR #3437](https://github.com/PHPOffice/PhpSpreadsheet/pull/3437)
 - NETWORKDAYS function erroneously being converted to NETWORK_xlfn.DAYS in Xlsx Writer [Issue #3461](https://github.com/PHPOffice/PhpSpreadsheet/issues/3461) [PR #3463](https://github.com/PHPOffice/PhpSpreadsheet/pull/3463)
 - Getting a style for a CellAddress instance fails if the worksheet is set in the CellAddress instance [Issue #3439](https://github.com/PHPOffice/PhpSpreadsheet/issues/3439) [PR #3469](https://github.com/PHPOffice/PhpSpreadsheet/pull/3469)
+- Shared Formulae outside the filter range when reading with a filter are not always being identified [Issue #3473](https://github.com/PHPOffice/PhpSpreadsheet/issues/3473) [PR #3474](https://github.com/PHPOffice/PhpSpreadsheet/pull/3474)
 
 
 ## 1.28.0 - 2023-02-25

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -790,7 +790,11 @@ class Xlsx extends BaseReader
                                             $coordinates = Coordinate::coordinateFromString($r);
 
                                             if (!$this->getReadFilter()->readCell($coordinates[0], (int) $coordinates[1], $docSheet->getTitle())) {
-                                                if (isset($cAttr->f)) {
+                                                // Normally, just testing for the f attribute should identify this cell as containing a formula
+                                                // that we need to read, even though it is outside of the filter range, in case it is a shared formula.
+                                                // But in some cases, this attribute isn't set; so we need to delve a level deeper and look at
+                                                // whether or not the cell has a child formula element that is shared.
+                                                if (isset($cAttr->f) || (isset($c->f, $c->f->attributes()['t']) && (string) $c->f->attributes()['t'] === 'shared')) {
                                                     $this->castToFormula($c, $r, $cellDataType, $value, $calculatedValue, $sharedFormulas, 'castToError');
                                                 }
                                                 ++$rowIndex;

--- a/src/PhpSpreadsheet/Reader/Xlsx/SharedFormula.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/SharedFormula.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Reader\Xlsx;
+
+class SharedFormula
+{
+    private string $master;
+
+    private string $formula;
+
+    public function __construct(string $master, string $formula)
+    {
+        $this->master = $master;
+        $this->formula = $formula;
+    }
+
+    public function master(): string
+    {
+        return $this->master;
+    }
+
+    public function formula(): string
+    {
+        return $this->formula;
+    }
+}


### PR DESCRIPTION
This is:

- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

[Issue #3473](https://github.com/PHPOffice/PhpSpreadsheet/issues/3473)

When loading a file and accessing cells outside a filter range, we still check for shared formulae that may need to be used inside the filter range; so we test for the cell's `f` attribute; and if it is a shared formula then it's saved in the Shared Formula table so that it can be used when we encounter a cell inside the filter range that does use it.

However, in some cases (like this one) no `f` attribute was set and we need to check for the presence of an `f` child element with a shared attribute to indicate a Shared Formula that needs saving in the Shared Formula table.
