### PR TITLE
Update Xlsx.php (fix overwriting drawingX.xml)

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -406,7 +406,32 @@ class Xlsx extends BaseWriter
                     if ($drawingFile !== false) {
                         //$drawingFile = ltrim($drawingFile, '.');
                         //$zipContent['xl' . $drawingFile] = $drawingXml;
-                        $zipContent['xl/drawings/drawing' . ($i + 1) . '.xml'] = $drawingXml;
+
+                        if(isset($zipContent['xl/drawings/drawing' . ($i + 1) . '.xml'])){
+                            $currentValue = $zipContent['xl/drawings/drawing' . ($i + 1) . '.xml'];
+
+                            $doc1 = new \DOMDocument();
+                            if($doc1!=null) $doc1->loadXML($currentValue);
+
+                            $doc2 = new \DOMDocument();
+                            if($doc2!=null) $doc2->loadXML($drawingXml);
+
+                            
+                            if($doc1 != null && $doc2 != null){
+                                $doc2_childs = $doc2->documentElement->childNodes;
+
+                                foreach ($doc2_childs as $doc2_child) {
+                                    $doc2_child = $doc1->importNode($doc2_child, true);
+                                    $doc1->documentElement->appendChild($doc2_child);
+                                }
+
+                                $zipContent['xl/drawings/drawing' . ($i + 1) . '.xml'] = $doc1->saveXML();
+                            } else { //Error during process, so overwriting
+                                $zipContent['xl/drawings/drawing' . ($i + 1) . '.xml'] = $drawingXml;
+                            }                            
+                        } else {
+                            $zipContent['xl/drawings/drawing' . ($i + 1) . '.xml'] = $drawingXml;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fix overwriting file xl/drawings/drawingX.xml if already exist by merging content

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

To use media and drawings at the same time by protecting against overwriting xl/drawings/drawingX.xml
