### PR TITLE
Update Rector Documentation

### DIFF
--- a/docs/topics/migration-from-PHPExcel.md
+++ b/docs/topics/migration-from-PHPExcel.md
@@ -8,12 +8,14 @@ need to be done.
 
 ## Automated tool
 
-[RectorPHP](https://github.com/rectorphp/rector) can be used to migrate
-automatically your codebase. Assuming your files to be migrated lives
+[RectorPHP](https://github.com/rectorphp/rector) can be used to automatically migrate your codebase.
+Note that this support has been dropped from current releases of rector,
+so you need to require an earlier release to do this.
+Assuming that your files to be migrated live
 in `src/`, you can run the migration like so:
 
 ```sh
-composer require rector/rector rector/rector-phpoffice phpoffice/phpspreadsheet --dev
+composer require rector/rector:0.15.10 rector/rector-phpoffice phpoffice/phpspreadsheet --dev
 
 # this creates rector.php config
 vendor/bin/rector init 


### PR DESCRIPTION
Rector no longer supports conversion from PhpExcel (issue #3953). Documentation is updated to suggest using a non-current release of Rector for conversion.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [ ] documentation change

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
