### PR TITLE
Update JpGraphRendererBase.php - check existing of PlotLabel

### DIFF
--- a/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
@@ -334,7 +334,8 @@ abstract class JpGraphRendererBase implements IRenderer
                 //    Set the appropriate plot marker
                 $this->formatPointMarker($seriesPlot, $marker);
             }
-            $dataLabel = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($index)->getDataValue();
+            if ($this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($index))
+                $dataLabel = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($index)->getDataValue();
             $seriesPlot->SetLegend($dataLabel);
 
             $seriesPlots[] = $seriesPlot;

--- a/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
@@ -334,8 +334,9 @@ abstract class JpGraphRendererBase implements IRenderer
                 //    Set the appropriate plot marker
                 $this->formatPointMarker($seriesPlot, $marker);
             }
-            if ($this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($index))
+            if ($this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($index)) {
                 $dataLabel = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($index)->getDataValue();
+            }
             $seriesPlot->SetLegend($dataLabel);
 
             $seriesPlots[] = $seriesPlot;

--- a/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
@@ -336,8 +336,8 @@ abstract class JpGraphRendererBase implements IRenderer
             }
             if ($this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($index)) {
                 $dataLabel = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($index)->getDataValue();
+                $seriesPlot->SetLegend($dataLabel);
             }
-            $seriesPlot->SetLegend($dataLabel);
 
             $seriesPlots[] = $seriesPlot;
         }

--- a/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
@@ -287,7 +287,7 @@ abstract class JpGraphRendererBase implements IRenderer
         if (!$plotLabel) {
             return '';
         }
-        
+
         return $plotLabel->getDataValue();
     }
 
@@ -757,7 +757,7 @@ abstract class JpGraphRendererBase implements IRenderer
                     break;
                 case 'bar3DChart':
                     $dimensions = '3d';
-                    // no break
+                // no break
                 case 'barChart':
                     $this->renderPlotBar($i, $dimensions);
 
@@ -818,35 +818,35 @@ abstract class JpGraphRendererBase implements IRenderer
         switch ($chartType) {
             case 'area3DChart':
                 $dimensions = '3d';
-                // no break
+            // no break
             case 'areaChart':
                 $this->renderAreaChart($groupCount);
 
                 break;
             case 'bar3DChart':
                 $dimensions = '3d';
-                // no break
+            // no break
             case 'barChart':
                 $this->renderBarChart($groupCount, $dimensions);
 
                 break;
             case 'line3DChart':
                 $dimensions = '3d';
-                // no break
+            // no break
             case 'lineChart':
                 $this->renderLineChart($groupCount);
 
                 break;
             case 'pie3DChart':
                 $dimensions = '3d';
-                // no break
+            // no break
             case 'pieChart':
                 $this->renderPieChart($groupCount, $dimensions, false, false);
 
                 break;
             case 'doughnut3DChart':
                 $dimensions = '3d';
-                // no break
+            // no break
             case 'doughnutChart':
                 $this->renderPieChart($groupCount, $dimensions, true, true);
 

--- a/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
@@ -287,6 +287,7 @@ abstract class JpGraphRendererBase implements IRenderer
         if (!$plotLabel) {
             return '';
         }
+        
         return $plotLabel->getDataValue();
     }
 

--- a/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
@@ -281,6 +281,16 @@ abstract class JpGraphRendererBase implements IRenderer
         $this->renderTitle();
     }
 
+    private function getDataLabel(int $groupId, int $index): mixed
+    {
+        $plotLabel = $this->chart->getPlotArea()->getPlotGroupByIndex($groupId)->getPlotLabelByIndex($index);
+        if (!$plotLabel) {
+            return '';
+        } else {
+            return $plotLabel->getDataValue();
+        }
+    }
+
     private function renderPlotLine(int $groupID, bool $filled = false, bool $combination = false): void
     {
         $grouping = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotGrouping();
@@ -334,10 +344,8 @@ abstract class JpGraphRendererBase implements IRenderer
                 //    Set the appropriate plot marker
                 $this->formatPointMarker($seriesPlot, $marker);
             }
-            if ($this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($index)) {
-                $dataLabel = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($index)->getDataValue();
-                $seriesPlot->SetLegend($dataLabel);
-            }
+
+            $seriesPlot->SetLegend($this->getDataLabel($groupID, $index));
 
             $seriesPlots[] = $seriesPlot;
         }
