### PR TITLE
POWER Needs to Accept NULL Args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com)
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## TBD - 2.2.0
+
+### Added
+
+- Nothing
+
+### Changed
+
+- Nothing
+
+### Deprecated
+
+- Nothing
+
+### Moved
+
+- Nothing
+
+### Fixed
+
+- Incorrect Reader CSV with BOM. [Issue #4028](https://github.com/PHPOffice/PhpSpreadsheet/issues/4028) [PR #4029](https://github.com/PHPOffice/PhpSpreadsheet/pull/4029)
+- POWER Null/Bool Args. [PR #4031](https://github.com/PHPOffice/PhpSpreadsheet/pull/4031) 
+
 ## 2024-05-11 - 2.1.0
 
 ### MINOR BREAKING CHANGE

--- a/src/PhpSpreadsheet/Calculation/MathTrig/Operations.php
+++ b/src/PhpSpreadsheet/Calculation/MathTrig/Operations.php
@@ -52,14 +52,14 @@ class Operations
      *
      * Computes x raised to the power y.
      *
-     * @param array|float|int|string $x Or can be an array of values
-     * @param array|float|int|string $y Or can be an array of values
+     * @param null|array|bool|float|int|string $x Or can be an array of values
+     * @param null|array|bool|float|int|string $y Or can be an array of values
      *
      * @return array|float|int|string The result, or a string containing an error
      *         If an array of numbers is passed as an argument, then the returned result will also be an array
      *            with the same dimensions
      */
-    public static function power(array|float|int|string $x, array|float|int|string $y): array|float|int|string
+    public static function power(null|array|bool|float|int|string $x, null|array|bool|float|int|string $y): array|float|int|string
     {
         if (is_array($x) || is_array($y)) {
             return self::evaluateArrayArguments([self::class, __FUNCTION__], $x, $y);

--- a/tests/data/Calculation/MathTrig/POWER.php
+++ b/tests/data/Calculation/MathTrig/POWER.php
@@ -410,4 +410,9 @@ return [
     ],
     ['#VALUE!', 'x', 2],
     ['#VALUE!', 2, 'x'],
+    'exponent is null' => [1, 2, null],
+    'base is null' => [0, null, 2],
+    'both null' => ['#NUM!', null, null],
+    'exponent is bool' => [2, 2, true],
+    'base is bool' => [0, false, 2],
 ];


### PR DESCRIPTION
Investigating issue #1622, I found that its extremely complicated formula, which had been leading to an incorrect result, now led to an exception. I am able to fix the exception; unfortunately, I am no closer to resolving the original issue. So I'll apply the baby step while continuing to investigate. Function POWER had changed from untyped args to a defined set of types. The set of types was determined according to the doc block, but that was incomplete - it had neglected to include `null` and `bool`. This PR corrects the function prototype and the doc block, and adds the missing tests for those conditions.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
