### PR TITLE
Do Not Output Alignment and Protection for Conditional Formats

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -2802,7 +2802,7 @@ class Worksheet extends BIFFwriter
 
         // $flags : Option flags
         // Alignment
-        $bAlignHz = ($conditional->getStyle()->getAlignment()->getHorizontal() === null ? 1 : 0);
+        /*$bAlignHz = ($conditional->getStyle()->getAlignment()->getHorizontal() === null ? 1 : 0);
         $bAlignVt = ($conditional->getStyle()->getAlignment()->getVertical() === null ? 1 : 0);
         $bAlignWrapTx = ($conditional->getStyle()->getAlignment()->getWrapText() === false ? 1 : 0);
         $bTxRotation = ($conditional->getStyle()->getAlignment()->getTextRotation() === null ? 1 : 0);
@@ -2812,15 +2812,15 @@ class Worksheet extends BIFFwriter
             $bFormatAlign = 1;
         } else {
             $bFormatAlign = 0;
-        }
+        }*/
         // Protection
-        $bProtLocked = ($conditional->getStyle()->getProtection()->getLocked() === null ? 1 : 0);
+        /*$bProtLocked = ($conditional->getStyle()->getProtection()->getLocked() === null ? 1 : 0);
         $bProtHidden = ($conditional->getStyle()->getProtection()->getHidden() === null ? 1 : 0);
         if ($bProtLocked == 0 || $bProtHidden == 0) {
             $bFormatProt = 1;
         } else {
             $bFormatProt = 0;
-        }
+        }*/
         // Border
         $bBorderLeft = ($conditional->getStyle()->getBorders()->getLeft()->getBorderStyle() !== Border::BORDER_OMIT) ? 1 : 0;
         $bBorderRight = ($conditional->getStyle()->getBorders()->getRight()->getBorderStyle() !== Border::BORDER_OMIT) ? 1 : 0;
@@ -2858,19 +2858,19 @@ class Worksheet extends BIFFwriter
         }
         // Alignment
         $flags = 0;
-        $flags |= (1 == $bAlignHz ? 0x00000001 : 0);
-        $flags |= (1 == $bAlignVt ? 0x00000002 : 0);
-        $flags |= (1 == $bAlignWrapTx ? 0x00000004 : 0);
-        $flags |= (1 == $bTxRotation ? 0x00000008 : 0);
+        //$flags |= (1 == $bAlignHz ? 0x00000001 : 0);
+        //$flags |= (1 == $bAlignVt ? 0x00000002 : 0);
+        //$flags |= (1 == $bAlignWrapTx ? 0x00000004 : 0);
+        //$flags |= (1 == $bTxRotation ? 0x00000008 : 0);
         // Justify last line flag
         $flags |= (1 == self::$always1 ? 0x00000010 : 0);
-        $flags |= (1 == $bIndent ? 0x00000020 : 0);
-        $flags |= (1 == $bShrinkToFit ? 0x00000040 : 0);
+        //$flags |= (1 == $bIndent ? 0x00000020 : 0);
+        //$flags |= (1 == $bShrinkToFit ? 0x00000040 : 0);
         // Default
         $flags |= (1 == self::$always1 ? 0x00000080 : 0);
         // Protection
-        $flags |= (1 == $bProtLocked ? 0x00000100 : 0);
-        $flags |= (1 == $bProtHidden ? 0x00000200 : 0);
+        //$flags |= (1 == $bProtLocked ? 0x00000100 : 0);
+        //$flags |= (1 == $bProtHidden ? 0x00000200 : 0);
         // Border
         $flags |= (1 == $bBorderLeft ? 0x00000400 : 0);
         $flags |= (1 == $bBorderRight ? 0x00000800 : 0);
@@ -2886,13 +2886,13 @@ class Worksheet extends BIFFwriter
         // Font
         $flags |= (1 == $bFormatFont ? 0x04000000 : 0);
         // Alignment:
-        $flags |= (1 == $bFormatAlign ? 0x08000000 : 0);
+        //$flags |= (1 == $bFormatAlign ? 0x08000000 : 0);
         // Border
         $flags |= (1 == $bFormatBorder ? 0x10000000 : 0);
         // Pattern
         $flags |= (1 == $bFormatFill ? 0x20000000 : 0);
         // Protection
