### PR TITLE
Hidden Rows and Columns - Tcpdf and Mpdf

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -24,7 +24,7 @@ tools:
         timeout: 600
 
 build_failure_conditions:
-    - 'elements.rating(<= C).new.exists'                        # No new classes/methods with a rating of C or worse allowed
+    - 'elements.rating(<= D).new.exists'                        # No new classes/methods with a rating of D or worse allowed
     - 'issues.severity(>= MAJOR).new.exists'                    # New issues of major or higher severity
     - 'project.metric_change("scrutinizer.test_coverage", < 0)' # Code Coverage decreased from previous inspection
     - 'patches.label("Unused Use Statements").new.exists'       # No new unused imports patches allowed

--- a/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
@@ -10,6 +10,11 @@ class Mpdf extends Pdf
     public const SIMULATED_BODY_START = '<!-- simulated body start -->';
     private const BODY_TAG = '<body>';
 
+    /**
+     * Is the current writer creating mPDF?
+     *
+     * @deprecated 2.0.1 use instanceof Mpdf instead
+     */
     protected bool $isMPdf = true;
 
     /**

--- a/tests/PhpSpreadsheetTests/Writer/Dompdf/HideTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Dompdf/HideTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Dompdf;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Pdf\Dompdf;
+use PHPUnit\Framework\TestCase;
+
+class HideTest extends TestCase
+{
+    public function testHide(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray([
+            ['a1', 'b1', 'c1', 'd1', 'e1', 'f1'],
+            ['a2', 'b2', 'c2', 'd2', 'e2', 'f2'],
+            ['a3', 'b3', 'c3', 'd3', 'e3', 'f3'],
+            ['a4', 'b4', 'c4', 'd4', 'e4', 'f4'],
+            ['a5', 'b5', 'c5', 'd5', 'e5', 'f5'],
+            ['a6', 'b6', 'c6', 'd6', 'e6', 'f6'],
+        ]);
+        $sheet->getColumnDimension('B')->setVisible(false);
+        $sheet->getRowDimension(3)->setVisible(false);
+        $writer = new Dompdf($spreadsheet);
+        $html = $writer->generateHtmlAll();
+        self::assertStringContainsString('table.sheet0 .column1 { display:none }', $html);
+        self::assertStringContainsString('table.sheet0 tr.row2 { display:none; visibility:hidden }', $html);
+        self::assertStringContainsString('.navigation {display: none;}', $html);
+        $count = substr_count($html, 'display:none');
+        self::assertSame(3, $count);
+        $spreadsheet->disconnectWorksheets();
+    }
+}

--- a/tests/PhpSpreadsheetTests/Writer/Html/HideTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/HideTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Html;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Html;
+use PHPUnit\Framework\TestCase;
+
+class HideTest extends TestCase
+{
+    public function testHide(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray([
+            ['a1', 'b1', 'c1', 'd1', 'e1', 'f1'],
+            ['a2', 'b2', 'c2', 'd2', 'e2', 'f2'],
+            ['a3', 'b3', 'c3', 'd3', 'e3', 'f3'],
+            ['a4', 'b4', 'c4', 'd4', 'e4', 'f4'],
+            ['a5', 'b5', 'c5', 'd5', 'e5', 'f5'],
+            ['a6', 'b6', 'c6', 'd6', 'e6', 'f6'],
+        ]);
+        $sheet->getColumnDimension('B')->setVisible(false);
+        $sheet->getRowDimension(3)->setVisible(false);
+        $writer = new Html($spreadsheet);
+        $html = $writer->generateHtmlAll();
+        self::assertStringContainsString('table.sheet0 .column1 { display:none }', $html);
+        self::assertStringContainsString('table.sheet0 tr.row2 { display:none; visibility:hidden }', $html);
+        self::assertStringContainsString('.navigation {display: none;}', $html);
+        $count = substr_count($html, 'display:none');
+        self::assertSame(3, $count);
+        $spreadsheet->disconnectWorksheets();
+    }
+}

--- a/tests/PhpSpreadsheetTests/Writer/Mpdf/HideTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Mpdf/HideTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Mpdf;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
+use PHPUnit\Framework\TestCase;
+
+class HideTest extends TestCase
+{
+    public function testHide(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray([
+            ['a1', 'b1', 'c1', 'd1', 'e1', 'f1'],
+            ['a2', 'b2', 'c2', 'd2', 'e2', 'f2'],
+            ['a3', 'b3', 'c3', 'd3', 'e3', 'f3'],
+            ['a4', 'b4', 'c4', 'd4', 'e4', 'f4'],
+            ['a5', 'b5', 'c5', 'd5', 'e5', 'f5'],
+            ['a6', 'b6', 'c6', 'd6', 'e6', 'f6'],
+        ]);
+        $sheet->getColumnDimension('B')->setVisible(false);
+        $sheet->getRowDimension(3)->setVisible(false);
+        $writer = new Mpdf($spreadsheet);
+        $html = $writer->generateHtmlAll();
+        self::assertStringNotContainsString('a3', $html);
+        self::assertStringNotContainsString('b1', $html);
+        self::assertStringContainsString('a1', $html);
+        $spreadsheet->disconnectWorksheets();
+    }
+}

--- a/tests/PhpSpreadsheetTests/Writer/Tcpdf/HideTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Tcpdf/HideTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Tcpdf;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Pdf\Tcpdf;
+use PHPUnit\Framework\TestCase;
+
+class HideTest extends TestCase
+{
+    public function testHide(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray([
+            ['a1', 'b1', 'c1', 'd1', 'e1', 'f1'],
+            ['a2', 'b2', 'c2', 'd2', 'e2', 'f2'],
+            ['a3', 'b3', 'c3', 'd3', 'e3', 'f3'],
+            ['a4', 'b4', 'c4', 'd4', 'e4', 'f4'],
+            ['a5', 'b5', 'c5', 'd5', 'e5', 'f5'],
+            ['a6', 'b6', 'c6', 'd6', 'e6', 'f6'],
+        ]);
+        $sheet->getColumnDimension('B')->setVisible(false);
+        $sheet->getRowDimension(3)->setVisible(false);
+        $writer = new Tcpdf($spreadsheet);
+        $html = $writer->generateHtmlAll();
+        self::assertStringNotContainsString('a3', $html);
+        self::assertStringNotContainsString('b1', $html);
+        self::assertStringContainsString('a1', $html);
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Tcpdf issues warnings when processing hidden rows. Some time ago, Mpdf was having problems in the same situation; this was resolved by not writing out hidden rows in the html which Mpdf uses to generate its file. The same solution can be easily applied to Tcpdf.

Neither Tcpdf nor Mpdf handles hidden columns. Dompdf doesn't have a problem with either rows or columns. At any rate, the solution for Tcpdf/Mpdf is to not write out the data in the hidden columns. It is more difficult to implement this for columns than for rows, but this PR should do the trick.

Html writer generally uses `display:none` for the data in suppressed columns. This works, but is technically incorrect - the "approved" method is `visibility:collapse` on the col element. However, Firefox doesn't handle that correctly (open bug was filed over a decade ago), and, since all browsers seem to handle the existing implementation, it is left alone.

Among other considerations, this PR is a necessary precursor for supporting printArea in Html/Pdf should we decide to do that (issue #3941).

Writer/Html protected property `$isMPdf` is deprecated with this PR in favor of testing for `instanceof Mpdf`.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
