### PR TITLE
Fix spelling of `Xlxs` in class names

### DIFF
--- a/samples/Basic/28_Iterator.php
+++ b/samples/Basic/28_Iterator.php
@@ -1,19 +1,19 @@
 <?php
 
-use PhpOffice\PhpSpreadsheet\Reader\Xlsx as XLsxReader;
-use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XLsxWriter;
+use PhpOffice\PhpSpreadsheet\Reader\Xlsx as XlsxReader;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
 
 require __DIR__ . '/../Header.php';
 
 $sampleSpreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 $filename = $helper->getTemporaryFilename();
-$writer = new XLsxWriter($sampleSpreadsheet);
+$writer = new XlsxWriter($sampleSpreadsheet);
 $callStartTime = microtime(true);
 $writer->save($filename);
 $helper->logWrite($writer, $filename, $callStartTime);
 
 $callStartTime = microtime(true);
-$reader = new XLsxReader();
+$reader = new XlsxReader();
 $spreadsheet = $reader->load($filename);
 $helper->logRead('Xlsx', $filename, $callStartTime);
 unlink($filename);


### PR DESCRIPTION
While not making a functional difference, it's nice to follow naming conventions.

This was discovered when reviewing https://github.com/PHPOffice/PhpSpreadsheet/pull/3887/files#diff-923ac4c5046834ceb5d9bbf617347caa125bbf85f29c62e36ed87d1fe99dd4ea.