-        $flags |= (1 == $bFormatProt ? 0x40000000 : 0);
+        //$flags |= (1 == $bFormatProt ? 0x40000000 : 0);
         // Text direction
         $flags |= (1 == self::$always0 ? 0x80000000 : 0);
 
@@ -2998,7 +2998,7 @@ class Worksheet extends BIFFwriter
             // Always
             $dataBlockFont .= pack('v', 0x0001);
         }
-        if ($bFormatAlign === 1) {
+        /*if ($bFormatAlign === 1) {
             // Alignment and text break
             $blockAlign = Style\CellAlignment::horizontal($conditional->getStyle()->getAlignment());
             $blockAlign |= Style\CellAlignment::wrap($conditional->getStyle()->getAlignment()) << 3;
@@ -3021,7 +3021,7 @@ class Worksheet extends BIFFwriter
             $blockIndentRelative = 255;
 
             $dataBlockAlign = pack('CCvvv', $blockAlign, $blockRotation, $blockIndent, $blockIndentRelative, 0x0000);
-        }
+        }*/
         if ($bFormatBorder === 1) {
             $blockLineStyle = Style\CellBorder::style($conditional->getStyle()->getBorders()->getLeft());
             $blockLineStyle |= Style\CellBorder::style($conditional->getStyle()->getBorders()->getRight()) << 4;
@@ -3055,18 +3055,18 @@ class Worksheet extends BIFFwriter
         if ($bFormatFont === 1) { // Block Formatting : OK
             $data .= $dataBlockFont;
         }
-        if ($bFormatAlign === 1) {
-            $data .= $dataBlockAlign;
-        }
+        //if ($bFormatAlign === 1) {
+        //    $data .= $dataBlockAlign;
+        //}
         if ($bFormatBorder === 1) {
             $data .= $dataBlockBorder;
         }
         if ($bFormatFill === 1) { // Block Formatting : OK
             $data .= $dataBlockFill;
         }
-        if ($bFormatProt == 1) {
-            $data .= $this->getDataBlockProtection($conditional);
-        }
+        //if ($bFormatProt == 1) {
+        //    $data .= $this->getDataBlockProtection($conditional);
+        //}
         if ($operand1 !== null) {
             $data .= $operand1;
         }
@@ -3130,7 +3130,7 @@ class Worksheet extends BIFFwriter
         return true;
     }
 
-    private function getDataBlockProtection(Conditional $conditional): int
+    /*private function getDataBlockProtection(Conditional $conditional): int
     {
         $dataBlockProtection = 0;
         if ($conditional->getStyle()->getProtection()->getLocked() == Protection::PROTECTION_PROTECTED) {
@@ -3141,5 +3141,5 @@ class Worksheet extends BIFFwriter
         }
 
         return $dataBlockProtection;
-    }
+    }*/
 }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Style.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Style.php
@@ -506,55 +506,8 @@ class Style extends WriterPart
         // fill
         $this->writeFill($objWriter, $style->getFill());
 
-        // alignment
-        $horizontal = Alignment::HORIZONTAL_ALIGNMENT_FOR_XLSX[$style->getAlignment()->getHorizontal()] ?? '';
-        $vertical = Alignment::VERTICAL_ALIGNMENT_FOR_XLSX[$style->getAlignment()->getVertical()] ?? '';
-        $rotation = $style->getAlignment()->getTextRotation();
-        if ($horizontal || $vertical || $rotation !== null) {
-            $objWriter->startElement('alignment');
-            if ($horizontal) {
-                $objWriter->writeAttribute('horizontal', $horizontal);
-            }
-            if ($vertical) {
-                $objWriter->writeAttribute('vertical', $vertical);
-            }
-
-            if ($rotation !== null) {
-                if ($rotation >= 0) {
-                    $textRotation = $rotation;
-                } else {
-                    $textRotation = 90 - $rotation;
-                }
-                $objWriter->writeAttribute('textRotation', (string) $textRotation);
-            }
-            $objWriter->endElement();
-        }
-
         // border
         $this->writeBorder($objWriter, $style->getBorders());
