### PR TITLE
Xlsx Reader and Print/Show Gridlines

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx/SheetViewOptions.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/SheetViewOptions.php
@@ -122,11 +122,12 @@ class SheetViewOptions extends BaseParserClass
     private function printOptions(SimpleXMLElement $printOptionsx): void
     {
         $printOptions = $printOptionsx->attributes() ?? [];
-        if (isset($printOptions['gridLinesSet']) && self::boolean((string) $printOptions['gridLinesSet'])) {
-            $this->worksheet->setShowGridlines(true);
-        }
+        // Spec is weird. gridLines (default false)
+        // and gridLinesSet (default true) must both be true.
         if (isset($printOptions['gridLines']) && self::boolean((string) $printOptions['gridLines'])) {
-            $this->worksheet->setPrintGridlines(true);
+            if (!isset($printOptions['gridLinesSet']) || self::boolean((string) $printOptions['gridLinesSet'])) {
+                $this->worksheet->setPrintGridlines(true);
+            }
         }
         if (isset($printOptions['horizontalCentered']) && self::boolean((string) $printOptions['horizontalCentered'])) {
             $this->worksheet->getPageSetup()->setHorizontalCentered(true);

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/GridlinesTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/GridlinesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class GridlinesTest extends AbstractFunctional
+{
+    /**
+     * @dataProvider loadDataProvider
+     */
+    public function testGridlines(bool $display, bool $print): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet1 = $spreadsheet->getActiveSheet();
+        $sheet2 = $spreadsheet->createSheet();
+        $sheet1->setShowGridlines($display);
+        $sheet1->setPrintGridlines($print);
+        $sheet1->fromArray(
+            [
+                [1, 2, 3],
+                [4, 5, 6],
+                [7, 8, 9],
+            ]
+        );
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Xlsx');
+        $spreadsheet->disconnectWorksheets();
+        $rsheet1 = $reloadedSpreadsheet->getSheet(0);
+        $rsheet2 = $reloadedSpreadsheet->getSheet(1);
+        self::assertSame($display, $rsheet1->getShowGridlines());
+        self::assertSame($print, $rsheet1->getPrintGridlines());
+        self::assertTrue($rsheet2->getShowGridlines());
+        self::assertFalse($rsheet2->getPrintGridlines());
+        $reloadedSpreadsheet->disconnectWorksheets();
+    }
+
+    public static function loadDataProvider(): array
+    {
+        return [
+            [true, true],
+            [true, false],
+            [false, true],
+            [false, false],
+        ];
+    }
+}

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/GridlinesTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/GridlinesTest.php
@@ -17,6 +17,7 @@ class GridlinesTest extends AbstractFunctional
         $spreadsheet = new Spreadsheet();
         $sheet1 = $spreadsheet->getActiveSheet();
         $sheet2 = $spreadsheet->createSheet();
+        $sheet2->setTitle('deliberatelyblank');
         $sheet1->setShowGridlines($display);
         $sheet1->setPrintGridlines($print);
         $sheet1->fromArray(


### PR DESCRIPTION
Fix #912, opened in Feb. 2019, and closed as stale in Apr. 2019, and which I have re-opened to be closed properly by this PR. Another "better late than never". Original issue says that print options should not affect ShowGridlines, which seems true enough. Aside from that, the existing code isn't quite correct anyhow. Excel looks for 2 attributes, one of which must be explicitly set to true and the other of which must not be explicitly set to false, in order to determine whether PrintGridlines should be set. PhpSpreadsheet is changed to do the same. This could be treated as a BC break for the unusual situation described in the issue, but it seems more like a bug fix to me.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
