### PR TITLE
Better Definitions for Mixed Parameters and Values Part 3 of Many

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -120,7 +120,7 @@ class Calculation
      */
     private Logger $debugLog;
 
-    private bool $suppressFormulaErrorsNew = false;
+    private bool $suppressFormulaErrors = false;
 
     /**
      * Error message for any error that was raised/thrown by the calculation engine.
@@ -5350,7 +5350,7 @@ class Calculation
     {
         $this->formulaError = $errorMessage;
         $this->cyclicReferenceStack->clear();
-        $suppress = $this->suppressFormulaErrors ?? $this->suppressFormulaErrorsNew;
+        $suppress = $this->suppressFormulaErrors;
         if (!$suppress) {
             throw new Exception($errorMessage, $code, $exception);
         }
@@ -5634,12 +5634,12 @@ class Calculation
 
     public function setSuppressFormulaErrors(bool $suppressFormulaErrors): void
     {
-        $this->suppressFormulaErrorsNew = $suppressFormulaErrors;
+        $this->suppressFormulaErrors = $suppressFormulaErrors;
     }
 
     public function getSuppressFormulaErrors(): bool
     {
-        return $this->suppressFormulaErrorsNew;
+        return $this->suppressFormulaErrors;
     }
 
     private static function boolToString(mixed $operand1): mixed

--- a/src/PhpSpreadsheet/Cell/AdvancedValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/AdvancedValueBinder.php
@@ -4,7 +4,6 @@ namespace PhpOffice\PhpSpreadsheet\Cell;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engine\FormattedNumber;
-use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
@@ -30,7 +29,7 @@ class AdvancedValueBinder extends DefaultValueBinder implements IValueBinder
         $dataType = parent::dataTypeForValue($value);
 
         // Style logic - strings
-        if ($dataType === DataType::TYPE_STRING && !$value instanceof RichText) {
+        if ($dataType === DataType::TYPE_STRING && is_string($value)) {
             //    Test for booleans using locale-setting
             if (StringHelper::strToUpper($value) === Calculation::getTRUE()) {
                 $cell->setValueExplicit(true, DataType::TYPE_BOOL);
@@ -54,17 +53,17 @@ class AdvancedValueBinder extends DefaultValueBinder implements IValueBinder
             $thousandsSeparator = preg_quote(StringHelper::getThousandsSeparator(), '/');
 
             // Check for percentage
-            if (preg_match('/^\-?\d*' . $decimalSeparator . '?\d*\s?\%$/', preg_replace('/(\d)' . $thousandsSeparator . '(\d)/u', '$1$2', $value))) {
-                return $this->setPercentage(preg_replace('/(\d)' . $thousandsSeparator . '(\d)/u', '$1$2', $value), $cell);
+            if (preg_match('/^\-?\d*' . $decimalSeparator . '?\d*\s?\%$/', (string) preg_replace('/(\d)' . $thousandsSeparator . '(\d)/u', '$1$2', $value))) {
+                return $this->setPercentage((string) preg_replace('/(\d)' . $thousandsSeparator . '(\d)/u', '$1$2', $value), $cell);
             }
 
             // Check for currency
-            if (preg_match(FormattedNumber::currencyMatcherRegexp(), preg_replace('/(\d)' . $thousandsSeparator . '(\d)/u', '$1$2', $value), $matches, PREG_UNMATCHED_AS_NULL)) {
+            if (preg_match(FormattedNumber::currencyMatcherRegexp(), (string) preg_replace('/(\d)' . $thousandsSeparator . '(\d)/u', '$1$2', $value), $matches, PREG_UNMATCHED_AS_NULL)) {
                 // Convert value to number
                 $sign = ($matches['PrefixedSign'] ?? $matches['PrefixedSign2'] ?? $matches['PostfixedSign']) ?? null;
                 $currencyCode = $matches['PrefixedCurrency'] ?? $matches['PostfixedCurrency'];
                 /** @var string */
