### PR TITLE
COUNTIFS Does Not Require _xlfn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Prevent loop in Shared/File. [Issue #3807](https://github.com/PHPOffice/PhpSpreadsheet/issues/3807) [PR #3809](https://github.com/PHPOffice/PhpSpreadsheet/pull/3809)
 - Consistent handling of decimal/thousands separators between StringHelper and Php setlocale. [Issue #3811](https://github.com/PHPOffice/PhpSpreadsheet/issues/3811) [PR #3815](https://github.com/PHPOffice/PhpSpreadsheet/pull/3815)
 - Clone worksheet with tables or charts. [Issue #3820](https://github.com/PHPOffice/PhpSpreadsheet/issues/3820) [PR #3821](https://github.com/PHPOffice/PhpSpreadsheet/pull/3821)
+- COUNTIFS Does Not Require xlfn. [Issue #3819](https://github.com/PHPOffice/PhpSpreadsheet/issues/3819) [PR #3827](https://github.com/PHPOffice/PhpSpreadsheet/pull/3827)
 
 ## 1.29.0 - 2023-06-15
 

--- a/src/PhpSpreadsheet/Writer/Xlsx/FunctionPrefix.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/FunctionPrefix.php
@@ -125,7 +125,6 @@ class FunctionPrefix
         . '|switch'
         // functions added with Excel 2019
         . '|concat'
-        . '|countifs'
         . '|ifs'
         . '|maxifs'
         . '|minifs'

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/FunctionPrefixTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/FunctionPrefixTest.php
@@ -16,6 +16,8 @@ class FunctionPrefixTest extends TestCase
     {
         $result = FunctionPrefix::addFunctionPrefix($functionString);
         self::assertSame($expectedResult, $result);
+        $result = FunctionPrefix::addFunctionPrefixStripEquals("=$functionString");
+        self::assertSame($expectedResult, $result);
     }
 
     public static function functionPrefixProvider(): array
@@ -34,28 +36,7 @@ class FunctionPrefixTest extends TestCase
             'DAYS/NETWORKDAYS 3' => ['ABS(_xlfn.DAYS(DATE(2023,1,1),TODAY()))', 'ABS(DAYS(DATE(2023,1,1),TODAY()))'],
             'DAYS/NETWORKDAYS 4' => ['ABS(_xlfn.DAYS(DATE(2023,1,1),TODAY()))', 'ABS(_xlfn.DAYS(DATE(2023,1,1),TODAY()))'],
             'DAYS/NETWORKDAYS 5' => ['NETWORKDAYS(DATE(2023,1,1),TODAY(), C:C)', 'NETWORKDAYS(DATE(2023,1,1),TODAY(), C:C)'],
+            'COUNTIFS reclassified as Legacy' => ['COUNTIFS()', 'COUNTIFS()'],
         ];
     }
-
-//    /**
-//     * @dataProvider functionPrefixWithEqualsProvider
-//     */
-//    public function testFunctionPrefixWithEquals(string $expectedResult, string $functionString): void
-//    {
-//        $result = FunctionPrefix::addFunctionPrefixStripEquals($functionString);
-//        self::assertSame($expectedResult, $result);
-//    }
-//
-//    public static function functionPrefixWithEqualsProvider(): array
-//    {
-//        return [
-//            'Basic Legacy Function' => ['SUM()', '=SUM()'],
-//            'New Function without Prefix' => ['_xlfn.ARABIC()', '=ARABIC()'],
-//            'New Function already Prefixed' => ['_xlfn.ARABIC()', '=_xlfn.ARABIC()'],
-//            'New Function requiring Double-Prefix' => ['_xlfn._xlws.FILTER()', '=FILTER()'],
-//            'New Function requiring Double-Prefix already partially Prefixed' => ['_xlfn._xlws.FILTER()', '=_xlfn.FILTER()'],
-//            'New Function requiring Double-Prefix already partially Prefixed #2' => ['_xlfn._xlws.FILTER()', '=_xlws.FILTER()'],
-//            'New Function requiring Double-Prefix already Fully Prefixed' => ['_xlfn._xlws.FILTER()', '=_xlfn._xlws.FILTER()'],
-//        ];
-//    }
 }


### PR DESCRIPTION
It was on our list as "introduced in 2019". It was, in fact, available with Excel 2007 (https://support.microsoft.com/en-us/office/excel-functions-alphabetical-b3944572-255d-4efb-bb96-c6d90033e188#bm3), so does not require a prefix when writing it to a spreadsheet. Brought to my attention with issue #3819, although I'm not sure correcting this will entirely solve the user's problem.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
