### PR TITLE
Plat 2145 deprecations fix

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -4350,7 +4350,7 @@ class Calculation
             }
 
             // if the token is a binary operator, pop the top two values off the stack, do the operation, and push the result back on the stack
-            if (isset(self::$binaryOperators[$token])) {
+            if (isset(self::$binaryOperators["$token"])) {
                 //    We must have two operands, error if we don't
                 if (($operand2Data = $stack->pop()) === null) {
                     return $this->raiseFormulaError('Internal error - Operand value missing from stack');
@@ -4897,7 +4897,7 @@ class Calculation
                 if (is_numeric($operand1) && is_numeric($operand2)) {
                     $result = (abs($operand1 - $operand2) < $this->delta);
                 } else {
-                    $result = strcmp($operand1, $operand2) == 0;
+                    $result = strcmp("$operand1", "$operand2") == 0;
                 }
 
                 break;

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -2112,7 +2112,7 @@ class Calculation
         ],
         'ROUND' => [
             'category' => Category::CATEGORY_MATH_AND_TRIG,
-            'functionCall' => 'round',
+            'functionCall' => [Kasko::class, 'ROUND'],
             'argumentCount' => '2',
         ],
         'ROUNDDOWN' => [

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -4241,7 +4241,7 @@ class Calculation
             $rowKey = array_shift($rKeys);
             $cKeys = array_keys(array_keys($operand[$rowKey]));
             $colKey = array_shift($cKeys);
-            if (ctype_upper($colKey)) {
+            if (ctype_upper("$colKey")) {
                 $operandData['reference'] = $colKey . $rowKey;
             }
         }

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -1402,7 +1402,7 @@ class Calculation
         ],
         'INDEX' => [
             'category' => Category::CATEGORY_LOOKUP_AND_REFERENCE,
-            'functionCall' => [LookupRef::class, 'INDEX'],
+            'functionCall' => [Kasko::class, 'INDEX'],
             'argumentCount' => '1-4',
         ],
         'INDIRECT' => [

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -4561,7 +4561,7 @@ class Calculation
                 } else {
                     $this->executeNumericBinaryOperation($multiplier, $arg, '*', 'arrayTimesEquals', $stack);
                 }
-            } elseif (preg_match('/^' . self::CALCULATION_REGEXP_CELLREF . '$/i', $token, $matches)) {
+            } elseif (preg_match('/^' . self::CALCULATION_REGEXP_CELLREF . '$/i', "$token", $matches)) {
                 $cellRef = null;
                 if (isset($matches[8])) {
                     if ($pCell === null) {
@@ -4636,7 +4636,7 @@ class Calculation
                 }
 
                 // if the token is a function, pop arguments off the stack, hand them to the function, and push the result back on
-            } elseif (preg_match('/^' . self::CALCULATION_REGEXP_FUNCTION . '$/miu', $token, $matches)) {
+            } elseif (preg_match('/^' . self::CALCULATION_REGEXP_FUNCTION . '$/miu', "$token", $matches)) {
                 if ($pCellParent) {
                     $pCell->attach($pCellParent);
                 }
@@ -4723,7 +4723,7 @@ class Calculation
                 }
             } else {
                 // if the token is a number, boolean, string or an Excel error, push it onto the stack
-                if (isset(self::$excelConstants[strtoupper($token)])) {
+                if (isset(self::$excelConstants[strtoupper($token ?? '')])) {
                     $excelConstant = strtoupper($token);
                     $stack->push('Constant Value', self::$excelConstants[$excelConstant]);
                     if (isset($storeKey)) {

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -4908,7 +4908,7 @@ class Calculation
                 } elseif ($useLowercaseFirstComparison) {
                     $result = $this->strcmpLowercaseFirst($operand1, $operand2) >= 0;
                 } else {
-                    $result = strcmp($operand1, $operand2) >= 0;
+                    $result = strcmp("$operand1", "$operand2") >= 0;
                 }
 
                 break;
@@ -4919,7 +4919,7 @@ class Calculation
                 } elseif ($useLowercaseFirstComparison) {
                     $result = $this->strcmpLowercaseFirst($operand1, $operand2) <= 0;
                 } else {
-                    $result = strcmp($operand1, $operand2) <= 0;
+                    $result = strcmp("$operand1", $operand2) <= 0;
                 }
 
                 break;

--- a/src/PhpSpreadsheet/Calculation/Functions.php
+++ b/src/PhpSpreadsheet/Calculation/Functions.php
@@ -255,7 +255,7 @@ class Functions
 
         if (!is_string($condition) || !in_array($condition[0], ['>', '<', '='])) {
             if (!is_numeric($condition)) {
-                $condition = Calculation::wrapResult(strtoupper($condition));
+                $condition = Calculation::wrapResult(strtoupper("$condition"));
             }
 
             return str_replace('""""', '""', '=' . $condition);

--- a/src/PhpSpreadsheet/Calculation/Kasko.php
+++ b/src/PhpSpreadsheet/Calculation/Kasko.php
@@ -9,6 +9,15 @@ class Kasko
      * Problem described here: https://github.com/PHPOffice/PhpSpreadsheet/issues/1789
      * It was fixed by just adding validation, but our templates are full of formulas like:
      * =ROUND('1.111'; 0)
+     *
+     * Other possible functions that we are not using, but might break:
+     *
+     * MathTrig:
+     * ABS, ACOS, ACOSH, ASIN, ASINH, ATAN, ATANH,
+     * COS, COSH, DEGREES (rad2deg), EXP, LN (log), LOG10,
+     * RADIANS (deg2rad), REPT (str_repeat), SIN, SINH, SQRT, TAN, TANH.
+     *
+     * TextData function (REPT) is also affected.
      */
     public static function ROUND($num, $precision)
     {

--- a/src/PhpSpreadsheet/Calculation/Kasko.php
+++ b/src/PhpSpreadsheet/Calculation/Kasko.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Calculation;
+
+class Kasko
+{
+    /**
+     * Replacing native function for php 8.0
+     */
+    public static function ROUND($num, $precision)
+    {
+        $num       = Functions::flattenSingleValue($num);
+        $precision = Functions::flattenSingleValue($precision);
+
+        return round((float) $num, $precision);
+    }
+}

--- a/src/PhpSpreadsheet/Calculation/Kasko.php
+++ b/src/PhpSpreadsheet/Calculation/Kasko.php
@@ -17,56 +17,12 @@ class Kasko
 
     public static function INDEX($arrayValues, $rowNum = 0, $columnNum = 0)
     {
-        $rowNum = Functions::flattenSingleValue($rowNum);
-        $columnNum = Functions::flattenSingleValue($columnNum);
-
-        // BC with our broken kasko insurer templates
+        // BC for our broken kasko insurer templates
         // This is obvious bug that was fixed: https://github.com/PHPOffice/PhpSpreadsheet/issues/2066
-        if (Functions::NA() === $rowNum) {
+        if (Functions::NA() === Functions::flattenSingleValue($rowNum)) {
             return $arrayValues;
         }
 
-        if (($rowNum < 0) || ($columnNum < 0)) {
-            return Functions::VALUE();
-        }
-
-        if (!is_array($arrayValues) || ($rowNum > count($arrayValues))) {
-            return Functions::REF();
-        }
-
-        $rowKeys = array_keys($arrayValues);
-        $columnKeys = @array_keys($arrayValues[$rowKeys[0]]);
-
-        if ($columnNum > count($columnKeys)) {
-            return Functions::VALUE();
-        } elseif ($columnNum == 0) {
-            if ($rowNum == 0) {
-                return $arrayValues;
-            }
-            $rowNum = $rowKeys[--$rowNum];
-            $returnArray = [];
-            foreach ($arrayValues as $arrayColumn) {
-                if (is_array($arrayColumn)) {
-                    if (isset($arrayColumn[$rowNum])) {
-                        $returnArray[] = $arrayColumn[$rowNum];
-                    } else {
-                        return [$rowNum => $arrayValues[$rowNum]];
-                    }
-                } else {
-                    return $arrayValues[$rowNum];
-                }
-            }
-
-            return $returnArray;
-        }
-        $columnNum = $columnKeys[--$columnNum];
-        if ($rowNum > count($rowKeys)) {
-            return Functions::VALUE();
-        } elseif ($rowNum == 0) {
-            return $arrayValues[$columnNum];
-        }
-        $rowNum = $rowKeys[--$rowNum];
-
-        return $arrayValues[$rowNum][$columnNum];
+        return LookupRef::INDEX($arrayValues, $rowNum, $columnNum);
     }
 }

--- a/src/PhpSpreadsheet/Calculation/Kasko.php
+++ b/src/PhpSpreadsheet/Calculation/Kasko.php
@@ -27,10 +27,13 @@ class Kasko
         return round((float) $num, $precision);
     }
 
+    /**
+     * BC for our broken kasko insurer templates
+     * This is obvious bug that was fixed: https://github.com/PHPOffice/PhpSpreadsheet/issues/2066
+     */
     public static function INDEX($arrayValues, $rowNum = 0, $columnNum = 0)
     {
-        // BC for our broken kasko insurer templates
-        // This is obvious bug that was fixed: https://github.com/PHPOffice/PhpSpreadsheet/issues/2066
+
         if (Functions::NA() === Functions::flattenSingleValue($rowNum)) {
             return $arrayValues;
         }

--- a/src/PhpSpreadsheet/Calculation/Kasko.php
+++ b/src/PhpSpreadsheet/Calculation/Kasko.php
@@ -14,4 +14,59 @@ class Kasko
 
         return round((float) $num, $precision);
     }
+
+    public static function INDEX($arrayValues, $rowNum = 0, $columnNum = 0)
+    {
+        $rowNum = Functions::flattenSingleValue($rowNum);
+        $columnNum = Functions::flattenSingleValue($columnNum);
+
+        // BC with our broken kasko insurer templates
+        // This is obvious bug that was fixed: https://github.com/PHPOffice/PhpSpreadsheet/issues/2066
+        if (Functions::NA() === $rowNum) {
+            return $arrayValues;
+        }
+
+        if (($rowNum < 0) || ($columnNum < 0)) {
+            return Functions::VALUE();
+        }
+
+        if (!is_array($arrayValues) || ($rowNum > count($arrayValues))) {
+            return Functions::REF();
+        }
+
+        $rowKeys = array_keys($arrayValues);
+        $columnKeys = @array_keys($arrayValues[$rowKeys[0]]);
+
+        if ($columnNum > count($columnKeys)) {
+            return Functions::VALUE();
+        } elseif ($columnNum == 0) {
+            if ($rowNum == 0) {
+                return $arrayValues;
+            }
+            $rowNum = $rowKeys[--$rowNum];
+            $returnArray = [];
+            foreach ($arrayValues as $arrayColumn) {
+                if (is_array($arrayColumn)) {
+                    if (isset($arrayColumn[$rowNum])) {
+                        $returnArray[] = $arrayColumn[$rowNum];
+                    } else {
+                        return [$rowNum => $arrayValues[$rowNum]];
+                    }
+                } else {
+                    return $arrayValues[$rowNum];
+                }
+            }
+
+            return $returnArray;
+        }
+        $columnNum = $columnKeys[--$columnNum];
+        if ($rowNum > count($rowKeys)) {
+            return Functions::VALUE();
+        } elseif ($rowNum == 0) {
+            return $arrayValues[$columnNum];
+        }
+        $rowNum = $rowKeys[--$rowNum];
+
+        return $arrayValues[$rowNum][$columnNum];
+    }
 }

--- a/src/PhpSpreadsheet/Calculation/Kasko.php
+++ b/src/PhpSpreadsheet/Calculation/Kasko.php
@@ -5,7 +5,10 @@ namespace PhpOffice\PhpSpreadsheet\Calculation;
 class Kasko
 {
     /**
-     * Replacing native function for php 8.0
+     * Casting num native function for php 8.0
+     * Problem described here: https://github.com/PHPOffice/PhpSpreadsheet/issues/1789
+     * It was fixed by just adding validation, but our templates are full of formulas like:
+     * =ROUND('1.111'; 0)
      */
     public static function ROUND($num, $precision)
     {

--- a/src/PhpSpreadsheet/Shared/StringHelper.php
+++ b/src/PhpSpreadsheet/Shared/StringHelper.php
@@ -464,7 +464,7 @@ class StringHelper
      */
     public static function countCharacters($value, $enc = 'UTF-8')
     {
-        return mb_strlen($value, $enc);
+        return mb_strlen("$value", $enc);
     }
 
     /**

--- a/src/PhpSpreadsheet/Shared/StringHelper.php
+++ b/src/PhpSpreadsheet/Shared/StringHelper.php
@@ -502,7 +502,7 @@ class StringHelper
      */
     public static function strToLower($pValue)
     {
-        return mb_convert_case($pValue, MB_CASE_LOWER, 'UTF-8');
+        return mb_convert_case("$pValue", MB_CASE_LOWER, 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

After PHP8.2 update, there are enormous amount of the deprecation warning in the v2-quote service 
coming from this lib. This PR fixes those warnings.

https://kasko.atlassian.net/browse/PLAT-2145
