### PR TITLE
Allow merge queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: main
-on: [ push, pull_request ]
+on: [ push, pull_request, merge_group ]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Allow [GitHub merge queue](https://github.blog/2023-07-12-github-merge-queue-is-generally-available/) in this repo, so we can save time merging multiple PRs.