### PR TITLE
WIP Excel Adding At-Signs to Functions

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -3489,6 +3489,7 @@ class Calculation
                     $testSheet->getCell($cellAddress['cell']);
                 }
             }
+            self::$returnArrayAsType = $returnArrayAsType;
 
             throw new Exception($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -356,7 +356,7 @@ class Cell implements Stringable
                 $this->getWorksheet()->setSelectedCells($selected);
                 $this->getWorksheet()->getParentOrThrow()->setActiveSheetIndex($index);
                 //    We don't yet handle array returns
-                if (is_array($result)) {
+                if (is_array($result) && Calculation::getArrayReturnType() !== Calculation::RETURN_ARRAY_AS_ARRAY) {
                     while (is_array($result)) {
                         $result = array_shift($result);
                     }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1402,10 +1402,24 @@ class Worksheet extends WriterPart
         }
 
         $attributes = $cell->getFormulaAttributes();
+        $ref = $cell->getCoordinate();
+        if (is_array($calculatedValue)) {
+            $attributes['t'] = 'array';
+            $rows = max(1, count($calculatedValue));
+            $cols = 1;
+            foreach ($calculatedValue as $row) {
+                $cols = max($cols, is_array($row) ? count($row) : 1);
+            }
+            $firstCellArray = Coordinate::indexesFromString($ref);
+            $lastRow = $firstCellArray[1] + $rows - 1;
+            $lastColumn = $firstCellArray[0] + $cols - 1;
+            $lastColumnString = Coordinate::stringFromColumnIndex($lastColumn);
+            $ref .= ":$lastColumnString$lastRow";
+        }
         if (($attributes['t'] ?? null) === 'array') {
             $objWriter->startElement('f');
             $objWriter->writeAttribute('t', 'array');
-            $objWriter->writeAttribute('ref', $cell->getCoordinate());
+            $objWriter->writeAttribute('ref', $ref);
             $objWriter->writeAttribute('aca', '1');
             $objWriter->writeAttribute('ca', '1');
             $objWriter->text(FunctionPrefix::addFunctionPrefixStripEquals($cellValue));

--- a/tests/PhpSpreadsheetTests/Worksheet/Table/Issue3659Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/Table/Issue3659Test.php
@@ -4,10 +4,24 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Worksheet\Table;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Worksheet\Table;
 
 class Issue3659Test extends SetupTeardown
 {
+    private string $arrayReturnType;
+
+    protected function setUp(): void
+    {
+        $this->arrayReturnType = Calculation::getArrayReturnType();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Calculation::setArrayReturnType($this->arrayReturnType);
+    }
+
     public function testTableOnOtherSheet(): void
     {
         $spreadsheet = $this->getSpreadsheet();
@@ -40,6 +54,53 @@ class Issue3659Test extends SetupTeardown
         self::assertSame(39, $sheet->getCell('A2')->getCalculatedValue());
         self::assertSame(39, $sheet->getCell('A3')->getCalculatedValue());
         self::assertSame('1020234', $sheet->getCell('A4')->getCalculatedValue(), 'Header row not included');
+        self::assertSame('F7', $sheet->getSelectedCells());
+        self::assertSame('F8', $tableSheet->getSelectedCells());
+        self::assertSame($sheet, $spreadsheet->getActiveSheet());
+    }
+
+    public function testTableAsArray(): void
+    {
+        Calculation::setArrayReturnType(Calculation::RETURN_ARRAY_AS_ARRAY);
+        $spreadsheet = $this->getSpreadsheet();
+        $sheet = $this->getSheet();
+        $sheet->setTitle('Feuil1');
+        $tableSheet = $spreadsheet->createSheet();
+        $tableSheet->setTitle('sheet_with_table');
+        $tableSheet->fromArray(
+            [
+                ['MyCol', 'Colonne2', 'Colonne3'],
+                [10, 20],
+                [2],
+                [3],
+                [4],
+            ],
+            null,
+            'B1',
+            true
+        );
+        $table = new Table('B1:D5', 'Tableau1');
+        $tableSheet->addTable($table);
+        $sheet->setSelectedCells('F7');
+        $tableSheet->setSelectedCells('F8');
+        self::assertSame($sheet, $spreadsheet->getActiveSheet());
+        $sheet->getCell('F1')->setValue('=Tableau1[MyCol]');
+        $sheet->getCell('H1')->setValue('=Tableau1[]');
+        $sheet->getCell('F9')->setValue('=Tableau1');
+        $sheet->getCell('J9')->setValue('=CONCAT(Tableau1)');
+        $sheet->getCell('J11')->setValue('=SUM(Tableau1[])');
+        $expectedResult = [2 => ['B' => 10], ['B' => 2], ['B' => 3], ['B' => 4]];
+        self::assertSame($expectedResult, $sheet->getCell('F1')->getCalculatedValue());
+        $expectedResult = [
+            2 => ['B' => 10, 'C' => 20, 'D' => null],
+            ['B' => 2, 'C' => null, 'D' => null],
+            ['B' => 3, 'C' => null, 'D' => null],
+            ['B' => 4, 'C' => null, 'D' => null],
+        ];
+        self::assertSame($expectedResult, $sheet->getCell('H1')->getCalculatedValue());
+        self::assertSame($expectedResult, $sheet->getCell('F9')->getCalculatedValue());
+        self::assertSame('1020234', $sheet->getCell('J9')->getCalculatedValue(), 'Header row not included');
+        self::assertSame(39, $sheet->getCell('J11')->getCalculatedValue(), 'Header row not included');
         self::assertSame('F7', $sheet->getSelectedCells());
         self::assertSame('F8', $tableSheet->getSelectedCells());
         self::assertSame($sheet, $spreadsheet->getActiveSheet());

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/ArrayFunctionsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/ArrayFunctionsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Reader\Xlsx as XlsxReader;
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PHPUnit\Framework\TestCase;
+
+class ArrayFunctionsTest extends TestCase
+{
+    private string $arrayReturnType;
+
+    private string $outputFile = '';
+
+    protected function setUp(): void
+    {
+        $this->arrayReturnType = Calculation::getArrayReturnType();
+    }
+
+    protected function tearDown(): void
+    {
+        Calculation::setArrayReturnType($this->arrayReturnType);
+        if ($this->outputFile !== '') {
+            unlink($this->outputFile);
+            $this->outputFile = '';
+        }
+    }
+
+    public function testArrayOutput(): void
+    {
+        Calculation::setArrayReturnType(Calculation::RETURN_ARRAY_AS_ARRAY);
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $columnArray = [
+            [41],
+            [57],
+            [51],
+            [54],
+            [49],
+            [43],
+            [35],
+            [35],
+            [44],
+            [47],
+            [48],
+            [26],
+            [57],
+            [34],
+            [61],
+            [34],
+            [28],
+            [29],
+            [41],
+        ];
+        $sheet->fromArray($columnArray, 'A1');
+        $sheet->setCellValue('C1', '=UNIQUE(A1:A19)');
+        $sheet->setCellValue('D1', '=SORT(A1:A19)');
+        $writer = new XlsxWriter($spreadsheet);
+        $this->outputFile = File::temporaryFilename();
+        $writer->save($this->outputFile);
+        $spreadsheet->disconnectWorksheets();
+
+        $reader = new XlsxReader();
+        $spreadsheet2 = $reader->load($this->outputFile);
+        $sheet2 = $spreadsheet2->getActiveSheet();
+        $expectedUnique = [
+            ['41'],
+            ['57'],
+            ['51'],
+            ['54'],
+            ['49'],
+            ['43'],
+            ['35'],
+            ['44'],
+            ['47'],
+            ['48'],
+            ['26'],
+            ['34'],
+            ['61'],
+            ['28'],
+            ['29'],
+        ];
+        self::assertCount(15, $expectedUnique);
+        self::assertSame($expectedUnique, $sheet2->getCell('C1')->getCalculatedValue());
+        $expectedSort = [
+            [26],
+            [28],
+            [29],
+            [34],
+            [34],
+            [35],
+            [35],
+            [41],
+            [41],
+            [43],
+            [44],
+            [47],
+            [48],
+            [49],
+            [51],
+            [54],
+            [57],
+            [57],
+            [61],
+        ];
+        self::assertCount(19, $expectedSort);
+        self::assertCount(19, $columnArray);
+        self::assertSame($expectedSort, $sheet2->getCell('D1')->getCalculatedValue());
+        $spreadsheet2->disconnectWorksheets();
+
+        $file = 'zip://';
+        $file .= $this->outputFile;
+        $file .= '#xl/worksheets/sheet1.xml';
+        $data = file_get_contents($file);
+        if ($data === false) {
+            self::fail('Unable to read file');
+        } else {
+            self::assertStringContainsString('<c r="C1"><f t="array" ref="C1:C15" aca="1" ca="1">_xlfn.UNIQUE(A1:A19)</f></c>', $data, '15 results for UNIQUE');
+            self::assertStringContainsString('<c r="D1"><f t="array" ref="D1:D19" aca="1" ca="1">_xlfn._xlws.SORT(A1:A19)</f></c>', $data, '19 results for SORT');
+        }
+    }
+}


### PR DESCRIPTION
This has come up a number of times, most recently with issue #3901, and also issue #3659. It will certainly come up more often in days to come. Excel is changing formulas which PhpSpreadsheet has output as `=UNIQUE(A1:A19)`; Excel is processing the formula as it were `=@UNIQUE(A1:A19)`. This behavior is explained, in part, by https://github.com/PHPOffice/PhpSpreadsheet/pull/3659#issuecomment-1663040464. It is doing so in order to ensure that the function returns only a single value rather than an array of values, in case the spreadsheet is being processed (or possibly was created) by a less current version of Excel which cannot handle the array result.

PhpSpreadsheet follows Excel to a certain extent; it defaults to returning a single calculated value when an array would be returned. Further, its support for outputting an array even when that default is overridden is incomplete. I am not prepared to do everything that Excel does for the array functions (details below), but this PR is a start in that direction. If the default is changed via:
```php
use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
Calculation::setArrayReturnType(Calculation::RETURN_ARRAY_AS_ARRAY);
```
When that is done, `getCalculatedValue` will return an array (no code change necessary). However, Writer/Xlsx will now be updated to look at that value, and if an array is returned in that circumstance, will indicate in the Xml that the result is an array *and* will include a reference to the bounds of the array. This gets us close, although not completely there, to what Excel does, and may be good enough for now. Excel will still mess with the formula, but now it will treat it as `{=UNIQUE(A1:A19)}`. This means that the spreadsheet will now look correct; there will be superficial differences, but all cells will have the expected value.

Technically, the major difference between what PhpSpreadsheet will output now, and what Excel does on its own, is that Excel supplies values in the xml for all the cells in the range. That would be difficult for PhpSpreadsheet to do; that could be a project for another day. Excel will treat the output from PhpSpreadsheet as "Array Formulas" (a.k.a. CSE (control shift enter) formulas because you need to use that combination of keys to manually enter them in older versions of Excel). Current versions of Excel will instead use "Dynamic Array Formulas". Dynamic Array Formulas can be changed by the user; Array Formulas need to be deleted and re-entered if you want to change them. I don't know what else might have to change to get Excel to use the latter for PhpSpreadsheet formulas, and I will probably not even try to look now, saving it for a future date.

Unit testing of this change uncovered a bug in Calculation::calculateCellValue. That routine saves off ArrayReturnType, and may change it, and is supposed to restore it. But it does not do the restore if the calculation throws an exception. It is changed to do so.

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
