### PR TITLE
Added a trait to help asserting cell values in PHPUnit tests

### DIFF
--- a/tests/PhpSpreadsheetTests/Custom/SpreadsheetAssertionsTrait.php
+++ b/tests/PhpSpreadsheetTests/Custom/SpreadsheetAssertionsTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Custom;
+
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PHPUnit\Framework\Assert;
+
+trait SpreadsheetAssertionsTrait
+{
+    /**
+     * Assert that the items of the passed value map are identical to the cell values of the worksheet.
+     *
+     * @example Basic usage: ```
+     *     $this->assertSpreadsheetCellValuesMap([
+     *         ['Firstname', 'Lastname', 'Age'],
+     *         ['Christian', 'Miller', '35'],
+     *         ['Tim', 'Lemon', '22'],
+     *     ], $spreadsheet->getActiveSheet());
+     * ```
+     * @example You can ommit the comparison of a row by adding an empty array: ```
+     *     $this->assertSpreadsheetCellValuesMap([
+     *         [], // the first row won't be compared
+     *         ['Christian', 'Miller', '35'],
+     *         ['Tim', 'Lemon', '22'],
+     *     ], $spreadsheet->getActiveSheet());
+     * ```
+     *
+     * @param iterable $expectedValueMap two dimensional array or iterator map
+     */
+    public static function assertSpreadsheetCellValuesMap(iterable $expectedValueMap, Worksheet $sheet): void
+    {
+        $actualValues = $sheet->toArray();
+
+        // Replace rows in the actual values if the expected row array is empty.
+        foreach ($expectedValueMap as $rowIndex => $expectedCellValues) {
+            if (0 === count($expectedCellValues)) {
+                $actualValues[$rowIndex] = [];
+            }
+        }
+
+        Assert::assertSame($expectedValueMap, $actualValues);
+    }
+}


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

When writing functional tests and one would like to check if the generated spreadsheet has the correct values it is possible to compare every cell by its coordinates. But this is very effortful and hard to read.

With this PR I want to add a trait that can be used in PHPUnit tests to compare all cell values at once.

Look at the following example where the underlying spreadsheet may look like that:

| Firstname | Lastname | Age |
|----------------|----------------|-------|
| Christian | Miller | 35 |
| Tim | Lemon | 22 |

The test file may look like that:

```php
class SpreadsheetGeneratorTest extends TestCase
{
    use \PhpOffice\PhpSpreadsheetTests\Custom\SpreadsheetAssertionsTrait;

    public function testGenerate(): void
    {
        // prepare the test
        $spreadsheet = IOFactory::load($generatedFile->getPathname());
        $this->assertSpreadsheetCellValuesMap([
             ['Firstname', 'Lastname', 'Age'],
             ['Christian', 'Miller', '35'],
             ['Tim', 'Lemon', '22'],
         ], $spreadsheet->getActiveSheet());
    }
}
```

If there are rows which are not needed to check, just add an empty array

```php
        $this->assertSpreadsheetCellValuesMap([
             [], // the first row is only informational text - no need to make any assertions
             ['Christian', 'Miller', '35'],
             ['Tim', 'Lemon', '22'],
         ], $spreadsheet->getActiveSheet());
```

If you like this. I can also add some documentation, if you can tell me where to add it.