@@ -410,12 +418,8 @@ abstract class JpGraphRendererBase implements IRenderer
             if ($dimensions == '3d') {
                 $seriesPlot->SetShadow();
             }
-            if (!$this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($j)) {
-                $dataLabel = '';
-            } else {
-                $dataLabel = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($j)->getDataValue();
-            }
-            $seriesPlot->SetLegend($dataLabel);
+
+            $seriesPlot->SetLegend($this->getDataLabel($groupID, $j));
 
             $seriesPlots[] = $seriesPlot;
         }
@@ -494,8 +498,7 @@ abstract class JpGraphRendererBase implements IRenderer
                 $marker = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotValuesByIndex($i)->getPointMarker();
                 $this->formatPointMarker($seriesPlot, $marker);
             }
-            $dataLabel = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($i)->getDataValue();
-            $seriesPlot->SetLegend($dataLabel);
+            $seriesPlot->SetLegend($this->getDataLabel($groupID, $i));
 
             $this->graph->Add($seriesPlot);
         }
@@ -526,13 +529,12 @@ abstract class JpGraphRendererBase implements IRenderer
 
             $seriesPlot = new RadarPlot(array_reverse($dataValuesX));
 
-            $dataLabel = $this->chart->getPlotArea()->getPlotGroupByIndex($groupID)->getPlotLabelByIndex($i)->getDataValue();
             $seriesPlot->SetColor(self::$colourSet[self::$plotColour++]);
             if ($radarStyle == 'filled') {
                 $seriesPlot->SetFillColor(self::$colourSet[self::$plotColour]);
             }
             $this->formatPointMarker($seriesPlot, $marker);
-            $seriesPlot->SetLegend($dataLabel);
+            $seriesPlot->SetLegend($this->getDataLabel($groupID, $i));
 
             $this->graph->Add($seriesPlot);
         }

--- a/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
@@ -286,9 +286,8 @@ abstract class JpGraphRendererBase implements IRenderer
         $plotLabel = $this->chart->getPlotArea()->getPlotGroupByIndex($groupId)->getPlotLabelByIndex($index);
         if (!$plotLabel) {
             return '';
-        } else {
-            return $plotLabel->getDataValue();
         }
+        return $plotLabel->getDataValue();
     }
 
     private function renderPlotLine(int $groupID, bool $filled = false, bool $combination = false): void

--- a/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
+++ b/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php
@@ -757,7 +757,7 @@ abstract class JpGraphRendererBase implements IRenderer
                     break;
                 case 'bar3DChart':
                     $dimensions = '3d';
-                // no break
+                    // no break
                 case 'barChart':
                     $this->renderPlotBar($i, $dimensions);
 
@@ -818,35 +818,35 @@ abstract class JpGraphRendererBase implements IRenderer
         switch ($chartType) {
             case 'area3DChart':
                 $dimensions = '3d';
-            // no break
+                // no break
             case 'areaChart':
                 $this->renderAreaChart($groupCount);
 
                 break;
             case 'bar3DChart':
                 $dimensions = '3d';
-            // no break
+                // no break
             case 'barChart':
                 $this->renderBarChart($groupCount, $dimensions);
 
                 break;
             case 'line3DChart':
                 $dimensions = '3d';
-            // no break
+                // no break
             case 'lineChart':
                 $this->renderLineChart($groupCount);
 
                 break;
             case 'pie3DChart':
                 $dimensions = '3d';
-            // no break
+                // no break
             case 'pieChart':
                 $this->renderPieChart($groupCount, $dimensions, false, false);
 
                 break;
             case 'doughnut3DChart':
                 $dimensions = '3d';
-            // no break
+                // no break
             case 'doughnutChart':
                 $this->renderPieChart($groupCount, $dimensions, true, true);
 


### PR DESCRIPTION
I've got
Uncaught PHP Exception Symfony\Component\ErrorHandler\Error\FatalError: "Error: Uncaught Error: Call to a member function getDataValue() on bool in .../vendor/phpoffice/phpspreadsheet/src/PhpSpreadsheet/Chart/Renderer/JpGraphRendererBase.php:337

I found that it's necessary to check existing of PlotLabel before using its method getDataValue().

This is:

- [x ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ x] Code style is respected
- [x ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
