### PR TITLE
Minor Changes to Writer/Mpdf and Writer/Html

### DIFF
--- a/samples/Basic/25_In_memory_image.php
+++ b/samples/Basic/25_In_memory_image.php
@@ -2,12 +2,19 @@
 
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\MemoryDrawing;
+use PhpOffice\PhpSpreadsheet\Writer\Html as HtmlWriter;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
 
 require __DIR__ . '/../Header.php';
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');
 $spreadsheet = new Spreadsheet();
+$sheet1 = $spreadsheet->getActiveSheet();
+$sheet1->setTitle('SheetWithData');
+$sheet1->getCell('G1')->setValue('X');
+$sheet1->getCell('E5')->setValue('Y');
+$sheet1->getCell('A8')->setValue('Z');
 
 // Set document properties
 $helper->log('Set document properties');
@@ -38,8 +45,39 @@ $drawing->setImageResource($gdImage);
 $drawing->setRenderingFunction(MemoryDrawing::RENDERING_JPEG);
 $drawing->setMimeType(MemoryDrawing::MIMETYPE_DEFAULT);
 $drawing->setHeight(36);
-$drawing->setWorksheet($spreadsheet->getActiveSheet());
+$drawing->setWorksheet($sheet1);
 $drawing->setCoordinates('C5');
 
+$helper->log('Create new sheet');
+$sheet2 = $spreadsheet->createSheet();
+$sheet2->setTitle('SheetWithoutData');
+
+// Add a drawing to the new worksheet
+$helper->log('Add a drawing to the new worksheet');
+$drawing = new MemoryDrawing();
+$drawing->setName('Sample image');
+$drawing->setDescription('Sample image');
+$drawing->setImageResource($gdImage);
+$drawing->setRenderingFunction(MemoryDrawing::RENDERING_JPEG);
+$drawing->setMimeType(MemoryDrawing::MIMETYPE_DEFAULT);
+$drawing->setHeight(36);
+$drawing->setWorksheet($sheet2);
+$drawing->setCoordinates('C5');
+
+/** @param HtmlWriter|XlsxWriter $writer */
+function setAllSheetsForHtml($writer): void
+{
+    if (method_exists($writer, 'writeAllSheets')) {
+        $writer->writeAllSheets();
+    }
+}
+
 // Save
-$helper->write($spreadsheet, __FILE__, ['Xlsx', 'Html']);
+$helper->write(
+    $spreadsheet,
+    __FILE__,
+    ['Xlsx', 'Html'],
+    false,
+    'setAllSheetsForHtml'
+);
+$spreadsheet->disconnectWorksheets();

--- a/samples/Basic/25_In_memory_image.php
+++ b/samples/Basic/25_In_memory_image.php
@@ -2,8 +2,7 @@
 
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\MemoryDrawing;
-use PhpOffice\PhpSpreadsheet\Writer\Html as HtmlWriter;
-use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PhpOffice\PhpSpreadsheet\Writer\BaseWriter;
 
 require __DIR__ . '/../Header.php';
 
@@ -64,20 +63,16 @@ $drawing->setHeight(36);
 $drawing->setWorksheet($sheet2);
 $drawing->setCoordinates('C5');
 
-/** @param HtmlWriter|XlsxWriter $writer */
-function setAllSheetsForHtml($writer): void
-{
-    if (method_exists($writer, 'writeAllSheets')) {
-        $writer->writeAllSheets();
-    }
-}
-
 // Save
 $helper->write(
     $spreadsheet,
     __FILE__,
     ['Xlsx', 'Html'],
     false,
-    'setAllSheetsForHtml'
+    function (BaseWriter $writer): void {
+        if (method_exists($writer, 'writeAllSheets')) {
+            $writer->writeAllSheets();
+        }
+    }
 );
 $spreadsheet->disconnectWorksheets();

--- a/samples/Pdf/21c_Pdf.php
+++ b/samples/Pdf/21c_Pdf.php
@@ -2,15 +2,52 @@
 
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
 
 require __DIR__ . '/../Header.php';
 
 // Issue 2432 - styles were too large to fit in first Mpdf chunk, causing problems.
