### PR TITLE
Improvements to Xml Reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Deprecated
 
-- Nothing
+- Reader/Xml trySimpleXMLLoadString should not have had public visibility, and will be removed.
 
 ### Removed
 
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Invalid Builtin Defined Name in Xls Reader [Issue #3935](https://github.com/PHPOffice/PhpSpreadsheet/issues/3935) [PR #3942](https://github.com/PHPOffice/PhpSpreadsheet/pull/3942)
 - Hidden Rows and Columns Tcpdf/Mpdf [PR #3945](https://github.com/PHPOffice/PhpSpreadsheet/pull/3945)
 - Protect Sheet But Allow Sort [Issue #3951](https://github.com/PHPOffice/PhpSpreadsheet/issues/3951) [PR #3956](https://github.com/PHPOffice/PhpSpreadsheet/pull/3956)
+- Default Value for Conditional::$text [PR #3946](https://github.com/PHPOffice/PhpSpreadsheet/pull/3946)
+- Table Filter Buttons [Issue #3988](https://github.com/PHPOffice/PhpSpreadsheet/issues/3988) [PR #3992](https://github.com/PHPOffice/PhpSpreadsheet/pull/3992)
+- Improvements to Xml Reader [Issue #3999](https://github.com/PHPOffice/PhpSpreadsheet/issues/3999) [Issue #4000](https://github.com/PHPOffice/PhpSpreadsheet/issues/4000) [Issue #4002](https://github.com/PHPOffice/PhpSpreadsheet/issues/4002) [PR #4003](https://github.com/PHPOffice/PhpSpreadsheet/pull/4003)
 
 ## 2.0.0 - 2024-01-04
 

--- a/src/PhpSpreadsheet/Reader/Xlsx/SheetViews.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/SheetViews.php
@@ -70,6 +70,20 @@ class SheetViews extends BaseParserClass
 
             $this->worksheet->getSheetView()->setZoomScaleNormal($zoomScaleNormal);
         }
+
+        if (isset($this->sheetViewAttributes->zoomScalePageLayoutView)) {
+            $zoomScaleNormal = (int) ($this->sheetViewAttributes->zoomScalePageLayoutView);
+            if ($zoomScaleNormal > 0) {
+                $this->worksheet->getSheetView()->setZoomScalePageLayoutView($zoomScaleNormal);
+            }
+        }
+
+        if (isset($this->sheetViewAttributes->zoomScaleSheetLayoutView)) {
+            $zoomScaleNormal = (int) ($this->sheetViewAttributes->zoomScaleSheetLayoutView);
+            if ($zoomScaleNormal > 0) {
+                $this->worksheet->getSheetView()->setZoomScaleSheetLayoutView($zoomScaleNormal);
+            }
+        }
     }
 
     private function view(): void

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -19,8 +19,10 @@ use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Shared\File;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\SheetView;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use SimpleXMLElement;
+use Throwable;
 
 /**
  * Reader for SpreadsheetML, the XML schema for Microsoft Office Excel 2003.
@@ -44,6 +46,8 @@ class Xml extends BaseReader
     }
 
     private string $fileContents = '';
+
+    private string $xmlFailMessage = '';
 
     public static function xmlMappings(): array
     {
@@ -106,17 +110,44 @@ class Xml extends BaseReader
      * Check if the file is a valid SimpleXML.
      *
      * @return false|SimpleXMLElement
+     *
+     * @deprecated 2.0.1 Should never have had public visibility
+     *
+     * @codeCoverageIgnore
      */
-    public function trySimpleXMLLoadString(string $filename): SimpleXMLElement|bool
+    public function trySimpleXMLLoadString(string $filename, string $fileOrString = 'file'): SimpleXMLElement|bool
     {
+        return $this->trySimpleXMLLoadStringPrivate($filename, $fileOrString);
+    }
+
+    /** @return false|SimpleXMLElement */
+    private function trySimpleXMLLoadStringPrivate(string $filename, string $fileOrString = 'file'): SimpleXMLElement|bool
+    {
+        $this->xmlFailMessage = "Cannot load invalid XML $fileOrString: " . $filename;
+        $xml = false;
+
         try {
-            $xml = simplexml_load_string(
-                $this->getSecurityScannerOrThrow()->scan($this->fileContents ?: file_get_contents($filename)),
-                'SimpleXMLElement',
-                Settings::getLibXmlLoaderOptions()
-            );
-        } catch (\Exception $e) {
-            throw new Exception('Cannot load invalid XML file: ' . $filename, 0, $e);
+            $data = $this->fileContents;
+            $continue = true;
+            if ($data === '' && $fileOrString === 'file') {
+                if ($filename === '') {
+                    $this->xmlFailMessage = 'Cannot load empty path';
+                    $continue = false;
+                } else {
+                    $datax = @file_get_contents($filename);
+                    $data = $datax ?: '';
+                    $continue = $datax !== false;
+                }
+            }
+            if ($continue) {
+                $xml = @simplexml_load_string(
+                    $this->getSecurityScannerOrThrow()->scan($data),
+                    'SimpleXMLElement',
+                    Settings::getLibXmlLoaderOptions()
+                );
+            }
+        } catch (Throwable $e) {
+            throw new Exception($this->xmlFailMessage, 0, $e);
         }
         $this->fileContents = '';
 
@@ -135,7 +166,7 @@ class Xml extends BaseReader
 
         $worksheetNames = [];
 
-        $xml = $this->trySimpleXMLLoadString($filename);
+        $xml = $this->trySimpleXMLLoadStringPrivate($filename);
         if ($xml === false) {
             throw new Exception("Problem reading {$filename}");
         }
@@ -161,7 +192,7 @@ class Xml extends BaseReader
 
         $worksheetInfo = [];
 
-        $xml = $this->trySimpleXMLLoadString($filename);
+        $xml = $this->trySimpleXMLLoadStringPrivate($filename);
         if ($xml === false) {
             throw new Exception("Problem reading {$filename}");
         }
@@ -252,16 +283,18 @@ class Xml extends BaseReader
     {
         if ($useContents) {
             $this->fileContents = $filename;
+            $fileOrString = 'string';
         } else {
             File::assertFile($filename);
             if (!$this->canRead($filename)) {
                 throw new Exception($filename . ' is an Invalid Spreadsheet file.');
             }
+            $fileOrString = 'file';
         }
 
-        $xml = $this->trySimpleXMLLoadString($filename);
+        $xml = $this->trySimpleXMLLoadStringPrivate($filename, $fileOrString);
         if ($xml === false) {
-            throw new Exception("Problem reading {$filename}");
+            throw new Exception($this->xmlFailMessage);
         }
 
         $namespaces = $xml->getNamespaces(true);
@@ -505,6 +538,25 @@ class Xml extends BaseReader
             $dataValidations->loadDataValidations($worksheet, $spreadsheet);
             $xmlX = $worksheet->children(Namespaces::URN_EXCEL);
             if (isset($xmlX->WorksheetOptions)) {
+                if (isset($xmlX->WorksheetOptions->ShowPageBreakZoom)) {
+                    $spreadsheet->getActiveSheet()->getSheetView()->setView(SheetView::SHEETVIEW_PAGE_BREAK_PREVIEW);
+                }
+                if (isset($xmlX->WorksheetOptions->Zoom)) {
+                    $zoomScaleNormal = (int) $xmlX->WorksheetOptions->Zoom;
+                    if ($zoomScaleNormal > 0) {
+                        $spreadsheet->getActiveSheet()->getSheetView()->setZoomScaleNormal($zoomScaleNormal);
+                        $spreadsheet->getActiveSheet()->getSheetView()->setZoomScale($zoomScaleNormal);
+                    }
+                }
+                if (isset($xmlX->WorksheetOptions->PageBreakZoom)) {
+                    $zoomScaleNormal = (int) $xmlX->WorksheetOptions->PageBreakZoom;
+                    if ($zoomScaleNormal > 0) {
+                        $spreadsheet->getActiveSheet()->getSheetView()->setZoomScaleSheetLayoutView($zoomScaleNormal);
+                    }
+                }
+                if (isset($xmlX->WorksheetOptions->ShowPageBreakZoom)) {
+                    $spreadsheet->getActiveSheet()->getSheetView()->setView(SheetView::SHEETVIEW_PAGE_BREAK_PREVIEW);
+                }
                 if (isset($xmlX->WorksheetOptions->FreezePanes)) {
                     $freezeRow = $freezeColumn = 1;
                     if (isset($xmlX->WorksheetOptions->SplitHorizontal)) {
@@ -587,6 +639,20 @@ class Xml extends BaseReader
                     if (is_numeric($activeRow) && is_numeric($activeColumn)) {
                         $selectedCell = Coordinate::stringFromColumnIndex((int) $activeColumn + 1) . (string) ($activeRow + 1);
                         $spreadsheet->getActiveSheet()->setSelectedCells($selectedCell);
+                    }
+                }
+            }
+            if (isset($xmlX->PageBreaks)) {
+                if (isset($xmlX->PageBreaks->ColBreaks)) {
+                    foreach ($xmlX->PageBreaks->ColBreaks->ColBreak as $colBreak) {
+                        $colBreak = (string) $colBreak->Column;
+                        $spreadsheet->getActiveSheet()->setBreak([1 + (int) $colBreak, 1], Worksheet::BREAK_COLUMN);
+                    }
+                }
+                if (isset($xmlX->PageBreaks->RowBreaks)) {
+                    foreach ($xmlX->PageBreaks->RowBreaks->RowBreak as $rowBreak) {
+                        $rowBreak = (string) $rowBreak->Row;
+                        $spreadsheet->getActiveSheet()->setBreak([1, (int) $rowBreak], Worksheet::BREAK_ROW);
                     }
                 }
             }

--- a/src/PhpSpreadsheet/Reader/Xml/Style.php
+++ b/src/PhpSpreadsheet/Reader/Xml/Style.php
@@ -14,7 +14,9 @@ class Style
 
     public function parseStyles(SimpleXMLElement $xml, array $namespaces): array
     {
-        if (!isset($xml->Styles) || !is_iterable($xml->Styles[0])) {
+        $children = $xml->children('urn:schemas-microsoft-com:office:spreadsheet');
+        $stylesXml = $children->Styles[0];
+        if (!isset($stylesXml) || !is_iterable($stylesXml)) {
             return [];
         }
 
@@ -24,7 +26,7 @@ class Style
         $fillStyleParser = new Style\Fill();
         $numberFormatStyleParser = new Style\NumberFormat();
 
-        foreach ($xml->Styles[0] as $style) {
+        foreach ($stylesXml as $style) {
             $style_ss = self::getAttributes($style, $namespaces['ss']);
             $styleID = (string) $style_ss['ID'];
             $this->styles[$styleID] = $this->styles['Default'] ?? [];

--- a/src/PhpSpreadsheet/Reader/Xml/Style/Border.php
+++ b/src/PhpSpreadsheet/Reader/Xml/Style/Border.php
@@ -20,6 +20,18 @@ class Border extends StyleBase
      */
     public const BORDER_MAPPINGS = [
         'borderStyle' => [
+            'continuous' => BorderStyle::BORDER_HAIR,
+            'dash' => BorderStyle::BORDER_DASHED,
+            'dashdot' => BorderStyle::BORDER_DASHDOT,
+            'dashdotdot' => BorderStyle::BORDER_DASHDOTDOT,
+            'dot' => BorderStyle::BORDER_DOTTED,
+            'double' => BorderStyle::BORDER_DOUBLE,
+            '0continuous' => BorderStyle::BORDER_HAIR,
+            '0dash' => BorderStyle::BORDER_DASHED,
+            '0dashdot' => BorderStyle::BORDER_DASHDOT,
+            '0dashdotdot' => BorderStyle::BORDER_DASHDOTDOT,
+            '0dot' => BorderStyle::BORDER_DOTTED,
+            '0double' => BorderStyle::BORDER_DOUBLE,
             '1continuous' => BorderStyle::BORDER_THIN,
             '1dash' => BorderStyle::BORDER_DASHED,
             '1dashdot' => BorderStyle::BORDER_DASHDOT,

--- a/src/PhpSpreadsheet/Worksheet/SheetView.php
+++ b/src/PhpSpreadsheet/Worksheet/SheetView.php
@@ -32,6 +32,20 @@ class SheetView
     private ?int $zoomScaleNormal = 100;
 
     /**
+     * ZoomScalePageLayoutView.
+     *
+     * Valid values range from 10 to 400.
+     */
+    private int $zoomScalePageLayoutView = 100;
+
+    /**
+     * ZoomScaleSheetLayoutView.
+     *
+     * Valid values range from 10 to 400.
+     */
+    private int $zoomScaleSheetLayoutView = 100;
+
+    /**
      * ShowZeros.
      *
      * If true, "null" values from a calculation will be shown as "0". This is the default Excel behaviour and can be changed
@@ -98,6 +112,38 @@ class SheetView
     {
         if ($zoomScaleNormal === null || $zoomScaleNormal >= 1) {
             $this->zoomScaleNormal = $zoomScaleNormal;
+        } else {
+            throw new PhpSpreadsheetException('Scale must be greater than or equal to 1.');
+        }
+
+        return $this;
+    }
+
+    public function getZoomScalePageLayoutView(): int
+    {
+        return $this->zoomScalePageLayoutView;
+    }
+
+    public function setZoomScalePageLayoutView(int $zoomScalePageLayoutView): static
+    {
+        if ($zoomScalePageLayoutView >= 1) {
+            $this->zoomScalePageLayoutView = $zoomScalePageLayoutView;
+        } else {
+            throw new PhpSpreadsheetException('Scale must be greater than or equal to 1.');
+        }
+
+        return $this;
+    }
+
+    public function getZoomScaleSheetLayoutView(): int
+    {
+        return $this->zoomScaleSheetLayoutView;
+    }
+
+    public function setZoomScaleSheetLayoutView(int $zoomScaleSheetLayoutView): static
+    {
+        if ($zoomScaleSheetLayoutView >= 1) {
+            $this->zoomScaleSheetLayoutView = $zoomScaleSheetLayoutView;
         } else {
             throw new PhpSpreadsheetException('Scale must be greater than or equal to 1.');
         }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -264,11 +264,21 @@ class Worksheet extends WriterPart
         $objWriter->writeAttribute('workbookViewId', '0');
 
         // Zoom scales
-        if ($worksheet->getSheetView()->getZoomScale() != 100) {
-            $objWriter->writeAttribute('zoomScale', (string) $worksheet->getSheetView()->getZoomScale());
+        $zoomScale = $worksheet->getSheetView()->getZoomScale();
+        if ($zoomScale !== 100 && $zoomScale !== null) {
+            $objWriter->writeAttribute('zoomScale', (string) $zoomScale);
         }
-        if ($worksheet->getSheetView()->getZoomScaleNormal() != 100) {
-            $objWriter->writeAttribute('zoomScaleNormal', (string) $worksheet->getSheetView()->getZoomScaleNormal());
+        $zoomScale = $worksheet->getSheetView()->getZoomScaleNormal();
+        if ($zoomScale !== 100 && $zoomScale !== null) {
+            $objWriter->writeAttribute('zoomScaleNormal', (string) $zoomScale);
+        }
+        $zoomScale = $worksheet->getSheetView()->getZoomScalePageLayoutView();
+        if ($zoomScale !== 100) {
+            $objWriter->writeAttribute('zoomScalePageLayoutView', (string) $zoomScale);
+        }
+        $zoomScale = $worksheet->getSheetView()->getZoomScaleSheetLayoutView();
+        if ($zoomScale !== 100) {
+            $objWriter->writeAttribute('zoomScaleSheetLayoutView', (string) $zoomScale);
         }
 
         // Show zeros (Excel also writes this attribute only if set to false)
@@ -1210,7 +1220,7 @@ class Worksheet extends WriterPart
             $objWriter->writeAttribute('manualBreakCount', (string) count($aColumnBreaks));
 
             foreach ($aColumnBreaks as $cell => $break) {
-                $coords = Coordinate::coordinateFromString($cell);
+                $coords = Coordinate::indexesFromString($cell);
 
                 $objWriter->startElement('brk');
                 $objWriter->writeAttribute('id', (string) ((int) $coords[0] - 1));

--- a/tests/PhpSpreadsheetTests/Reader/Xml/XmlIssue4000Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/XmlIssue4000Test.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xml;
+
+use PhpOffice\PhpSpreadsheet\Reader\Xml;
+use PhpOffice\PhpSpreadsheet\Style\Border;
+use PHPUnit\Framework\TestCase;
+
+class XmlIssue4000Test extends TestCase
+{
+    public function testFontBoldItalic(): void
+    {
+        // Styles tag and children have ss: prefixes
+        $xmldata = <<< 'EOT'
+            <?xml version="1.0"?>
+            <?mso-application progid="Excel.Sheet"?>
+            <Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+             xmlns:o="urn:schemas-microsoft-com:office:office"
+             xmlns:x="urn:schemas-microsoft-com:office:excel"
+             xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"
+             xmlns:html="http://www.w3.org/TR/REC-html40">
+             <DocumentProperties xmlns="urn:schemas-microsoft-com:office:office">
+              <Version>16.00</Version>
+             </DocumentProperties>
+             <OfficeDocumentSettings xmlns="urn:schemas-microsoft-com:office:office">
+              <AllowPNG/>
+             </OfficeDocumentSettings>
+             <ExcelWorkbook xmlns="urn:schemas-microsoft-com:office:excel">
+              <WindowHeight>6510</WindowHeight>
+              <WindowWidth>19200</WindowWidth>
+              <WindowTopX>32767</WindowTopX>
+              <WindowTopY>32767</WindowTopY>
+              <ProtectStructure>False</ProtectStructure>
+              <ProtectWindows>False</ProtectWindows>
+             </ExcelWorkbook>
+             <ss:Styles>
+              <ss:Style ss:ID="Default" ss:Name="Normal">
+               <ss:Alignment ss:Vertical="Bottom"/>
+               <ss:Borders/>
+               <ss:Font ss:FontName="Aptos Narrow" x:Family="Swiss" ss:Size="11"
+                ss:Color="#000000"/>
+               <ss:Interior/>
+               <ss:NumberFormat/>
+               <ss:Protection/>
+              </ss:Style>
+              <ss:Style ss:ID="s63">
+               <ss:Alignment ss:Vertical="Bottom"/>
+               <ss:Borders>
+                <ss:Border ss:Position="Bottom" ss:LineStyle="Double" ss:Weight="3"/>
+                <ss:Border ss:Position="Left" ss:LineStyle="Continuous"/>
+                <ss:Border ss:Position="Right" ss:LineStyle="DashDot" ss:Weight="2"/>
+                <ss:Border ss:Position="Top" ss:LineStyle="Dash" ss:Weight="1"/>
+               </ss:Borders>
+               <ss:Font ss:FontName="Aptos Narrow" x:Family="Swiss" ss:Size="11"
+                ss:Color="#000000" ss:Bold="1"/>
+               <ss:Interior/>
+               <ss:NumberFormat/>
+               <ss:Protection/>
+              </ss:Style>
+             </ss:Styles>
+             <Worksheet ss:Name="Test">
+              <Table ss:ExpandedColumnCount="2" ss:ExpandedRowCount="2" x:FullColumns="1"
+               x:FullRows="1" ss:DefaultRowHeight="14.5">
+               <Row ss:Index="2" ss:Height="15">
+                <Cell ss:Index="2" ss:StyleID="s63"><Data ss:Type="String">TEST</Data></Cell>
+               </Row>
+              </Table>
+              <WorksheetOptions xmlns="urn:schemas-microsoft-com:office:excel">
+               <Selected/>
+               <ProtectObjects>False</ProtectObjects>
+               <ProtectScenarios>False</ProtectScenarios>
+              </WorksheetOptions>
+             </Worksheet>
+            </Workbook>
+            EOT;
+        $reader = new Xml();
+        $spreadsheet = $reader->loadSpreadsheetFromString($xmldata);
+        self::assertEquals(1, $spreadsheet->getSheetCount());
+
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertEquals('Test', $sheet->getTitle());
+        self::assertSame(Border::BORDER_DOUBLE, $sheet->getStyle('B2')->getBorders()->getBottom()->getBorderStyle());
+        self::assertSame(Border::BORDER_MEDIUMDASHDOT, $sheet->getStyle('B2')->getBorders()->getRight()->getBorderStyle());
+        self::assertSame(Border::BORDER_DASHED, $sheet->getStyle('B2')->getBorders()->getTop()->getBorderStyle());
+        self::assertSame(Border::BORDER_HAIR, $sheet->getStyle('B2')->getBorders()->getLeft()->getBorderStyle());
+
+        $spreadsheet->disconnectWorksheets();
+    }
+}

--- a/tests/PhpSpreadsheetTests/Reader/Xml/XmlIssue4002Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/XmlIssue4002Test.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xml;
+
+use PhpOffice\PhpSpreadsheet\Reader\Xml;
+use PhpOffice\PhpSpreadsheet\Style\Border;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class XmlIssue4002Test extends AbstractFunctional
+{
+    private const XML_DATA = <<< 'EOT'
+        <?xml version="1.0"?>
+        <?mso-application progid="Excel.Sheet"?>
+        <Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+         xmlns:o="urn:schemas-microsoft-com:office:office"
+         xmlns:x="urn:schemas-microsoft-com:office:excel"
+         xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"
+         xmlns:html="http://www.w3.org/TR/REC-html40">
+         <DocumentProperties xmlns="urn:schemas-microsoft-com:office:office">
+          <LastAuthor>Owen Leibman</LastAuthor>
+          <Created>2024-04-25T19:31:48Z</Created>
+          <Version>16.00</Version>
+         </DocumentProperties>
+         <OfficeDocumentSettings xmlns="urn:schemas-microsoft-com:office:office">
+          <AllowPNG/>
+         </OfficeDocumentSettings>
+         <ExcelWorkbook xmlns="urn:schemas-microsoft-com:office:excel">
+          <WindowHeight>6510</WindowHeight>
+          <WindowWidth>19200</WindowWidth>
+          <WindowTopX>32767</WindowTopX>
+          <WindowTopY>32767</WindowTopY>
+          <ProtectStructure>False</ProtectStructure>
+          <ProtectWindows>False</ProtectWindows>
+         </ExcelWorkbook>
+         <Styles>
+          <Style ss:ID="Default" ss:Name="Normal">
+           <Alignment ss:Vertical="Bottom"/>
+           <Borders/>
+           <Font ss:FontName="Aptos Narrow" x:Family="Swiss" ss:Size="11"
+            ss:Color="#000000"/>
+           <Interior/>
+           <NumberFormat/>
+           <Protection/>
+          </Style>
+          <Style ss:ID="s62">
+           <Alignment ss:Vertical="Bottom"/>
+           <Borders>
+            <Border ss:Position="Bottom" ss:LineStyle="Double" ss:Weight="3"/>
+            <Border ss:Position="Left" ss:LineStyle="Continuous"/>
+            <Border ss:Position="Right" ss:LineStyle="DashDot" ss:Weight="2"/>
+            <Border ss:Position="Top" ss:LineStyle="Dash" ss:Weight="1"/>
+           </Borders>
+           <Font ss:FontName="Aptos Narrow" x:Family="Swiss" ss:Size="11"
+            ss:Color="#000000" ss:Bold="1"/>
+           <Interior/>
+           <NumberFormat/>
+           <Protection/>
+          </Style>
+         </Styles>
+         <Worksheet ss:Name="Test">
+          <Table ss:ExpandedColumnCount="5" ss:ExpandedRowCount="4" x:FullColumns="1"
+           x:FullRows="1" ss:DefaultRowHeight="14.5">
+           <Row ss:AutoFitHeight="0"/>
+           <Row ss:AutoFitHeight="0" ss:Height="15">
+            <Cell ss:Index="2" ss:StyleID="s62"><Data ss:Type="String">TEST</Data></Cell>
+            <Cell ss:Index="5"><Data ss:Type="String">Vertical</Data></Cell>
+           </Row>
+           <Row ss:AutoFitHeight="0"/>
+           <Row ss:AutoFitHeight="0">
+            <Cell ss:Index="2"><Data ss:Type="String">New Page</Data></Cell>
+            <Cell ss:Index="5"><Data ss:Type="String">Last</Data></Cell>
+           </Row>
+          </Table>
+          <WorksheetOptions xmlns="urn:schemas-microsoft-com:office:excel">
+           <Unsynced/>
+           <Print>
+            <ValidPrinterInfo/>
+            <HorizontalResolution>600</HorizontalResolution>
+            <VerticalResolution>600</VerticalResolution>
+           </Print>
+           <ShowPageBreakZoom/>
+           <Zoom>200</Zoom>
+           <PageBreakZoom>200</PageBreakZoom>
+           <Selected/>
+           <Panes>
+            <Pane>
+             <Number>3</Number>
+             <ActiveRow>2</ActiveRow>
+             <ActiveCol>3</ActiveCol>
+            </Pane>
+           </Panes>
+           <ProtectObjects>False</ProtectObjects>
+           <ProtectScenarios>False</ProtectScenarios>
+          </WorksheetOptions>
+          <PageBreaks xmlns="urn:schemas-microsoft-com:office:excel">
+           <ColBreaks>
+            <ColBreak>
+             <Column>3</Column>
+            </ColBreak>
+           </ColBreaks>
+           <RowBreaks>
+            <RowBreak>
+             <Row>2</Row>
+            </RowBreak>
+           </RowBreaks>
+          </PageBreaks>
+         </Worksheet>
+        </Workbook>
+        EOT;
+
+    public function testZoomAndPageBreaks(): void
+    {
+        $reader = new Xml();
+        $spreadsheet = $reader->loadSpreadsheetFromString(self::XML_DATA);
+        self::assertEquals(1, $spreadsheet->getSheetCount());
+
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertEquals('Test', $sheet->getTitle());
+        self::assertSame(Border::BORDER_DOUBLE, $sheet->getStyle('B2')->getBorders()->getBottom()->getBorderStyle());
+        self::assertSame(Border::BORDER_MEDIUMDASHDOT, $sheet->getStyle('B2')->getBorders()->getRight()->getBorderStyle());
+        self::assertSame(Border::BORDER_DASHED, $sheet->getStyle('B2')->getBorders()->getTop()->getBorderStyle());
+        self::assertSame(Border::BORDER_HAIR, $sheet->getStyle('B2')->getBorders()->getLeft()->getBorderStyle());
+
+        self::assertSame(['A2'], array_keys($sheet->getRowBreaks()));
+        self::assertSame(['D1'], array_keys($sheet->getColumnBreaks()));
+        $sheetView = $sheet->getSheetView();
+        self::assertSame(200, $sheetView->getZoomScale());
+        self::assertSame(200, $sheetView->getZoomScaleNormal());
+        self::assertSame(100, $sheetView->getZoomScalePageLayoutView());
+        self::assertSame(200, $sheetView->getZoomScaleSheetLayoutView());
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testXlsxWriterAndReader(): void
+    {
+        $reader = new Xml();
+        $spreadsheet = $reader->loadSpreadsheetFromString(self::XML_DATA);
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Xlsx');
+        $spreadsheet->disconnectWorksheets();
+        $rsheet = $reloadedSpreadsheet->getActiveSheet();
+        self::assertSame(['A2'], array_keys($rsheet->getRowBreaks()));
+        self::assertSame(['D1'], array_keys($rsheet->getColumnBreaks()));
+        $rsheetView = $rsheet->getSheetView();
+        self::assertSame(200, $rsheetView->getZoomScale());
+        self::assertSame(200, $rsheetView->getZoomScaleNormal());
+        self::assertSame(100, $rsheetView->getZoomScalePageLayoutView());
+        self::assertSame(200, $rsheetView->getZoomScaleSheetLayoutView());
+        $reloadedSpreadsheet->disconnectWorksheets();
+    }
+
+    public function testXlsWriterAndReader(): void
+    {
+        $reader = new Xml();
+        $spreadsheet = $reader->loadSpreadsheetFromString(self::XML_DATA);
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Xls');
+        $spreadsheet->disconnectWorksheets();
+        $rsheet = $reloadedSpreadsheet->getActiveSheet();
+        self::assertSame(['A2'], array_keys($rsheet->getRowBreaks()));
+        self::assertSame(['D1'], array_keys($rsheet->getColumnBreaks()));
+        $rsheetView = $rsheet->getSheetView();
+        self::assertSame(200, $rsheetView->getZoomScale());
+        self::assertSame(200, $rsheetView->getZoomScaleNormal());
+        self::assertSame(100, $rsheetView->getZoomScalePageLayoutView());
+        self::assertSame(100, $rsheetView->getZoomScaleSheetLayoutView(), 'different value than Xml or Xlsx but I do not see any consequence of that');
+        $reloadedSpreadsheet->disconnectWorksheets();
+    }
+}

--- a/tests/PhpSpreadsheetTests/Reader/Xml/XmlStyleCoverageTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/XmlStyleCoverageTest.php
@@ -68,6 +68,18 @@ class XmlStyleCoverageTest extends TestCase
     public static function providerBorderStyle(): array
     {
         return [
+            ['continuous', Border::BORDER_HAIR],
+            ['dash', Border::BORDER_DASHED],
+            ['dashdot', Border::BORDER_DASHDOT],
+            ['dashdotdot', Border::BORDER_DASHDOTDOT],
+            ['dot', Border::BORDER_DOTTED],
+            ['double', Border::BORDER_DOUBLE],
+            ['0continuous', Border::BORDER_HAIR],
+            ['0dash', Border::BORDER_DASHED],
+            ['0dashdot', Border::BORDER_DASHDOT],
+            ['0dashdotdot', Border::BORDER_DASHDOTDOT],
+            ['0dot', Border::BORDER_DOTTED],
+            ['0double', Border::BORDER_DOUBLE],
             ['1continuous', Border::BORDER_THIN],
             ['1dash', Border::BORDER_DASHED],
             ['1dashdot', Border::BORDER_DASHDOT],

--- a/tests/PhpSpreadsheetTests/Reader/Xml/XmlTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/XmlTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Xml;
 
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Reader\Exception as ReaderException;
 use PhpOffice\PhpSpreadsheet\Reader\Xml;
 use PHPUnit\Framework\TestCase;
 
@@ -16,12 +17,9 @@ class XmlTest extends TestCase
     public function testInvalidSimpleXML(string $filename): void
     {
         $xmlReader = new Xml();
-        if (method_exists($this, 'setOutputCallback')) {
-            $this->expectException(\PhpOffice\PhpSpreadsheet\Reader\Exception::class);
-            self::assertFalse($xmlReader->trySimpleXMLLoadString($filename));
-        }
-
-        self::assertFalse(@$xmlReader->trySimpleXMLLoadString($filename));
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('Invalid Spreadsheet file');
+        $xmlReader->load($filename);
     }
 
     public static function providerInvalidSimpleXML(): array
@@ -56,7 +54,8 @@ class XmlTest extends TestCase
 
     public function testLoadCorruptedFile(): void
     {
-        $this->expectException(\PhpOffice\PhpSpreadsheet\Reader\Exception::class);
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('Cannot load invalid XML file');
 
         $xmlReader = new Xml();
         $spreadsheet = @$xmlReader->load('tests/data/Reader/Xml/CorruptedXmlFile.xml');
@@ -65,7 +64,8 @@ class XmlTest extends TestCase
 
     public function testListWorksheetNamesCorruptedFile(): void
     {
-        $this->expectException(\PhpOffice\PhpSpreadsheet\Reader\Exception::class);
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('Problem reading');
 
         $xmlReader = new Xml();
         $names = @$xmlReader->listWorksheetNames('tests/data/Reader/Xml/CorruptedXmlFile.xml');
@@ -74,10 +74,35 @@ class XmlTest extends TestCase
 
     public function testListWorksheetInfoCorruptedFile(): void
     {
-        $this->expectException(\PhpOffice\PhpSpreadsheet\Reader\Exception::class);
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('Problem reading');
 
         $xmlReader = new Xml();
         $info = @$xmlReader->listWorksheetInfo('tests/data/Reader/Xml/CorruptedXmlFile.xml');
         self::assertNotEmpty($info);
+    }
+
+    public function testInvalidXMLFromString(): void
+    {
+        $xmlReader = new Xml();
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('Cannot load invalid XML string: 0');
+        $xmlReader->loadSpreadsheetFromString('0');
+    }
+
+    public function testInvalidXMLFromEmptyString(): void
+    {
+        $xmlReader = new Xml();
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('Cannot load invalid XML string: ');
+        $xmlReader->loadSpreadsheetFromString('');
+    }
+
+    public function testEmptyFilename(): void
+    {
+        $xmlReader = new Xml();
+        $this->expectException(ReaderException::class);
+        $this->expectExceptionMessage('File "" does not exist');
+        $xmlReader->load('');
     }
 }


### PR DESCRIPTION
Fix #3999. Fix #4000. Fix #4002. Several bug reports and feature requests for Xml Reader arrived practically simultaneously. They are all small and hit the same code modules, so I have bundled them together in one PR.
- `loadSpreadsheetFromString` might try to open a file with a falsy name (like '0'), which results in an exception with a misleading message (or a completely unexpected result if a file with that name exists). Code will still throw an exception, but the message will no longer be misleading, and no file I/O will be attempted.
- function `trySimpleXmlLoadString` is deprecated. It should never have been implemented with public visibility, and the fact that it was made the fix above a little more difficult than it would otherwise have been. It is replaced with a private equivalent.
- Style reader function `parseStyles` will now use a better namespace-aware method of reading its Xml data. Peculiarly, the Xml for the Style elements can either include or not a namespace prefix. This is probably because the global namespace and the styles namespace are the same. The existing prefix-based code does not recognize their equivalence, but the new namespace-based code does. Xml Reader continues to use prefix-based code in several other places.
- Border line styles with Weight omitted or equal to 0 have been treated as no border, but they should be treated as 'hair' thickness.
- Support for Zoom is added to Xml Reader.
- In support of the above, new properties (and getters and setters) zoomScalePageLayoutView and zoomScaleSheetLayoutView are added to Worksheet/SheetView. (As far as I can tell, Excel does not support Sheet Layout View for Xml spreadsheets).
- Support is added for those new properties in Xlsx Reader and Writer.
- Xls Reader and Writer seem to work okay without changes. There is one test where Xls shows a different value for one of the properties than Xml or Xlsx, but the spreadsheet looks okay and I don't see any practical consequences of the difference.
- PageBreak support is added to Xml Reader.
- Code for writing out Column Page Breaks in Xlsx Writer was wrong (and, unsurprisingly, untested). A one-line change fixes it, and tests are added.

This is:

- [x] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