-
-        // protection
-        if ((!empty($style->getProtection()->getLocked())) || (!empty($style->getProtection()->getHidden()))) {
-            if (
-                $style->getProtection()->getLocked() !== Protection::PROTECTION_INHERIT
-                || $style->getProtection()->getHidden() !== Protection::PROTECTION_INHERIT
-            ) {
-                $objWriter->startElement('protection');
-                if (
-                    ($style->getProtection()->getLocked() !== null)
-                    && ($style->getProtection()->getLocked() !== Protection::PROTECTION_INHERIT)
-                ) {
-                    $objWriter->writeAttribute('locked', ($style->getProtection()->getLocked() == Protection::PROTECTION_PROTECTED ? 'true' : 'false'));
-                }
-                if (
-                    ($style->getProtection()->getHidden() !== null)
-                    && ($style->getProtection()->getHidden() !== Protection::PROTECTION_INHERIT)
-                ) {
-                    $objWriter->writeAttribute('hidden', ($style->getProtection()->getHidden() == Protection::PROTECTION_PROTECTED ? 'true' : 'false'));
-                }
-                $objWriter->endElement();
-            }
-        }
 
         $objWriter->endElement();
     }

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue4025Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue4025Test.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Style\Conditional;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PHPUnit\Framework\TestCase;
+
+class Issue4025Test extends TestCase
+{
+    private static function merge(Worksheet $sheet, string $start, string $end): void
+    {
+        $sheet->mergeCells("$start:$end");
+        $sheet->getStyle($start)->getAlignment()->setHorizontal(Alignment::HORIZONTAL_CENTER);
+        $sheet->getStyle($start)->getAlignment()->setVertical(Alignment::VERTICAL_CENTER);
+    }
+
+    public function testIssue4025(): void
+    {
+        // Writing alignment in conditional style caused weirdness
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setRightToLeft(true);
+        $sheet->setCellValue('E1', 'אושר עד');
+        $sheet->setCellValue('M1', 'ויקטורי');
+        $sheet->setCellValue('E2', '2024-05-01');
+        $sheet->setCellValue('H2', '2024-05-12');
+        $sheet->setCellValue('M2', '2024-05-01');
+        $sheet->setCellValue('P2', '2024-05-12');
+        $sheet->setCellValue('A3', 'ברקוד');
+        $sheet->setCellValue('B3', 'תיאור מוצר');
+        $sheet->setCellValue('C3', 'קטגוריה');
+        $sheet->setCellValue('D3', 'יצרן');
+        $sheet->setCellValue('E3', 'מחיר');
+        $sheet->setCellValue('F3', 'מבצע');
+        $sheet->setCellValue('G3', 'קובע');
+        $sheet->setCellValue('H3', 'מחיר');
+        $sheet->setCellValue('I3', 'מבצע');
+        $sheet->setCellValue('J3', 'קובע');
+        $sheet->setCellValue('K3', 'הפרש ב-₪');
+        $sheet->setCellValue('L3', 'הפרש ב-₪');
+        $sheet->setCellValue('M3', 'מחיר');
+        $sheet->setCellValue('N3', 'מבצע');
+        $sheet->setCellValue('O3', 'קובע');
+        $sheet->setCellValue('P3', 'מחיר');
+        $sheet->setCellValue('Q3', 'מבצע');
+        $sheet->setCellValue('R3', 'קובע');
+        $sheet->setCellValue('S3', 'הפרש ב-₪');
+        $sheet->setCellValue('T3', 'הפרש ב-₪');
+        $sheet->setCellValue('A4', '7290010945306');
+        $sheet->setCellValue('B4', 'חלב טרי בקרטון 3% בד"צ טרה 2 ליטר');
+        $sheet->setCellValue('C4', 'חלב טרי');
+        $sheet->setCellValue('D4', 'החברה המרכזית ל.מ.ק - טרה');
+
+        $sheet->setCellValue('E4', 13.50);
+        $sheet->setCellValue('F4', '-');
+        //$sheet->setCellValue('G4', 13.50);
+        $sheet->setCellValue('G4', 14.70);
+        $sheet->setCellValue('H4', 14.20);
+        $sheet->setCellValue('I4', '-');
+        $sheet->setCellValue('J4', 14.20);
+        $sheet->setCellValue('K4', 0.70);
+        $sheet->setCellValue('L4', 0.0519);
+        $sheet->setCellValue('M4', 13.62);
+        $sheet->setCellValue('N4', '-');
+        $sheet->setCellValue('O4', 13.62);
+        $sheet->setCellValue('P4', 14.22);
+        $sheet->setCellValue('Q4', '-');
+        $sheet->setCellValue('R4', 14.22);
+        $sheet->setCellValue('S4', 0.60);
+        $sheet->setCellValue('T4', 0.0441);
+
+        $sheet->setCellValue('E10', '=SUM(G4:G10)');
+        $sheet->setCellValue('H10', '=SUM(J4:J10)');
+        $sheet->setCellValue('K10', '=COUNTIF(K4:K9,">0")');
+        $sheet->setCellValue('M10', '=SUM(O4:O10)');
+        $sheet->setCellValue('P10', '=SUM(R4:R10)');
+        $sheet->setCellValue('S10', '=COUNTIF(S4:S9,">0")');
+        $sheet->setCellValue('H11', '=(SUM(J4:J10) / SUM(G4:G10) - 1)');
+        $sheet->setCellValue('K11', '=COUNTIF(K4:K9,"<0")');
+        $sheet->setCellValue('P11', '=(SUM(R4:R10) / SUM(O4:O10) - 1)');
+        $sheet->setCellValue('S11', '=COUNTIF(S4:S9,"<0")');
+
+        $sheet->setAutoFilter('A3:T3');
+        self::merge($sheet, 'E1', 'L1');
+        self::merge($sheet, 'E2', 'G2');
+        self::merge($sheet, 'H2', 'J2');
+        self::merge($sheet, 'K2', 'L2');
+        self::merge($sheet, 'M1', 'T1');
+        self::merge($sheet, 'M2', 'O2');
+        self::merge($sheet, 'P2', 'R2');
+        self::merge($sheet, 'S2', 'T2');
+        self::merge($sheet, 'E10', 'G10');
+        self::merge($sheet, 'H10', 'J10');
+        self::merge($sheet, 'H11', 'J11');
+        self::merge($sheet, 'M10', 'O10');
+        self::merge($sheet, 'P10', 'R10');
+        self::merge($sheet, 'P11', 'R11');
+        self::merge($sheet, 'K10', 'L10');
+        self::merge($sheet, 'K11', 'L11');
+        self::merge($sheet, 'S10', 'T10');
+        self::merge($sheet, 'S11', 'T11');
+
+        $sheet->getStyle('E4:K8')->getNumberFormat()->setFormatCode('0.00');
+        $sheet->getStyle('L4:L8')->getNumberFormat()->setFormatCode('0.00%');
+        $sheet->getStyle('M4:S8')->getNumberFormat()->setFormatCode('0.00');
+        $sheet->getStyle('T4:T8')->getNumberFormat()->setFormatCode('0.00%');
+        $sheet->getStyle('P10')->getNumberFormat()->setFormatCode('0.00');
+        $sheet->getStyle('P11')->getNumberFormat()->setFormatCode('0.00%');
+        $sheet->getStyle('H1')->getNumberFormat()->setFormatCode('0.00');
+        $sheet->getStyle('H11')->getNumberFormat()->setFormatCode('0.00%');
+
+        $center = [
+            'alignment' => ['horizontal' => Alignment::HORIZONTAL_CENTER],
+        ];
+        $pink = [
+            'alignment' => ['horizontal' => Alignment::HORIZONTAL_CENTER, 'vertical' => Alignment::VERTICAL_CENTER],
+            'font' => ['color' => ['rgb' => 'FF0000']],
+            'fill' => ['fillType' => Fill::FILL_SOLID, 'endColor' => ['argb' => 'FFFFE5E8'], 'startColor' => ['argb' => 'FFFFE5E8']],
+        ];
+        $green = [
+            'alignment' => ['horizontal' => Alignment::HORIZONTAL_CENTER, 'vertical' => Alignment::VERTICAL_CENTER],
+            'font' => ['color' => ['rgb' => '339966']],
+            'fill' => ['fillType' => Fill::FILL_SOLID, 'endColor' => ['argb' => 'ffccffcc'], 'startColor' => ['argb' => 'ffccffcc']],
+        ];
+        //$sheet->getStyle('E4:T8')->getAlignment()->setHorizontal(Alignment::HORIZONTAL_CENTER);
+        $sheet->getStyle('E4:T8')->applyFromArray($center);
+        $sheet->getStyle('H4')->applyFromArray($pink);
+        $sheet->getStyle('J4:L4')->applyFromArray($pink);
+        $sheet->getStyle('P4')->applyFromArray($pink);
+        $sheet->getStyle('R4:T4')->applyFromArray($pink);
+        $sheet->getStyle('K10')->applyFromArray($pink);
+        $sheet->getStyle('S10')->applyFromArray($pink);
+        $sheet->getStyle('K11')->applyFromArray($green);
+        $sheet->getStyle('S11')->applyFromArray($green);
+
+        $condition1a = new Conditional();
+        $condition1a->setConditionType(Conditional::CONDITION_EXPRESSION);
+        $condition1a->addCondition('$H$10 < $E$10');
+        $condition1a->getStyle()->applyFromArray($green);
+        $condition1b = new Conditional();
+        $condition1b->setConditionType(Conditional::CONDITION_EXPRESSION);
+        $condition1b->addCondition('$H$10 > $E$10');
+        $condition1b->getStyle()->applyFromArray($pink);
+        $conditionalStyles = [$condition1a, $condition1b];
+        $sheet->getStyle('H10:H11')->setConditionalStyles($conditionalStyles);
+
+        $condition2a = new Conditional();
+        $condition2a->setConditionType(Conditional::CONDITION_EXPRESSION);
+        $condition2a->addCondition('$P$10 < $M$10');
+        $condition2a->getStyle()->applyFromArray($green);
+        $condition2b = new Conditional();
+        $condition2b->setConditionType(Conditional::CONDITION_EXPRESSION);
+        $condition2b->addCondition('$P$10 > $M$10');
+        $condition2b->getStyle()->applyFromArray($pink);
+        $conditionalStyles2 = [$condition2a, $condition2b];
+        $sheet->getStyle('P10:P11')->setConditionalStyles($conditionalStyles2);
+
+        $sheet->setSelectedCells('A1');
+        $oufil = 'issue.4025b.xlsx';
+        $writer = new XlsxWriter($spreadsheet);
+
+        $writer->getStylesConditionalHashTable()->addFromSource($writer->getWriterPartStyle()->allConditionalStyles($spreadsheet));
+        $writerStyle = new XlsxWriter\Style($writer);
+        $data = $writerStyle->writeStyles($spreadsheet);
+        $spreadsheet->disconnectWorksheets();
+
+        $preg = preg_match('~<dxfs.*</dxfs>~ms', $data, $matches);
+        if ($preg !== 1) {
+            self::fail('preg failed');
+        } else {
+            self::assertStringContainsString('<font', $matches[0]);
+            self::assertStringContainsString('<fill', $matches[0]);
+            self::assertStringNotContainsString('<align', $matches[0]);
+        }
+    }
+}


### PR DESCRIPTION
Fix #4025. With Conditional Formatting, Excel can change Font, Fill, Borders, and NumberFormat. It does not support Alignment nor Protection, at least not natively. This PR removes all code supporting Conditional Alignment or Protection from Xlsx and Xls Writer. Attached to the issue report is a spreadsheet where a conditionally formatted merged cell shows its value twice when Alignment is included with the Conditional Style; it is fixed by this PR. It is not entirely certain which particular combination of CF, Alignment, Merge, AutoFilter, and right-to-left sheet alignment trigger this problem. I am sure that it shows up for Vertical Alignment Center, and I am sure that Xls Writer (which is somewhat buggy anyhow regarding CF support - see issue #3403) has the same problem. The now-unused Xls code is commented out rather than deleted, for documentation purposes.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