+
+function addHeadersFootersMpdf2000(string $html): string
+{
+    $pagerepl = <<<EOF
+        @page page0 {
+        odd-header-name: html_myHeader1;
+        odd-footer-name: html_myFooter2;
+
+        EOF;
+    $html = preg_replace('/@page page0 {/', $pagerepl, $html);
+    $bodystring = '/<body>/';
+    $simulatedBodyStart = Mpdf::SIMULATED_BODY_START;
+    $bodyrepl = <<<EOF
+        <body>
+            <htmlpageheader name="myHeader1" style="display:none">
+                <div style="text-align: right; border-bottom: 1px solid #000000; font-weight: bold; font-size: 10pt;">
+                    My document header
+                </div>
+            </htmlpageheader>
+
+            <htmlpagefooter name="myFooter2" style="display:none">
+                <table width="100%">
+                    <tr>
+                        <td width="33%">My document</td>
+                        <td width="33%" align="center">Page {PAGENO} of {nbpg}</td>
+                        <td width="33%" style="text-align: right;">{DATE Y-m-j}</td>
+                    </tr>
+                </table>
+            </htmlpagefooter>
+            $simulatedBodyStart
+
+        EOF;
+
+    return preg_replace($bodystring, $bodyrepl, $html);
+}
+
 $spreadsheet = new Spreadsheet();
 $sheet = $spreadsheet->getActiveSheet();
 $counter = 0;
 $helper->log('Populate spreadsheet');
-for ($row = 1; $row < 501; ++$row) {
+for ($row = 1; $row < 1001; ++$row) {
     $sheet->getCell("A$row")->setValue(++$counter);
     // Add many styles by using slight variations of font color for each.
     $sheet->getCell("A$row")->getStyle()->getFont()->getColor()->setRgb(sprintf('%06x', $counter));
@@ -21,4 +58,13 @@ for ($row = 1; $row < 501; ++$row) {
 $helper->log('Write to Mpdf');
 IOFactory::registerWriter('Pdf', \PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf::class);
 $helper->write($spreadsheet, __FILE__, ['Pdf']);
+$helper->write(
+    $spreadsheet,
+    __FILE__,
+    ['Pdf'],
+    false,
+    function (Mpdf $writer): void {
+        $writer->setEditHtmlCallback('addHeadersFootersMpdf2000');
+    }
+);
 $spreadsheet->disconnectWorksheets();

--- a/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
@@ -77,8 +77,7 @@ class Mpdf extends Pdf
             $pdf->WriteHTML(substr($html, 0, $bodyLocation));
             $html = substr($html, $bodyLocation);
         }
-        $lines = explode("\n", $html);
-        foreach ($lines as $line) {
+        foreach (explode("\n", $html) as $line) {
             $pdf->WriteHTML("$line\n");
         }
 

--- a/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
@@ -3,11 +3,13 @@
 namespace PhpOffice\PhpSpreadsheet\Writer\Pdf;
 
 use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
-use PhpOffice\PhpSpreadsheet\Writer\Html;
 use PhpOffice\PhpSpreadsheet\Writer\Pdf;
 
 class Mpdf extends Pdf
 {
+    public const SIMULATED_BODY_START = '<!-- simulated body start -->';
+    private const BODY_TAG = '<body>';
+
     /** @var bool */
     protected $isMPdf = true;
 
@@ -61,16 +63,23 @@ class Mpdf extends Pdf
         $pdf->SetCreator($this->spreadsheet->getProperties()->getCreator());
 
         $html = $this->generateHTMLAll();
-        $bodyLocation = strpos($html, Html::BODY_LINE);
+        $bodyLocation = strpos($html, self::SIMULATED_BODY_START);
+        if ($bodyLocation === false) {
+            $bodyLocation = strpos($html, self::BODY_TAG);
+            if ($bodyLocation !== false) {
+                $bodyLocation += strlen(self::BODY_TAG);
+            }
+        }
         // Make sure first data presented to Mpdf includes body tag
+        //   (and any htmlpageheader/htmlpagefooter tags)
         //   so that Mpdf doesn't parse it as content. Issue 2432.
         if ($bodyLocation !== false) {
-            $bodyLocation += strlen(Html::BODY_LINE);
             $pdf->WriteHTML(substr($html, 0, $bodyLocation));
             $html = substr($html, $bodyLocation);
         }
-        foreach (\array_chunk(\explode(PHP_EOL, $html), 1000) as $lines) {
-            $pdf->WriteHTML(\implode(PHP_EOL, $lines));
+        $lines = explode("\n", $html);
+        foreach ($lines as $line) {
+            $pdf->WriteHTML("$line\n");
         }
 
         //  Write to file


### PR DESCRIPTION
Changed a sample to illustrate how to add header/footer in Mpdf using setHtmlEditCallback. This uses custom Html tags, and, like body, it appears that these must be defined in the first writeHtml. Adjust writeMpdf to permit this by using a new constant `SIMULATED_BODY_START`, defined as an Html comment, as a delimiter.

Sample 21c_Pdf, to which the header/footer code is added, had been introduced with PR #2434 to ensure that the body tag was always in the first chunk. However, PR #3016 accidentally invalidated that test by reducing the number of style lines so that the sample now included the body tag in its first 1000 records rather than afterwards. This change puts it past record 1000 again.

Mpdf support for hidden rows is poor - it nominally requires the use of invalid html, and, even so, may lead to errors. Change Writer/Html to instead simply omit hidden rows from Html when generating Mpdf.

Inspecting the results of all the Html/Pdf samples after this change, it turns out that sample 25_In_memory_image was accidentally broken by PR #3535 - the combination of `max-width:100%` (already present before that change) with `position:absolute` (introduced with that change) made the memory drawing disappear from the rendered html when the image occurs in a column after the last column with data in it. It appears that there is no need for max-width (drawings which are not memory drawings do not use it), so it is dropped. The sample is changed to add a second page with a memory drawing, one page with the memory drawing after the last data column, and one with it before. The Html results now reflect the Xlsx result, as they should.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
