### PR TITLE
Floating Point and Php Nightly 8.4

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Financial/Amortization.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Amortization.php
@@ -9,6 +9,8 @@ use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 
 class Amortization
 {
+    private const ROUNDING_ADJUSTMENT = (PHP_VERSION_ID < 80400) ? 0 : 1e-14;
+
     /**
      * AMORDEGRC.
      *
@@ -80,6 +82,7 @@ class Amortization
         $amortiseCoeff = self::getAmortizationCoefficient($rate);
 
         $rate *= $amortiseCoeff;
+        $rate += self::ROUNDING_ADJUSTMENT;
         $fNRate = round($yearFrac * $rate * $cost, 0);
         $cost -= $fNRate;
         $fRest = $cost - $salvage;

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Round.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Round.php
@@ -10,6 +10,8 @@ class Round
 {
     use ArrayEnabled;
 
+    private const ROUNDING_ADJUSTMENT = (PHP_VERSION_ID < 80400) ? 0 : 1e-14;
+
     /**
      * ROUND.
      *
@@ -68,10 +70,10 @@ class Round
         }
 
         if ($number < 0.0) {
-            return round($number - 0.5 * 0.1 ** $digits, $digits, PHP_ROUND_HALF_DOWN);
+            return round($number - 0.5 * 0.1 ** $digits + self::ROUNDING_ADJUSTMENT, $digits, PHP_ROUND_HALF_DOWN);
         }
 
-        return round($number + 0.5 * 0.1 ** $digits, $digits, PHP_ROUND_HALF_DOWN);
+        return round($number + 0.5 * 0.1 ** $digits - self::ROUNDING_ADJUSTMENT, $digits, PHP_ROUND_HALF_DOWN);
     }
 
     /**
@@ -104,10 +106,10 @@ class Round
         }
 
         if ($number < 0.0) {
-            return round($number + 0.5 * 0.1 ** $digits, $digits, PHP_ROUND_HALF_UP);
+            return round($number + 0.5 * 0.1 ** $digits - self::ROUNDING_ADJUSTMENT, $digits, PHP_ROUND_HALF_UP);
         }
 
-        return round($number - 0.5 * 0.1 ** $digits, $digits, PHP_ROUND_HALF_UP);
+        return round($number - 0.5 * 0.1 ** $digits + self::ROUNDING_ADJUSTMENT, $digits, PHP_ROUND_HALF_UP);
     }
 
     /**


### PR DESCRIPTION
Fix #3896. It appears that floating-point arithmetic will give different results in Php 8.4 vs. all earlier releases. This causes tests to fail in the nightly run for ROUNDDOWN, ROUNDUP, and AMORDEGRC. I imagine this won't be the last we hear of this. The failures are a distraction when reviewing PR's. This PR eliminates the distraction by adding in a fudge factor for Php 8.4+ while not changing Php 8.3-. It is not a particularly robust solution, but it should be stable for Php 8.3-, and good enough for Php 8.4+ while I study if a better solution is available.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
