### PR TITLE
Avoid allocating RowDimension when the row is visible by default

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/AutoFilter.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter.php
@@ -1049,7 +1049,11 @@ class AutoFilter
                 }
             }
             //    Set show/hide for the row based on the result of the autoFilter result
-            $this->workSheet->getRowDimension((int) $row)->setVisible($result);
+            //    If the RowDimension object has not been allocated yet and the row should be visible,
+            //    then we can avoid any operation since the rows are visible by default (saves a lot of memory)
+            if ($this->workSheet->rowDimensionExists((int) $row) || $result === false) {
+                $this->workSheet->getRowDimension((int) $row)->setVisible($result);
+            }
         }
         $this->evaluated = true;
 


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

When there is an auto filter range defined as A1:A:100000, it forces the filter to iterate over all the rows in the range and see if needs to hide them ($this->workSheet->getRowDimension((int) $row)->setVisible($result);)

that allocates a RowDimension object for each row for each sheet, and boom, a lot of memory wasted.

This change allocates the `RowDimension` object only if the row visibility needs to be changed.
