### PR TITLE
make voku package optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,8 +84,7 @@
         "markbaker/matrix": "^3.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-        "voku/anti-xss": "^4.1"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "dev-main",
@@ -105,7 +104,8 @@
         "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
         "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
         "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer",
-        "mitoteam/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers"
+        "mitoteam/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
+        "voku/anti-xss": "Option for sanitizing HTML content"
     },
     "autoload": {
         "psr-4": {

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -28,7 +28,6 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\MemoryDrawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use voku\helper\AntiXSS;
 
 class Html extends BaseWriter
 {
@@ -1703,8 +1702,12 @@ class Html extends BaseWriter
     {
         $result = '';
         if (!$this->isPdf && isset($worksheet->getComments()[$coordinate])) {
-            $sanitizer = new AntiXSS();
-            $sanitizedString = $sanitizer->xss_clean($worksheet->getComment($coordinate)->getText()->getPlainText());
+            if(class_exists('\voku\helper\AntiXSS\AntiXSS')) {
+                $sanitizer = new \voku\helper\AntiXSS\AntiXSS();
+                $sanitizedString = $sanitizer->xss_clean($worksheet->getComment($coordinate)->getText()->getPlainText());
+            } else {
+                $sanitizedString = $worksheet->getComment($coordinate)->getText()->getPlainText();
+            }
             if ($sanitizedString !== '') {
                 $result .= '<a class="comment-indicator"></a>';
                 $result .= '<div class="comment">' . nl2br($sanitizedString) . '</div>';


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [ ] a new feature
- [ x ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ x ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Because the voku/portable--utf8 has a bootstrap which runs an ini_set() on all requests. #3954
