### PR TITLE
Table Filter Buttons

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/AutoFilter.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter.php
@@ -810,7 +810,7 @@ class AutoFilter implements Stringable
                             'method' => 'filterTestInSimpleDataSet',
                             'arguments' => ['filterValues' => $ruleDataSet, 'blanks' => $blanks],
                         ];
-                    } else {
+                    } elseif ($ruleType !== null) {
                         //    Filter on date group values
                         $arguments = [
                             'date' => [],

--- a/src/PhpSpreadsheet/Writer/Xlsx/Table.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Table.php
@@ -50,7 +50,6 @@ class Table extends WriterPart
         if ($table->getShowHeaderRow() && $table->getAllowFilter() === true) {
             $objWriter->startElement('autoFilter');
             $objWriter->writeAttribute('ref', $range);
-            $objWriter->endElement();
             foreach (range($rangeStart[0], $rangeEnd[0]) as $offset => $columnIndex) {
                 $column = $table->getColumnByOffset($offset);
 
@@ -64,6 +63,7 @@ class Table extends WriterPart
                     AutoFilter::writeAutoFilterColumn($objWriter, $column, $offset);
                 }
             }
+            $objWriter->endElement(); // autoFilter
         }
 
         // Table Columns

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue3988Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue3988Test.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Reader\Xlsx as XlsxReader;
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter;
+use PhpOffice\PhpSpreadsheet\Worksheet\Table;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PHPUnit\Framework\TestCase;
+
+class Issue3988Test extends TestCase
+{
+    public function testIssue3988(): void
+    {
+        // code liberally borrowed from samples/Table/01_Table
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->setActiveSheetIndex(0);
+        $spreadsheet->getActiveSheet()->setCellValue('A1', 'Year')
+            ->setCellValue('B1', 'Quarter')
+            ->setCellValue('C1', 'Country')
+            ->setCellValue('D1', 'Sales');
+
+        $dataArray = [
+            ['2010', 'Q1', 'United States', 790],
+            ['2010', 'Q2', 'United States', 730],
+            ['2010', 'Q3', 'United States', 860],
+            ['2010', 'Q4', 'United States', 850],
+            ['2011', 'Q1', 'United States', 800],
+            ['2011', 'Q2', 'United States', 700],
+            ['2011', 'Q3', 'United States', 900],
+            ['2011', 'Q4', 'United States', 950],
+            ['2010', 'Q1', 'Belgium', 380],
+            ['2010', 'Q2', 'Belgium', 390],
+            ['2010', 'Q3', 'Belgium', 420],
+            ['2010', 'Q4', 'Belgium', 460],
+            ['2011', 'Q1', 'Belgium', 400],
+            ['2011', 'Q2', 'Belgium', 350],
+            ['2011', 'Q3', 'Belgium', 450],
+            ['2011', 'Q4', 'Belgium', 500],
+            ['2010', 'Q1', 'UK', 690],
+            ['2010', 'Q2', 'UK', 610],
+            ['2010', 'Q3', 'UK', 620],
+            ['2010', 'Q4', 'UK', 600],
+            ['2011', 'Q1', 'UK', 720],
+            ['2011', 'Q2', 'UK', 650],
+            ['2011', 'Q3', 'UK', 580],
+            ['2011', 'Q4', 'UK', 510],
+            ['2010', 'Q1', 'France', 510],
+            ['2010', 'Q2', 'France', 490],
+            ['2010', 'Q3', 'France', 460],
+            ['2010', 'Q4', 'France', 590],
+            ['2011', 'Q1', 'France', 620],
+            ['2011', 'Q2', 'France', 650],
+            ['2011', 'Q3', 'France', 415],
+            ['2011', 'Q4', 'France', 570],
+        ];
+        $spreadsheet->getActiveSheet()->fromArray($dataArray, null, 'A2');
+
+        $table = new Table('A1:D33', 'Sales_Data');
+
+        // Create Columns
+        $table->getColumn('D')->setShowFilterButton(false);
+        $table->getAutoFilter()->getColumn('A')
+            ->setFilterType(AutoFilter\Column::AUTOFILTER_FILTERTYPE_CUSTOMFILTER)
+            ->createRule()
+            ->setRule(AutoFilter\Column\Rule::AUTOFILTER_COLUMN_RULE_GREATERTHANOREQUAL, 2011)
+            ->setRuleType(AutoFilter\Column\Rule::AUTOFILTER_RULETYPE_CUSTOMFILTER);
+
+        $spreadsheet->getActiveSheet()->addTable($table);
+
+        $outfile = File::temporaryFilename();
+        $writer = new XlsxWriter($spreadsheet);
+        $writer->save($outfile);
+        $spreadsheet->disconnectWorksheets();
+
+        // Make sure Reader handles row visibility properly.
+        $reader = new XlsxReader();
+        $spreadsheet2 = $reader->load($outfile);
+        self::assertFalse($spreadsheet2->getActiveSheet()->getRowDimension(5)->getVisible());
+        self::assertTrue($spreadsheet2->getActiveSheet()->getRowDimension(6)->getVisible());
+        $spreadsheet2->disconnectWorksheets();
+
+        // Make sure filterColumn tags are children of autoFilter.
+        $file = 'zip://';
+        $file .= $outfile;
+        $file .= '#xl/tables/table1.xml';
+        $data = file_get_contents($file);
+        unlink($outfile);
+        $expected = '<autoFilter ref="A1:D33">'
+            . '<filterColumn colId="0">'
+            . '<customFilters>'
+            . '<customFilter operator="greaterThanOrEqual" val="2011"/>'
+            . '</customFilters>'
+            . '</filterColumn>'
+            . '<filterColumn colId="3" hiddenButton="1"/>'
+            . '</autoFilter>';
+        self::assertStringContainsString($expected, $data);
+    }
+}


### PR DESCRIPTION
Fix #3988. Excel allows a table to have some colums with filter buttons exposed and some with filter buttons hidden. However you cannot do this in "native" Excel - VBA is required for this feature. PhpSpreadsheet is supposed to be able to handle this, but Xlsx/Writer/Table had a bug. The `filterColumn` tags in the xml should be children of the `autoFilter` tag, but were generated as siblings. Moving one statement fixes that problem. Fixing that exposed another problem - autoFilter `showHideRows` was not properly recognizing that a filter could exist without any rules, which is what happens when a table filter button is hidden. Another simple change fixes that problem.

The parent issue correctly points out the problem for Column D in samples/Table/01_Table. However, that sample also has a problem with Column A - unlike columns B and C, there is a filter appled to column A, so its dropdown button should appear different than those in B and C. That problem is also corrected with the fixes above. I also added some formal tests based on that sample.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing samples
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
