### PR TITLE
Invalid Builtin Defined Name in Xls Reader

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -2740,6 +2740,7 @@ class Xls extends BaseReader
                 $formula = $this->getFormulaFromStructure($formulaStructure);
             } catch (PhpSpreadsheetException) {
                 $formula = '';
+                $isBuiltInName = 0;
             }
 
             $this->definedname[] = [


### PR DESCRIPTION
Fix #3935. Xls Reader cannot parse user's spreadsheet, failing on a token of 3d. I believe that, according to https://msopenspecs.azureedge.net/files/MS-XLS/%5bMS-XLS%5d.pdf, this represents a PtgAreaErr3d, i.e. an invalid reference. User cannot provide spreadsheet, but was quite forthcoming in providing additional debugging information. I am usually reluctant to make changes without a test case, however, in this case, the action being taken (treat "builtin" defined name as "not builtin" when it cannot be parsed) makes sense, and it satisfies the user's processing.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
