### PR TITLE
Use DateTime::format Rather than cal_days_in_month in Sample

### DIFF
--- a/samples/Chart/33_Chart_create_line_dateaxis.php
+++ b/samples/Chart/33_Chart_create_line_dateaxis.php
@@ -361,8 +361,8 @@ function dateRange(int $nrows, Spreadsheet $wrkbk): array
     $lastYr = (int) $lastDate->format('Y');
     $qtr = intdiv($lastMonth, 3) + (($lastMonth % 3 > 0) ? 1 : 0);
     $qtrEndMonth = 3 + (($qtr - 1) * 3);
-    $lastDOM = cal_days_in_month(CAL_GREGORIAN, $qtrEndMonth, $lastYr);
     $qtrEndMonth = sprintf('%02d', $qtrEndMonth);
+    $lastDOM = DateTime::createFromFormat('Y-m-d', "$lastYr-$qtrEndMonth-01")->format('t');
     $qtrEndStr = "$lastYr-$qtrEndMonth-$lastDOM";
     $ExcelQtrEndDateVal = SharedDate::convertIsoDate($qtrEndStr);
 


### PR DESCRIPTION
Fix #3760. That problem actually was easily fixed, by enabling calendar extension in user's environment. Astonishingly, however, this is the only use of calendar in the entire project. Since the same functionality is available in DateTime, which is used throughout the project, use that instead to eliminate the dependency on calendar.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
