### PR TITLE
add date format `dd-mm-yyyy` in NumberFormat.php

### DIFF
--- a/src/PhpSpreadsheet/Style/NumberFormat.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat.php
@@ -23,6 +23,7 @@ class NumberFormat extends Supervisor
     const FORMAT_DATE_DDMMYYYY = 'dd/mm/yyyy';
     const FORMAT_DATE_DMYSLASH = 'd/m/yy';
     const FORMAT_DATE_DMYMINUS = 'd-m-yy';
+    const FORMAT_DATE_DDMMYYYYMINUS = 'dd-mm-yyyy';
     const FORMAT_DATE_DMMINUS = 'd-m';
     const FORMAT_DATE_MYMINUS = 'm-yy';
     const FORMAT_DATE_XLSX14 = 'mm-dd-yy';
@@ -46,6 +47,7 @@ class NumberFormat extends Supervisor
         self::FORMAT_DATE_DDMMYYYY,
         self::FORMAT_DATE_DMYSLASH,
         self::FORMAT_DATE_DMYMINUS,
+        self::FORMAT_DATE_DDMMYYYYMINUS,
         self::FORMAT_DATE_DMMINUS,
         self::FORMAT_DATE_MYMINUS,
         self::FORMAT_DATE_XLSX14,


### PR DESCRIPTION
added FORMAT_DATE_DDMMYYYYMINUS = 'dd-mm-yyyy'

This is:

- [ ] a bugfix
- [*] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [*] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

To use data format of 'dd-mm-yyyy'
