### PR TITLE
Html Reader Tolerate Invalid Sheet Title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Recurse directories searching for font file. [Issue #2809](https://github.com/PHPOffice/PhpSpreadsheet/issues/2809) [PR #3830](https://github.com/PHPOffice/PhpSpreadsheet/pull/3830)
 - Reduce memory consumption of Worksheet::rangeToArray() when many empty rows are read. [Issue #3814](https://github.com/PHPOffice/PhpSpreadsheet/pull/3814) [PR #3834](https://github.com/PHPOffice/PhpSpreadsheet/pull/3834)
 - Reduce time used by Worksheet::rangeToArray() when many empty rows are read. [PR #3839](https://github.com/PHPOffice/PhpSpreadsheet/pull/3839)
+- Html Reader Tolerate Invalid Sheet Title. [PR #3845](https://github.com/PHPOffice/PhpSpreadsheet/pull/3845)
 
 ## 1.29.0 - 2023-06-15
 

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -9,6 +9,7 @@ use DOMText;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Document\Properties;
+use PhpOffice\PhpSpreadsheet\Exception as SpreadsheetException;
 use PhpOffice\PhpSpreadsheet\Helper\Dimension as CssDimension;
 use PhpOffice\PhpSpreadsheet\Reader\Security\XmlScanner;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
@@ -345,7 +346,12 @@ class Html extends BaseReader
     {
         if ($child->nodeName === 'title') {
             $this->processDomElement($child, $sheet, $row, $column, $cellContent);
-            $sheet->setTitle($cellContent, true, true);
+
+            try {
+                $sheet->setTitle($cellContent, true, true);
+            } catch (SpreadsheetException) {
+                // leave default title if too long or illegal chars
+            }
             $cellContent = '';
         } else {
             $this->processDomElementSpanEtc($sheet, $row, $column, $cellContent, $child, $attributeArray);

--- a/tests/PhpSpreadsheetTests/Writer/Html/LongTitleTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/LongTitleTest.php
@@ -17,13 +17,13 @@ class LongTitleTest extends AbstractFunctional
         $spreadsheet = new Spreadsheet();
         $spreadsheet
             ->getProperties()
-            ->setTitle('PhpSpreadsheet Table Test Document');
+            ->setTitle($title);
         $sheet = $spreadsheet->getActiveSheet();
         $sheet->setCellValue('A1', 1);
 
         $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Html');
         $spreadsheet->disconnectWorksheets();
-        self::assertSame('Worksheet', $reloadedSpreadsheet->getActiveSheet()->getTitle());
+        self::assertSame($expected, $reloadedSpreadsheet->getActiveSheet()->getTitle());
         $reloadedSpreadsheet->disconnectWorksheets();
     }
 

--- a/tests/PhpSpreadsheetTests/Writer/Html/LongTitleTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/LongTitleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Html;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class LongTitleTest extends AbstractFunctional
+{
+    /**
+     * @dataProvider providerTitles
+     */
+    public function testLongTitle(string $expected, string $title): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet
+            ->getProperties()
+            ->setTitle('PhpSpreadsheet Table Test Document');
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 1);
+
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Html');
+        $spreadsheet->disconnectWorksheets();
+        self::assertSame('Worksheet', $reloadedSpreadsheet->getActiveSheet()->getTitle());
+        $reloadedSpreadsheet->disconnectWorksheets();
+    }
+
+    public static function providerTitles(): array
+    {
+        return [
+            ['Worksheet', 'This title is just a bit too long'],
+            ['Worksheet', 'Invalid * character'],
+            ['Legitimate Title', 'Legitimate Title'],
+        ];
+    }
+}


### PR DESCRIPTION
There are different rules for Title between Excel and Html, in particular maximum length and which characters are valid. Html Reader can throw an exception because of this difference. This PR allows it to tolerate an invalid title, retaining the default title if the Html suggests an invalid one.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
