### PR TITLE
Configure Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file for MkDocs projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+    os: ubuntu-22.04
+    tools:
+        python: "3"
+
+mkdocs:
+    configuration: mkdocs.yml


### PR DESCRIPTION
In response to https://github.com/PHPOffice/PhpSpreadsheet/pull/3793#issuecomment-1850882630

readthedocs.org build every commit pushed on `master`. However builds have been failing for the past two months, because they now require a config file. I assumed that config file was added, but I was wrong. So I added it.