### PR TITLE
IF Empty Arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## Unreleased - TBD
 
+### Added
+
+- Nothing
+
+### Changed
+
+- Nothing
+
+### Deprecated
+
+- Nothing
+
+### Removed
+
+- Nothing
+
+### Fixed
+
+- IF Empty Arguments. [Issue #3875](https://github.com/PHPOffice/PhpSpreadsheet/issues/3875) [Issue #2146](https://github.com/PHPOffice/PhpSpreadsheet/issues/2146) [PR #3879](https://github.com/PHPOffice/PhpSpreadsheet/pull/3879)
+
+## 2.0.0 - 2024-01-04
+
 ### BREAKING CHANGE
 
 - Typing was strengthened by leveraging native typing. This should not change any behavior. However, if you implement

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -1307,7 +1307,7 @@ class Calculation
         'IF' => [
             'category' => Category::CATEGORY_LOGICAL,
             'functionCall' => [Logical\Conditional::class, 'statementIf'],
-            'argumentCount' => '1-3',
+            'argumentCount' => '2-3',
         ],
         'IFERROR' => [
             'category' => Category::CATEGORY_LOGICAL,
@@ -4189,7 +4189,7 @@ class Calculation
                 //    If we've a comma when we're expecting an operand, then what we actually have is a null operand;
                 //        so push a null onto the stack
                 if (($expectingOperand) || (!$expectingOperator)) {
-                    $output[] = ['type' => 'Empty Argument', 'value' => self::$excelConstants['NULL'], 'reference' => 'NULL'];
+                    $output[] = $stack->getStackItem('Empty Argument', null, 'NULL');
                 }
                 // make sure there was a function
                 $d = $stack->last(2);
@@ -4436,7 +4436,7 @@ class Calculation
                 ++$index;
             } elseif ($opCharacter === ')') { // miscellaneous error checking
                 if ($expectingOperand) {
-                    $output[] = ['type' => 'Empty Argument', 'value' => self::$excelConstants['NULL'], 'reference' => 'NULL'];
+                    $output[] = $stack->getStackItem('Empty Argument', null, 'NULL');
                     $expectingOperand = false;
                     $expectingOperator = true;
                 } else {
@@ -4996,11 +4996,12 @@ class Calculation
                                 }
                             }
                         } else {
-                            $emptyArguments[] = ($arg['type'] === 'Empty Argument');
-                            if ($arg['type'] === 'Empty Argument' && in_array($functionName, ['MIN', 'MINA', 'MAX', 'MAXA'], true)) {
+                            if ($arg['type'] === 'Empty Argument' && in_array($functionName, ['MIN', 'MINA', 'MAX', 'MAXA', 'IF'], true)) {
+                                $emptyArguments[] = false;
                                 $args[] = $arg['value'] = 0;
                                 $this->debugLog->writeDebugLog('Empty Argument reevaluated as 0');
                             } else {
+                                $emptyArguments[] = $arg['type'] === 'Empty Argument';
                                 $args[] = self::unwrapResult($arg['value']);
                             }
                             if ($functionName !== 'MKMATRIX') {

--- a/tests/PhpSpreadsheetTests/Calculation/MissingArgumentsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/MissingArgumentsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalcExp;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit\Framework\TestCase;
 
@@ -17,7 +18,14 @@ class MissingArgumentsTest extends TestCase
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
         $sheet->getCell('A1')->setValue($formula);
-        self::assertSame($expected, $sheet->getCell('A1')->getCalculatedValue());
+        $sheet->getCell('B1')->setValue(1);
+
+        try {
+            self::assertSame($expected, $sheet->getCell('A1')->getCalculatedValue());
+        } catch (CalcExp $e) {
+            self::assertSame('exception', $expected);
+        }
+
         $spreadsheet->disconnectWorksheets();
     }
 
@@ -35,6 +43,20 @@ class MissingArgumentsTest extends TestCase
             'product ignores null argument' => [6.0, '=product(3,2,)'],
             'embedded function' => [5, '=sum(3,2,min(3,2,))'],
             'unaffected embedded function' => [8, '=sum(3,2,max(3,2,))'],
+            'if true missing at end' => [0, '=if(b1=1,min(3,2,),product(3,2,))'],
+            'if false missing at end' => [6.0, '=if(b1=2,min(3,2,),product(3,2,))'],
+            'if true missing in middle' => [0, '=if(b1=1,min(3,,2),product(3,,2))'],
+            'if false missing in middle' => [6.0, '=if(b1=2,min(3,,2),product(3,,2))'],
+            'if true missing at beginning' => [0, '=if(b1=1,min(,3,2),product(,3,2))'],
+            'if false missing at beginning' => [6.0, '=if(b1=2,min(,3,2),product(,3,2))'],
+            'if true nothing missing' => [2, '=if(b1=1,min(3,2),product(3,2))'],
+            'if false nothing missing' => [6.0, '=if(b1=2,min(3,2),product(3,2))'],
+            'if true empty arg' => [0, '=if(b1=1,)'],
+            'if true omitted args' => ['exception', '=if(b1=1)'],
+            'if true missing arg' => [0, '=if(b1=1,,6)'],
+            'if false missing arg' => [0, '=if(b1=2,6,)'],
+            'if false omitted arg' => [false, '=if(b1=2,6)'],
+            'multiple ifs and omissions' => [0, '=IF(0<9,,IF(0=0,,1))'],
         ];
     }
 }


### PR DESCRIPTION
Fix #3875. Even better, fix #2146, which has been open for 2.5 years.

Empty arguments are improperly placed on the stack; in particular, they are added without `onlyIf` and `onlyIfNot` attributes.This results in problems described in 3875.

IF has a somewhat unexpected design. In Excel, `IF(false, valueIfTrue)` evaluates as `false`, but `IF(false, valueIfTrue,)` evaluates as 0. This means that IF empty arguments should be handled in the same manner as MIN/MAX/MINA/MAXA, but you need to be careful to distinguish empty from omitted.

Also note that IF requires 2 operands - `IF(true)` is an error, but `IF(true,)` evaluates to 0.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
