### PR TITLE
Php 8.3 Problem - Add Casts to RowColumnInformation

### DIFF
--- a/src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/RowColumnInformation.php
@@ -159,8 +159,8 @@ class RowColumnInformation
         [, $cellAddress] = Worksheet::extractSheetTitle($cellAddress, true);
         if (strpos($cellAddress, ':') !== false) {
             [$startAddress, $endAddress] = explode(':', $cellAddress);
-            $startAddress = (string) preg_replace('/\D/', '', $startAddress);
-            $endAddress = (string) preg_replace('/\D/', '', $endAddress);
+            $startAddress = (int) (string) preg_replace('/\D/', '', $startAddress);
+            $endAddress = (int) (string) preg_replace('/\D/', '', $endAddress);
 
             return array_map(
                 function ($value) {


### PR DESCRIPTION
Some tests were failing with Php nightly. Row values, which were expected to be int, were now being returned as string. Adding a couple of casts eliminated the problem in Php 8.3 without adverse effects in other releases.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
