### PR TITLE
Loading mitoteam/jpgraph 10.3+ in Extended Mode (with some bugs fixed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ or the appropriate PDF Writer wrapper for the library that you have chosen to in
 For Chart export, we support following packages, which you will also need to install yourself using `composer require`
  - [jpgraph/jpgraph](https://packagist.org/packages/jpgraph/jpgraph) (this package was abandoned at version 4.0. 
    You can manually download the latest version that supports PHP 8 and above from [jpgraph.net](https://jpgraph.net/))
- - [mitoteam/jpgraph](https://packagist.org/packages/mitoteam/jpgraph) - fork with modern PHP versions support.
+ - [mitoteam/jpgraph](https://packagist.org/packages/mitoteam/jpgraph) - up to date fork with modern PHP versions support and some bugs fixed.
 
 and then configure PhpSpreadsheet using:
 ```php

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "dev-main",
         "dompdf/dompdf": "^1.0 || ^2.0",
         "friendsofphp/php-cs-fixer": "^3.2",
-        "mitoteam/jpgraph": "^10.2.4",
+        "mitoteam/jpgraph": "^10.3.1",
         "mpdf/mpdf": "^8.1.1",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpstan/phpstan": "^1.1",

--- a/src/PhpSpreadsheet/Chart/Renderer/MtJpGraphRenderer.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/MtJpGraphRenderer.php
@@ -3,12 +3,12 @@
 namespace PhpOffice\PhpSpreadsheet\Chart\Renderer;
 
 /**
- * Jpgraph is not oficially maintained in Composer.
+ * Jpgraph is not officially maintained by Composer at packagist.org.
  *
  * This renderer implementation uses package
  * https://packagist.org/packages/mitoteam/jpgraph
  *
- * This package is up to date for August 2022 and has PHP 8.1 support.
+ * This package is up to date for June 2023 and has PHP 8.2 support.
  */
 class MtJpGraphRenderer extends JpGraphRendererBase
 {
@@ -19,17 +19,20 @@ class MtJpGraphRenderer extends JpGraphRendererBase
             return;
         }
 
-        \mitoteam\jpgraph\MtJpGraph::load([
-            'bar',
-            'contour',
-            'line',
-            'pie',
-            'pie3d',
-            'radar',
-            'regstat',
-            'scatter',
-            'stock',
-        ]);
+        \mitoteam\jpgraph\MtJpGraph::load(
+            array(
+                'bar',
+                'contour',
+                'line',
+                'pie',
+                'pie3d',
+                'radar',
+                'regstat',
+                'scatter',
+                'stock',
+            ),
+            true // enable Extended Mode
+        );
 
         $loaded = true;
     }


### PR DESCRIPTION
- minor refactoring. Details at https://github.com/mitoteam/jpgraph/issues/14

1) changed required version to 10.3@rc
2) enabled loading library in Extended Mode with additional patches
3) minor README changes