### PR TITLE
Add stream support to IReader

### DIFF
--- a/src/PhpSpreadsheet/Reader/BaseReader.php
+++ b/src/PhpSpreadsheet/Reader/BaseReader.php
@@ -194,7 +194,6 @@ abstract class BaseReader implements IReader
      */
     protected function openFile($file): void
     {
-        $fileHandle = false;
         if (is_string($file)) {
             $filename = $file;
             File::assertFile($file);
@@ -204,6 +203,8 @@ abstract class BaseReader implements IReader
         } elseif (is_resource($file)) {
             $filename = 'stream';
             $fileHandle = $file;
+        } else {
+            throw new ReaderException('invalid type for file. Only file path or a stream resource is allowed');
         }
         if ($fileHandle === false) {
             throw new ReaderException('Could not open file ' . $filename . ' for reading.');

--- a/src/PhpSpreadsheet/Reader/BaseReader.php
+++ b/src/PhpSpreadsheet/Reader/BaseReader.php
@@ -160,7 +160,10 @@ abstract class BaseReader implements IReader
         }
     }
 
-    protected function loadSpreadsheetFromFile(string $filename): Spreadsheet
+    /**
+     * @param resource|string $file
+     */
+    protected function loadSpreadsheetFromFile($file): Spreadsheet
     {
         throw new PhpSpreadsheetException('Reader classes must implement their own loadSpreadsheetFromFile() method');
     }
@@ -168,16 +171,17 @@ abstract class BaseReader implements IReader
     /**
      * Loads Spreadsheet from file.
      *
+     * @param resource|string $file
      * @param int $flags the optional second parameter flags may be used to identify specific elements
      *                       that should be loaded, but which won't be loaded by default, using these values:
      *                            IReader::LOAD_WITH_CHARTS - Include any charts that are defined in the loaded file
      */