-                $temp = str_replace([$decimalSeparatorNoPreg, $currencyCode, ' ', '-'], ['.', '', '', ''], preg_replace('/(\d)' . $thousandsSeparator . '(\d)/u', '$1$2', $value));
+                $temp = str_replace([$decimalSeparatorNoPreg, $currencyCode, ' ', '-'], ['.', '', '', ''], (string) preg_replace('/(\d)' . $thousandsSeparator . '(\d)/u', '$1$2', $value));
                 $value = (float) ($sign . trim($temp));
 
                 return $this->setCurrency($value, $cell, $currencyCode ?? '');

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -188,13 +188,15 @@ class Cell implements Stringable
     public function getFormattedValue(): string
     {
         return (string) NumberFormat::toFormattedString(
-            $this->getCalculatedValue(),
+            $this->getCalculatedValueString(),
             (string) $this->getStyle()->getNumberFormat()->getFormatCode(true)
         );
     }
 
     protected static function updateIfCellIsTableHeader(?Worksheet $workSheet, self $cell, mixed $oldValue, mixed $newValue): void
     {
+        $oldValue = (is_scalar($oldValue) || $oldValue instanceof Stringable) ? ((string) $oldValue) : null;
+        $newValue = (is_scalar($newValue) || $newValue instanceof Stringable) ? ((string) $newValue) : null;
         if (StringHelper::strToLower($oldValue ?? '') === StringHelper::strToLower($newValue ?? '') || $workSheet === null) {
             return;
         }
@@ -262,7 +264,10 @@ class Cell implements Stringable
                 // Synonym for string
             case DataType::TYPE_INLINE:
                 // Rich text
-                $this->value = DataType::checkString($value);
+                if ($value !== null && !is_scalar($value) && !($value instanceof Stringable)) {
+                    throw new SpreadsheetException('Invalid unstringable value for datatype Inline/String/String2');
+                }
+                $this->value = DataType::checkString(($value instanceof RichText) ? $value : ((string) $value));
 
                 break;
             case DataType::TYPE_NUMERIC:
@@ -273,6 +278,9 @@ class Cell implements Stringable
 
                 break;
             case DataType::TYPE_FORMULA:
+                if ($value !== null && !is_scalar($value) && !($value instanceof Stringable)) {
+                    throw new SpreadsheetException('Invalid unstringable value for datatype Formula');
+                }
                 $this->value = (string) $value;
 
                 break;
@@ -790,7 +798,9 @@ class Cell implements Stringable
      */
     public function __toString(): string
     {
-        return (string) $this->getValue();
+        $retVal = $this->value;
+
+        return ($retVal === null || is_scalar($retVal) || $retVal instanceof Stringable) ? ((string) $retVal) : '';
     }
 
     public function getIgnoredErrors(): IgnoredErrors

--- a/src/PhpSpreadsheet/Cell/DataType.php
+++ b/src/PhpSpreadsheet/Cell/DataType.php
@@ -4,6 +4,7 @@ namespace PhpOffice\PhpSpreadsheet\Cell;
 
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
+use Stringable;
 
 class DataType
 {
@@ -78,7 +79,7 @@ class DataType
      */
     public static function checkErrorCode(mixed $value): string
     {
-        $value = (string) $value;
+        $value = (is_scalar($value) || $value instanceof Stringable) ? ((string) $value) : '#NULL!';
 
         if (!isset(self::$errorCodes[$value])) {
             $value = '#NULL!';

--- a/src/PhpSpreadsheet/Cell/DataValidator.php
+++ b/src/PhpSpreadsheet/Cell/DataValidator.php
@@ -46,7 +46,7 @@ class DataValidator
                 $returnValue = $this->numericOperator($dataValidation, (float) $cellValue);
             }
         } elseif ($type === DataValidation::TYPE_TEXTLENGTH) {
-            $returnValue = $this->numericOperator($dataValidation, mb_strlen((string) $cellValue));
+            $returnValue = $this->numericOperator($dataValidation, mb_strlen($cell->getValueString()));
         }
 
         return $returnValue;
@@ -86,14 +86,14 @@ class DataValidator
      */
     private function isValueInList(Cell $cell): bool
     {
-        $cellValue = $cell->getValue();
+        $cellValueString = $cell->getValueString();
         $dataValidation = $cell->getDataValidation();
 
         $formula1 = $dataValidation->getFormula1();
         if (!empty($formula1)) {
             // inline values list
             if ($formula1[0] === '"') {
-                return in_array(strtolower($cellValue), explode(',', strtolower(trim($formula1, '"'))), true);
+                return in_array(strtolower($cellValueString), explode(',', strtolower(trim($formula1, '"'))), true);
             } elseif (strpos($formula1, ':') > 0) {
                 // values list cells
                 $matchFormula = '=MATCH(' . $cell->getCoordinate() . ', ' . $formula1 . ', 0)';

--- a/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
@@ -46,19 +46,33 @@ class DefaultValueBinder implements IValueBinder
         // Match the value against a few data types
         if ($value === null) {
             return DataType::TYPE_NULL;
-        } elseif (is_float($value) || is_int($value)) {
+        }
+        if (is_float($value) || is_int($value)) {
             return DataType::TYPE_NUMERIC;
-        } elseif (is_bool($value)) {
+        }
+        if (is_bool($value)) {
             return DataType::TYPE_BOOL;
-        } elseif ($value === '') {
+        }
+        if ($value === '') {
             return DataType::TYPE_STRING;
-        } elseif ($value instanceof RichText) {
+        }
+        if ($value instanceof RichText) {
             return DataType::TYPE_INLINE;
-        } elseif (is_string($value) && strlen($value) > 1 && $value[0] === '=') {
+        }
+        if ($value instanceof Stringable) {
+            $value = (string) $value;
+        }
+        if (!is_string($value)) {
+            $gettype = is_object($value) ? get_class($value) : gettype($value);
+
+            throw new SpreadsheetException("unusable type $gettype");
+        }
+        if (strlen($value) > 1 && $value[0] === '=') {
             return DataType::TYPE_FORMULA;
-        } elseif (preg_match('/^[\+\-]?(\d+\\.?\d*|\d*\\.?\d+)([Ee][\-\+]?[0-2]?\d{1,3})?$/', $value)) {
+        }
+        if (preg_match('/^[\+\-]?(\d+\\.?\d*|\d*\\.?\d+)([Ee][\-\+]?[0-2]?\d{1,3})?$/', $value)) {
             $tValue = ltrim($value, '+-');
-            if (is_string($value) && strlen($tValue) > 1 && $tValue[0] === '0' && $tValue[1] !== '.') {
+            if (strlen($tValue) > 1 && $tValue[0] === '0' && $tValue[1] !== '.') {
                 return DataType::TYPE_STRING;
             } elseif ((!str_contains($value, '.')) && ($value > PHP_INT_MAX)) {
                 return DataType::TYPE_STRING;
@@ -67,11 +81,10 @@ class DefaultValueBinder implements IValueBinder
             }
 
             return DataType::TYPE_NUMERIC;
-        } elseif (is_string($value)) {
-            $errorCodes = DataType::getErrorCodes();
-            if (isset($errorCodes[$value])) {
-                return DataType::TYPE_ERROR;
-            }
+        }
+        $errorCodes = DataType::getErrorCodes();
+        if (isset($errorCodes[$value])) {
+            return DataType::TYPE_ERROR;
         }
 
         return DataType::TYPE_STRING;

--- a/src/PhpSpreadsheet/Chart/Axis.php
+++ b/src/PhpSpreadsheet/Chart/Axis.php
@@ -37,7 +37,7 @@ class Axis extends Properties
     /**
      * Axis Number.
      *
-     * @var mixed[]
+     * @var array{format: string, source_linked: int, numeric: ?bool}
      */
     private array $axisNumber = [
         'format' => self::FORMAT_CODE_GENERAL,

--- a/src/PhpSpreadsheet/Chart/DataSeriesValues.php
+++ b/src/PhpSpreadsheet/Chart/DataSeriesValues.php
@@ -451,12 +451,14 @@ class DataSeriesValues extends Properties
                 if (($dimensions[0] == 1) || ($dimensions[1] == 1)) {
                     $this->dataValues = Functions::flattenArray($newDataValues);
                 } else {
-                    $newArray = array_values(array_shift($newDataValues));
+                    /** @var array<int, array> */
+                    $newDataValuesx = $newDataValues;
+                    $newArray = array_values(array_shift($newDataValuesx) ?? []);
                     foreach ($newArray as $i => $newDataSet) {
                         $newArray[$i] = [$newDataSet];
                     }
 
-                    foreach ($newDataValues as $newDataSet) {
+                    foreach ($newDataValuesx as $newDataSet) {
                         $i = 0;
                         foreach ($newDataSet as $newDataVal) {
                             array_unshift($newArray[$i++], $newDataVal);

--- a/src/PhpSpreadsheet/Chart/Properties.php
+++ b/src/PhpSpreadsheet/Chart/Properties.php
@@ -647,8 +647,16 @@ abstract class Properties
                 'alpha' => $this->shadowColor->getAlpha(),
             ];
         }
+        $retVal = $this->getArrayElementsValue($this->shadowProperties, $elements);
+        if (is_scalar($retVal)) {
+            $retVal = (string) $retVal;
+        } elseif ($retVal !== null && !is_array($retVal)) {
+            // @codeCoverageIgnoreStart
+            throw new Exception('Unexpected value for shadowProperty');
+            // @codeCoverageIgnoreEnd
+        }
 
-        return $this->getArrayElementsValue($this->shadowProperties, $elements);
+        return $retVal;
     }
 
     public function getShadowArray(): array
@@ -825,7 +833,16 @@ abstract class Properties
      */
     public function getLineStyleProperty(array|string $elements): ?string
     {
-        return $this->getArrayElementsValue($this->lineStyleProperties, $elements);
+        $retVal = $this->getArrayElementsValue($this->lineStyleProperties, $elements);
+        if (is_scalar($retVal)) {
+            $retVal = (string) $retVal;
+        } elseif ($retVal !== null) {
+            // @codeCoverageIgnoreStart
+            throw new Exception('Unexpected value for lineStyleProperty');
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $retVal;
     }
 
     protected const ARROW_SIZES = [

--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -444,7 +444,7 @@ class ReferenceHelper
                 if ($cell->getDataType() === DataType::TYPE_FORMULA) {
                     // Formula should be adjusted
                     $worksheet->getCell($newCoordinate)
-                        ->setValue($this->updateFormulaReferences($cell->getValue(), $beforeCellAddress, $numberOfColumns, $numberOfRows, $worksheet->getTitle(), true));
+                        ->setValue($this->updateFormulaReferences($cell->getValueString(), $beforeCellAddress, $numberOfColumns, $numberOfRows, $worksheet->getTitle(), true));
                 } else {
                     // Cell value should not be adjusted
                     $worksheet->getCell($newCoordinate)->setValueExplicit($cell->getValue(), $cell->getDataType());
@@ -457,7 +457,7 @@ class ReferenceHelper
                         but we do still need to adjust any formulae in those cells                    */
                 if ($cell->getDataType() === DataType::TYPE_FORMULA) {
                     // Formula should be adjusted
-                    $cell->setValue($this->updateFormulaReferences($cell->getValue(), $beforeCellAddress, $numberOfColumns, $numberOfRows, $worksheet->getTitle(), true));
+                    $cell->setValue($this->updateFormulaReferences($cell->getValueString(), $beforeCellAddress, $numberOfColumns, $numberOfRows, $worksheet->getTitle(), true));
                 }
             }
         }
@@ -897,7 +897,7 @@ class ReferenceHelper
             foreach ($sheet->getCoordinates(false) as $coordinate) {
                 $cell = $sheet->getCell($coordinate);
                 if ($cell->getDataType() === DataType::TYPE_FORMULA) {
-                    $formula = $cell->getValue();
+                    $formula = $cell->getValueString();
                     if (str_contains($formula, $oldName)) {
                         $formula = str_replace("'" . $oldName . "'!", "'" . $newName . "'!", $formula);
                         $formula = str_replace($oldName . '!', $newName . '!', $formula);

--- a/src/PhpSpreadsheet/RichText/RichText.php
+++ b/src/PhpSpreadsheet/RichText/RichText.php
@@ -27,8 +27,8 @@ class RichText implements IComparable, Stringable
         // Rich-Text string attached to cell?
         if ($cell !== null) {
             // Add cell text and style
-            if ($cell->getValue() != '') {
-                $objRun = new Run($cell->getValue());
+            if ($cell->getValueString() !== '') {
+                $objRun = new Run($cell->getValueString());
                 $objRun->setFont(clone $cell->getWorksheet()->getStyle($cell->getCoordinate())->getFont());
                 $this->addText($objRun);
             }

--- a/src/PhpSpreadsheet/Shared/Trend/PolynomialBestFit.php
+++ b/src/PhpSpreadsheet/Shared/Trend/PolynomialBestFit.php
@@ -159,13 +159,15 @@ class PolynomialBestFit extends BestFit
         $coefficients = [];
         for ($i = 0; $i < $C->rows; ++$i) {
             $r = $C->getValue($i + 1, 1); // row and column are origin-1
-            if (abs($r) <= 10 ** (-9)) {
+            if (!is_numeric($r) || abs($r) <= 10 ** (-9)) {
                 $r = 0;
+            } else {
+                $r += 0;
             }
             $coefficients[] = $r;
         }
 
-        $this->intersect = array_shift($coefficients);
+        $this->intersect = (float) array_shift($coefficients);
         // Phpstan is correct
         //* @phpstan-ignore-next-line
         $this->slope = $coefficients;

--- a/tests/PhpSpreadsheetTests/Cell/CellTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CellTest.php
@@ -19,16 +19,20 @@ use PHPUnit\Framework\TestCase;
 
 class CellTest extends TestCase
 {
+    private ?Spreadsheet $spreadsheet = null;
+
     protected function setUp(): void
     {
-        parent::setUp();
         Cell::setValueBinder(new DefaultValueBinder());
     }
 
     protected function tearDown(): void
     {
-        parent::tearDown();
         Cell::setValueBinder(new DefaultValueBinder());
+        if ($this->spreadsheet !== null) {
+            $this->spreadsheet->disconnectWorksheets();
+            $this->spreadsheet = null;
+        }
     }
 
     public function testSetValueBinderOverride(): void
@@ -92,15 +96,13 @@ class CellTest extends TestCase
 
     public function testInvalidIsoDateSetValueExplicit(): void
     {
-        $spreadsheet = new Spreadsheet();
-        $cell = $spreadsheet->getActiveSheet()->getCell('A1');
+        $this->spreadsheet = new Spreadsheet();
+        $cell = $this->spreadsheet->getActiveSheet()->getCell('A1');
 
         $dateValue = '2022-02-29'; // Invalid leap year
         $this->expectException(Exception::class);
         $this->expectExceptionMessage("Invalid string {$dateValue} supplied for datatype Date");
         $cell->setValueExplicit($dateValue, DataType::TYPE_ISO_DATE);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     /**
@@ -110,8 +112,8 @@ class CellTest extends TestCase
     {
         $this->expectException(Exception::class);
 
-        $spreadsheet = new Spreadsheet();
-        $cell = $spreadsheet->getActiveSheet()->getCell('A1');
+        $this->spreadsheet = new Spreadsheet();
+        $cell = $this->spreadsheet->getActiveSheet()->getCell('A1');
         $cell->setValueExplicit($value, $dataType);
     }
 
@@ -166,8 +168,8 @@ class CellTest extends TestCase
 
     public function testDestroyCell2(): void
     {
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
+        $this->spreadsheet = new Spreadsheet();
+        $sheet = $this->spreadsheet->getActiveSheet();
         $cell = $sheet->getCell('A1');
         self::assertSame('A1', $cell->getCoordinate());
         $this->expectException(Exception::class);
@@ -245,6 +247,7 @@ class CellTest extends TestCase
             $greenStyle->getFill()->getStartColor()->getARGB(),
             $style->getFill()->getStartColor()->getARGB()
         );
+        $spreadsheet->disconnectWorksheets();
     }
 
     /**
@@ -296,6 +299,7 @@ class CellTest extends TestCase
         if ($fillStyle === Fill::FILL_SOLID) {
             self::assertEquals($fillColor, $style->getFill()->getStartColor()->getARGB());
         }
+        $spreadsheet->disconnectWorksheets();
     }
 
     public static function appliedStyling(): array

--- a/tests/PhpSpreadsheetTests/Cell/DefaultValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/DefaultValueBinderTest.php
@@ -108,4 +108,27 @@ class DefaultValueBinderTest extends TestCase
         self::assertTrue($binder::$called);
         $spreadsheet->disconnectWorksheets();
     }
+
+    public function testDataTypeForValueExceptions(): void
+    {
+        try {
+            self::assertSame('s', DefaultValueBinder::dataTypeForValue(new SpreadsheetException()));
+        } catch (SpreadsheetException $e) {
+            self::fail('Should not have failed for stringable');
+        }
+
+        try {
+            DefaultValueBinder::dataTypeForValue([]);
+            self::fail('Should have failed for array');
+        } catch (SpreadsheetException $e) {
+            self::assertStringContainsString('unusable type array', $e->getMessage());
+        }
+
+        try {
+            DefaultValueBinder::dataTypeForValue(new DateTime());
+            self::fail('Should have failed for DateTime');
+        } catch (SpreadsheetException $e) {
+            self::assertStringContainsString('unusable type DateTime', $e->getMessage());
+        }
+    }
 }

--- a/tests/data/Cell/SetValueExplicitException.php
+++ b/tests/data/Cell/SetValueExplicitException.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 
 return [
-    [
-        'XYZ',
-        DataType::TYPE_NUMERIC,
-    ],
+    'invalid numeric' => ['XYZ', DataType::TYPE_NUMERIC],
+    'invalid array' => [[], DataType::TYPE_STRING],
+    'invalid unstringable object' => [new DateTime(), DataType::TYPE_INLINE],
 ];


### PR DESCRIPTION
Continuing work started with PR #4016 and PR #4026. Improve documentation within program by making explicit what types of values are allowed for variables described as "mixed". In order to avoid broken functionality, this is done mainly through doc-blocks. This will get us closer to Phpstan Level 9, but many changes will be needed before we can consider that.

This change has more executable code changes than its predecessor. I will wait longer than normal before merging it to allow for additional testing.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] improve code base quality

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
