### PR TITLE
Use case insentive comparison to get sheet name

### DIFF
--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -701,7 +701,7 @@ class Spreadsheet implements JsonSerializable
     {
         $worksheetCount = count($this->workSheetCollection);
         for ($i = 0; $i < $worksheetCount; ++$i) {
-            if ($this->workSheetCollection[$i]->getTitle() === trim($worksheetName, "'")) {
+            if (strcasecmp($this->workSheetCollection[$i]->getTitle(), trim($worksheetName, "'")) === 0) {
                 return $this->workSheetCollection[$i];
             }
         }

--- a/tests/PhpSpreadsheetTests/SpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/SpreadsheetTest.php
@@ -70,8 +70,19 @@ class SpreadsheetTest extends TestCase
     {
         $spreadsheet = $this->getSpreadsheet();
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Workbook already contains a worksheet named 'someSheet2'. Rename this worksheet first.");
         $sheet = new Worksheet();
         $sheet->setTitle('someSheet2');
+        $spreadsheet->addSheet($sheet);
+    }
+
+    public function testAddSheetDuplicateTitleWithDifferentCase(): void
+    {
+        $spreadsheet = $this->getSpreadsheet();
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Workbook already contains a worksheet named 'SomeSheet2'. Rename this worksheet first.");
+        $sheet = new Worksheet();
+        $sheet->setTitle('SomeSheet2');
         $spreadsheet->addSheet($sheet);
     }
 
@@ -101,6 +112,7 @@ class SpreadsheetTest extends TestCase
     {
         $spreadsheet = $this->getSpreadsheet();
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('You tried to remove a sheet by the out of bounds index: 4. The actual number of sheets is 3.');
         $spreadsheet->removeSheetByIndex(4);
     }
 
@@ -126,6 +138,7 @@ class SpreadsheetTest extends TestCase
     {
         $spreadsheet = $this->getSpreadsheet();
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Your requested sheet index: 4 is out of bounds. The actual number of sheets is 3.');
         $spreadsheet->getSheet(4);
     }
 
@@ -133,6 +146,7 @@ class SpreadsheetTest extends TestCase
     {
         $spreadsheet = $this->getSpreadsheet();
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Sheet does not exist.');
         $sheet = new Worksheet();
         $sheet->setTitle('someSheet4');
         $spreadsheet->getIndex($sheet);
@@ -178,6 +192,7 @@ class SpreadsheetTest extends TestCase
     {
         $spreadsheet = $this->getSpreadsheet();
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('You tried to set a sheet active by the out of bounds index: 4. The actual number of sheets is 3.');
         $spreadsheet->setActiveSheetIndex(4);
     }
 
@@ -185,6 +200,7 @@ class SpreadsheetTest extends TestCase
     {
         $spreadsheet = $this->getSpreadsheet();
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Workbook does not contain sheet:unknown');
         $spreadsheet->setActiveSheetIndexByName('unknown');
     }
 
@@ -213,6 +229,7 @@ class SpreadsheetTest extends TestCase
     public function testAddExternalDuplicateName(): void
     {
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Workbook already contains a worksheet named 'someSheet1'. Rename the external sheet first.");
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->createSheet()->setTitle('someSheet1');
         $sheet->getCell('A1')->setValue(1);


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

For now, the method which check if a sheetname already exists, uses a case-sensitive comparison which can cause issue as Excel doesn't allow to have 2 sheets with the same name and uses a case-insensitive comparison. So, I propose to respect the same rule.
