### PR TITLE
Ods Boolean Data

### DIFF
--- a/src/PhpSpreadsheet/Reader/Ods.php
+++ b/src/PhpSpreadsheet/Reader/Ods.php
@@ -492,7 +492,7 @@ class Ods extends BaseReader
                                             break;
                                         case 'boolean':
                                             $type = DataType::TYPE_BOOL;
-                                            $dataValue = ($allCellDataText == 'TRUE') ? true : false;
+                                            $dataValue = ($cellData->getAttributeNS($officeNs, 'boolean-value') === 'true') ? true : false;
 
                                             break;
                                         case 'percentage':

--- a/src/PhpSpreadsheet/Writer/Ods/Content.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Content.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Writer\Ods;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
@@ -209,8 +210,8 @@ class Content extends WriterPart
             switch ($cell->getDataType()) {
                 case DataType::TYPE_BOOL:
                     $objWriter->writeAttribute('office:value-type', 'boolean');
-                    $objWriter->writeAttribute('office:value', $cell->getValueString());
-                    $objWriter->writeElement('text:p', $cell->getValueString());
+                    $objWriter->writeAttribute('office:boolean-value', $cell->getValue() ? 'true' : 'false');
+                    $objWriter->writeElement('text:p', Calculation::getInstance()->getLocaleBoolean($cell->getValue() ? 'TRUE' : 'FALSE'));
 
                     break;
                 case DataType::TYPE_ERROR:

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationFunctionListTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationFunctionListTest.php
@@ -13,21 +13,15 @@ class CalculationFunctionListTest extends TestCase
 {
     private string $compatibilityMode;
 
-    private string $locale;
-
     protected function setUp(): void
     {
         $this->compatibilityMode = Functions::getCompatibilityMode();
-        $calculation = Calculation::getInstance();
-        $this->locale = $calculation->getLocale();
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
     }
 
     protected function tearDown(): void
     {
         Functions::setCompatibilityMode($this->compatibilityMode);
-        $calculation = Calculation::getInstance();
-        $calculation->setLocale($this->locale);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -15,21 +15,15 @@ class CalculationTest extends TestCase
 {
     private string $compatibilityMode;
 
-    private string $locale;
-
     protected function setUp(): void
     {
         $this->compatibilityMode = Functions::getCompatibilityMode();
-        $calculation = Calculation::getInstance();
-        $this->locale = $calculation->getLocale();
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
     }
 
     protected function tearDown(): void
     {
         Functions::setCompatibilityMode($this->compatibilityMode);
-        $calculation = Calculation::getInstance();
-        $calculation->setLocale($this->locale);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Reader/Ods/BooleanDataTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Ods/BooleanDataTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Ods;
+
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Reader\Ods as OdsReader;
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Ods as OdsWriter;
+use PHPUnit\Framework\TestCase;
+
+class BooleanDataTest extends TestCase
+{
+    private string $tempfile = '';
+
+    private string $locale;
+
+    protected function setUp(): void
+    {
+        $calculation = Calculation::getInstance();
+        $this->locale = $calculation->getLocale();
+    }
+
+    protected function tearDown(): void
+    {
+        $calculation = Calculation::getInstance();
+        $calculation->setLocale($this->locale);
+        if ($this->tempfile !== '') {
+            unlink($this->tempfile);
+            $this->tempfile = '';
+        }
+    }
+
+    public function testBooleanData(): void
+    {
+        $spreadsheetOld = new Spreadsheet();
+        $sheetOld = $spreadsheetOld->getActiveSheet();
+        $sheetOld->getCell('A1')->setValue(true);
+        $sheetOld->getCell('A2')->setValue(false);
+        $writer = new OdsWriter($spreadsheetOld);
+        $this->tempfile = File::temporaryFileName();
+        $writer->save($this->tempfile);
+        $spreadsheetOld->disconnectWorksheets();
+        $reader = new OdsReader();
+        $spreadsheet = $reader->load($this->tempfile);
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertTrue($sheet->getCell('A1')->getValue());
+        self::assertFalse($sheet->getCell('A2')->getValue());
+        $spreadsheet->disconnectWorksheets();
+        $zipFile = 'zip://' . $this->tempfile . '#content.xml';
+        $contents = (string) file_get_contents($zipFile);
+        self::assertStringContainsString('<text:p>TRUE</text:p>', $contents);
+        self::assertStringContainsString('<text:p>FALSE</text:p>', $contents);
+    }
+
+    public function testBooleanDataGerman(): void
+    {
+        $calculation = Calculation::getInstance();
+        $calculation->setLocale('de');
+        $spreadsheetOld = new Spreadsheet();
+        $sheetOld = $spreadsheetOld->getActiveSheet();
+        $sheetOld->getCell('A1')->setValue(true);
+        $sheetOld->getCell('A2')->setValue(false);
+        $writer = new OdsWriter($spreadsheetOld);
+        $this->tempfile = File::temporaryFileName();
+        $writer->save($this->tempfile);
+        $spreadsheetOld->disconnectWorksheets();
+        $reader = new OdsReader();
+        $spreadsheet = $reader->load($this->tempfile);
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertTrue($sheet->getCell('A1')->getValue());
+        self::assertFalse($sheet->getCell('A2')->getValue());
+        $spreadsheet->disconnectWorksheets();
+        $zipFile = 'zip://' . $this->tempfile . '#content.xml';
+        $contents = (string) file_get_contents($zipFile);
+        self::assertStringContainsString('<text:p>WAHR</text:p>', $contents);
+        self::assertStringContainsString('<text:p>FALSCH</text:p>', $contents);
+        self::assertStringNotContainsString('<text:p>TRUE</text:p>', $contents);
+        self::assertStringNotContainsString('<text:p>FALSE</text:p>', $contents);
+    }
+}

--- a/tests/data/Writer/Ods/content-with-data.xml
+++ b/tests/data/Writer/Ods/content-with-data.xml
@@ -95,11 +95,11 @@
                     <table:table-cell table:number-columns-repeated="1017"/>
                 </table:table-row>
                 <table:table-row>
-                    <table:table-cell office:value="1" office:value-type="boolean" table:style-name="ce0">
-                        <text:p>1</text:p>
+                    <table:table-cell office:boolean-value="true" office:value-type="boolean" table:style-name="ce0">
+                        <text:p>TRUE</text:p>
                     </table:table-cell>
-                    <table:table-cell office:value="" office:value-type="boolean" table:style-name="ce0">
-                        <text:p/>
+                    <table:table-cell office:boolean-value="false" office:value-type="boolean" table:style-name="ce0">
+                        <text:p>FALSE</text:p>
                     </table:table-cell>
                     <table:table-cell office:value="1 1" office:value-type="string" table:formula="of:=IF([.A3]; CONCATENATE([.A1]; &quot; &quot;; [.A2]); CONCATENATE([.A2]; &quot; &quot;; [.A1]))" table:style-name="ce10">
                         <text:p>1 1</text:p>


### PR DESCRIPTION
Fix #460. Another in the "better late than never" series, closed as stale in June 2018. Ods Writer and Ods Reader handle booleans differently; what is worse, neither of them do it correctly. They will now match the behavior of LibreOffice. Reporter said that part of the xml would vary depending on locale; I believe that part is never actually used, but I do emulate that behavior.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
