### PR TITLE
fix: IReader returning type

### DIFF
--- a/src/PhpSpreadsheet/Reader/IReader.php
+++ b/src/PhpSpreadsheet/Reader/IReader.php
@@ -141,5 +141,5 @@ interface IReader
      *
      * @return Spreadsheet
      */
-    public function load(string $filename, int $flags = 0);
+    public function load(string $filename, int $flags = 0): Spreadsheet;
 }


### PR DESCRIPTION
This is:

- [Y] a bugfix
- [N] a new feature
- [N] refactoring
- [N] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

*BaseReader* obviously returning *Spreadsheet* in *load* method, but IReader doesn't specify that.
