### PR TITLE
Csv Reader Allow Use of mimetype=text/html Files Without Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - POWER Null/Bool Args. [PR #4031](https://github.com/PHPOffice/PhpSpreadsheet/pull/4031)
 - Do Not Output Alignment and Protection for Conditional Format. [Issue #4025](https://github.com/PHPOffice/PhpSpreadsheet/issues/4025) [PR #4027](https://github.com/PHPOffice/PhpSpreadsheet/pull/4027)
 - Xls Conditional Format Improvements. [PR #4030](https://github.com/PHPOffice/PhpSpreadsheet/pull/4030)
+- Csv Reader allow use of html mimetype. [Issue #4036](https://github.com/PHPOffice/PhpSpreadsheet/issues/4036) [PR #4049](https://github.com/PHPOffice/PhpSpreadsheet/pull/4040)
 
 ## 2024-05-11 - 2.1.0
 

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -566,6 +566,7 @@ class Csv extends BaseReader
             'text/csv',
             'text/plain',
             'inode/x-empty',
+            'text/html',
         ];
 
         return in_array($type, $supportedTypes, true);

--- a/src/PhpSpreadsheet/Writer/ZipStream3.php
+++ b/src/PhpSpreadsheet/Writer/ZipStream3.php
@@ -2,7 +2,6 @@
 
 namespace PhpOffice\PhpSpreadsheet\Writer;
 
-use ZipStream\Option\Archive;
 use ZipStream\ZipStream;
 
 class ZipStream3

--- a/tests/PhpSpreadsheetTests/IOFactoryTest.php
+++ b/tests/PhpSpreadsheetTests/IOFactoryTest.php
@@ -103,6 +103,8 @@ class IOFactoryTest extends TestCase
             //['samples/templates/Excel2003XMLTest.xml', 'Xml', Reader\Xml::class],
             ['samples/templates/46readHtml.html', 'Html', Reader\Html::class],
             ['tests/data/Reader/CSV/encoding.utf8bom.csv', 'Csv', Reader\Csv::class],
+            ['tests/data/Reader/HTML/charset.UTF-16.lebom.html', 'Html', Reader\Html::class],
+            ['tests/data/Reader/HTML/charset.UTF-8.bom.html', 'Html', Reader\Html::class],
         ];
     }
 

--- a/tests/PhpSpreadsheetTests/Reader/Csv/NotHtmlTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/NotHtmlTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Csv;
+
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Reader\Csv as CsvReader;
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PHPUnit\Framework\TestCase;
+
+class NotHtmlTest extends TestCase
+{
+    private string $tempFile = '';
+
+    protected function tearDown(): void
+    {
+        if ($this->tempFile !== '') {
+            unlink($this->tempFile);
+            $this->tempFile = '';
+        }
+    }
+
+    public function testHtmlCantRead(): void
+    {
+        // This test has a file which IOFactory will identify as Csv.
+        // So file can be read using either Csv Reader or IOFactory.
+        $this->tempFile = $filename = File::temporaryFilename();
+        $cells = [
+            ['1', '<a href="http://example.com">example</a>', '3'],
+            ['4', '5', '6'],
+        ];
+        $handle = fopen($filename, 'wb');
+        self::assertNotFalse($handle);
+        foreach ($cells as $row) {
+            fwrite($handle, "{$row[0]},{$row[1]},{$row[2]}\n");
+        }
+        fclose($handle);
+        self::assertSame('text/html', mime_content_type($filename));
+        self::assertSame('Csv', IOFactory::identify($filename));
+        $reader = new CsvReader();
+        $spreadsheet = $reader->load($filename);
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertSame($cells, $sheet->toArray());
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testHtmlCanRead(): void
+    {
+        // This test has a file which IOFactory will identify as Html.
+        // So file has to be read using Csv Reader, not IOFactory.
+        $this->tempFile = $filename = File::temporaryFilename();
+        $cells = [
+            ['<a href="http://example.com">example</a>', '<div>hello', '3'],
+            ['4', '5', '</div>'],
+        ];
+        $handle = fopen($filename, 'wb');
+        self::assertNotFalse($handle);
+        foreach ($cells as $row) {
+            fwrite($handle, "{$row[0]},{$row[1]},{$row[2]}\n");
+        }
+        fclose($handle);
+        self::assertSame('text/html', mime_content_type($filename));
+        self::assertSame('Html', IOFactory::identify($filename));
+        $reader = new CsvReader();
+        $spreadsheet = $reader->load($filename);
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertSame($cells, $sheet->toArray());
+        $spreadsheet->disconnectWorksheets();
+    }
+}

--- a/tests/PhpSpreadsheetTests/Reader/Csv/NotHtmlTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/NotHtmlTest.php
@@ -36,7 +36,13 @@ class NotHtmlTest extends TestCase
             fwrite($handle, "{$row[0]},{$row[1]},{$row[2]}\n");
         }
         fclose($handle);
-        self::assertSame('text/html', mime_content_type($filename));
+        // Php8.3- identify file as text/html.
+        // Php8.4+ identify file as text/csv, and this type of change
+        //    has been known to be retrofitted to prior versions.
+        $mime = mime_content_type($filename);
+        if ($mime !== 'text/csv') {
+            self::assertSame('text/html', $mime);
+        }
         self::assertSame('Csv', IOFactory::identify($filename));
         $reader = new CsvReader();
         $spreadsheet = $reader->load($filename);
@@ -60,7 +66,13 @@ class NotHtmlTest extends TestCase
             fwrite($handle, "{$row[0]},{$row[1]},{$row[2]}\n");
         }
         fclose($handle);
-        self::assertSame('text/html', mime_content_type($filename));
+        // Php8.3- identify file as text/html.
+        // Php8.4+ identify file as text/csv, and this type of change
+        //    has been known to be retrofitted to prior versions.
+        $mime = mime_content_type($filename);
+        if ($mime !== 'text/csv') {
+            self::assertSame('text/html', $mime);
+        }
         self::assertSame('Html', IOFactory::identify($filename));
         $reader = new CsvReader();
         $spreadsheet = $reader->load($filename);


### PR DESCRIPTION
Fix #4036. The issue was originally reported as #564 (and #811) and fixed for the most part, but this is a variation that was not covered by the original. Cells with html fragments can cause `mime_content_type` to identify the file as `text\html`. Original fix was to ignore mime_content_type when file extension is 'csv' or 'tsv'. However, if the file does not have one of those extensions, it will be rejected by Csv Reader as invalid mimetype. This PR adds text\html to the list of valid mimetypes.

I imagine that this type of problem might occur for other mimetypes. If any of those are reported in future, it might be better to just add a "suppress mimetype" check option, rather than extending the list forever. Html is unusual in that its rules are so lax, which is why it seems appropriate to add it here.

Note that IOFactory may still identify a file as Html even when intended as Csv. The sample associated with this issue does not fall into this category, but one of the unit tests on this ticket does. The file will still be read correctly by Csv Reader, but IOFactory load may cause it to use Html Reader instead.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
