### PR TITLE
Reference to Defined Name Specifying Worksheet Name

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -5074,9 +5074,10 @@ class Calculation
                     if ($cell === null || $pCellWorksheet === null) {
                         return $this->raiseFormulaError("undefined name '$token'");
                     }
+                    $specifiedWorksheet = trim($matches[2], "'");
 
                     $this->debugLog->writeDebugLog('Evaluating Defined Name %s', $definedName);
-                    $namedRange = DefinedName::resolveName($definedName, $pCellWorksheet);
+                    $namedRange = DefinedName::resolveName($definedName, $pCellWorksheet, $specifiedWorksheet);
                     // If not Defined Name, try as Table.
                     if ($namedRange === null && $this->spreadsheet !== null) {
                         $table = $this->spreadsheet->getTableByName($definedName);
@@ -5101,7 +5102,7 @@ class Calculation
                         return $this->raiseFormulaError("undefined name '$definedName'");
                     }
 
-                    $result = $this->evaluateDefinedName($cell, $namedRange, $pCellWorksheet, $stack);
+                    $result = $this->evaluateDefinedName($cell, $namedRange, $pCellWorksheet, $stack, $specifiedWorksheet !== '');
                     if (isset($storeKey)) {
                         $branchStore[$storeKey] = $result;
                     }
@@ -5580,10 +5581,10 @@ class Calculation
         return $args;
     }
 
-    private function evaluateDefinedName(Cell $cell, DefinedName $namedRange, Worksheet $cellWorksheet, Stack $stack): mixed
+    private function evaluateDefinedName(Cell $cell, DefinedName $namedRange, Worksheet $cellWorksheet, Stack $stack, bool $ignoreScope = false): mixed
     {
         $definedNameScope = $namedRange->getScope();
-        if ($definedNameScope !== null && $definedNameScope !== $cellWorksheet) {
+        if ($definedNameScope !== null && $definedNameScope !== $cellWorksheet && !$ignoreScope) {
             // The defined name isn't in our current scope, so #REF
             $result = ExcelError::REF();
             $stack->push('Error', $result, $namedRange->getName());

--- a/tests/PhpSpreadsheetTests/NamedRange3Test.php
+++ b/tests/PhpSpreadsheetTests/NamedRange3Test.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests;
+
+use PhpOffice\PhpSpreadsheet\NamedRange;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+class NamedRange3Test extends TestCase
+{
+    public function testSheetNamePlusDefinedName(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet1 = $spreadsheet->getActiveSheet();
+        $sheet1->setTitle('sheet1');
+        $sheet1->setCellValue('B1', 100);
+        $sheet1->setCellValue('B2', 200);
+        $sheet1->setCellValue('B3', 300);
+        $sheet1->setCellValue('B4', 400);
+        $sheet1->setCellValue('B5', 500);
+
+        $sheet2 = $spreadsheet->createsheet();
+        $sheet2->setTitle('sheet2');
+        $sheet2->setCellValue('A1', 10);
+        $sheet2->setCellValue('A2', 20);
+        $sheet2->setCellValue('A3', 30);
+        $sheet2->setCellValue('A4', 40);
+        $sheet2->setCellValue('A5', 50);
+
+        $spreadsheet->addNamedRange(
+            new NamedRange('somecells', $sheet2, '$A$1:$A$5', true)
+        );
+        $spreadsheet->addNamedRange(
+            new NamedRange('cellsonsheet1', $sheet1, '$B$1:$B$5')
+        );
+
+        $sheet1->getCell('G1')->setValue('=SUM(cellsonsheet1)');
+        self::assertSame(1500, $sheet1->getCell('G1')->getCalculatedValue());
+        $sheet1->getCell('G2')->setValue('=SUM(sheet2!somecells)');
+        self::assertSame(150, $sheet1->getCell('G2')->getCalculatedValue());
+        $sheet1->getCell('G3')->setValue('=SUM(somecells)');
+        self::assertSame('#NAME?', $sheet1->getCell('G3')->getCalculatedValue());
+        $sheet1->getCell('G4')->setValue('=SUM(sheet2!cellsonsheet1)');
+        self::assertSame(1500, $sheet1->getCell('G4')->getCalculatedValue());
+        $sheet1->getCell('G5')->setValue('=SUM(sheet2xxx!cellsonsheet1)');
+        self::assertSame('#NAME?', $sheet1->getCell('G5')->getCalculatedValue());
+
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Fix #296, another entry in our magical history tour (closed as stale in 2018). Excel allows you to use a name defined on another worksheet by prefixing the sheet name, even when the scope of the defined name is its worksheet rather than the entire workbook.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
