### PR TITLE
Fix issue with online samples - Use <pre> tag in Helper Grid

### DIFF
--- a/src/PhpSpreadsheet/Helper/TextGrid.php
+++ b/src/PhpSpreadsheet/Helper/TextGrid.php
@@ -48,7 +48,7 @@ class TextGrid
 
     public function render(): string
     {
-        $this->gridDisplay = $this->isCli ? '' : '<code>';
+        $this->gridDisplay = $this->isCli ? '' : '<pre>';
 
         $maxRow = max($this->rows);
         $maxRowLength = strlen((string) $maxRow) + 1;
@@ -58,7 +58,7 @@ class TextGrid
         $this->renderRows($maxRowLength, $columnWidths);
         $this->renderFooter($maxRowLength, $columnWidths);
 
-        $this->gridDisplay .= $this->isCli ? '' : '</code>';
+        $this->gridDisplay .= $this->isCli ? '' : '</pre>';
 
         return $this->gridDisplay;
     }


### PR DESCRIPTION
This is:

- [X] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [X] documentation/examples

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Helper grid using <code> tag for html rendering, which treats newlines as whitespace; needs <pre> tag to render correctly
