### PR TITLE
Handling of User-supplied Decimal and Thousands Separators

### DIFF
--- a/src/PhpSpreadsheet/Style/NumberFormat/BaseFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/BaseFormatter.php
@@ -17,7 +17,7 @@ abstract class BaseFormatter
         $thousandsSeparator = StringHelper::getThousandsSeparator();
         $decimalSeparator = StringHelper::getDecimalSeparator();
         if ($thousandsSeparator !== ',' || $decimalSeparator !== '.') {
-            $value = str_replace(['.', ',', "\u{fffd}"], ["\u{fffd}", '.', ','], $value);
+            $value = str_replace(['.', ',', "\u{fffd}"], ["\u{fffd}", $thousandsSeparator, $decimalSeparator], $value);
         }
 
         return $value;

--- a/tests/PhpSpreadsheetTests/Shared/StringHelperTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/StringHelperTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Shared;
 
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Csv;
 use PHPUnit\Framework\TestCase;
 
 class StringHelperTest extends TestCase
@@ -97,5 +99,25 @@ class StringHelperTest extends TestCase
         $result = StringHelper::SYLKtoUTF8("foo\x1B ;bar");
 
         self::assertEquals($expectedResult, $result);
+    }
+
+    public function testIssue3900(): void
+    {
+        StringHelper::setDecimalSeparator('.');
+        StringHelper::setThousandsSeparator('');
+
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 1.4);
+        $sheet->setCellValue('B1', 1004.5);
+        $sheet->setCellValue('C1', 1000000.5);
+
+        ob_start();
+        $ioWriter = new Csv($spreadsheet);
+        $ioWriter->setDelimiter(';');
+        $ioWriter->save('php://output');
+        $output = ob_get_clean();
+        $spreadsheet->disconnectWorksheets();
+        self::assertSame('"1.4";"1004.5";"1000000.5"' . PHP_EOL, $output);
     }
 }


### PR DESCRIPTION
Fix #3900. The code to adjust Decimal and Thousands separators to user-specified choices expects to convert periods to commas and vice versa - hard-coded without taking the user specification into account. This is likely to be the only significant use case, however, as the issue demonstrates, it is not the only possibility. In particular, it will mess up Csv output if decimal separator is kept as period, but thousands separator is set to null string. The code is altered to replace period with the user-selected decimal separator, and comma with the user-selected thousands separator. No existing tests broke as a result of this change in behavior.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
