### PR TITLE
#3995 check charset in HTML reader

### DIFF
--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -640,7 +640,7 @@ class Html extends BaseReader
         if ($charset !== 'UTF-8') {
             $html = self::forceString(mb_convert_encoding($html, 'UTF-8', $charset));
 
-            $result = preg_match($pattern, $html, $matches, 0, intval($matches[1][1]) + strlen($charset));
+            $result = preg_match($pattern, $html, $matches, 0, ((int) $matches[1][1]) + strlen($charset));
             $charset = strtoupper($result ? $matches[1] : 'UTF-8');
             if ($charset !== 'UTF-8') {
                 throw new Exception('Suspicious Double-encoded XML, spreadsheet file load() aborted to prevent XXE/XEE attacks');

--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlLoadIso_8859_1.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlLoadIso_8859_1.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Html;
+
+use PhpOffice\PhpSpreadsheet\Reader\Html;
+use PHPUnit\Framework\TestCase;
+
+/**
+ *
+ */
+class HtmlLoadIso_8859_1 extends TestCase
+{
+    public function testLoadIso_8859_1_http_equiv(): void
+    {
+        $iso_8859_1 = mb_convert_encoding('£', 'ISO-8859-1', 'UTF-8');
+        $content = <<<EOF
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+            </head>
+            <body>
+              <table>
+                <tr>
+                  <td>Date</td>
+                  <td>Description</td>
+                  <td>Money in</td>
+                  <td>Money Out</td>
+                  <td>Balance</td>
+                </tr>
+                <tr>
+                  <td>2024-01-14</td>
+                  <td>PHPOffice/PhpSpreadSheet release</td>
+                  <td></td>
+                  <td>{$iso_8859_1}75.00</td>
+                  <td>{$iso_8859_1}999925.00</td>
+                </tr>
+                <tr>
+                  <td>2024-01-24</td>
+                  <td>PHPOffice/PhpSpreadSheet release</td>
+                  <td>{$iso_8859_1}75.00</td>
+                  <td></td>
+                  <td>{$iso_8859_1}1000000.00</td>
+                </tr>
+              </table>
+            </body>
+            </html>
+EOF;
+        $reader = new Html();
+        $spreadsheet = $reader->loadFromString($content);
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertSame('Date', $sheet->getCell('A1')->getValue());
+        self::assertSame('Description', $sheet->getCell('B1')->getValue());
+        self::assertSame('PHPOffice/PhpSpreadSheet release', $sheet->getCell('B3')->getValue());
+        self::assertSame('£75.00', $sheet->getCell('D2')->getValue());
+        self::assertSame('£75.00', $sheet->getCell('C3')->getValue());
+    }
+    public function testLoadIso_8859_1_charset(): void
+    {
+        $iso_8859_1 = mb_convert_encoding('£', 'ISO-8859-1', 'UTF-8');
+        $content = <<<EOF
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="iso-8859-1">
+            </head>
+            <body>
+              <table>
+                <tr>
+                  <td>Date</td>
+                  <td>Description</td>
+                  <td>Money in</td>
+                  <td>Money Out</td>
+                  <td>Balance</td>
+                </tr>
+                <tr>
+                  <td>2024-01-14</td>
+                  <td>PHPOffice/PhpSpreadSheet release</td>
+                  <td></td>
+                  <td>{$iso_8859_1}75.00</td>
+                  <td>{$iso_8859_1}999925.00</td>
+                </tr>
+                <tr>
+                  <td>2024-01-24</td>
+                  <td>PHPOffice/PhpSpreadSheet release</td>
+                  <td>{$iso_8859_1}75.00</td>
+                  <td></td>
+                  <td>{$iso_8859_1}1000000.00</td>
+                </tr>
+              </table>
+            </body>
+            </html>
+EOF;
+        $reader = new Html();
+        $spreadsheet = $reader->loadFromString($content);
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertSame('Date', $sheet->getCell('A1')->getValue());
+        self::assertSame('Description', $sheet->getCell('B1')->getValue());
+        self::assertSame('PHPOffice/PhpSpreadSheet release', $sheet->getCell('B3')->getValue());
+        self::assertSame('£75.00', $sheet->getCell('D2')->getValue());
+        self::assertSame('£75.00', $sheet->getCell('C3')->getValue());
+    }
+}

--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlLoadNonUtf8Charset.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlLoadNonUtf8Charset.php
@@ -52,6 +52,7 @@ class HtmlLoadNonUtf8Charset extends TestCase
         self::assertSame('£75.00', $sheet->getCell('D2')->getValue());
         self::assertSame('£75.00', $sheet->getCell('C3')->getValue());
     }
+
     public function testLoadNonUtf8CharsetHttpEquiv(): void
     {
         $iso_8859_1 = mb_convert_encoding('£', 'ISO-8859-1', 'UTF-8');

--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlLoadNonUtf8Charset.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlLoadNonUtf8Charset.php
@@ -5,57 +5,9 @@ namespace PhpOffice\PhpSpreadsheetTests\Reader\Html;
 use PhpOffice\PhpSpreadsheet\Reader\Html;
 use PHPUnit\Framework\TestCase;
 
-/**
- *
- */
-class HtmlLoadIso_8859_1 extends TestCase
+class HtmlLoadNonUtf8Charset extends TestCase
 {
-    public function testLoadIso_8859_1_http_equiv(): void
-    {
-        $iso_8859_1 = mb_convert_encoding('£', 'ISO-8859-1', 'UTF-8');
-        $content = <<<EOF
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-            </head>
-            <body>
-              <table>
-                <tr>
-                  <td>Date</td>
-                  <td>Description</td>
-                  <td>Money in</td>
-                  <td>Money Out</td>
-                  <td>Balance</td>
-                </tr>
-                <tr>
-                  <td>2024-01-14</td>
-                  <td>PHPOffice/PhpSpreadSheet release</td>
-                  <td></td>
-                  <td>{$iso_8859_1}75.00</td>
-                  <td>{$iso_8859_1}999925.00</td>
-                </tr>
-                <tr>
-                  <td>2024-01-24</td>
-                  <td>PHPOffice/PhpSpreadSheet release</td>
-                  <td>{$iso_8859_1}75.00</td>
-                  <td></td>
-                  <td>{$iso_8859_1}1000000.00</td>
-                </tr>
-              </table>
-            </body>
-            </html>
-EOF;
-        $reader = new Html();
-        $spreadsheet = $reader->loadFromString($content);
-        $sheet = $spreadsheet->getActiveSheet();
-        self::assertSame('Date', $sheet->getCell('A1')->getValue());
-        self::assertSame('Description', $sheet->getCell('B1')->getValue());
-        self::assertSame('PHPOffice/PhpSpreadSheet release', $sheet->getCell('B3')->getValue());
-        self::assertSame('£75.00', $sheet->getCell('D2')->getValue());
-        self::assertSame('£75.00', $sheet->getCell('C3')->getValue());
-    }
-    public function testLoadIso_8859_1_charset(): void
+    public function testLoadNonUtf8Charset(): void
     {
         $iso_8859_1 = mb_convert_encoding('£', 'ISO-8859-1', 'UTF-8');
         $content = <<<EOF
@@ -90,7 +42,52 @@ EOF;
               </table>
             </body>
             </html>
-EOF;
+            EOF;
+        $reader = new Html();
+        $spreadsheet = $reader->loadFromString($content);
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertSame('Date', $sheet->getCell('A1')->getValue());
+        self::assertSame('Description', $sheet->getCell('B1')->getValue());
+        self::assertSame('PHPOffice/PhpSpreadSheet release', $sheet->getCell('B3')->getValue());
+        self::assertSame('£75.00', $sheet->getCell('D2')->getValue());
+        self::assertSame('£75.00', $sheet->getCell('C3')->getValue());
+    }
+    public function testLoadNonUtf8CharsetHttpEquiv(): void
+    {
+        $iso_8859_1 = mb_convert_encoding('£', 'ISO-8859-1', 'UTF-8');
+        $content = <<<EOF
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+            </head>
+            <body>
+              <table>
+                <tr>
+                  <td>Date</td>
+                  <td>Description</td>
+                  <td>Money in</td>
+                  <td>Money Out</td>
+                  <td>Balance</td>
+                </tr>
+                <tr>
+                  <td>2024-01-14</td>
+                  <td>PHPOffice/PhpSpreadSheet release</td>
+                  <td></td>
+                  <td>{$iso_8859_1}75.00</td>
+                  <td>{$iso_8859_1}999925.00</td>
+                </tr>
+                <tr>
+                  <td>2024-01-24</td>
+                  <td>PHPOffice/PhpSpreadSheet release</td>
+                  <td>{$iso_8859_1}75.00</td>
+                  <td></td>
+                  <td>{$iso_8859_1}1000000.00</td>
+                </tr>
+              </table>
+            </body>
+            </html>
+            EOF;
         $reader = new Html();
         $spreadsheet = $reader->loadFromString($content);
         $sheet = $spreadsheet->getActiveSheet();


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

#3995 this change allows PhpSpreadSheet to detect the character set in HTML files and then using that information convert the encoding to UTF-8.
