### PR TITLE
Drop PHP 8.0 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,6 @@ jobs:
         experimental:
           - false
         php-version:
-          - '8.0'
           - '8.1'
           - '8.2'
           - '8.3'
@@ -174,7 +173,7 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Version Compatibility check with PHP_CodeSniffer
-        run: ./vendor/bin/phpcs -q --report-width=200 --report=summary,full src/ --standard=PHPCompatibility --runtime-set testVersion 8.0-
+        run: ./vendor/bin/phpcs -q --report-width=200 --report=summary,full src/ --standard=PHPCompatibility --runtime-set testVersion 8.1-
 
   phpstan:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -11,80 +11,9 @@
 PhpSpreadsheet is a library written in pure PHP and offers a set of classes that
 allow you to read and write various spreadsheet file formats such as Excel and LibreOffice Calc.
 
-## PHP Version Support
-
-LTS: Support for PHP versions will only be maintained for a period of six months beyond the
-[end of life](https://www.php.net/supported-versions) of that PHP version.
-
-Currently the required PHP minimum version is PHP __8.0__, and we [will support that version](https://www.php.net/eol.php) until May 2024.
-
-See the `composer.json` for other requirements.
-
 ## Installation
 
-Use [composer](https://getcomposer.org) to install PhpSpreadsheet into your project:
-
-```sh
-composer require phpoffice/phpspreadsheet
-```
-
-If you are building your installation on a development machine that is on a different PHP version to the server where it will be deployed, or if your PHP CLI version is not the same as your run-time such as `php-fpm` or Apache's `mod_php`, then you might want to add the following to your `composer.json` before installing:
-```json
-{
-    "config": {
-        "platform": {
-            "php": "8.0"
-        }
-    }
-}
-```
-and then run
-```sh
-composer install
-```
-to ensure that the correct dependencies are retrieved to match your deployment environment.
-
-See [CLI vs Application run-time](https://php.watch/articles/composer-platform-check) for more details.
-
-### Additional Installation Options
-
-If you want to write to PDF, or to include Charts when you write to HTML or PDF, then you will need to install additional libraries:
-
-#### PDF
-
-For PDF Generation, you can install any of the following, and then configure PhpSpreadsheet to indicate which library you are going to use:
- - mpdf/mpdf
- - dompdf/dompdf
- - tecnickcom/tcpdf
-
-and configure PhpSpreadsheet using:
-
-```php
-// Dompdf, Mpdf or Tcpdf (as appropriate)
-$className = \PhpOffice\PhpSpreadsheet\Writer\Pdf\Dompdf::class;
-IOFactory::registerWriter('Pdf', $className);
-```
-or the appropriate PDF Writer wrapper for the library that you have chosen to install.
-
-#### Chart Export
-
-For Chart export, we support following packages, which you will also need to install yourself using `composer require`
- - [jpgraph/jpgraph](https://packagist.org/packages/jpgraph/jpgraph) (this package was abandoned at version 4.0. 
-   You can manually download the latest version that supports PHP 8 and above from [jpgraph.net](https://jpgraph.net/))
- - [mitoteam/jpgraph](https://packagist.org/packages/mitoteam/jpgraph) - up to date fork with modern PHP versions support and some bugs fixed.
-
-and then configure PhpSpreadsheet using:
-```php
-// to use jpgraph/jpgraph
-Settings::setChartRenderer(\PhpOffice\PhpSpreadsheet\Chart\Renderer\JpGraph::class);
-//or
-// to use mitoteam/jpgraph
-Settings::setChartRenderer(\PhpOffice\PhpSpreadsheet\Chart\Renderer\MtJpGraphRenderer::class);
-```
-
-One or the other of these libraries is necessary if you want to generate HTML or PDF files that include charts; or to render a Chart to an Image format from within your code.
-They are not necessary to define charts for writing to `Xlsx` files.
-Other file formats don't support writing Charts.
+See the [install instructions](https://phpspreadsheet.readthedocs.io/en/latest/#installation).
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "config": {
         "platform": {
-            "php" : "8.0.99"
+            "php" : "8.1.99"
         },
         "sort-packages": true,
         "allow-plugins": {
@@ -65,7 +65,7 @@
         ]
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-fileinfo": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7a7ba2e1cc9ac479e06ab28916c6b80",
+    "content-hash": "6834323fd4da085a7c32c477804d8310",
     "packages": [
         {
             "name": "maennchen/zipstream-php",
@@ -759,8 +759,23 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
             "time": "2023-11-26T02:51:26+00:00"
         },
         {
@@ -4987,7 +5002,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-fileinfo": "*",
@@ -5004,7 +5019,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ allow you to read and write various spreadsheet file formats such as Excel and L
 
 ## Software requirements
 
-PHP version 8.0 or newer to develop using PhpSpreadsheet. Other requirements, such as PHP extensions, are enforced by
+PHP version 8.1 or newer to develop using PhpSpreadsheet. Other requirements, such as PHP extensions, are enforced by
 composer. See the `require` section of [the composer.json file](https://github.com/PHPOffice/PhpSpreadsheet/blob/master/composer.json)
 for details.
 
@@ -33,7 +33,7 @@ for details.
 LTS: Support for PHP versions will only be maintained for a period of six months beyond the
 [end of life of that PHP version](https://www.php.net/eol.php).
 
-Currently, the required PHP minimum version is PHP 8.0.
+Currently, the required PHP minimum version is __PHP 8.1__, and we [will support that version](https://www.php.net/eol.php) until June 2026.
 
 Support for PHP versions will only be maintained for a period of six months beyond the
 [end of life](https://www.php.net/supported-versions) of that PHP version.
@@ -54,23 +54,54 @@ Or also download the documentation and samples if you plan to use them:
 composer require phpoffice/phpspreadsheet --prefer-source
 ```
 
-If you are building your installation on a development machine that is on a different PHP version to the server where it will be deployed, or if your PHP CLI version is not the same as your run-time such as `php-fpm` or Apache's `mod_php`, then you might want to add the following to your `composer.json` before installing:
-```json
-{
-    "config": {
-        "platform": {
-            "php": "8.0"
-        }
-    }
-}
-```
-and then run
-```sh
-composer install
-```
-to ensure that the correct dependencies are retrieved to match your deployment environment.
+If you are building your installation on a development machine that is on a different PHP version to the server where it
+will be deployed, or if your PHP CLI version is different from your run-time such as `php-fpm` or Apache's `mod_php`,
+then you might want to configure composer for that.
+See [composer documentation](https://getcomposer.org/doc/06-config.md#platform)
+on how to edit your `composer.json` to ensure that the correct dependencies are retrieved to match your deployment
+environment.
 
 See [CLI vs Application run-time](https://php.watch/articles/composer-platform-check) for more details.
+
+### Additional Installation Options
+
+If you want to write to PDF, or to include Charts when you write to HTML or PDF, then you will need to install additional libraries:
+
+#### PDF
+
+For PDF Generation, you can install any of the following, and then configure PhpSpreadsheet to indicate which library you are going to use:
+- mpdf/mpdf
+- dompdf/dompdf
+- tecnickcom/tcpdf
+
+and configure PhpSpreadsheet using:
+
+```php
+// Dompdf, Mpdf or Tcpdf (as appropriate)
+$className = \PhpOffice\PhpSpreadsheet\Writer\Pdf\Dompdf::class;
+IOFactory::registerWriter('Pdf', $className);
+```
+or the appropriate PDF Writer wrapper for the library that you have chosen to install.
+
+#### Chart Export
+
+For Chart export, we support following packages, which you will also need to install yourself using `composer require`
+- [jpgraph/jpgraph](https://packagist.org/packages/jpgraph/jpgraph) (this package was abandoned at version 4.0.
+  You can manually download the latest version that supports PHP 8 and above from [jpgraph.net](https://jpgraph.net/))
+- [mitoteam/jpgraph](https://packagist.org/packages/mitoteam/jpgraph) - up to date fork with modern PHP versions support and some bugs fixed.
+
+and then configure PhpSpreadsheet using:
+```php
+// to use jpgraph/jpgraph
+Settings::setChartRenderer(\PhpOffice\PhpSpreadsheet\Chart\Renderer\JpGraph::class);
+//or
+// to use mitoteam/jpgraph
+Settings::setChartRenderer(\PhpOffice\PhpSpreadsheet\Chart\Renderer\MtJpGraphRenderer::class);
+```
+
+One or the other of these libraries is necessary if you want to generate HTML or PDF files that include charts; or to render a Chart to an Image format from within your code.
+They are not necessary to define charts for writing to `Xlsx` files.
+Other file formats don't support writing Charts.
 
 ## Hello World
 

--- a/docs/topics/reading-and-writing-to-file.md
+++ b/docs/topics/reading-and-writing-to-file.md
@@ -577,12 +577,10 @@ $reader->loadIntoExisting("05featuredemo.csv", $spreadsheet);
 
 Line endings for Unix (`\n`) and Windows (`\r\n`) are supported.
 
-Mac line endings (`\r`) are supported as long as PHP itself
-supports them, which it does through release 8.0.
-Support for Mac line endings is deprecated for 8.1,
+Support for Mac line endings  (`\r`) is deprecated since PHP 8.1,
 and is scheduled to remain deprecated for all later PHP8 releases;
-PhpSpreadsheet will continue to support them for 8.*.
-Support is scheduled to be dropped with release 9;
+PhpSpreadsheet will continue to support them for PHP 8.*.
+Support is scheduled to be dropped with PHP 9;
 PhpSpreadsheet will then no longer handle CSV files
 with Mac line endings correctly.
 

--- a/samples/index.php
+++ b/samples/index.php
@@ -3,7 +3,7 @@
 require_once 'Header.php';
 
 $requirements = [
-    'PHP 8.0' => version_compare(PHP_VERSION, '8.0', '>='),
+    'PHP 8.1' => version_compare(PHP_VERSION, '8.1', '>='),
     'PHP extension XML' => extension_loaded('xml'),
     'PHP extension xmlwriter' => extension_loaded('xmlwriter'),
     'PHP extension mbstring' => extension_loaded('mbstring'),

--- a/src/PhpSpreadsheet/Style/NumberFormat/Wizard/DateTime.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Wizard/DateTime.php
@@ -31,9 +31,8 @@ class DateTime extends DateTimeWizard
     private function mapFormatBlocks(DateTimeWizard|string $value): string
     {
         // Any date masking codes are returned as lower case values
-        if (is_object($value)) {
-            // We can't explicitly test for Stringable until PHP >= 8.0
-            return $value;
+        if ($value instanceof DateTimeWizard) {
+            return $value->__toString();
         }
 
         // Wrap any string literals in quotes, so that they're clearly defined as string literals


### PR DESCRIPTION
This is according to our formal, published, policy to only support EOL PHP after 6 months.

See https://phpspreadsheet.readthedocs.io/en/latest/#php-version-support

Also consolidate documentation in a single place, not in the README, because it's a pain to maintain almost-duplicated-but-not-really documentation.

