### PR TITLE
Better Typing in Test Members

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -3,7 +3,7 @@
 $finder = PhpCsFixer\Finder::create()
     ->exclude('vendor')
     ->notPath('src/PhpSpreadsheet/Writer/ZipStream3.php')
-    ->name('/(\.php|^generate-document|^generate-locales)$/')
+    ->name('/(\.php|^generate-document|^generate-locales|^check-phpdoc-types)$/')
     ->in(__DIR__);
 
 $config = new PhpCsFixer\Config();

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -8,6 +8,7 @@
     <file>infra</file>
     <file>bin/generate-document</file>
     <file>bin/generate-locales</file>
+    <file>bin/check-phpdoc-types</file>
 
     <exclude-pattern>samples/Header.php</exclude-pattern>
     <exclude-pattern>*/tests/Core/*/*Test\.(inc|css|js)$</exclude-pattern>

--- a/bin/check-phpdoc-types
+++ b/bin/check-phpdoc-types
@@ -10,9 +10,9 @@
  */
 function checkPhpDocTypes(): void
 {
-    $content = `git diff --cached` ?? `git diff` ?? `git show HEAD`;
-    preg_match_all('~^\+ +\* @(param|var) (mixed|string|int|float|bool|null|array|\?|\|)+( \$\w+)?$~m', $content, $parameters);
-    preg_match_all('~^\+ +\* @return (mixed|string|int|float|bool|null|array|void|\?|\|)+$~m', $content, $returns);
+    $content = shell_exec('git diff --cached') ?? shell_exec('git diff') ?? shell_exec('git show HEAD');
+    preg_match_all('~^\+ +\* @(param|var) (mixed|string|int|float|bool|null|array|\?|\|)+( \$\w+)?$~m', "$content", $parameters);
+    preg_match_all('~^\+ +\* @return (mixed|string|int|float|bool|null|array|void|\?|\|)+$~m', "$content", $returns);
 
     $errors = [
         ...$parameters[0],
@@ -21,7 +21,7 @@ function checkPhpDocTypes(): void
 
     if ($errors) {
         echo 'PHP native types must be used instead of PHPDoc types (without comments), for the following lines:' . PHP_EOL . PHP_EOL;
-        echo join(PHP_EOL, $errors) . PHP_EOL;
+        echo implode(PHP_EOL, $errors) . PHP_EOL;
         exit(1);
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,6 +12,7 @@ parameters:
         - infra/
         - bin/generate-document
         - bin/generate-locales
+        - bin/check-phpdoc-types
     excludePaths:
         - src/PhpSpreadsheet/Chart/Renderer/JpGraph.php
         - src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/Date.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/Date.php
@@ -27,7 +27,7 @@ class Date
      * A Month name or abbreviation (English only at this point) such as 'January' or 'Jan' will still be accepted,
      *     as will a day value with a suffix (e.g. '21st' rather than simply 21); again only English language.
      *
-     * @param array|int|string $year The value of the year argument can include one to four digits.
+     * @param array|float|int|string $year The value of the year argument can include one to four digits.
      *                                Excel interprets the year argument according to the configured
      *                                date system: 1900 or 1904.
      *                                If year is between 0 (zero) and 1899 (inclusive), Excel adds that
@@ -63,7 +63,7 @@ class Date
      *         If an array of numbers is passed as the argument, then the returned result will also be an array
      *            with the same dimensions
      */
-    public static function fromYMD(array|int|string $year, array|float|int|string $month, array|float|int|string $day): mixed
+    public static function fromYMD(array|float|int|string $year, array|float|int|string $month, array|float|int|string $day): mixed
     {
         if (is_array($year) || is_array($month) || is_array($day)) {
             return self::evaluateArrayArguments([self::class, __FUNCTION__], $year, $month, $day);

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/DateValue.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/DateValue.php
@@ -24,7 +24,7 @@ class DateValue
      * Excel Function:
      *        DATEVALUE(dateValue)
      *
-     * @param null|array|int|string $dateValue Text that represents a date in a Microsoft Excel date format.
+     * @param null|array|bool|float|int|string $dateValue Text that represents a date in a Microsoft Excel date format.
      *                                    For example, "1/30/2008" or "30-Jan-2008" are text strings within
      *                                    quotation marks that represent dates. Using the default date
      *                                    system in Excel for Windows, date_text must represent a date from
@@ -39,7 +39,7 @@ class DateValue
      *         If an array of numbers is passed as the argument, then the returned result will also be an array
      *            with the same dimensions
      */
-    public static function fromString(null|array|string|int|bool $dateValue): mixed
+    public static function fromString(null|array|string|int|bool|float $dateValue): mixed
     {
         if (is_array($dateValue)) {
             return self::evaluateSingleArgumentArray([self::class, __FUNCTION__], $dateValue);

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/TimeValue.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/TimeValue.php
@@ -25,7 +25,7 @@ class TimeValue
      * Excel Function:
      *        TIMEVALUE(timeValue)
      *
-     * @param null|array|string $timeValue A text string that represents a time in any one of the Microsoft
+     * @param null|array|bool|int|string $timeValue A text string that represents a time in any one of the Microsoft
      *                                    Excel time formats; for example, "6:45 PM" and "18:45" text strings
      *                                    within quotation marks that represent time.
      *                                    Date information in time_text is ignored.

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/Week.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/Week.php
@@ -137,7 +137,7 @@ class Week
      * Excel Function:
      *        WEEKDAY(dateValue[,style])
      *
-     * @param null|array|float|int|string $dateValue Excel date serial value (float), PHP date timestamp (integer),
+     * @param null|array|bool|float|int|string $dateValue Excel date serial value (float), PHP date timestamp (integer),
      *                                    PHP DateTime object, or a standard date string
      *                         Or can be an array of date values
      * @param mixed $style A number that determines the type of return value

--- a/src/PhpSpreadsheet/Calculation/Engineering/Compare.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/Compare.php
@@ -20,16 +20,16 @@ class Compare
      *        functions you calculate the count of equal pairs. This function is also known as the
      *        Kronecker Delta function.
      *
-     * @param array|float $a the first number
+     * @param array|bool|float|int|string $a the first number
      *                      Or can be an array of values
-     * @param array|float $b The second number. If omitted, b is assumed to be zero.
+     * @param array|bool|float|int|string $b The second number. If omitted, b is assumed to be zero.
      *                      Or can be an array of values
      *
      * @return array|int|string (string in the event of an error)
      *         If an array of numbers is passed as an argument, then the returned result will also be an array
      *            with the same dimensions
      */
-    public static function DELTA(array|float|bool|string $a, array|float|bool|string $b = 0.0): array|string|int
+    public static function DELTA(array|float|bool|string|int $a, array|float|bool|string|int $b = 0.0): array|string|int
     {
         if (is_array($a) || is_array($b)) {
             return self::evaluateArrayArguments([self::class, __FUNCTION__], $a, $b);
@@ -55,16 +55,16 @@ class Compare
      *    Use this function to filter a set of values. For example, by summing several GESTEP
      *        functions you calculate the count of values that exceed a threshold.
      *
-     * @param array|float $number the value to test against step
+     * @param array|bool|float|int|string $number the value to test against step
      *                      Or can be an array of values
-     * @param null|array|float $step The threshold value. If you omit a value for step, GESTEP uses zero.
+     * @param null|array|bool|float|int|string $step The threshold value. If you omit a value for step, GESTEP uses zero.
      *                      Or can be an array of values
      *
      * @return array|int|string (string in the event of an error)
      *         If an array of numbers is passed as an argument, then the returned result will also be an array
      *            with the same dimensions
      */
-    public static function GESTEP(array|float|bool|string $number, $step = 0.0): array|string|int
+    public static function GESTEP(array|float|bool|string|int $number, $step = 0.0): array|string|int
     {
         if (is_array($number) || is_array($step)) {
             return self::evaluateArrayArguments([self::class, __FUNCTION__], $number, $step);

--- a/src/PhpSpreadsheet/Calculation/Engineering/ConvertBinary.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/ConvertBinary.php
@@ -15,7 +15,7 @@ class ConvertBinary extends ConvertBase
      * Excel Function:
      *        BIN2DEC(x)
      *
-     * @param array|string $value The binary number (as a string) that you want to convert. The number
+     * @param array|bool|float|int|string $value The binary number (as a string) that you want to convert. The number
      *                                cannot contain more than 10 characters (10 bits). The most significant
      *                                bit of number is the sign bit. The remaining 9 bits are magnitude bits.
      *                                Negative numbers are represented using two's-complement notation.
@@ -58,14 +58,14 @@ class ConvertBinary extends ConvertBase
      * Excel Function:
      *        BIN2HEX(x[,places])
      *
-     * @param array|string $value The binary number (as a string) that you want to convert. The number
+     * @param array|bool|float|int|string $value The binary number (as a string) that you want to convert. The number
      *                                cannot contain more than 10 characters (10 bits). The most significant
      *                                bit of number is the sign bit. The remaining 9 bits are magnitude bits.
      *                                Negative numbers are represented using two's-complement notation.
      *                                If number is not a valid binary number, or if number contains more than
      *                                10 characters (10 bits), BIN2HEX returns the #NUM! error value.
      *                      Or can be an array of values
-     * @param array|int $places The number of characters to use. If places is omitted, BIN2HEX uses the
+     * @param null|array|float|int|string $places The number of characters to use. If places is omitted, BIN2HEX uses the
      *                                minimum number of characters necessary. Places is useful for padding the
      *                                return value with leading 0s (zeros).
      *                                If places is not an integer, it is truncated.
@@ -111,14 +111,14 @@ class ConvertBinary extends ConvertBase
      * Excel Function:
      *        BIN2OCT(x[,places])
      *
-     * @param array|string $value The binary number (as a string) that you want to convert. The number
+     * @param array|bool|float|int|string $value The binary number (as a string) that you want to convert. The number
      *                                cannot contain more than 10 characters (10 bits). The most significant
      *                                bit of number is the sign bit. The remaining 9 bits are magnitude bits.
      *                                Negative numbers are represented using two's-complement notation.
      *                                If number is not a valid binary number, or if number contains more than
      *                                10 characters (10 bits), BIN2OCT returns the #NUM! error value.
      *                      Or can be an array of values
-     * @param array|int $places The number of characters to use. If places is omitted, BIN2OCT uses the
+     * @param null|array|float|int|string $places The number of characters to use. If places is omitted, BIN2OCT uses the
      *                                minimum number of characters necessary. Places is useful for padding the
      *                                return value with leading 0s (zeros).
      *                                If places is not an integer, it is truncated.

--- a/src/PhpSpreadsheet/Calculation/Engineering/ConvertDecimal.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/ConvertDecimal.php
@@ -22,7 +22,7 @@ class ConvertDecimal extends ConvertBase
      * Excel Function:
      *        DEC2BIN(x[,places])
      *
-     * @param array|string $value The decimal integer you want to convert. If number is negative,
+     * @param array|bool|float|int|string $value The decimal integer you want to convert. If number is negative,
      *                          valid place values are ignored and DEC2BIN returns a 10-character
      *                          (10-bit) binary number in which the most significant bit is the sign
      *                          bit. The remaining 9 bits are magnitude bits. Negative numbers are
@@ -33,7 +33,7 @@ class ConvertDecimal extends ConvertBase
      *                      If DEC2BIN requires more than places characters, it returns the #NUM!
      *                          error value.
      *                      Or can be an array of values
-     * @param array|int $places The number of characters to use. If places is omitted, DEC2BIN uses
+     * @param null|array|float|int|string $places The number of characters to use. If places is omitted, DEC2BIN uses
      *                          the minimum number of characters necessary. Places is useful for
      *                          padding the return value with leading 0s (zeros).
      *                      If places is not an integer, it is truncated.
@@ -79,7 +79,7 @@ class ConvertDecimal extends ConvertBase
      * Excel Function:
      *        DEC2HEX(x[,places])
      *
-     * @param array|string $value The decimal integer you want to convert. If number is negative,
+     * @param array|bool|float|int|string $value The decimal integer you want to convert. If number is negative,
      *                          places is ignored and DEC2HEX returns a 10-character (40-bit)
      *                          hexadecimal number in which the most significant bit is the sign
      *                          bit. The remaining 39 bits are magnitude bits. Negative numbers
@@ -90,7 +90,7 @@ class ConvertDecimal extends ConvertBase
      *                      If DEC2HEX requires more than places characters, it returns the
      *                          #NUM! error value.
      *                      Or can be an array of values
-     * @param array|int $places The number of characters to use. If places is omitted, DEC2HEX uses
+     * @param null|array|float|int|string $places The number of characters to use. If places is omitted, DEC2HEX uses
      *                          the minimum number of characters necessary. Places is useful for
      *                          padding the return value with leading 0s (zeros).
      *                      If places is not an integer, it is truncated.
@@ -155,7 +155,7 @@ class ConvertDecimal extends ConvertBase
      * Excel Function:
      *        DEC2OCT(x[,places])
      *
-     * @param array|string $value The decimal integer you want to convert. If number is negative,
+     * @param array|bool|float|int|string $value The decimal integer you want to convert. If number is negative,
      *                          places is ignored and DEC2OCT returns a 10-character (30-bit)
      *                          octal number in which the most significant bit is the sign bit.
      *                          The remaining 29 bits are magnitude bits. Negative numbers are

--- a/src/PhpSpreadsheet/Calculation/Engineering/ConvertHex.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/ConvertHex.php
@@ -15,7 +15,7 @@ class ConvertHex extends ConvertBase
      * Excel Function:
      *        HEX2BIN(x[,places])
      *
-     * @param array|string $value The hexadecimal number you want to convert.
+     * @param array|bool|float|string $value The hexadecimal number you want to convert.
      *                      Number cannot contain more than 10 characters.
      *                      The most significant bit of number is the sign bit (40th bit from the right).
      *                      The remaining 9 bits are magnitude bits.
@@ -65,7 +65,7 @@ class ConvertHex extends ConvertBase
      * Excel Function:
      *        HEX2DEC(x)
      *
-     * @param array|string $value The hexadecimal number you want to convert. This number cannot
+     * @param array|bool|float|int|string $value The hexadecimal number you want to convert. This number cannot
      *                          contain more than 10 characters (40 bits). The most significant
      *                          bit of number is the sign bit. The remaining 39 bits are magnitude
      *                          bits. Negative numbers are represented using two's-complement
@@ -118,7 +118,7 @@ class ConvertHex extends ConvertBase
      * Excel Function:
      *        HEX2OCT(x[,places])
      *
-     * @param array|string $value The hexadecimal number you want to convert. Number cannot
+     * @param array|bool|float|int|string $value The hexadecimal number you want to convert. Number cannot
      *                                    contain more than 10 characters. The most significant bit of
      *                                    number is the sign bit. The remaining 39 bits are magnitude
      *                                    bits. Negative numbers are represented using two's-complement

--- a/src/PhpSpreadsheet/Calculation/Engineering/ConvertOctal.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/ConvertOctal.php
@@ -15,7 +15,7 @@ class ConvertOctal extends ConvertBase
      * Excel Function:
      *        OCT2BIN(x[,places])
      *
-     * @param array|string $value The octal number you want to convert. Number may not
+     * @param array|bool|float|int|string $value The octal number you want to convert. Number may not
      *                          contain more than 10 characters. The most significant
      *                          bit of number is the sign bit. The remaining 29 bits
      *                          are magnitude bits. Negative numbers are represented
@@ -69,7 +69,7 @@ class ConvertOctal extends ConvertBase
      * Excel Function:
      *        OCT2DEC(x)
      *
-     * @param array|string $value The octal number you want to convert. Number may not contain
+     * @param array|bool|float|int|string $value The octal number you want to convert. Number may not contain
      *                          more than 10 octal characters (30 bits). The most significant
      *                          bit of number is the sign bit. The remaining 29 bits are
      *                          magnitude bits. Negative numbers are represented using
@@ -118,7 +118,7 @@ class ConvertOctal extends ConvertBase
      * Excel Function:
      *        OCT2HEX(x[,places])
      *
-     * @param array|string $value The octal number you want to convert. Number may not contain
+     * @param array|bool|float|int|string $value The octal number you want to convert. Number may not contain
      *                          more than 10 octal characters (30 bits). The most significant
      *                          bit of number is the sign bit. The remaining 29 bits are
      *                          magnitude bits. Negative numbers are represented using

--- a/src/PhpSpreadsheet/Shared/Font.php
+++ b/src/PhpSpreadsheet/Shared/Font.php
@@ -499,11 +499,11 @@ class Font
     /**
      * Calculate an (approximate) pixel size, based on a font points size.
      *
-     * @param int $fontSizeInPoints Font size (in points)
+     * @param float|int $fontSizeInPoints Font size (in points)
      *
      * @return int Font size (in pixels)
      */
-    public static function fontSizeToPixels(int $fontSizeInPoints): int
+    public static function fontSizeToPixels(float|int $fontSizeInPoints): int
     {
         return (int) ((4 / 3) * $fontSizeInPoints);
     }

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -35,7 +35,7 @@ class CalculationTest extends TestCase
     /**
      * @dataProvider providerBinaryComparisonOperation
      */
-    public function testBinaryComparisonOperation(mixed $formula, mixed $expectedResultExcel, mixed $expectedResultOpenOffice): void
+    public function testBinaryComparisonOperation(string $formula, mixed $expectedResultExcel, mixed $expectedResultOpenOffice): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
         $resultExcel = Calculation::getInstance()->_calculateFormulaValue($formula);
@@ -360,7 +360,7 @@ class CalculationTest extends TestCase
      */
     public function testFullExecutionDataPruning(
         mixed $expectedResult,
-        mixed $dataArray,
+        array $dataArray,
         string $formula,
         string $cellCoordinates,
         array $shouldBeSetInCacheCells = [],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateTest.php
@@ -39,9 +39,9 @@ class DateTest extends TestCase
     /**
      * @dataProvider providerDATE
      */
-    public function testDirectCallToDATE(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToDATE(float|string $expectedResult, int|string $year, float|int|string $month, float|int|string $day): void
     {
-        $result = Date::fromYMD(...$args);
+        $result = Date::fromYMD($year, $month, $day);
         self::assertSame($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateValueTest.php
@@ -42,32 +42,35 @@ class DateValueTest extends TestCase
         return is_string($expectedResult) && str_starts_with($expectedResult, 'Y-');
     }
 
-    private function parseTemplatedExpectation(string $expectedResult): string
+    private function parseTemplatedExpectation(float|int|string $expectedResult): string
     {
-        return (string) DateValue::fromString(
+        /** @var float */
+        $x = DateValue::fromString(
             (new DateTimeImmutable(
-                str_replace('Y', (new DateTimeImmutable('now'))->format('Y'), $expectedResult)
+                str_replace('Y', (new DateTimeImmutable('now'))->format('Y'), (string) $expectedResult)
             ))->format('Y-m-d')
         );
+
+        return (string) $x;
     }
 
     /**
      * @dataProvider providerDATEVALUE
      */
-    public function testDirectCallToDATEVALUE(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToDATEVALUE(int|string $expectedResult, bool|int|string $value): void
     {
         if ($this->expectationIsTemplate($expectedResult)) {
-            $expectedResult = $this->parseTemplatedExpectation($expectedResult);
+            $expectedResult = $this->parseTemplatedExpectation((string) $expectedResult);
         }
 
-        $result = DateValue::fromString(...$args);
+        $result = DateValue::fromString($value);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-8);
     }
 
     /**
      * @dataProvider providerDATEVALUE
      */
-    public function testDATEVALUEAsFormula(mixed $expectedResult, mixed ...$args): void
+    public function testDATEVALUEAsFormula(float|int|string $expectedResult, mixed ...$args): void
     {
         if ($this->expectationIsTemplate($expectedResult)) {
             $expectedResult = $this->parseTemplatedExpectation($expectedResult);
@@ -85,7 +88,7 @@ class DateValueTest extends TestCase
     /**
      * @dataProvider providerDATEVALUE
      */
-    public function testDATEVALUEInWorksheet(mixed $expectedResult, mixed ...$args): void
+    public function testDATEVALUEInWorksheet(float|int|string $expectedResult, mixed ...$args): void
     {
         if ($this->expectationIsTemplate($expectedResult)) {
             $expectedResult = $this->parseTemplatedExpectation($expectedResult);

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DaysTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DaysTest.php
@@ -18,9 +18,9 @@ class DaysTest extends TestCase
     /**
      * @dataProvider providerDAYS
      */
-    public function testDirectCallToDAYS(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToDAYS(int|string $expectedResult, int|string $date1, int|string $date2): void
     {
-        $result = Days::between(...$args);
+        $result = Days::between($date1, $date2);
         self::assertSame($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeTest.php
@@ -39,9 +39,9 @@ class TimeTest extends TestCase
     /**
      * @dataProvider providerTIME
      */
-    public function testDirectCallToTIME(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToTIME(float|string $expectedResult, int|string $hour, bool|int $minute, int $second): void
     {
-        $result = Time::fromHMS(...$args);
+        $result = Time::fromHMS($hour, $minute, $second);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-12);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeValueTest.php
@@ -33,9 +33,9 @@ class TimeValueTest extends TestCase
     /**
      * @dataProvider providerTIMEVALUE
      */
-    public function testDirectCallToTIMEVALUE(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToTIMEVALUE(int|float|string $expectedResult, bool|int|string $value): void
     {
-        $result = TimeValue::fromString(...$args);
+        $result = TimeValue::fromString($value);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-8);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WeekDayTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WeekDayTest.php
@@ -32,9 +32,9 @@ class WeekDayTest extends TestCase
     /**
      * @dataProvider providerWEEKDAY
      */
-    public function testDirectCallToWEEKDAY(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToWEEKDAY(int|string $expectedResult, bool|int|string $dateValue, null|int|string $style = null): void
     {
-        $result = Week::day(...$args);
+        $result = ($style === null) ? Week::day($dateValue) : Week::day($dateValue, $style);
         self::assertSame($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2DecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2DecTest.php
@@ -30,9 +30,9 @@ class Bin2DecTest extends TestCase
     /**
      * @dataProvider providerBIN2DEC
      */
-    public function testDirectCallToBIN2DEC(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToBIN2DEC(string $expectedResult, bool|int|string $arg1): void
     {
-        $result = ConvertBinary::toDecimal(...$args);
+        $result = ConvertBinary::toDecimal($arg1);
         self::assertSame($expectedResult, $result);
     }
 
@@ -51,6 +51,7 @@ class Bin2DecTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BIN2DEC({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }
@@ -111,11 +112,11 @@ class Bin2DecTest extends TestCase
     /**
      * @dataProvider providerBIN2DECOds
      */
-    public function testBIN2DECOds(mixed $expectedResult, mixed ...$args): void
+    public function testBIN2DECOds(string $expectedResult, bool $arg1): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
-        $result = ConvertBinary::toDecimal(...$args);
+        $result = ConvertBinary::toDecimal($arg1);
         self::assertSame($expectedResult, $result);
     }
 
@@ -130,14 +131,17 @@ class Bin2DecTest extends TestCase
         $formula = '=BIN2DEC(101.1)';
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('5', $this->trimIfQuoted((string) $result), 'Gnumeric');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2HexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2HexTest.php
@@ -30,9 +30,9 @@ class Bin2HexTest extends TestCase
     /**
      * @dataProvider providerBIN2HEX
      */
-    public function testDirectCallToBIN2HEX(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToBIN2HEX(mixed $expectedResult, bool|float|int|string $value, null|float|int|string $digits = null): void
     {
-        $result = ConvertBinary::toHex(...$args);
+        $result = ($digits === null) ? ConvertBinary::toHex($value) : ConvertBinary::toHex($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -51,6 +51,7 @@ class Bin2HexTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BIN2HEX({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }
@@ -111,11 +112,11 @@ class Bin2HexTest extends TestCase
     /**
      * @dataProvider providerBIN2HEXOds
      */
-    public function testBIN2HEXOds(mixed $expectedResult, mixed ...$args): void
+    public function testBIN2HEXOds(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
-        $result = ConvertBinary::toDecimal(...$args);
+        $result = ($digits === null) ? ConvertBinary::toHex($value) : ConvertBinary::toHex($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -130,14 +131,17 @@ class Bin2HexTest extends TestCase
         $formula = '=BIN2HEX(101.1)';
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('5', $this->trimIfQuoted((string) $result), 'Gnumeric');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2OctTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2OctTest.php
@@ -30,9 +30,9 @@ class Bin2OctTest extends TestCase
     /**
      * @dataProvider providerBIN2OCT
      */
-    public function testDirectCallToBIN2OCT(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToBIN2OCT(mixed $expectedResult, bool|float|int|string $value, null|float|int|string $digits = null): void
     {
-        $result = ConvertBinary::toOctal(...$args);
+        $result = ($digits === null) ? ConvertBinary::toOctal($value) : ConvertBinary::toOctal($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -51,6 +51,7 @@ class Bin2OctTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BIN2OCT({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }
@@ -111,11 +112,11 @@ class Bin2OctTest extends TestCase
     /**
      * @dataProvider providerBIN2OCTOds
      */
-    public function testBIN2OCTOds(mixed $expectedResult, mixed ...$args): void
+    public function testBIN2OCTOds(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
-        $result = ConvertBinary::toDecimal(...$args);
+        $result = ($digits === null) ? ConvertBinary::toOctal($value) : ConvertBinary::toOctal($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -130,14 +131,17 @@ class Bin2OctTest extends TestCase
         $formula = '=BIN2OCT(101.1)';
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('5', $this->trimIfQuoted((string) $result), 'Gnumeric');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitAndTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitAndTest.php
@@ -16,9 +16,9 @@ class BitAndTest extends TestCase
     /**
      * @dataProvider providerBITAND
      */
-    public function testDirectCallToBITAND(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToBITAND(mixed $expectedResult, null|bool|int|float|string $arg1, null|bool|int|float|string $arg2): void
     {
-        $result = BitWise::BITAND(...$args);
+        $result = BitWise::BITAND($arg1, $arg2);
         self::assertSame($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitLShiftTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitLShiftTest.php
@@ -16,9 +16,9 @@ class BitLShiftTest extends TestCase
     /**
      * @dataProvider providerBITLSHIFT
      */
-    public function testDirectCallToBITLSHIFT(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToBITLSHIFT(float|int|string $expectedResult, null|bool|int|float|string $arg1, null|bool|int|float|string $arg2): void
     {
-        $result = BitWise::BITLSHIFT(...$args);
+        $result = BitWise::BITLSHIFT($arg1, $arg2);
         self::assertSame($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitOrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitOrTest.php
@@ -16,9 +16,9 @@ class BitOrTest extends TestCase
     /**
      * @dataProvider providerBITOR
      */
-    public function testDirectCallToBITOR(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToBITOR(mixed $expectedResult, null|bool|int|float|string $arg1, null|bool|int|float|string $arg2): void
     {
-        $result = BitWise::BITOR(...$args);
+        $result = BitWise::BITOR($arg1, $arg2);
         self::assertSame($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitRShiftTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitRShiftTest.php
@@ -16,9 +16,9 @@ class BitRShiftTest extends TestCase
     /**
      * @dataProvider providerBITRSHIFT
      */
-    public function testDirectCallToBITRSHIFT(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToBITRSHIFT(float|int|string $expectedResult, null|bool|int|float|string $arg1, null|bool|int|float|string $arg2): void
     {
-        $result = BitWise::BITRSHIFT(...$args);
+        $result = BitWise::BITRSHIFT($arg1, $arg2);
         self::assertSame($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitXorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitXorTest.php
@@ -16,9 +16,9 @@ class BitXorTest extends TestCase
     /**
      * @dataProvider providerBITXOR
      */
-    public function testDirectCallToBITXOR(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToBITXOR(int|string $expectedResult, null|bool|int|float|string $arg1, null|bool|int|float|string $arg2): void
     {
-        $result = BitWise::BITXOR(...$args);
+        $result = BitWise::BITXOR($arg1, $arg2);
         self::assertSame($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ComplexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ComplexTest.php
@@ -36,6 +36,7 @@ class ComplexTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=COMPLEX({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ConvertUoMTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ConvertUoMTest.php
@@ -48,9 +48,9 @@ class ConvertUoMTest extends TestCase
     /**
      * @dataProvider providerCONVERTUOM
      */
-    public function testDirectCallToCONVERTUOM(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToCONVERTUOM(float|int|string $expectedResult, float|int|string $value, string $from, string $to): void
     {
-        $result = ConvertUOM::convert(...$args);
+        $result = ConvertUOM::convert($value, $from, $to);
         self::assertEqualsWithDelta($expectedResult, $result, self::UOM_PRECISION);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2BinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2BinTest.php
@@ -29,9 +29,9 @@ class Dec2BinTest extends TestCase
     /**
      * @dataProvider providerDEC2BIN
      */
-    public function testDirectCallToDEC2BIN(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToDEC2BIN(mixed $expectedResult, bool|float|int|string $value, null|float|int|string $digits = null): void
     {
-        $result = ConvertDecimal::toBinary(...$args);
+        $result = ($digits === null) ? ConvertDecimal::toBinary($value) : ConvertDecimal::toBinary($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -50,6 +50,7 @@ class Dec2BinTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DEC2BIN({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }
@@ -110,11 +111,11 @@ class Dec2BinTest extends TestCase
     /**
      * @dataProvider providerDEC2BINOds
      */
-    public function testDEC2BINOds(mixed $expectedResult, mixed ...$args): void
+    public function testDEC2BINOds(mixed $expectedResult, bool|float|int|string $value, null|float|int|string $digits = null): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
-        $result = ConvertDecimal::toBinary(...$args);
+        $result = ($digits === null) ? ConvertDecimal::toBinary($value) : ConvertDecimal::toBinary($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -129,14 +130,17 @@ class Dec2BinTest extends TestCase
         $formula = '=DEC2BIN(5.1)';
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('101', $this->trimIfQuoted((string) $result), 'Gnumeric');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('101', $this->trimIfQuoted((string) $result), 'OpenOffice');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('101', $this->trimIfQuoted((string) $result), 'Excel');
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2HexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2HexTest.php
@@ -29,9 +29,9 @@ class Dec2HexTest extends TestCase
     /**
      * @dataProvider providerDEC2HEX
      */
-    public function testDirectCallToDEC2HEX(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToDEC2HEX(mixed $expectedResult, bool|float|int|string $value, null|float|int|string $digits = null): void
     {
-        $result = ConvertDecimal::toHex(...$args);
+        $result = ($digits === null) ? ConvertDecimal::toHex($value) : ConvertDecimal::toHex($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -50,6 +50,7 @@ class Dec2HexTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DEC2HEX({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }
@@ -110,11 +111,11 @@ class Dec2HexTest extends TestCase
     /**
      * @dataProvider providerDEC2HEXOds
      */
-    public function testDEC2HEXOds(mixed $expectedResult, mixed ...$args): void
+    public function testDEC2HEXOds(mixed $expectedResult, bool|float|int|string $value, null|float|int|string $digits = null): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
-        $result = ConvertDecimal::toHex(...$args);
+        $result = ($digits === null) ? ConvertDecimal::toHex($value) : ConvertDecimal::toHex($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -129,14 +130,17 @@ class Dec2HexTest extends TestCase
         $formula = '=DEC2HEX(17.1)';
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('11', $this->trimIfQuoted((string) $result), 'Gnumeric');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('11', $this->trimIfQuoted((string) $result), 'OpenOffice');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('11', $this->trimIfQuoted((string) $result), 'Excel');
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2OctTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2OctTest.php
@@ -29,9 +29,9 @@ class Dec2OctTest extends TestCase
     /**
      * @dataProvider providerDEC2OCT
      */
-    public function testDirectCallToDEC2OCT(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToDEC2OCT(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
-        $result = ConvertDecimal::toOctal(...$args);
+        $result = ($digits === null) ? ConvertDecimal::toOctal($value) : ConvertDecimal::toOctal($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -50,6 +50,7 @@ class Dec2OctTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DEC2OCT({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }
@@ -110,11 +111,11 @@ class Dec2OctTest extends TestCase
     /**
      * @dataProvider providerDEC2OCTOds
      */
-    public function testDEC2OCTOds(mixed $expectedResult, mixed ...$args): void
+    public function testDEC2OCTOds(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
-        $result = ConvertDecimal::toOctal(...$args);
+        $result = ($digits === null) ? ConvertDecimal::toOctal($value) : ConvertDecimal::toOctal($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -129,14 +130,17 @@ class Dec2OctTest extends TestCase
         $formula = '=DEC2OCT(17.1)';
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('21', $this->trimIfQuoted((string) $result), 'Gnumeric');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('21', $this->trimIfQuoted((string) $result), 'OpenOffice');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('21', $this->trimIfQuoted((string) $result), 'Excel');
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/DeltaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/DeltaTest.php
@@ -16,9 +16,9 @@ class DeltaTest extends TestCase
     /**
      * @dataProvider providerDELTA
      */
-    public function testDirectCallToDELTA(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToDELTA(mixed $expectedResult, bool|float|int|string $arg1, null|bool|float|int|string $arg2 = null): void
     {
-        $result = Compare::delta(...$args);
+        $result = ($arg2 === null) ? Compare::delta($arg1) : Compare::delta($arg1, $arg2);
         self::assertSame($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/GeStepTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/GeStepTest.php
@@ -16,9 +16,9 @@ class GeStepTest extends TestCase
     /**
      * @dataProvider providerGESTEP
      */
-    public function testDirectCallToGESTEP(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToGESTEP(int|string $expectedResult, bool|float|int|string $arg1, null|bool|float|int|string $arg2 = null): void
     {
-        $result = Compare::geStep(...$args);
+        $result = ($arg2 === null) ? Compare::geStep($arg1) : Compare::geStep($arg1, $arg2);
         self::assertSame($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2BinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2BinTest.php
@@ -30,9 +30,9 @@ class Hex2BinTest extends TestCase
     /**
      * @dataProvider providerHEX2BIN
      */
-    public function testDirectCallToHEX2BIN(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToHEX2BIN(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
-        $result = ConvertHex::toBinary(...$args);
+        $result = ($digits === null) ? ConvertHex::toBinary($value) : ConvertHex::toBinary($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -51,6 +51,7 @@ class Hex2BinTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=HEX2BIN({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }
@@ -111,11 +112,11 @@ class Hex2BinTest extends TestCase
     /**
      * @dataProvider providerHEX2BINOds
      */
-    public function testHEX2BINOds(mixed $expectedResult, mixed ...$args): void
+    public function testHEX2BINOds(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
-        $result = ConvertHex::toBinary(...$args);
+        $result = ($digits === null) ? ConvertHex::toBinary($value) : ConvertHex::toBinary($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -130,14 +131,17 @@ class Hex2BinTest extends TestCase
         $formula = '=HEX2BIN(10.1)';
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('10000', $this->trimIfQuoted((string) $result), 'Gnumeric');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2DecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2DecTest.php
@@ -30,9 +30,9 @@ class Hex2DecTest extends TestCase
     /**
      * @dataProvider providerHEX2DEC
      */
-    public function testDirectCallToHEX2DEC(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToHEX2DEC(mixed $expectedResult, bool|float|int|string $value): void
     {
-        $result = ConvertHex::toDecimal(...$args);
+        $result = ConvertHex::toDecimal($value);
         self::assertSame($expectedResult, $result);
     }
 
@@ -51,6 +51,7 @@ class Hex2DecTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=HEX2DEC({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }
@@ -111,11 +112,11 @@ class Hex2DecTest extends TestCase
     /**
      * @dataProvider providerHEX2DECOds
      */
-    public function testHEX2DECOds(mixed $expectedResult, mixed ...$args): void
+    public function testHEX2DECOds(mixed $expectedResult, bool|float|int|string $value): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
-        $result = ConvertHex::toDecimal(...$args);
+        $result = ConvertHex::toDecimal($value);
         self::assertSame($expectedResult, $result);
     }
 
@@ -130,14 +131,17 @@ class Hex2DecTest extends TestCase
         $formula = '=HEX2DEC(10.1)';
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('16', $this->trimIfQuoted((string) $result), 'Gnumeric');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2OctTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2OctTest.php
@@ -30,9 +30,9 @@ class Hex2OctTest extends TestCase
     /**
      * @dataProvider providerHEX2OCT
      */
-    public function testDirectCallToHEX2OCT(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToHEX2OCT(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
-        $result = ConvertHex::toOctal(...$args);
+        $result = ($digits === null) ? ConvertHex::toOctal($value) : ConvertHex::toOctal($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -51,6 +51,7 @@ class Hex2OctTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=HEX2OCT({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }
@@ -111,11 +112,11 @@ class Hex2OctTest extends TestCase
     /**
      * @dataProvider providerHEX2OCTOds
      */
-    public function testHEX2OCTOds(mixed $expectedResult, mixed ...$args): void
+    public function testHEX2OCTOds(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
-        $result = ConvertHex::toOctal(...$args);
+        $result = ($digits === null) ? ConvertHex::toOctal($value) : ConvertHex::toOctal($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -130,14 +131,17 @@ class Hex2OctTest extends TestCase
         $formula = '=HEX2OCT(10.1)';
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('20', $this->trimIfQuoted((string) $result), 'Gnumeric');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImAbsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImAbsTest.php
@@ -18,9 +18,9 @@ class ImAbsTest extends TestCase
     /**
      * @dataProvider providerIMABS
      */
-    public function testDirectCallToIMABS(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMABS(float|int|string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMABS(...$args);
+        $result = ComplexFunctions::IMABS($arg);
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImArgumentTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImArgumentTest.php
@@ -24,9 +24,9 @@ class ImArgumentTest extends TestCase
     /**
      * @dataProvider providerIMARGUMENT
      */
-    public function testDirectCallToIMARGUMENT(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMARGUMENT(float|int|string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMARGUMENT(...$args);
+        $result = ComplexFunctions::IMARGUMENT($arg);
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImConjugateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImConjugateTest.php
@@ -28,9 +28,9 @@ class ImConjugateTest extends TestCase
     /**
      * @dataProvider providerIMCONJUGATE
      */
-    public function testDirectCallToIMCONJUGATE(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMCONJUGATE(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMCONJUGATE(...$args);
+        $result = ComplexFunctions::IMCONJUGATE($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImConjugateTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMCONJUGATE({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCosTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCosTest.php
@@ -28,9 +28,9 @@ class ImCosTest extends TestCase
     /**
      * @dataProvider providerIMCOS
      */
-    public function testDirectCallToIMCOS(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMCOS(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMCOS(...$args);
+        $result = ComplexFunctions::IMCOS($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImCosTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMCOS({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCoshTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCoshTest.php
@@ -28,9 +28,9 @@ class ImCoshTest extends TestCase
     /**
      * @dataProvider providerIMCOSH
      */
-    public function testDirectCallToIMCOSH(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMCOSH(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMCOSH(...$args);
+        $result = ComplexFunctions::IMCOSH($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImCoshTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMCOSH({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCotTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCotTest.php
@@ -28,9 +28,9 @@ class ImCotTest extends TestCase
     /**
      * @dataProvider providerIMCOT
      */
-    public function testDirectCallToIMCOT(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMCOT(float|string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMCOT(...$args);
+        $result = ComplexFunctions::IMCOT($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImCotTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMCOT({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCscTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCscTest.php
@@ -28,9 +28,9 @@ class ImCscTest extends TestCase
     /**
      * @dataProvider providerIMCSC
      */
-    public function testDirectCallToIMCSC(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMCSC(float|string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMCSC(...$args);
+        $result = ComplexFunctions::IMCSC($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImCscTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMCSC({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
@@ -123,6 +124,7 @@ class ImCscTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=IMCSC({$complex})";
+        /** @var array<string, array<string, string>> */
         $result = $calculation->_calculateFormulaValue($formula);
         // Avoid testing for excess precision
         foreach ($expectedResult as &$array) {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCschTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCschTest.php
@@ -28,9 +28,9 @@ class ImCschTest extends TestCase
     /**
      * @dataProvider providerIMCSCH
      */
-    public function testDirectCallToIMCSCH(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMCSCH(float|string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMCSCH(...$args);
+        $result = ComplexFunctions::IMCSCH($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImCschTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMCSCH({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImDivTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImDivTest.php
@@ -28,9 +28,9 @@ class ImDivTest extends TestCase
     /**
      * @dataProvider providerIMDIV
      */
-    public function testDirectCallToIMDIV(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMDIV(string $expectedResult, string $dividend, string $divisor): void
     {
-        $result = ComplexOperations::IMDIV(...$args);
+        $result = ComplexOperations::IMDIV($dividend, $divisor);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImDivTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMDIV({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImExpTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImExpTest.php
@@ -28,9 +28,9 @@ class ImExpTest extends TestCase
     /**
      * @dataProvider providerIMEXP
      */
-    public function testDirectCallToIMEXP(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMEXP(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMEXP(...$args);
+        $result = ComplexFunctions::IMEXP($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImExpTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMEXP({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLnTest.php
@@ -28,9 +28,9 @@ class ImLnTest extends TestCase
     /**
      * @dataProvider providerIMLN
      */
-    public function testDirectCallToIMLN(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMLN(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMLN(...$args);
+        $result = ComplexFunctions::IMLN($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImLnTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMLN({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog10Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog10Test.php
@@ -28,9 +28,9 @@ class ImLog10Test extends TestCase
     /**
      * @dataProvider providerIMLOG10
      */
-    public function testDirectCallToIMLOG10(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMLOG10(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMLOG10(...$args);
+        $result = ComplexFunctions::IMLOG10($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImLog10Test extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMLOG10({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog2Test.php
@@ -28,9 +28,9 @@ class ImLog2Test extends TestCase
     /**
      * @dataProvider providerIMLOG2
      */
-    public function testDirectCallToIMLOG2(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMLOG2(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMLOG2(...$args);
+        $result = ComplexFunctions::IMLOG2($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImLog2Test extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMLOG2({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImPowerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImPowerTest.php
@@ -28,9 +28,9 @@ class ImPowerTest extends TestCase
     /**
      * @dataProvider providerIMPOWER
      */
-    public function testDirectCallToIMPOWER(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMPOWER(float|int|string $expectedResult, string $arg1, float|int|string $arg2): void
     {
-        $result = ComplexFunctions::IMPOWER(...$args);
+        $result = ComplexFunctions::IMPOWER($arg1, $arg2);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImPowerTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMPOWER({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImProductTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImProductTest.php
@@ -27,8 +27,10 @@ class ImProductTest extends TestCase
 
     /**
      * @dataProvider providerIMPRODUCT
+     *
+     * @param string ...$args variadic arguments
      */
-    public function testDirectCallToIMPRODUCT(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMPRODUCT(mixed $expectedResult, ...$args): void
     {
         $result = ComplexOperations::IMPRODUCT(...$args);
         self::assertTrue(
@@ -52,6 +54,7 @@ class ImProductTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMPRODUCT({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImRealTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImRealTest.php
@@ -24,9 +24,9 @@ class ImRealTest extends TestCase
     /**
      * @dataProvider providerIMREAL
      */
-    public function testDirectCallToIMREAL(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMREAL(float|int|string $expectedResult, float|int|string $arg): void
     {
-        $result = Complex::IMREAL(...$args);
+        $result = Complex::IMREAL((string) $arg);
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSecTest.php
@@ -28,9 +28,9 @@ class ImSecTest extends TestCase
     /**
      * @dataProvider providerIMSEC
      */
-    public function testDirectCallToIMSEC(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMSEC(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMSEC(...$args);
+        $result = ComplexFunctions::IMSEC($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImSecTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMSEC({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSechTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSechTest.php
@@ -28,9 +28,9 @@ class ImSechTest extends TestCase
     /**
      * @dataProvider providerIMSECH
      */
-    public function testDirectCallToIMSECH(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMSECH(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMSECH(...$args);
+        $result = ComplexFunctions::IMSECH($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImSechTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMSECH({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinTest.php
@@ -28,9 +28,9 @@ class ImSinTest extends TestCase
     /**
      * @dataProvider providerIMSIN
      */
-    public function testDirectCallToIMSIN(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMSIN(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMSIN(...$args);
+        $result = ComplexFunctions::IMSIN($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImSinTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMSIN({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinhTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinhTest.php
@@ -28,9 +28,9 @@ class ImSinhTest extends TestCase
     /**
      * @dataProvider providerIMSINH
      */
-    public function testDirectCallToIMSINH(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMSINH(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMSINH(...$args);
+        $result = ComplexFunctions::IMSINH($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImSinhTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMSINH({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSqrtTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSqrtTest.php
@@ -28,9 +28,9 @@ class ImSqrtTest extends TestCase
     /**
      * @dataProvider providerIMSQRT
      */
-    public function testDirectCallToIMSQRT(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMSQRT(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMSQRT(...$args);
+        $result = ComplexFunctions::IMSQRT($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImSqrtTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMSQRT({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSubTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSubTest.php
@@ -28,9 +28,9 @@ class ImSubTest extends TestCase
     /**
      * @dataProvider providerIMSUB
      */
-    public function testDirectCallToIMSUB(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMSUB(string $expectedResult, string $arg1, string $arg2): void
     {
-        $result = ComplexOperations::IMSUB(...$args);
+        $result = ComplexOperations::IMSUB($arg1, $arg2);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImSubTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMSUB({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSumTest.php
@@ -27,8 +27,10 @@ class ImSumTest extends TestCase
 
     /**
      * @dataProvider providerIMSUM
+     *
+     * @param string ...$args variadic arguments
      */
-    public function testDirectCallToIMSUM(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMSUM(mixed $expectedResult, ...$args): void
     {
         $result = ComplexOperations::IMSUM(...$args);
         self::assertTrue(
@@ -52,6 +54,7 @@ class ImSumTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMSUM({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImTanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImTanTest.php
@@ -28,9 +28,9 @@ class ImTanTest extends TestCase
     /**
      * @dataProvider providerIMTAN
      */
-    public function testDirectCallToIMTAN(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMTAN(string $expectedResult, string $arg): void
     {
-        $result = ComplexFunctions::IMTAN(...$args);
+        $result = ComplexFunctions::IMTAN($arg);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
             $this->complexAssert->getErrorMessage()
@@ -52,6 +52,7 @@ class ImTanTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMTAN({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertTrue(
             $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImaginaryTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImaginaryTest.php
@@ -24,9 +24,9 @@ class ImaginaryTest extends TestCase
     /**
      * @dataProvider providerIMAGINARY
      */
-    public function testDirectCallToIMAGINARY(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToIMAGINARY(float|int|string $expectedResult, float|int|string $arg): void
     {
-        $result = Complex::IMAGINARY(...$args);
+        $result = Complex::IMAGINARY((string) $arg);
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2BinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2BinTest.php
@@ -30,9 +30,9 @@ class Oct2BinTest extends TestCase
     /**
      * @dataProvider providerOCT2BIN
      */
-    public function testDirectCallToOCT2BIN(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToOCT2BIN(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
-        $result = ConvertOctal::toBinary(...$args);
+        $result = ($digits === null) ? ConvertOctal::toBinary($value) : ConvertOctal::toBinary($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -51,6 +51,7 @@ class Oct2BinTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=OCT2BIN({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }
@@ -111,11 +112,11 @@ class Oct2BinTest extends TestCase
     /**
      * @dataProvider providerOCT2BINOds
      */
-    public function testOCT2BINOds(mixed $expectedResult, mixed ...$args): void
+    public function testOCT2BINOds(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
-        $result = ConvertOctal::toBinary(...$args);
+        $result = ($digits === null) ? ConvertOctal::toBinary($value) : ConvertOctal::toBinary($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -130,14 +131,17 @@ class Oct2BinTest extends TestCase
         $formula = '=OCT2BIN(10.1)';
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('1000', $this->trimIfQuoted((string) $result), 'Gnumeric');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2DecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2DecTest.php
@@ -30,9 +30,9 @@ class Oct2DecTest extends TestCase
     /**
      * @dataProvider providerOCT2DEC
      */
-    public function testDirectCallToOCT2DEC(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToOCT2DEC(mixed $expectedResult, bool|string $value): void
     {
-        $result = ConvertOctal::toDecimal(...$args);
+        $result = ConvertOctal::toDecimal($value);
         self::assertSame($expectedResult, $result);
     }
 
@@ -51,6 +51,7 @@ class Oct2DecTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=OCT2DEC({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }
@@ -111,11 +112,11 @@ class Oct2DecTest extends TestCase
     /**
      * @dataProvider providerOCT2DECOds
      */
-    public function testOCT2DECOds(mixed $expectedResult, mixed ...$args): void
+    public function testOCT2DECOds(mixed $expectedResult, bool|string $value): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
-        $result = ConvertOctal::toDecimal(...$args);
+        $result = ConvertOctal::toDecimal($value);
         self::assertSame($expectedResult, $result);
     }
 
@@ -130,14 +131,17 @@ class Oct2DecTest extends TestCase
         $formula = '=OCT2DEC(10.1)';
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('8', $this->trimIfQuoted((string) $result), 'Gnumeric');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2HexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2HexTest.php
@@ -30,9 +30,9 @@ class Oct2HexTest extends TestCase
     /**
      * @dataProvider providerOCT2HEX
      */
-    public function testDirectCallToOCT2HEX(mixed $expectedResult, mixed ...$args): void
+    public function testDirectCallToOCT2HEX(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
-        $result = ConvertOctal::toHex(...$args);
+        $result = ($digits === null) ? ConvertOctal::toHex($value) : ConvertOctal::toHex($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -51,6 +51,7 @@ class Oct2HexTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=OCT2HEX({$arguments})";
 
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
     }
@@ -111,11 +112,11 @@ class Oct2HexTest extends TestCase
     /**
      * @dataProvider providerOCT2HEXOds
      */
-    public function testOCT2HEXOds(mixed $expectedResult, mixed ...$args): void
+    public function testOCT2HEXOds(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
 
-        $result = ConvertOctal::toHex(...$args);
+        $result = ($digits === null) ? ConvertOctal::toHex($value) : ConvertOctal::toHex($value, $digits);
         self::assertSame($expectedResult, $result);
     }
 
@@ -130,14 +131,17 @@ class Oct2HexTest extends TestCase
         $formula = '=OCT2HEX(20.1)';
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame('10', $this->trimIfQuoted((string) $result), 'Gnumeric');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/HelpersTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/HelpersTest.php
@@ -12,7 +12,7 @@ class HelpersTest extends TestCase
     /**
      * @dataProvider providerDaysPerYear
      */
-    public function testDaysPerYear(mixed $expectedResult, mixed $year, mixed $basis): void
+    public function testDaysPerYear(mixed $expectedResult, int $year, int|string $basis): void
     {
         $result = Helpers::daysPerYear($year, $basis);
         self::assertSame($expectedResult, $result);

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/FormulaArguments.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/FormulaArguments.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions;
 
+use Exception;
 use PhpOffice\PhpSpreadsheet\Cell\CellAddress;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Stringable;
@@ -81,7 +82,11 @@ class FormulaArguments implements Stringable
             return $value ? 'TRUE' : 'FALSE';
         }
 
-        return (string) $value;
+        if (is_scalar($value) || $value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        throw new Exception('Cannot convert object to string');
     }
 
     public function __toString(): string

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/AndTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/AndTest.php
@@ -22,7 +22,7 @@ class AndTest extends AllSetupTeardown
     /**
      * @dataProvider providerANDLiteral
      */
-    public function testANDLiteral(mixed $expectedResult, mixed $formula): void
+    public function testANDLiteral(bool|string $expectedResult, float|int|string $formula): void
     {
         $sheet = $this->getSheet();
         $sheet->getCell('A1')->setValue("=AND($formula)");

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/OrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/OrTest.php
@@ -22,7 +22,7 @@ class OrTest extends AllSetupTeardown
     /**
      * @dataProvider providerORLiteral
      */
-    public function testORLiteral(mixed $expectedResult, mixed $formula): void
+    public function testORLiteral(bool|string $expectedResult, float|int|string $formula): void
     {
         $sheet = $this->getSheet();
         $sheet->getCell('A1')->setValue("=OR($formula)");

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/SwitchTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/SwitchTest.php
@@ -24,7 +24,7 @@ class SwitchTest extends AllSetupTeardown
     /**
      * @dataProvider providerSwitchArray
      */
-    public function testIfsArray(array $expectedResult, mixed $expression, mixed $value1, string $result1, mixed $value2, string $result2, string $default): void
+    public function testIfsArray(array $expectedResult, int $expression, int $value1, string $result1, int $value2, string $result2, string $default): void
     {
         $calculation = Calculation::getInstance();
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndirectInternationalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndirectInternationalTest.php
@@ -53,6 +53,7 @@ class IndirectInternationalTest extends AllSetupTeardown
         $sheet->getCell('B10')->setValue('=INDIRECT("R1C3", false)');
         $maxRow = $sheet->getHighestRow();
         for ($row = 2; $row <= $maxRow; ++$row) {
+            /** @var null|bool|float|int|string */
             $rowLocale = $sheet->getCell("A$row")->getValue();
             if (in_array($rowLocale, $sameAsEnglish, true) && in_array($locale, $sameAsEnglish, true)) {
                 $expectedResult = 'text';

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/MatchTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/MatchTest.php
@@ -11,7 +11,7 @@ class MatchTest extends AllSetupTeardown
     /**
      * @dataProvider providerMATCH
      */
-    public function testMATCH(mixed $expectedResult, mixed $input, array $array, mixed $type = null): void
+    public function testMATCH(mixed $expectedResult, mixed $input, array $array, null|float|int|string $type = null): void
     {
         if (is_array($expectedResult)) {
             $expectedResult = $expectedResult[0];
@@ -42,7 +42,7 @@ class MatchTest extends AllSetupTeardown
     /**
      * @dataProvider providerMATCH
      */
-    public function testMATCHLibre(mixed $expectedResult, mixed $input, array $array, mixed $type = null): void
+    public function testMATCHLibre(mixed $expectedResult, mixed $input, array $array, null|float|int|string $type = null): void
     {
         $this->setOpenOffice();
         if (is_array($expectedResult)) {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcotTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcotTest.php
@@ -11,7 +11,7 @@ class AcotTest extends AllSetupTeardown
     /**
      * @dataProvider providerACOT
      */
-    public function testACOT(mixed $expectedResult, mixed $number): void
+    public function testACOT(float|int|string $expectedResult, float|int|string $number): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcothTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcothTest.php
@@ -11,7 +11,7 @@ class AcothTest extends AllSetupTeardown
     /**
      * @dataProvider providerACOTH
      */
-    public function testACOTH(mixed $expectedResult, mixed $number): void
+    public function testACOTH(float|int|string $expectedResult, float|int|string $number): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CotTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CotTest.php
@@ -11,7 +11,7 @@ class CotTest extends AllSetupTeardown
     /**
      * @dataProvider providerCOT
      */
-    public function testCOT(mixed $expectedResult, mixed $angle): void
+    public function testCOT(float|int|string $expectedResult, float|int|string $angle): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CothTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CothTest.php
@@ -11,7 +11,7 @@ class CothTest extends AllSetupTeardown
     /**
      * @dataProvider providerCOTH
      */
-    public function testCOTH(mixed $expectedResult, mixed $angle): void
+    public function testCOTH(float|int|string $expectedResult, float|int|string $angle): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CscTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CscTest.php
@@ -11,7 +11,7 @@ class CscTest extends AllSetupTeardown
     /**
      * @dataProvider providerCSC
      */
-    public function testCSC(mixed $expectedResult, mixed $angle): void
+    public function testCSC(float|int|string $expectedResult, float|int|string $angle): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CschTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CschTest.php
@@ -11,7 +11,7 @@ class CschTest extends AllSetupTeardown
     /**
      * @dataProvider providerCSCH
      */
-    public function testCSCH(mixed $expectedResult, mixed $angle): void
+    public function testCSCH(float|int|string $expectedResult, float|int|string $angle): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/EvenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/EvenTest.php
@@ -11,7 +11,7 @@ class EvenTest extends AllSetupTeardown
     /**
      * @dataProvider providerEVEN
      */
-    public function testEVEN(mixed $expectedResult, mixed $value): void
+    public function testEVEN(int|string $expectedResult, float|int|string $value): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MRoundTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MRoundTest.php
@@ -11,7 +11,7 @@ class MRoundTest extends AllSetupTeardown
     /**
      * @dataProvider providerMROUND
      */
-    public function testMROUND(mixed $expectedResult, mixed $formula): void
+    public function testMROUND(float|int|string $expectedResult, string $formula): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MdeTermTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MdeTermTest.php
@@ -9,7 +9,7 @@ class MdeTermTest extends AllSetupTeardown
     /**
      * @dataProvider providerMDETERM
      */
-    public function testMDETERM2(mixed $expectedResult, mixed $matrix): void
+    public function testMDETERM2(float|int|string $expectedResult, array|int|float|string $matrix): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/OddTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/OddTest.php
@@ -11,7 +11,7 @@ class OddTest extends AllSetupTeardown
     /**
      * @dataProvider providerODD
      */
-    public function testODD(mixed $expectedResult, mixed $value): void
+    public function testODD(int|string $expectedResult, float|int|string $value): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RandBetweenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RandBetweenTest.php
@@ -11,7 +11,7 @@ class RandBetweenTest extends AllSetupTeardown
     /**
      * @dataProvider providerRANDBETWEEN
      */
-    public function testRANDBETWEEN(mixed $expectedResult, mixed $min = 'omitted', mixed $max = 'omitted'): void
+    public function testRANDBETWEEN(int|string $expectedResult, null|bool|int|string $min = 'omitted', null|bool|int|string $max = 'omitted'): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RomanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RomanTest.php
@@ -11,7 +11,7 @@ class RomanTest extends AllSetupTeardown
     /**
      * @dataProvider providerROMAN
      */
-    public function testROMAN(mixed $expectedResult, mixed $formula): void
+    public function testROMAN(string $expectedResult, string $formula): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundDownTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundDownTest.php
@@ -11,7 +11,7 @@ class RoundDownTest extends AllSetupTeardown
     /**
      * @dataProvider providerRoundDown
      */
-    public function testRoundDown(mixed $expectedResult, mixed $formula): void
+    public function testRoundDown(float|int|string $expectedResult, float|int|string $formula): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundTest.php
@@ -11,7 +11,7 @@ class RoundTest extends AllSetupTeardown
     /**
      * @dataProvider providerRound
      */
-    public function testRound(mixed $expectedResult, mixed $formula): void
+    public function testRound(float|int|string $expectedResult, float|int|string $formula): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundUpTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundUpTest.php
@@ -11,7 +11,7 @@ class RoundUpTest extends AllSetupTeardown
     /**
      * @dataProvider providerRoundUp
      */
-    public function testRoundUp(mixed $expectedResult, mixed $formula): void
+    public function testRoundUp(float|int|string $expectedResult, float|int|string $formula): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SecTest.php
@@ -11,7 +11,7 @@ class SecTest extends AllSetupTeardown
     /**
      * @dataProvider providerSEC
      */
-    public function testSEC(mixed $expectedResult, mixed $angle): void
+    public function testSEC(float|int|string $expectedResult, float|int|string $angle): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SechTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SechTest.php
@@ -11,7 +11,7 @@ class SechTest extends AllSetupTeardown
     /**
      * @dataProvider providerSECH
      */
-    public function testSECH(mixed $expectedResult, mixed $angle): void
+    public function testSECH(float|int|string $expectedResult, float|int|string $angle): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SignTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SignTest.php
@@ -11,7 +11,7 @@ class SignTest extends AllSetupTeardown
     /**
      * @dataProvider providerSIGN
      */
-    public function testSIGN(mixed $expectedResult, mixed $value): void
+    public function testSIGN(float|int|string $expectedResult, float|int|string $value): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SubTotalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SubTotalTest.php
@@ -9,7 +9,7 @@ class SubTotalTest extends AllSetupTeardown
     /**
      * @dataProvider providerSUBTOTAL
      */
-    public function testSubtotal(mixed $expectedResult, mixed $type): void
+    public function testSubtotal(float|int|string $expectedResult, float|int|string $type): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();
@@ -29,7 +29,7 @@ class SubTotalTest extends AllSetupTeardown
     /**
      * @dataProvider providerSUBTOTAL
      */
-    public function testSubtotalColumnHidden(mixed $expectedResult, mixed $type): void
+    public function testSubtotalColumnHidden(float|int|string $expectedResult, float|int|string $type): void
     {
         // Hidden columns don't affect calculation, only hidden rows
         $this->mightHaveException($expectedResult);
@@ -63,7 +63,7 @@ class SubTotalTest extends AllSetupTeardown
     /**
      * @dataProvider providerSUBTOTALHIDDEN
      */
-    public function testSubtotalRowHidden(mixed $expectedResult, mixed $type): void
+    public function testSubtotalRowHidden(mixed $expectedResult, int $type): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AllSetupTeardown.php
@@ -10,6 +10,7 @@ use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PHPUnit\Framework\TestCase;
+use Stringable;
 
 class AllSetupTeardown extends TestCase
 {
@@ -162,7 +163,9 @@ class AllSetupTeardown extends TestCase
             } else {
                 $formula .= $comma;
                 $comma = ',';
-                $formula .= $this->convertToString($arg);
+                /** @var string */
+                $argx = $arg;
+                $formula .= $this->convertToString($argx);
             }
         }
         $formula .= ')';
@@ -210,7 +213,7 @@ class AllSetupTeardown extends TestCase
         self::assertEqualsWithDelta($expectedResult, $sheet->getCell('Z99')->getCalculatedValue(), 1.0e-8, 'arguments supplied as ranges');
     }
 
-    private function convertToString(mixed $arg): string
+    private function convertToString(null|bool|float|int|string|Stringable $arg): string
     {
         if (is_string($arg)) {
             return '"' . $arg . '"';

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiDistLeftTailTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiDistLeftTailTest.php
@@ -29,6 +29,7 @@ class ChiDistLeftTailTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CHISQ.DIST({$values}, {$degrees}, false)";
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiInvLeftTailTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiInvLeftTailTest.php
@@ -28,6 +28,7 @@ class ChiInvLeftTailTest extends AllSetupTeardown
         $degrees = 7;
         $calculation = Calculation::getInstance();
         $formula = "=CHISQ.INV($probability, $degrees)";
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-8);
         $formula = "=CHISQ.DIST($result, $degrees)";

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiInvRightTailTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiInvRightTailTest.php
@@ -28,6 +28,7 @@ class ChiInvRightTailTest extends AllSetupTeardown
         $degrees = 7;
         $calculation = Calculation::getInstance();
         $formula = "=CHISQ.INV.RT($probability, $degrees)";
+        /** @var float|int|string */
         $result = $calculation->_calculateFormulaValue($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-8);
         $formula = "=CHISQ.DIST.RT($result, $degrees)";

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LinEstTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LinEstTest.php
@@ -13,7 +13,7 @@ class LinEstTest extends TestCase
     /**
      * @dataProvider providerLINEST
      */
-    public function testLINEST(array $expectedResult, mixed $yValues, mixed $xValues, mixed $const, mixed $stats): void
+    public function testLINEST(array $expectedResult, array $yValues, array $xValues, mixed $const, mixed $stats): void
     {
         $result = Statistical\Trends::LINEST($yValues, $xValues, $const, $stats);
         self::assertIsArray($result);

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogEstTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogEstTest.php
@@ -13,7 +13,7 @@ class LogEstTest extends TestCase
     /**
      * @dataProvider providerLOGEST
      */
-    public function testLOGEST(array $expectedResult, mixed $yValues, mixed $xValues, mixed $const, mixed $stats): void
+    public function testLOGEST(array $expectedResult, array $yValues, array $xValues, mixed $const, mixed $stats): void
     {
         $result = Statistical\Trends::LOGEST($yValues, $xValues, $const, $stats);
         self::assertIsArray($result);

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LeftTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LeftTest.php
@@ -42,7 +42,7 @@ class LeftTest extends AllSetupTeardown
     /**
      * @dataProvider providerLocaleLEFT
      */
-    public function testLowerWithLocaleBoolean(string $expectedResult, mixed $locale, mixed $value, mixed $characters): void
+    public function testLowerWithLocaleBoolean(string $expectedResult, string $locale, mixed $value, mixed $characters): void
     {
         $newLocale = Settings::setLocale($locale);
         if ($newLocale === false) {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LowerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LowerTest.php
@@ -34,7 +34,7 @@ class LowerTest extends AllSetupTeardown
     /**
      * @dataProvider providerLocaleLOWER
      */
-    public function testLowerWithLocaleBoolean(string $expectedResult, mixed $locale, mixed $value): void
+    public function testLowerWithLocaleBoolean(string $expectedResult, string $locale, mixed $value): void
     {
         $newLocale = Settings::setLocale($locale);
         if ($newLocale === false) {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/MidTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/MidTest.php
@@ -48,7 +48,7 @@ class MidTest extends AllSetupTeardown
     /**
      * @dataProvider providerLocaleMID
      */
-    public function testMiddleWithLocaleBoolean(string $expectedResult, mixed $locale, mixed $value, mixed $offset, mixed $characters): void
+    public function testMiddleWithLocaleBoolean(string $expectedResult, string $locale, mixed $value, mixed $offset, mixed $characters): void
     {
         $newLocale = Settings::setLocale($locale);
         if ($newLocale === false) {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ProperTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ProperTest.php
@@ -34,7 +34,7 @@ class ProperTest extends AllSetupTeardown
     /**
      * @dataProvider providerLocaleLOWER
      */
-    public function testLowerWithLocaleBoolean(string $expectedResult, mixed $locale, mixed $value): void
+    public function testLowerWithLocaleBoolean(string $expectedResult, string $locale, mixed $value): void
     {
         $newLocale = Settings::setLocale($locale);
         if ($newLocale === false) {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/RightTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/RightTest.php
@@ -42,7 +42,7 @@ class RightTest extends AllSetupTeardown
     /**
      * @dataProvider providerLocaleRIGHT
      */
-    public function testLowerWithLocaleBoolean(string $expectedResult, mixed $locale, mixed $value, mixed $characters): void
+    public function testLowerWithLocaleBoolean(string $expectedResult, string $locale, mixed $value, mixed $characters): void
     {
         $newLocale = Settings::setLocale($locale);
         if ($newLocale === false) {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/UpperTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/UpperTest.php
@@ -34,7 +34,7 @@ class UpperTest extends AllSetupTeardown
     /**
      * @dataProvider providerLocaleLOWER
      */
-    public function testLowerWithLocaleBoolean(string $expectedResult, mixed $locale, mixed $value): void
+    public function testLowerWithLocaleBoolean(string $expectedResult, string $locale, mixed $value): void
     {
         $newLocale = Settings::setLocale($locale);
         if ($newLocale === false) {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ValueToTextTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ValueToTextTest.php
@@ -12,7 +12,7 @@ class ValueToTextTest extends AllSetupTeardown
     /**
      * @dataProvider providerVALUE
      */
-    public function testVALUETOTEXT(mixed $expectedResult, mixed $value, mixed $format): void
+    public function testVALUETOTEXT(mixed $expectedResult, mixed $value, int|string $format): void
     {
         $sheet = $this->getSheet();
         $this->setCell('A1', $value);

--- a/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
@@ -86,7 +86,7 @@ class AdvancedValueBinderTest extends TestCase
     /**
      * @dataProvider currencyProvider
      */
-    public function testCurrency(mixed $value, mixed $valueBinded, mixed $thousandsSeparator, mixed $decimalSeparator, mixed $currencyCode): void
+    public function testCurrency(string $value, float $valueBinded, string $thousandsSeparator, string $decimalSeparator, string $currencyCode): void
     {
         StringHelper::setCurrencyCode($currencyCode);
         StringHelper::setDecimalSeparator($decimalSeparator);

--- a/tests/PhpSpreadsheetTests/Cell/CellAddressTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CellAddressTest.php
@@ -41,7 +41,7 @@ class CellAddressTest extends TestCase
     /**
      * @dataProvider providerCreateFromCellAddressException
      */
-    public function testCreateFromCellAddressException(mixed $cellAddress): void
+    public function testCreateFromCellAddressException(int|string $cellAddress): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(

--- a/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
@@ -14,7 +14,7 @@ class CoordinateTest extends TestCase
     /**
      * @dataProvider providerColumnString
      */
-    public function testColumnIndexFromString(mixed $expectedResult, mixed $string): void
+    public function testColumnIndexFromString(mixed $expectedResult, string $string): void
     {
         $columnIndex = Coordinate::columnIndexFromString($string);
         self::assertEquals($expectedResult, $columnIndex);
@@ -180,9 +180,9 @@ class CoordinateTest extends TestCase
     /**
      * @dataProvider providerAbsoluteReferences
      */
-    public function testAbsoluteReferenceFromString(mixed $expectedResult, mixed $rangeSet): void
+    public function testAbsoluteReferenceFromString(mixed $expectedResult, int|string $rangeSet): void
     {
-        $result = Coordinate::absoluteReference($rangeSet);
+        $result = Coordinate::absoluteReference((string) $rangeSet);
         self::assertEquals($expectedResult, $result);
     }
 
@@ -209,7 +209,7 @@ class CoordinateTest extends TestCase
     /**
      * @dataProvider providerSplitRange
      */
-    public function testSplitRange(mixed $expectedResult, string $rangeSet): void
+    public function testSplitRange(array $expectedResult, string $rangeSet): void
     {
         $result = Coordinate::splitRange($rangeSet);
         foreach ($result as $key => $split) {
@@ -229,7 +229,7 @@ class CoordinateTest extends TestCase
     /**
      * @dataProvider providerBuildRange
      */
-    public function testBuildRange(mixed $expectedResult, mixed $rangeSets): void
+    public function testBuildRange(mixed $expectedResult, array $rangeSets): void
     {
         $result = Coordinate::buildRange($rangeSets);
         self::assertEquals($expectedResult, $result);
@@ -368,7 +368,7 @@ class CoordinateTest extends TestCase
     /**
      * @dataProvider providerMergeRangesInCollection
      */
-    public function testMergeRangesInCollection(mixed $expectedResult, mixed $rangeSets): void
+    public function testMergeRangesInCollection(mixed $expectedResult, array $rangeSets): void
     {
         $result = Coordinate::mergeRangesInCollection($rangeSets);
         self::assertEquals($expectedResult, $result);

--- a/tests/PhpSpreadsheetTests/Custom/ComplexAssert.php
+++ b/tests/PhpSpreadsheetTests/Custom/ComplexAssert.php
@@ -53,7 +53,7 @@ class ComplexAssert extends TestCase
     public function assertComplexEquals(mixed $expected, mixed $actual, ?float $delta = null): bool
     {
         if ($expected === INF || (is_string($expected) && $expected[0] === '#')) {
-            return $this->testExpectedExceptions($expected, $actual);
+            return $this->testExpectedExceptions($expected, (is_string($actual) || is_float($actual)) ? $actual : 'neither string nor float');
         }
 
         if ($delta === null) {
@@ -90,7 +90,7 @@ class ComplexAssert extends TestCase
         return $this->errorMessage;
     }
 
-    public function runAssertComplexEquals(mixed $expected, mixed $actual, ?float $delta = null): void
+    public function runAssertComplexEquals(string $expected, array|float|string $actual, ?float $delta = null): void
     {
         self::assertTrue($this->assertComplexEquals($expected, $actual, $delta), $this->getErrorMessage());
     }

--- a/tests/PhpSpreadsheetTests/Document/PropertiesTest.php
+++ b/tests/PhpSpreadsheetTests/Document/PropertiesTest.php
@@ -47,7 +47,7 @@ class PropertiesTest extends TestCase
     /**
      * @dataProvider providerCreationTime
      */
-    public function testSetCreated(mixed $expectedCreationTime, mixed $created): void
+    public function testSetCreated(null|int $expectedCreationTime, null|int|string $created): void
     {
         $expectedCreationTime = $expectedCreationTime ?? $this->startTime;
 
@@ -76,7 +76,7 @@ class PropertiesTest extends TestCase
     /**
      * @dataProvider providerModifiedTime
      */
-    public function testSetModified(mixed $expectedModifiedTime, mixed $modified): void
+    public function testSetModified(mixed $expectedModifiedTime, null|int|string $modified): void
     {
         $expectedModifiedTime = $expectedModifiedTime ?? $this->startTime;
 
@@ -162,6 +162,7 @@ class PropertiesTest extends TestCase
         }
         self::assertTrue($this->properties->isCustomPropertySet($propertyName));
         self::assertSame($expectedType, $this->properties->getCustomPropertyType($propertyName));
+        /** @var float|int|string */
         $result = $this->properties->getCustomPropertyValue($propertyName);
         if ($expectedType === Properties::PROPERTY_TYPE_DATE) {
             $result = Date::formattedDateTimeFromTimestamp("$result", 'Y-m-d', new DateTimeZone('UTC'));

--- a/tests/PhpSpreadsheetTests/Functional/ReadFilterTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/ReadFilterTest.php
@@ -36,7 +36,7 @@ class ReadFilterTest extends AbstractFunctional
      *
      * @dataProvider providerCellsValues
      */
-    public function testXlsxLoadWithoutReadFilter(mixed $format, array $arrayData): void
+    public function testXlsxLoadWithoutReadFilter(string $format, array $arrayData): void
     {
         $spreadsheet = new Spreadsheet();
 
@@ -61,7 +61,7 @@ class ReadFilterTest extends AbstractFunctional
      *
      * @dataProvider providerCellsValues
      */
-    public function testXlsxLoadWithReadFilter(mixed $format, array $arrayData): void
+    public function testXlsxLoadWithReadFilter(string $format, array $arrayData): void
     {
         $spreadsheet = new Spreadsheet();
         $spreadsheet->getActiveSheet()->fromArray($arrayData, null, 'A1');

--- a/tests/PhpSpreadsheetTests/Helper/HtmlTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/HtmlTest.php
@@ -13,7 +13,7 @@ class HtmlTest extends TestCase
     /**
      * @dataProvider providerUtf8EncodingSupport
      */
-    public function testUtf8EncodingSupport(mixed $expected, mixed $input): void
+    public function testUtf8EncodingSupport(string $expected, string $input): void
     {
         $html = new Html();
         $actual = $html->toRichTextObject($input);

--- a/tests/PhpSpreadsheetTests/Reader/Ods/OdsPropertiesTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Ods/OdsPropertiesTest.php
@@ -58,6 +58,7 @@ class OdsPropertiesTest extends AbstractFunctional
         foreach ($customPropertySet as $propertyName => $testData) {
             self::assertTrue($properties->isCustomPropertySet($propertyName));
             self::assertSame($testData['type'], $properties->getCustomPropertyType($propertyName));
+            /** @var float|int|string */
             $result = $properties->getCustomPropertyValue($propertyName);
             if ($properties->getCustomPropertyType($propertyName) == Properties::PROPERTY_TYPE_DATE) {
                 $result = Date::formattedDateTimeFromTimestamp("$result", 'Y-m-d');
@@ -103,6 +104,7 @@ class OdsPropertiesTest extends AbstractFunctional
         foreach ($customPropertySet as $propertyName => $testData) {
             self::assertTrue($properties->isCustomPropertySet($propertyName));
             self::assertSame($testData['type'], $properties->getCustomPropertyType($propertyName));
+            /** @var float|int|string */
             $result = $properties->getCustomPropertyValue($propertyName);
             if ($properties->getCustomPropertyType($propertyName) == Properties::PROPERTY_TYPE_DATE) {
                 $result = Date::formattedDateTimeFromTimestamp("$result", 'Y-m-d');

--- a/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
@@ -16,7 +16,7 @@ class XmlScannerTest extends TestCase
     /**
      * @dataProvider providerValidXML
      */
-    public function testValidXML(mixed $filename, mixed $expectedResult): void
+    public function testValidXML(string $filename, string $expectedResult): void
     {
         $reader = XmlScanner::getInstance(new \PhpOffice\PhpSpreadsheet\Reader\Xml());
         $result = $reader->scanFile($filename);
@@ -40,7 +40,7 @@ class XmlScannerTest extends TestCase
     /**
      * @dataProvider providerInvalidXML
      */
-    public function testInvalidXML(mixed $filename): void
+    public function testInvalidXML(string $filename): void
     {
         $this->expectException(ReaderException::class);
 
@@ -93,7 +93,7 @@ class XmlScannerTest extends TestCase
     /**
      * @dataProvider providerValidXMLForCallback
      */
-    public function testSecurityScanWithCallback(mixed $filename, mixed $expectedResult): void
+    public function testSecurityScanWithCallback(string $filename, string $expectedResult): void
     {
         $fileReader = new Xlsx();
         $scanner = $fileReader->getSecurityScannerOrThrow();

--- a/tests/PhpSpreadsheetTests/Reader/Xls/RichTextSizeTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xls/RichTextSizeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Xls;
 
 use PhpOffice\PhpSpreadsheet\Reader\Xls;
+use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
 class RichTextSizeTest extends AbstractFunctional
@@ -16,8 +17,9 @@ class RichTextSizeTest extends AbstractFunctional
         $spreadsheet = $reader->load($filename);
         $sheet = $spreadsheet->getSheetByNameOrThrow('橱柜门板');
         $text = $sheet->getCell('L15')->getValue();
+        self::assertInstanceOf(RichText::class, $text);
         $elements = $text->getRichTextElements();
-        self::assertEquals(10, $elements[2]->getFont()->getSize());
+        self::assertEquals(10, $elements[2]->getFont()?->getSize());
         $spreadsheet->disconnectWorksheets();
     }
 }

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/PropertiesTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/PropertiesTest.php
@@ -45,6 +45,7 @@ class PropertiesTest extends AbstractFunctional
         foreach ($customPropertySet as $propertyName => $testData) {
             self::assertTrue($properties->isCustomPropertySet($propertyName));
             self::assertSame($testData['type'], $properties->getCustomPropertyType($propertyName));
+            /** @var float|int */
             $result = $properties->getCustomPropertyValue($propertyName);
             if ($properties->getCustomPropertyType($propertyName) == Properties::PROPERTY_TYPE_DATE) {
                 $result = Date::formattedDateTimeFromTimestamp("$result", 'Y-m-d', new DateTimeZone('UTC'));
@@ -87,6 +88,7 @@ class PropertiesTest extends AbstractFunctional
         foreach ($customPropertySet as $propertyName => $testData) {
             self::assertTrue($properties->isCustomPropertySet($propertyName));
             self::assertSame($testData['type'], $properties->getCustomPropertyType($propertyName));
+            /** @var float|int */
             $result = $properties->getCustomPropertyValue($propertyName);
             if ($properties->getCustomPropertyType($propertyName) == Properties::PROPERTY_TYPE_DATE) {
                 $result = Date::formattedDateTimeFromTimestamp("$result", 'Y-m-d', new DateTimeZone('UTC'));

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxRootZipFilesTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxRootZipFilesTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
+use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PHPUnit\Framework\TestCase;
 
 class XlsxRootZipFilesTest extends TestCase
@@ -17,6 +18,7 @@ class XlsxRootZipFilesTest extends TestCase
         $reader = new Xlsx();
         $spreadsheet = $reader->load($filename);
         $sheet = $spreadsheet->getActiveSheet();
+        /** @var RichText */
         $value = $sheet->getCell('A1')->getValue();
         self::assertSame('TEST CELL', $value->getPlainText());
     }

--- a/tests/PhpSpreadsheetTests/Reader/Xml/XmlLoadTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/XmlLoadTest.php
@@ -66,6 +66,7 @@ class XmlLoadTest extends TestCase
         self::assertEquals('2010-09-03T21:48:39Z', $result);
         self::assertEquals('AbCd1234', $props->getCustomPropertyValue('my_API_Token'));
         self::assertEquals('2', $props->getCustomPropertyValue('myאInt'));
+        /** @var string */
         $creationDate = $props->getCustomPropertyValue('my_API_Token_Expiry');
         $result = Date::formattedDateTimeFromTimestamp("$creationDate", 'Y-m-d\\TH:i:s\\Z', new DateTimeZone('UTC'));
         self::assertEquals('2019-01-31T07:00:00Z', $result);

--- a/tests/PhpSpreadsheetTests/Shared/CodePageTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/CodePageTest.php
@@ -12,8 +12,10 @@ class CodePageTest extends TestCase
 {
     /**
      * @dataProvider providerCodePage
+     *
+     * @param string|string[] $expectedResult
      */
-    public function testCodePageNumberToName(mixed $expectedResult, mixed $codePageIndex): void
+    public function testCodePageNumberToName(array|string $expectedResult, int $codePageIndex): void
     {
         if ($expectedResult === 'exception') {
             $this->expectException(Exception::class);

--- a/tests/PhpSpreadsheetTests/Shared/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/DateTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Shared;
 
+use DateTimeInterface;
 use DateTimeZone;
 use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
@@ -51,9 +52,9 @@ class DateTest extends TestCase
     /**
      * @dataProvider providerDateTimeExcelToTimestamp1900
      */
-    public function testDateTimeExcelToTimestamp1900(mixed $expectedResult, mixed $excelDateTimeValue): void
+    public function testDateTimeExcelToTimestamp1900(float|int $expectedResult, float|int $excelDateTimeValue): void
     {
-        if (is_numeric($expectedResult) && ($expectedResult > PHP_INT_MAX || $expectedResult < PHP_INT_MIN)) {
+        if ($expectedResult > PHP_INT_MAX || $expectedResult < PHP_INT_MIN) {
             self::markTestSkipped('Test invalid on 32-bit system.');
         }
         Date::setExcelCalendar(Date::CALENDAR_WINDOWS_1900);
@@ -70,7 +71,7 @@ class DateTest extends TestCase
     /**
      * @dataProvider providerDateTimeTimestampToExcel1900
      */
-    public function testDateTimeTimestampToExcel1900(mixed $expectedResult, mixed $unixTimestamp): void
+    public function testDateTimeTimestampToExcel1900(float|int $expectedResult, float|int|string $unixTimestamp): void
     {
         Date::setExcelCalendar(Date::CALENDAR_WINDOWS_1900);
 
@@ -86,7 +87,7 @@ class DateTest extends TestCase
     /**
      * @dataProvider providerDateTimeDateTimeToExcel
      */
-    public function testDateTimeDateTimeToExcel(mixed $expectedResult, mixed $dateTimeObject): void
+    public function testDateTimeDateTimeToExcel(float|int $expectedResult, DateTimeInterface $dateTimeObject): void
     {
         Date::setExcelCalendar(Date::CALENDAR_WINDOWS_1900);
 
@@ -101,12 +102,14 @@ class DateTest extends TestCase
 
     /**
      * @dataProvider providerDateTimeFormattedPHPToExcel1900
+     *
+     * @param array{0: int, 1: int, 2: int, 3: int, 4: int, 5: float|int} $args Array containing year/month/day/hours/minutes/seconds
      */
-    public function testDateTimeFormattedPHPToExcel1900(mixed $expectedResult, mixed ...$args): void
+    public function testDateTimeFormattedPHPToExcel1900(mixed $expectedResult, ...$args): void
     {
         Date::setExcelCalendar(Date::CALENDAR_WINDOWS_1900);
 
-        $result = Date::formattedPHPToExcel(...$args);
+        $result = Date::formattedPHPToExcel(...$args); // @phpstan-ignore-line
         self::assertEqualsWithDelta($expectedResult, $result, 1E-5);
     }
 
@@ -118,9 +121,9 @@ class DateTest extends TestCase
     /**
      * @dataProvider providerDateTimeExcelToTimestamp1904
      */
-    public function testDateTimeExcelToTimestamp1904(mixed $expectedResult, mixed $excelDateTimeValue): void
+    public function testDateTimeExcelToTimestamp1904(float|int $expectedResult, float|int $excelDateTimeValue): void
     {
-        if (is_numeric($expectedResult) && ($expectedResult > PHP_INT_MAX || $expectedResult < PHP_INT_MIN)) {
+        if ($expectedResult > PHP_INT_MAX || $expectedResult < PHP_INT_MIN) {
             self::markTestSkipped('Test invalid on 32-bit system.');
         }
         Date::setExcelCalendar(Date::CALENDAR_MAC_1904);
@@ -137,7 +140,7 @@ class DateTest extends TestCase
     /**
      * @dataProvider providerDateTimeTimestampToExcel1904
      */
-    public function testDateTimeTimestampToExcel1904(mixed $expectedResult, mixed $unixTimestamp): void
+    public function testDateTimeTimestampToExcel1904(mixed $expectedResult, float|int|string $unixTimestamp): void
     {
         Date::setExcelCalendar(Date::CALENDAR_MAC_1904);
 
@@ -167,7 +170,7 @@ class DateTest extends TestCase
     /**
      * @dataProvider providerDateTimeExcelToTimestamp1900Timezone
      */
-    public function testDateTimeExcelToTimestamp1900Timezone(mixed $expectedResult, mixed $excelDateTimeValue, mixed $timezone): void
+    public function testDateTimeExcelToTimestamp1900Timezone(int $expectedResult, float|int $excelDateTimeValue, string $timezone): void
     {
         if (is_numeric($expectedResult) && ($expectedResult > PHP_INT_MAX || $expectedResult < PHP_INT_MIN)) {
             self::markTestSkipped('Test invalid on 32-bit system.');
@@ -206,6 +209,7 @@ class DateTest extends TestCase
         $spreadsheet = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
         $sheet->setCellValue('B1', 'x');
+        /** @var float|int|string */
         $val = $sheet->getCell('B1')->getValue();
         self::assertFalse(Date::timestampToExcel($val));
 

--- a/tests/PhpSpreadsheetTests/Shared/FontTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/FontTest.php
@@ -44,7 +44,7 @@ class FontTest extends TestCase
     /**
      * @dataProvider providerFontSizeToPixels
      */
-    public function testFontSizeToPixels(mixed $expectedResult, mixed $size): void
+    public function testFontSizeToPixels(float|int $expectedResult, float|int $size): void
     {
         $result = Font::fontSizeToPixels($size);
         self::assertEquals($expectedResult, $result);
@@ -58,7 +58,7 @@ class FontTest extends TestCase
     /**
      * @dataProvider providerInchSizeToPixels
      */
-    public function testInchSizeToPixels(mixed $expectedResult, mixed $size): void
+    public function testInchSizeToPixels(float|int $expectedResult, float|int $size): void
     {
         $result = Font::inchSizeToPixels($size);
         self::assertEqualsWithDelta($expectedResult, $result, self::FONT_PRECISION);
@@ -72,7 +72,7 @@ class FontTest extends TestCase
     /**
      * @dataProvider providerCentimeterSizeToPixels
      */
-    public function testCentimeterSizeToPixels(mixed $expectedResult, mixed $size): void
+    public function testCentimeterSizeToPixels(float $expectedResult, float $size): void
     {
         $result = Font::centimeterSizeToPixels($size);
         self::assertEqualsWithDelta($expectedResult, $result, self::FONT_PRECISION);

--- a/tests/PhpSpreadsheetTests/Shared/StringHelperInvalidCharTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/StringHelperInvalidCharTest.php
@@ -36,6 +36,7 @@ class StringHelperInvalidCharTest extends TestCase
             self::assertSame($value[1] === $value[2], StringHelper::isUTF8((string) $value[1]));
             ++$row;
             $expected = $value[2];
+            self::assertIsString($sheet->getCell("A$row")->getValue());
             self::assertSame(
                 $expected,
                 $sheet->getCell("B$row")->getValue(),

--- a/tests/PhpSpreadsheetTests/Shared/Trend/ExponentialBestFitTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/Trend/ExponentialBestFitTest.php
@@ -11,14 +11,17 @@ class ExponentialBestFitTest extends TestCase
 {
     /**
      * @dataProvider providerExponentialBestFit
+     *
+     * @param array<float> $yValues
+     * @param array<float> $xValues
      */
     public function testExponentialBestFit(
-        mixed $expectedSlope,
-        mixed $expectedIntersect,
-        mixed $expectedGoodnessOfFit,
+        array $expectedSlope,
+        array $expectedIntersect,
+        array $expectedGoodnessOfFit,
         mixed $expectedEquation,
-        mixed $yValues,
-        mixed $xValues
+        array $yValues,
+        array $xValues
     ): void {
         $bestFit = new ExponentialBestFit($yValues, $xValues);
         $slope = $bestFit->getSlope(1);

--- a/tests/PhpSpreadsheetTests/Shared/Trend/LinearBestFitTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/Trend/LinearBestFitTest.php
@@ -13,14 +13,17 @@ class LinearBestFitTest extends TestCase
 
     /**
      * @dataProvider providerLinearBestFit
+     *
+     * @param array<float> $yValues
+     * @param array<float> $xValues
      */
     public function testLinearBestFit(
-        mixed $expectedSlope,
-        mixed $expectedIntersect,
-        mixed $expectedGoodnessOfFit,
+        array $expectedSlope,
+        array $expectedIntersect,
+        array $expectedGoodnessOfFit,
         mixed $expectedEquation,
-        mixed $yValues,
-        mixed $xValues
+        array $yValues,
+        array $xValues
     ): void {
         $bestFit = new LinearBestFit($yValues, $xValues);
         $slope = $bestFit->getSlope(1);

--- a/tests/PhpSpreadsheetTests/Style/ColorTest.php
+++ b/tests/PhpSpreadsheetTests/Style/ColorTest.php
@@ -133,9 +133,9 @@ class ColorTest extends TestCase
     /**
      * @dataProvider providerColorChangeBrightness
      */
-    public function testChangeBrightness(mixed $expectedResult, mixed ...$args): void
+    public function testChangeBrightness(string $expectedResult, string $hexColorValue, float $adjustPercentages): void
     {
-        $result = Color::changeBrightness(...$args);
+        $result = Color::changeBrightness($hexColorValue, $adjustPercentages);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/DateGroupTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/DateGroupTest.php
@@ -128,6 +128,7 @@ class DateGroupTest extends SetupTeardown
     {
         $year = 2011;
         $sheet = $this->initSheet($year);
+        /** @var int|string */
         $cellA2 = $sheet->getCell('A2')->getCalculatedValue();
         $columnFilter = $sheet->getAutoFilter()->getColumn('C');
         $columnFilter->setFilterType(Column::AUTOFILTER_FILTERTYPE_FILTER);

--- a/tests/PhpSpreadsheetTests/Writer/Html/HtmlNumberFormatTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/HtmlNumberFormatTest.php
@@ -138,7 +138,7 @@ class HtmlNumberFormatTest extends Functional\AbstractFunctional
     /**
      * @dataProvider providerNumberFormat
      */
-    public function testFormatValueWithMask(mixed $expectedResult, mixed $val, mixed $fmt): void
+    public function testFormatValueWithMask(mixed $expectedResult, mixed $val, string $fmt): void
     {
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
@@ -170,7 +170,7 @@ class HtmlNumberFormatTest extends Functional\AbstractFunctional
     /**
      * @dataProvider providerNumberFormatDates
      */
-    public function testFormatValueWithMaskDate(mixed $expectedResult, mixed $val, mixed $fmt): void
+    public function testFormatValueWithMaskDate(mixed $expectedResult, mixed $val, string $fmt): void
     {
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();

--- a/tests/PhpSpreadsheetTests/Writer/Xls/WorkbookTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/WorkbookTest.php
@@ -77,6 +77,7 @@ class WorkbookTest extends TestCase
         $propertyPalette->setAccessible(true);
 
         $palette = $propertyPalette->getValue($this->workbook);
+        self::assertIsArray($palette);
 
         $newColor1 = [0x00, 0x00, 0x01, 0x00];
         $newColor2 = [0x00, 0x00, 0x02, 0x00];

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/ArrayFormulaPrefixTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/ArrayFormulaPrefixTest.php
@@ -38,6 +38,7 @@ class ArrayFormulaPrefixTest extends AbstractFunctional
         //Write formula
         $cell = $worksheet->getCell('A7');
         $cell->setValueExplicit('=TEXTJOIN("",TRUE,IF(ISNUMBER(A1:A6), A1:A6,""))', DataType::TYPE_FORMULA);
+        /** @var array<string, string> */
         $attrs = $cell->getFormulaAttributes();
         $attrs['t'] = 'array';
         $cell->setFormulaAttributes($attrs);
@@ -74,6 +75,7 @@ class ArrayFormulaPrefixTest extends AbstractFunctional
         //Write formula
         $cell = $worksheet->getCell('A7');
         $cell->setValueExplicit('=SUM(LEN(A1:A6))', DataType::TYPE_FORMULA);
+        /** @var array<string, string> */
         $attrs = $cell->getFormulaAttributes();
         $attrs['t'] = 'array';
         $cell->setFormulaAttributes($attrs);


### PR DESCRIPTION
Change "mixed" declarations to more accurate types in test members; in particular, change those that would be flagged if we were to run Phpstan at level 9 (we currently run level 8). I may or may not follow up with source code (over 700 level-9 problems remain for src), but, as with strict typing, there is no reason to avoid the effort for test members.

It was necessary to update some doc blocks in src to accommodate this change. However, no executable code is touched.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] code quality

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
