### PR TITLE
Html Reader Preserve Unicode Whitespace Characters

### DIFF
--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -627,7 +627,10 @@ class Html extends BaseReader
     {
         foreach ($element->childNodes as $child) {
             if ($child instanceof DOMText) {
-                $domText = (string) preg_replace('/\s+/u', ' ', trim($child->nodeValue ?? ''));
+                $domText = (string) preg_replace('/\s+/', ' ', trim($child->nodeValue ?? ''));
+                if ($domText === "\u{a0}") {
+                    $domText = '';
+                }
                 if (is_string($cellContent)) {
                     //    simply append the text if the cell content is a plain text string
                     $cellContent .= $domText;

--- a/tests/PhpSpreadsheetTests/Reader/Html/Issue1284Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/Issue1284Test.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Html;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class Issue1284Test extends AbstractFunctional
+{
+    public function testIssue1284(): void
+    {
+        $ideographicSpace = "\u{3000}";
+        $nbsp = "\u{a0}";
+        $spreadsheetOld = new Spreadsheet();
+        $osheet = $spreadsheetOld->getActiveSheet();
+        $osheet->getCell('A1')->setValue('# item 1');
+        $osheet->getCell('A2')->setValue("$ideographicSpace# item 2");
+        $osheet->getCell('A3')->setValue("$ideographicSpace$ideographicSpace# item 3");
+        $osheet->getCell('A4')->setValue("$nbsp#  item\t4");
+        $osheet->getCell('A5')->setValue("$nbsp$nbsp# item    5");
+
+        $spreadsheet = $this->writeAndReload($spreadsheetOld, 'Html');
+        $spreadsheetOld->disconnectWorksheets();
+
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertSame('# item 1', $sheet->getCell('A1')->getValue(), 'nothing changed');
+        self::assertSame("$ideographicSpace# item 2", $sheet->getCell('A2')->getValue(), 'nothing changed including 1 ideographic space');
+        self::assertSame("$ideographicSpace$ideographicSpace# item 3", $sheet->getCell('A3')->getValue(), 'nothing changed including 2 ideographic spaces');
+        self::assertSame("$nbsp# item 4", $sheet->getCell('A4')->getValue(), 'nbsp unchanged, 2 spaces reduced to 1, tab changed to space');
+        self::assertSame("$nbsp$nbsp# item 5", $sheet->getCell('A5')->getValue(), 'many spaces reduced to 1');
+
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Fix #1284, which was closed as stale in 2019, but which I will now reopen. Html Reader converts *Unicode* whitespace characters in a DOM text node to space. However, Html treats only space, tab, CR, LF, vertical tab, and form-feed as whitespace. Using a regular expression with the `u` (Unicode) modifier causes a number of other characters to be converted to space inappropriately. The issue mentions "ideographic space" in particular, stating that it is used for formatting and should be preserved. "Non-breaking space" is also used in the same way and should also be preserved. An exception is made for a text node consisting of a single non-breaking space, since that is used as a placeholder by Html Writer; my own guess is that this is the reason why the Unicode modifier was used in the first place.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
