### PR TITLE
FIxed typo in code example in reading-files.md

### DIFF
--- a/docs/topics/reading-files.md
+++ b/docs/topics/reading-files.md
@@ -303,7 +303,7 @@ class MyReadFilter implements \PhpOffice\PhpSpreadsheet\Reader\IReadFilter
     public function readCell($columnAddress, $row, $worksheetName = '') {
         //  Read rows 1 to 7 and columns A to E only
         if ($row >= 1 && $row <= 7) {
-            if (in_array($column,range('A','E'))) {
+            if (in_array($columnAddress,range('A','E'))) {
                 return true;
             }
         }
@@ -348,7 +348,7 @@ class MyReadFilter implements \PhpOffice\PhpSpreadsheet\Reader\IReadFilter
     public function readCell($columnAddress, $row, $worksheetName = '') {
         //  Only read the rows and columns that were configured
         if ($row >= $this->startRow && $row <= $this->endRow) {
-            if (in_array($column,$this->columns)) {
+            if (in_array($columnAddress,$this->columns)) {
                 return true;
             }
         }


### PR DESCRIPTION
Fixed typo in documentation `reading-files.md` in code examples in name of variable `$columnAddress` that was wrongly shortened to `$column`. Long version of the variable name $columnAddress is used in the corresponding samples scripts so now the docs match the samples.
No actual code was modified, just the documentation.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] documentation review

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
