### PR TITLE
Update Xlsx.php (fix overwriting existing drawing file)

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -406,7 +406,27 @@ class Xlsx extends BaseWriter
                     if ($drawingFile !== false) {
                         //$drawingFile = ltrim($drawingFile, '.');
                         //$zipContent['xl' . $drawingFile] = $drawingXml;
-                        $zipContent['xl/drawings/drawing' . ($i + 1) . '.xml'] = $drawingXml;
+
+                        // If drawingX.xml already exist, merge data (fix for use images)
+                        if(isset($zipContent['xl/drawings/drawing' . ($i + 1) . '.xml'])){
+							$currentValue = $zipContent['xl/drawings/drawing' . ($i + 1) . '.xml'];
+
+							$doc1 = new \DOMDocument();
+							$doc1->loadXML($currentValue);
+
+							$doc2 = new \DOMDocument();
+							$doc2->loadXML($drawingXml);
+							$doc2_childs = $doc2->documentElement->childNodes;
+
+							foreach ($doc2_childs as $doc2_child) {
+								$doc2_child = $doc1->importNode($doc2_child, true);
+								$doc1->documentElement->appendChild($doc2_child);
+							}
+
+							$zipContent['xl/drawings/drawing' . ($i + 1) . '.xml'] = $doc1->saveXML();
+						} else {
+							$zipContent['xl/drawings/drawing' . ($i + 1) . '.xml'] = $drawingXml;
+						}
                     }
                 }
             }


### PR DESCRIPTION
Ability to merge xml content instead of overwriting content of xl/drawings/drawingX.xml

This is:

- [x ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ x] Changes are covered by unit tests
  - [ x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [ x] Code style is respected
- [ x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

To support ability to use drawings without overwriting media configuration file
