### PR TITLE
RTL Text Alignment in Xlsx Comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Unallocated Cells Affected by Column/Row Insert/Delete [Issue #3933](https://github.com/PHPOffice/PhpSpreadsheet/issues/3933) [PR #3940](https://github.com/PHPOffice/PhpSpreadsheet/pull/3940)
 - Invalid Builtin Defined Name in Xls Reader [Issue #3935](https://github.com/PHPOffice/PhpSpreadsheet/issues/3935) [PR #3942](https://github.com/PHPOffice/PhpSpreadsheet/pull/3942)
 - Hidden Rows and Columns Tcpdf/Mpdf [PR #3945](https://github.com/PHPOffice/PhpSpreadsheet/pull/3945)
+- RTL Text Alignment in Xlsx Comments [Issue #4004](https://github.com/PHPOffice/PhpSpreadsheet/issues/4004) [PR #4006](https://github.com/PHPOffice/PhpSpreadsheet/pull/4006)
 - Protect Sheet But Allow Sort [Issue #3951](https://github.com/PHPOffice/PhpSpreadsheet/issues/3951) [PR #3956](https://github.com/PHPOffice/PhpSpreadsheet/pull/3956)
 
 ## 2.0.0 - 2024-01-04

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1132,6 +1132,7 @@ class Xlsx extends BaseReader
                                             $fillColor = strtoupper(substr((string) $shape['fillcolor'], 1));
                                             $column = null;
                                             $row = null;
+                                            $textHAlign = null;
                                             $fillImageRelId = null;
                                             $fillImageTitle = '';
 
@@ -1149,7 +1150,16 @@ class Xlsx extends BaseReader
                                                     if (is_array($temp)) {
                                                         $column = $temp[0];
                                                     }
+                                                    $temp = $clientData->xpath('.//x:TextHAlign');
+                                                    if (!empty($temp)) {
+                                                        $textHAlign = $temp[0];
+                                                    }
                                                 }
+                                            }
+                                            $rowx = (string) $row;
+                                            $colx = (string) $column;
+                                            if (is_numeric($rowx) && is_numeric($colx) && $textHAlign !== null) {
+                                                $docSheet->getComment([1 + (int) $colx, 1 + (int) $rowx], false)->setAlignment((string) $textHAlign);
                                             }
 
                                             $fillImageRelNode = $shape->xpath('.//v:fill/@o:relid');

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2626,7 +2626,7 @@ class Worksheet implements IComparable
      * @param array{0: int, 1: int}|CellAddress|string $cellCoordinate Coordinate of the cell as a string, eg: 'C5';
      *               or as an array of [$columnIndex, $row] (e.g. [3, 5]), or a CellAddress object.
      */
-    public function getComment(CellAddress|string|array $cellCoordinate): Comment
+    public function getComment(CellAddress|string|array $cellCoordinate, bool $attachNew = true): Comment
     {
         $cellAddress = Functions::trimSheetFromCellReference(Validations::validateCellAddress($cellCoordinate));
 
@@ -2645,7 +2645,9 @@ class Worksheet implements IComparable
 
         // If not, create a new comment.
         $newComment = new Comment();
-        $this->comments[$cellAddress] = $newComment;
+        if ($attachNew) {
+            $this->comments[$cellAddress] = $newComment;
+        }
 
         return $newComment;
     }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Comments.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Comments.php
@@ -6,9 +6,18 @@ use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Comment;
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx\Namespaces;
 use PhpOffice\PhpSpreadsheet\Shared\XMLWriter;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
 
 class Comments extends WriterPart
 {
+    private const VALID_HORIZONTAL_ALIGNMENT = [
+        Alignment::HORIZONTAL_CENTER,
+        Alignment::HORIZONTAL_DISTRIBUTED,
+        Alignment::HORIZONTAL_JUSTIFY,
+        Alignment::HORIZONTAL_LEFT,
+        Alignment::HORIZONTAL_RIGHT,
+    ];
+
     /**
      * Write comments to XML format.
      *
@@ -222,6 +231,12 @@ class Comments extends WriterPart
 
         // x:AutoFill
         $objWriter->writeElement('x:AutoFill', 'False');
+
+        // x:TextHAlign horizontal alignment of text
+        $alignment = strtolower($comment->getAlignment());
+        if (in_array($alignment, self::VALID_HORIZONTAL_ALIGNMENT, true)) {
+            $objWriter->writeElement('x:TextHAlign', ucfirst($alignment));
+        }
 
         // x:Row
         $objWriter->writeElement('x:Row', (string) ($row - 1));

--- a/tests/PhpSpreadsheetTests/CommentTest.php
+++ b/tests/PhpSpreadsheetTests/CommentTest.php
@@ -96,5 +96,6 @@ class CommentTest extends TestCase
         self::assertArrayHasKey('A2', $comments1);
         $sheet->removeComment('A2');
         self::assertEmpty($sheet->getComments());
+        $spreadsheet->disconnectWorksheets();
     }
 }

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/CommentAlignmentTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/CommentAlignmentTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class CommentAlignmentTest extends AbstractFunctional
+{
+    public function testIssue4004(): void
+    {
+        $type = 'Xlsx';
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->getComment('A3')->getText()->createText('Comment');
+        $sheet->getComment('A4')->getText()->createText('שלום');
+        $sheet->getComment('A4')->setAlignment(Alignment::HORIZONTAL_RIGHT);
+
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, $type);
+        $spreadsheet->disconnectWorksheets();
+
+        self::assertCount(1, $reloadedSpreadsheet->getAllSheets());
+
+        $rsheet = $reloadedSpreadsheet->getActiveSheet();
+        $comment1 = $rsheet->getComment('A3');
+        self::assertSame('Comment', $comment1->getText()->getPlainText());
+        self::assertSame('general', $comment1->getAlignment());
+        $comment2 = $rsheet->getComment('A4');
+        self::assertSame('שלום', $comment2->getText()->getPlainText());
+        self::assertSame('Right', $comment2->getAlignment());
+
+        $reloadedSpreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Fix #4004. RTL text can be included in a comment, and will display correctly, but the comment as a whole will be left-aligned. There already exists an `alignment` property for Comment, but it is unused. This PR will allow that property to be set, and to be read from and written to an Xlsx spreadsheet when possible.

The Xml tags that govern this property are found, unusually, in a drawing Vml file. The important property is `x:TextHAlign`, which can be set to Left, Right, Center, Justified, or Distributed. There are other tags which seemed like they were relevant to this problem, but I don't think they actually matter:
```xml
  <v:textbox style='mso-direction-alt:auto'>
   <div style='text-align:right;direction:rtl'></div>
  </v:textbox>
```

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
