### PR TITLE
Performance Improvements for Csv Reader

### DIFF
--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -9,7 +9,6 @@ use PhpOffice\PhpSpreadsheet\Reader\Csv\Delimiter;
 use PhpOffice\PhpSpreadsheet\Reader\Exception as ReaderException;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
-use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class Csv extends BaseReader
@@ -105,6 +104,10 @@ class Csv extends BaseReader
     private string $getTrue = 'true';
 
     private string $getFalse = 'false';
+
+    private string $thousandsSeparator = ',';
+
+    private string $decimalSeparator = '.';
 
     /**
      * Create a new CSV Reader instance.
@@ -397,6 +400,8 @@ class Csv extends BaseReader
         $preserveBooleanString = method_exists($valueBinder, 'getBooleanConversion') && $valueBinder->getBooleanConversion();
         $this->getTrue = Calculation::getTRUE();
         $this->getFalse = Calculation::getFALSE();
+        $this->thousandsSeparator = StringHelper::getThousandsSeparator();
+        $this->decimalSeparator = StringHelper::getDecimalSeparator();
         while (is_array($rowData)) {
             $noOutputYet = true;
             $columnLetter = 'A';
@@ -461,18 +466,18 @@ class Csv extends BaseReader
      */
     private function convertFormattedNumber(mixed &$rowDatum): string
     {
-        $numberFormatMask = NumberFormat::FORMAT_GENERAL;
+        $numberFormatMask = '';
         if ($this->castFormattedNumberToNumeric === true && is_string($rowDatum)) {
             $numeric = str_replace(
-                [StringHelper::getThousandsSeparator(), StringHelper::getDecimalSeparator()],
+                [$this->thousandsSeparator, $this->decimalSeparator],
                 ['', '.'],
                 $rowDatum
             );
 
             if (is_numeric($numeric)) {
-                $decimalPos = strpos($rowDatum, StringHelper::getDecimalSeparator());
+                $decimalPos = strpos($rowDatum, $this->decimalSeparator);
                 if ($this->preserveNumericFormatting === true) {
-                    $numberFormatMask = (str_contains($rowDatum, StringHelper::getThousandsSeparator()))
+                    $numberFormatMask = (str_contains($rowDatum, $this->thousandsSeparator))
                         ? '#,##0' : '0';
                     if ($decimalPos !== false) {
                         $decimals = strlen($rowDatum) - $decimalPos - 1;

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvIssue2232Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvIssue2232Test.php
@@ -65,7 +65,7 @@ class CsvIssue2232Test extends TestCase
     /**
      * @dataProvider providerIssue2232locale
      */
-    public function testBooleanConversionsLocaleAware(bool $useStringBinder, ?bool $preserveBoolString, mixed $b4Value, mixed $b5Value): void
+    public function testBooleanConversionsLocaleAware(bool $useStringBinder, ?bool $preserveBoolString, mixed $b2Value, mixed $b3Value, mixed $b4Value, mixed $b5Value): void
     {
         if ($useStringBinder) {
             $binder = new StringValueBinder();
@@ -81,6 +81,8 @@ class CsvIssue2232Test extends TestCase
         $filename = 'tests/data/Reader/CSV/issue.2232.csv';
         $spreadsheet = $reader->load($filename);
         $sheet = $spreadsheet->getActiveSheet();
+        self::assertSame($b2Value, $sheet->getCell('B2')->getValue());
+        self::assertSame($b3Value, $sheet->getCell('B3')->getValue());
         self::assertSame($b4Value, $sheet->getCell('B4')->getValue());
         self::assertSame($b5Value, $sheet->getCell('B5')->getValue());
         $spreadsheet->disconnectWorksheets();
@@ -89,10 +91,9 @@ class CsvIssue2232Test extends TestCase
     public static function providerIssue2232locale(): array
     {
         return [
-            [true, true, 'Faux', 'Vrai'],
-            [true, true, 'Faux', 'Vrai'],
-            [false, false, false, true],
-            [false, false, false, true],
+            'string binder preserve boolean string' => [true, true, 'FaLSe', 'tRUE', 'Faux', 'Vrai'],
+            'string binder convert boolean string' => [true, false, false, true, false, true],
+            'default binder' => [false, null, false, true, false, true],
         ];
     }
 }


### PR DESCRIPTION
Investigating issue #381, a means was suggested to duplicated a problem, but no problem occurred ... except for performance. This involved a spreadsheet with a large number of cells, definitely not PhpSpreadsheet's strong point; even so, the program (entirely available in the issue) took a disastrous two or so hours to complete on my system. Looking at the Csv Reader code, several opportunities to cache results and avoid function calls jumped out, none of which seem to materially add to the maintenance burden of the program. Testing these changes resulted in a run time of about 20 minutes, still hardly a thing of beauty, but a huge improvement over the original and therefore worth proceeding with.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] performance

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