-    public function load(string $filename, int $flags = 0): Spreadsheet
+    public function load($file, int $flags = 0): Spreadsheet
     {
         $this->processFlags($flags);
 
         try {
-            return $this->loadSpreadsheetFromFile($filename);
+            return $this->loadSpreadsheetFromFile($file);
         } catch (ReaderException $e) {
             throw $e;
         }
@@ -185,15 +189,21 @@ abstract class BaseReader implements IReader
 
     /**
      * Open file for reading.
+     *
+     * @param resource|string $file
      */
-    protected function openFile(string $filename): void
+    protected function openFile($file): void
     {
         $fileHandle = false;
-        if ($filename) {
-            File::assertFile($filename);
+        if (is_string($file)) {
+            $filename = $file;
+            File::assertFile($file);
 
             // Open file
-            $fileHandle = fopen($filename, 'rb');
+            $fileHandle = fopen($file, 'rb');
+        } elseif (is_resource($file)) {
+            $filename = 'stream';
+            $fileHandle = $file;
         }
         if ($fileHandle === false) {
             throw new ReaderException('Could not open file ' . $filename . ' for reading.');
@@ -204,8 +214,10 @@ abstract class BaseReader implements IReader
 
     /**
      * Return worksheet info (Name, Last Column Letter, Last Column Index, Total Rows, Total Columns).
+     *
+     * @param resource|string $file
      */
-    public function listWorksheetInfo(string $filename): array
+    public function listWorksheetInfo($file): array
     {
         throw new PhpSpreadsheetException('Reader classes must implement their own listWorksheetInfo() method');
     }
@@ -215,11 +227,13 @@ abstract class BaseReader implements IReader
      * possibly without parsing the whole file to a Spreadsheet object.
      * Readers will often have a more efficient method with which
      * they can override this method.
+     *
+     * @param resource|string $file
      */
-    public function listWorksheetNames(string $filename): array
+    public function listWorksheetNames($file): array
     {
         $returnArray = [];
-        $info = $this->listWorksheetInfo($filename);
+        $info = $this->listWorksheetInfo($file);
         foreach ($info as $infoArray) {
             if (isset($infoArray['worksheetName'])) {
                 $returnArray[] = $infoArray['worksheetName'];

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -216,11 +216,13 @@ class Csv extends BaseReader
 
     /**
      * Return worksheet info (Name, Last Column Letter, Last Column Index, Total Rows, Total Columns).
+     *
+     * @param resource|string $file
      */
-    public function listWorksheetInfo(string $filename): array
+    public function listWorksheetInfo($file): array
     {
         // Open file
-        $this->openFileOrMemory($filename);
+        $this->openFileOrMemory($file);
         $fileHandle = $this->fileHandle;
 
         // Skip BOM, if any
@@ -254,14 +256,16 @@ class Csv extends BaseReader
 
     /**
      * Loads Spreadsheet from file.
+     *
+     * @param resource|string $file
      */
-    protected function loadSpreadsheetFromFile(string $filename): Spreadsheet
+    protected function loadSpreadsheetFromFile($file): Spreadsheet
     {
         // Create new Spreadsheet
         $spreadsheet = new Spreadsheet();
 
         // Load into this instance
-        return $this->loadIntoExisting($filename, $spreadsheet);
+        return $this->loadIntoExisting($file, $spreadsheet);
     }
 
     /**
@@ -276,7 +280,10 @@ class Csv extends BaseReader
         return $this->loadStringOrFile('data://text/plain,' . urlencode($contents), $spreadsheet, true);
     }
 
-    private function openFileOrMemory(string $filename): void
+    /**
+     * @param resource|string $filename
+     */
+    private function openFileOrMemory($filename): void
     {
         // Open file
         $fhandle = $this->canRead($filename);
@@ -345,6 +352,8 @@ class Csv extends BaseReader
 
     /**
      * Loads PhpSpreadsheet from file into PhpSpreadsheet instance.
+     *
+     * @param resource|string $file
      */
     public function loadIntoExisting(string $filename, Spreadsheet $spreadsheet): Spreadsheet
     {
@@ -353,6 +362,8 @@ class Csv extends BaseReader
 
     /**
      * Loads PhpSpreadsheet from file into PhpSpreadsheet instance.
+     *
+     * @param resource|string $file
      */
     private function loadStringOrFile(string $filename, Spreadsheet $spreadsheet, bool $dataUri): Spreadsheet
     {
@@ -539,11 +550,11 @@ class Csv extends BaseReader
     /**
      * Can the current IReader read the file?
      */
-    public function canRead(string $filename): bool
+    public function canRead($file): bool
     {
         // Check if file exists
         try {
-            $this->openFile($filename);
+            $this->openFile($file);
         } catch (ReaderException) {
             return false;
         }
@@ -551,13 +562,13 @@ class Csv extends BaseReader
         fclose($this->fileHandle);
 
         // Trust file extension if any
-        $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+        $extension = strtolower(pathinfo($file, PATHINFO_EXTENSION));
         if (in_array($extension, ['csv', 'tsv'])) {
             return true;
         }
 
         // Attempt to guess mimetype
-        $type = mime_content_type($filename);
+        $type = mime_content_type($file);
         $supportedTypes = [
             'application/csv',
             'text/csv',

--- a/src/PhpSpreadsheet/Reader/Gnumeric.php
+++ b/src/PhpSpreadsheet/Reader/Gnumeric.php
@@ -76,12 +76,18 @@ class Gnumeric extends BaseReader
 
     /**
      * Can the current IReader read the file?
+     *
+     * @param resource|string $file
      */
-    public function canRead(string $filename): bool
+    public function canRead($file): bool
     {
+        if (is_resource($file)) {
+            return false; // TODO
+        }
+
         $data = null;
-        if (File::testFileNoThrow($filename)) {
-            $data = $this->gzfileGetContents($filename);
+        if (File::testFileNoThrow($file)) {
+            $data = $this->gzfileGetContents($file);
             if (!str_contains($data, self::NAMESPACE_GNM)) {
                 $data = '';
             }
@@ -99,16 +105,22 @@ class Gnumeric extends BaseReader
 
     /**
      * Reads names of the worksheets from a file, without parsing the whole file to a Spreadsheet object.
+     *
+     * @param resource|string $file
      */
-    public function listWorksheetNames(string $filename): array
+    public function listWorksheetNames($file): array
     {
-        File::assertFile($filename);
-        if (!$this->canRead($filename)) {
-            throw new Exception($filename . ' is an invalid Gnumeric file.');
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
+        File::assertFile($file);
+        if (!$this->canRead($file)) {
+            throw new Exception($file . ' is an invalid Gnumeric file.');
         }
 
         $xml = new XMLReader();
-        $contents = $this->gzfileGetContents($filename);
+        $contents = $this->gzfileGetContents($file);
         $xml->xml($contents, null, Settings::getLibXmlLoaderOptions());
         $xml->setParserProperty(2, true);
 
@@ -128,16 +140,22 @@ class Gnumeric extends BaseReader
 
     /**
      * Return worksheet info (Name, Last Column Letter, Last Column Index, Total Rows, Total Columns).
+     *
+     * @param resource|string $file
      */
-    public function listWorksheetInfo(string $filename): array
+    public function listWorksheetInfo($file): array
     {
-        File::assertFile($filename);
-        if (!$this->canRead($filename)) {
-            throw new Exception($filename . ' is an invalid Gnumeric file.');
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
+        File::assertFile($file);
+        if (!$this->canRead($file)) {
+            throw new Exception($file . ' is an invalid Gnumeric file.');
         }
 
         $xml = new XMLReader();
-        $contents = $this->gzfileGetContents($filename);
+        $contents = $this->gzfileGetContents($file);
         $xml->xml($contents, null, Settings::getLibXmlLoaderOptions());
         $xml->setParserProperty(2, true);
 
@@ -229,15 +247,21 @@ class Gnumeric extends BaseReader
 
     /**
      * Loads Spreadsheet from file.
+     *
+     * @param resource|string $file
      */
-    protected function loadSpreadsheetFromFile(string $filename): Spreadsheet
+    protected function loadSpreadsheetFromFile($file): Spreadsheet
     {
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
         // Create new Spreadsheet
         $spreadsheet = new Spreadsheet();
         $spreadsheet->removeSheetByIndex(0);
 
         // Load into this instance
-        return $this->loadIntoExisting($filename, $spreadsheet);
+        return $this->loadIntoExisting($file, $spreadsheet);
     }
 
     /**

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -138,12 +138,14 @@ class Html extends BaseReader
 
     /**
      * Validate that the current file is an HTML file.
+     *
+     * @param resource|string $file
      */
-    public function canRead(string $filename): bool
+    public function canRead($file): bool
     {
         // Check if file exists
         try {
-            $this->openFile($filename);
+            $this->openFile($file);
         } catch (Exception) {
             return false;
         }
@@ -202,14 +204,16 @@ class Html extends BaseReader
 
     /**
      * Loads Spreadsheet from file.
+     *
+     * @param resource|string $file
      */
-    public function loadSpreadsheetFromFile(string $filename): Spreadsheet
+    public function loadSpreadsheetFromFile($file): Spreadsheet
     {
         // Create new Spreadsheet
         $spreadsheet = new Spreadsheet();
 
         // Load into this instance
-        return $this->loadIntoExisting($filename, $spreadsheet);
+        return $this->loadIntoExisting($file, $spreadsheet);
     }
 
     /**
@@ -661,12 +665,18 @@ class Html extends BaseReader
 
     /**
      * Loads PhpSpreadsheet from file into PhpSpreadsheet instance.
+     *
+     * @param resource|string $file
      */
-    public function loadIntoExisting(string $filename, Spreadsheet $spreadsheet): Spreadsheet
+    public function loadIntoExisting($file, Spreadsheet $spreadsheet): Spreadsheet
     {
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
         // Validate
-        if (!$this->canRead($filename)) {
-            throw new Exception($filename . ' is an Invalid HTML file.');
+        if (!$this->canRead($file)) {
+            throw new Exception($file . ' is an Invalid HTML file.');
         }
 
         // Create a new DOM object
@@ -674,7 +684,7 @@ class Html extends BaseReader
 
         // Reload the HTML file into the DOM object
         try {
-            $convert = $this->getSecurityScannerOrThrow()->scanFile($filename);
+            $convert = $this->getSecurityScannerOrThrow()->scanFile($file);
             $lowend = "\u{80}";
             $highend = "\u{10ffff}";
             $regexp = "/[$lowend-$highend]/u";
@@ -686,7 +696,7 @@ class Html extends BaseReader
             $loaded = false;
         }
         if ($loaded === false) {
-            throw new Exception('Failed to load ' . $filename . ' as a DOM Document', 0, $e ?? null);
+            throw new Exception('Failed to load ' . $file . ' as a DOM Document', 0, $e ?? null);
         }
         self::loadProperties($dom, $spreadsheet);
 
@@ -1152,12 +1162,18 @@ class Html extends BaseReader
 
     /**
      * Return worksheet info (Name, Last Column Letter, Last Column Index, Total Rows, Total Columns).
+     *
+     * @param resource|string $file
      */
-    public function listWorksheetInfo(string $filename): array
+    public function listWorksheetInfo($file): array
     {
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
         $info = [];
         $spreadsheet = new Spreadsheet();
-        $this->loadIntoExisting($filename, $spreadsheet);
+        $this->loadIntoExisting($file, $spreadsheet);
         foreach ($spreadsheet->getAllSheets() as $sheet) {
             $newEntry = ['worksheetName' => $sheet->getTitle()];
             $newEntry['lastColumnLetter'] = $sheet->getHighestDataColumn();

--- a/src/PhpSpreadsheet/Reader/IReader.php
+++ b/src/PhpSpreadsheet/Reader/IReader.php
@@ -20,8 +20,10 @@ interface IReader
 
     /**
      * Can the current IReader read the file?
+     *
+     * @param resource|string $file
      */
-    public function canRead(string $filename): bool;
+    public function canRead($file): bool;
 
     /**
      * Read data only?
@@ -132,7 +134,7 @@ interface IReader
     /**
      * Loads PhpSpreadsheet from file.
      *
-     * @param string $filename The name of the file to load
+     * @param resource|string $file A resource or the name of the file to load
      * @param int $flags Flags that can change the behaviour of the Writer:
      *            self::LOAD_WITH_CHARTS    Load any charts that are defined (if the Reader supports Charts)
      *            self::READ_DATA_ONLY      Read only data, not style or structure information, from the file
@@ -141,5 +143,5 @@ interface IReader
      *
      * @return Spreadsheet
      */
-    public function load(string $filename, int $flags = 0);
+    public function load($file, int $flags = 0);
 }

--- a/src/PhpSpreadsheet/Reader/Ods.php
+++ b/src/PhpSpreadsheet/Reader/Ods.php
@@ -41,16 +41,22 @@ class Ods extends BaseReader
 
     /**
      * Can the current IReader read the file?
+     *
+     * @param resource|string $file
      */
-    public function canRead(string $filename): bool
+    public function canRead($file): bool
     {
+        if (is_resource($file)) {
+            return false; // TODO
+        }
+
         $mimeType = 'UNKNOWN';
 
         // Load file
 
-        if (File::testFileNoThrow($filename, '')) {
+        if (File::testFileNoThrow($file, '')) {
             $zip = new ZipArchive();
-            if ($zip->open($filename) === true) {
+            if ($zip->open($file) === true) {
                 // check if it is an OOXML archive
                 $stat = $zip->statName('mimetype');
                 if (!empty($stat) && ($stat['size'] <= 255)) {
@@ -87,17 +93,22 @@ class Ods extends BaseReader
     /**
      * Reads names of the worksheets from a file, without parsing the whole file to a PhpSpreadsheet object.
      *
+     * @param resource|string $file
+     *
      * @return string[]
      */
-    public function listWorksheetNames(string $filename): array
+    public function listWorksheetNames($file): array
     {
-        File::assertFile($filename, self::INITIAL_FILE);
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+        File::assertFile($file, self::INITIAL_FILE);
 
         $worksheetNames = [];
 
         $xml = new XMLReader();
         $xml->xml(
-            $this->getSecurityScannerOrThrow()->scanFile('zip://' . realpath($filename) . '#' . self::INITIAL_FILE),
+            $this->getSecurityScannerOrThrow()->scanFile('zip://' . realpath($file) . '#' . self::INITIAL_FILE),
             null,
             Settings::getLibXmlLoaderOptions()
         );
@@ -135,16 +146,22 @@ class Ods extends BaseReader
 
     /**
      * Return worksheet info (Name, Last Column Letter, Last Column Index, Total Rows, Total Columns).
+     *
+     * @param resource|string $file
      */
-    public function listWorksheetInfo(string $filename): array
+    public function listWorksheetInfo($file): array
     {
-        File::assertFile($filename, self::INITIAL_FILE);
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
+        File::assertFile($file, self::INITIAL_FILE);
 
         $worksheetInfo = [];
 
         $xml = new XMLReader();
         $xml->xml(
-            $this->getSecurityScannerOrThrow()->scanFile('zip://' . realpath($filename) . '#' . self::INITIAL_FILE),
+            $this->getSecurityScannerOrThrow()->scanFile('zip://' . realpath($file) . '#' . self::INITIAL_FILE),
             null,
             Settings::getLibXmlLoaderOptions()
         );
@@ -228,15 +245,21 @@ class Ods extends BaseReader
 
     /**
      * Loads PhpSpreadsheet from file.
+     *
+     * @param resource|string $file
      */
-    protected function loadSpreadsheetFromFile(string $filename): Spreadsheet
+    protected function loadSpreadsheetFromFile($file): Spreadsheet
     {
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
         // Create new Spreadsheet
         $spreadsheet = new Spreadsheet();
         $spreadsheet->removeSheetByIndex(0);
 
         // Load into this instance
-        return $this->loadIntoExisting($filename, $spreadsheet);
+        return $this->loadIntoExisting($file, $spreadsheet);
     }
 
     /**

--- a/src/PhpSpreadsheet/Reader/Slk.php
+++ b/src/PhpSpreadsheet/Reader/Slk.php
@@ -65,11 +65,13 @@ class Slk extends BaseReader
 
     /**
      * Validate that the current file is a SYLK file.
+     *
+     * @param resource|string $file
      */
-    public function canRead(string $filename): bool
+    public function canRead($file): bool
     {
         try {
-            $this->openFile($filename);
+            $this->openFile($file);
         } catch (ReaderException) {
             return false;
         }
@@ -133,15 +135,19 @@ class Slk extends BaseReader
     /**
      * Return worksheet info (Name, Last Column Letter, Last Column Index, Total Rows, Total Columns).
      */
-    public function listWorksheetInfo(string $filename): array
+    public function listWorksheetInfo($file): array
     {
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
         // Open file
-        $this->canReadOrBust($filename);
+        $this->canReadOrBust($file);
         $fileHandle = $this->fileHandle;
         rewind($fileHandle);
 
         $worksheetInfo = [];
-        $worksheetInfo[0]['worksheetName'] = basename($filename, '.slk');
+        $worksheetInfo[0]['worksheetName'] = basename($file, '.slk');
 
         // loop through one row (line) at a time in the file
         $rowIndex = 0;
@@ -188,14 +194,20 @@ class Slk extends BaseReader
 
     /**
      * Loads PhpSpreadsheet from file.
+     *
+     * @param resource|string $file
      */
-    protected function loadSpreadsheetFromFile(string $filename): Spreadsheet
+    protected function loadSpreadsheetFromFile($file): Spreadsheet
     {
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
         // Create new Spreadsheet
         $spreadsheet = new Spreadsheet();
 
         // Load into this instance
-        return $this->loadIntoExisting($filename, $spreadsheet);
+        return $this->loadIntoExisting($file, $spreadsheet);
     }
 
     private const COLOR_ARRAY = [

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -428,10 +428,16 @@ class Xls extends BaseReader
 
     /**
      * Can the current IReader read the file?
+     *
+     * @param resource|string $file
      */
-    public function canRead(string $filename): bool
+    public function canRead($file): bool
     {
-        if (File::testFileNoThrow($filename) === false) {
+        if (is_resource($file)) {
+            return false; // TODO
+        }
+
+        if (File::testFileNoThrow($file) === false) {
             return false;
         }
 
@@ -440,9 +446,9 @@ class Xls extends BaseReader
             $ole = new OLERead();
 
             // get excel data
-            $ole->read($filename);
+            $ole->read($file);
             if ($ole->wrkbook === null) {
-                throw new Exception('The filename ' . $filename . ' is not recognised as a Spreadsheet file');
+                throw new Exception('The filename ' . $file . ' is not recognised as a Spreadsheet file');
             }
 
             return true;
@@ -467,15 +473,21 @@ class Xls extends BaseReader
 
     /**
      * Reads names of the worksheets from a file, without parsing the whole file to a PhpSpreadsheet object.
+     *
+     * @param resource|string $file
      */
-    public function listWorksheetNames(string $filename): array
+    public function listWorksheetNames($file): array
     {
-        File::assertFile($filename);
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
+        File::assertFile($file);
 
         $worksheetNames = [];
 
         // Read the OLE file
-        $this->loadOLE($filename);
+        $this->loadOLE($file);
 
         // total byte size of Excel data (workbook global substream + sheet substreams)
         $this->dataSize = strlen($this->data);
@@ -514,15 +526,21 @@ class Xls extends BaseReader
 
     /**
      * Return worksheet info (Name, Last Column Letter, Last Column Index, Total Rows, Total Columns).
+     *
+     * @param resource|string $file
      */
-    public function listWorksheetInfo(string $filename): array
+    public function listWorksheetInfo($file): array
     {
-        File::assertFile($filename);
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
+        File::assertFile($file);
 
         $worksheetInfo = [];
 
         // Read the OLE file
-        $this->loadOLE($filename);
+        $this->loadOLE($file);
 
         // total byte size of Excel data (workbook global substream + sheet substreams)
         $this->dataSize = strlen($this->data);
@@ -615,11 +633,17 @@ class Xls extends BaseReader
 
     /**
      * Loads PhpSpreadsheet from file.
+     *
+     * @param resource|string $file
      */
-    protected function loadSpreadsheetFromFile(string $filename): Spreadsheet
+    protected function loadSpreadsheetFromFile($file): Spreadsheet
     {
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
         // Read the OLE file
-        $this->loadOLE($filename);
+        $this->loadOLE($file);
 
         // Initialisations
         $this->spreadsheet = new Spreadsheet();

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -59,8 +59,12 @@ class Xml extends BaseReader
     /**
      * Can the current IReader read the file?
      */
-    public function canRead(string $filename): bool
+    public function canRead($file): bool
     {
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
         //    Office                    xmlns:o="urn:schemas-microsoft-com:office:office"
         //    Excel                    xmlns:x="urn:schemas-microsoft-com:office:excel"
         //    XML Spreadsheet            xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"
@@ -77,7 +81,7 @@ class Xml extends BaseReader
         ];
 
         // Open file
-        $data = file_get_contents($filename) ?: '';
+        $data = file_get_contents($file) ?: '';
 
         // Why?
         //$data = str_replace("'", '"', $data); // fix headers with single quote
@@ -128,19 +132,25 @@ class Xml extends BaseReader
 
     /**
      * Reads names of the worksheets from a file, without parsing the whole file to a Spreadsheet object.
+     *
+     * @param resource|string $file
      */
-    public function listWorksheetNames(string $filename): array
+    public function listWorksheetNames($file): array
     {
-        File::assertFile($filename);
-        if (!$this->canRead($filename)) {
-            throw new Exception($filename . ' is an Invalid Spreadsheet file.');
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
+        File::assertFile($file);
+        if (!$this->canRead($file)) {
+            throw new Exception($file . ' is an Invalid Spreadsheet file.');
         }
 
         $worksheetNames = [];
 
-        $xml = $this->trySimpleXMLLoadString($filename);
+        $xml = $this->trySimpleXMLLoadString($file);
         if ($xml === false) {
-            throw new Exception("Problem reading {$filename}");
+            throw new Exception("Problem reading {$file}");
         }
 
         $xml_ss = $xml->children(self::NAMESPACES_SS);
@@ -154,19 +164,25 @@ class Xml extends BaseReader
 
     /**
      * Return worksheet info (Name, Last Column Letter, Last Column Index, Total Rows, Total Columns).
+     *
+     * @param resource|string $file
      */
-    public function listWorksheetInfo(string $filename): array
+    public function listWorksheetInfo($file): array
     {
-        File::assertFile($filename);
-        if (!$this->canRead($filename)) {
-            throw new Exception($filename . ' is an Invalid Spreadsheet file.');
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
+        File::assertFile($file);
+        if (!$this->canRead($file)) {
+            throw new Exception($file . ' is an Invalid Spreadsheet file.');
         }
 
         $worksheetInfo = [];
 
-        $xml = $this->trySimpleXMLLoadString($filename);
+        $xml = $this->trySimpleXMLLoadString($file);
         if ($xml === false) {
-            throw new Exception("Problem reading {$filename}");
+            throw new Exception("Problem reading {$file}");
         }
 
         $worksheetID = 1;
@@ -235,15 +251,21 @@ class Xml extends BaseReader
 
     /**
      * Loads Spreadsheet from file.
+     *
+     * @param resource|string $file
      */
-    protected function loadSpreadsheetFromFile(string $filename): Spreadsheet
+    protected function loadSpreadsheetFromFile($file): Spreadsheet
     {
+        if (is_resource($file)) {
+            throw new Exception('file as stream not supported');
+        }
+
         // Create new Spreadsheet
         $spreadsheet = new Spreadsheet();
         $spreadsheet->removeSheetByIndex(0);
 
         // Load into this instance
-        return $this->loadIntoExisting($filename, $spreadsheet);
+        return $this->loadIntoExisting($file, $spreadsheet);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Reader/BaseNoLoad.php
+++ b/tests/PhpSpreadsheetTests/Reader/BaseNoLoad.php
@@ -8,8 +8,11 @@ use PhpOffice\PhpSpreadsheet\Reader\BaseReader;
 
 class BaseNoLoad extends BaseReader
 {
-    public function canRead(string $filename): bool
+    /**
+     * @param resource|string $file
+     */
+    public function canRead($file): bool
     {
-        return $filename !== '';
+        return is_string($file) && $file !== '';
     }
 }

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvLoadFromStringTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvLoadFromStringTest.php
@@ -25,4 +25,23 @@ class CsvLoadFromStringTest extends TestCase
         self::AssertSame('7 , 8', $sheet->getCell('A3')->getValue());
         self::AssertSame("12\n13", $sheet->getCell('B4')->getValue());
     }
+
+    public function testLoadFromStream(): void
+    {
+        $data = <<<EOF
+            1,2,3
+            4,2+3,6
+            "7 , 8", 9, 10
+            11,"12
+            13",14
+            EOF;
+        $stream = fopen('data://text/plain;base64,' . base64_encode($data), 'rb');
+        self::assertNotFalse($stream);
+        $reader = new Csv();
+        $spreadsheet = $reader->load($stream);
+        $sheet = $spreadsheet->getActiveSheet();
+        self::AssertSame('2+3', $sheet->getCell('B2')->getValue());
+        self::AssertSame('7 , 8', $sheet->getCell('A3')->getValue());
+        self::AssertSame("12\n13", $sheet->getCell('B4')->getValue());
+    }
 }

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvTest.php
@@ -96,6 +96,23 @@ class CsvTest extends TestCase
         self::assertSame($expected, $reader->canRead($filename));
     }
 
+    /**
+     * @dataProvider providerCanLoad
+     */
+    public function testCanLoadFromStream(bool $expected, string $filename): void
+    {
+        $reader = new Csv();
+        $stream = fopen('php://memory', 'r+b');
+        self::assertNotFalse($stream);
+
+        $contents = file_get_contents($filename);
+        self::assertNotFalse($contents);
+        fwrite($stream, $contents);
+        rewind($stream);
+
+        self::assertSame($expected, $reader->canRead($stream));
+    }
+
     public static function providerCanLoad(): array
     {
         return [


### PR DESCRIPTION
When using backends like minio or s3 to store files, those files are usually retrieved into memory. This pull request tries to add stream support for IReaders. This will allow to load files in memory using a php://memory stream.

I've only started with changing the interface and adding stream support to csv. I'd like to know, if this is a desirable feature which has the chance of being merged, before I continue with changing the other readers. 

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
