### PR TITLE
Fix default value for Conditional::$text

### DIFF
--- a/src/PhpSpreadsheet/Style/Conditional.php
+++ b/src/PhpSpreadsheet/Style/Conditional.php
@@ -84,7 +84,7 @@ class Conditional implements IComparable
     /**
      * Text.
      */
-    private string $text;
+    private string $text = '';
 
     /**
      * Stop on this condition, if it matches.

--- a/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/PR3946Test.php
+++ b/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/PR3946Test.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Style\ConditionalFormatting;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Conditional;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Style\Style;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PHPUnit\Framework\TestCase;
+
+class PR3946Test extends TestCase
+{
+    public function testConditionalTextInitialized(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        $cellRange = 'C3:E5';
+        $style = new Style();
+        $style->applyFromArray([
+            'fill' => [
+                'color' => ['argb' => 'FFFFC000'],
+                'fillType' => Fill::FILL_SOLID,
+            ],
+        ]);
+
+        $condition = new Conditional();
+        $condition->setConditionType(Conditional::CONDITION_CONTAINSTEXT);
+        $condition->setOperatorType(Conditional::OPERATOR_CONTAINSTEXT);
+        $condition->setStyle($style);
+        $sheet->setConditionalStyles($cellRange, [$condition]);
+
+        $writer = new XlsxWriter($spreadsheet);
+
+        $writerWorksheet = new XlsxWriter\Worksheet($writer);
+        $data = $writerWorksheet->writeWorksheet($sheet, []);
+        self::assertStringContainsString('<conditionalFormatting sqref="C3:E5">', $data);
+    }
+}


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

[`Worksheet:640`](https://github.com/PHPOffice/PhpSpreadsheet/blob/master/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php#L640) call `Conditional::getText()`, but if the `Conditional::$text` field is not initialized with a value by calling `getText()` PHP throw a typed error.  
The fix is just to set a default value to empty string to avoid error by calling `getText()` uninitialized.  
In addition `Worksheet` call `getText()` to check if the value is not empty, so empty string is already handled. 
