### PR TITLE
Addsheet May Leave Active Sheet Uninitialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- Nothing
+- Add Sheet may leave Active Sheet uninitialized. [Issue #4112](https://github.com/PHPOffice/PhpSpreadsheet/issues/4112) [PR #4113](https://github.com/PHPOffice/PhpSpreadsheet/pull/4113)
 
 ## 2024-07-24 - 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- Add Sheet may leave Active Sheet uninitialized. [Issue #4112](https://github.com/PHPOffice/PhpSpreadsheet/issues/4112) [PR #4113](https://github.com/PHPOffice/PhpSpreadsheet/pull/4113)
+- Add Sheet may leave Active Sheet uninitialized. [Issue #4112](https://github.com/PHPOffice/PhpSpreadsheet/issues/4112) [PR #4114](https://github.com/PHPOffice/PhpSpreadsheet/pull/4114)
 
 ## 2024-07-24 - 2.2.0
 

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -558,6 +558,9 @@ class Spreadsheet implements JsonSerializable
             if ($this->activeSheetIndex >= $sheetIndex) {
                 ++$this->activeSheetIndex;
             }
+            if ($this->activeSheetIndex < 0) {
+                $this->activeSheetIndex = 0;
+            }
         }
 
         if ($worksheet->getParent() === null) {

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -3684,7 +3684,9 @@ class Worksheet implements IComparable
         $originalSelected = $this->selectedCells;
         $this->getStyle($coordinate)->applyFromArray($styleArray);
         $this->selectedCells = $originalSelected;
-        $spreadsheet->setActiveSheetIndex($activeSheetIndex);
+        if ($activeSheetIndex >= 0) {
+            $spreadsheet->setActiveSheetIndex($activeSheetIndex);
+        }
 
         return true;
     }

--- a/tests/PhpSpreadsheetTests/Worksheet/Issue4112Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/Issue4112Test.php
@@ -21,7 +21,7 @@ class Issue4112Test extends AbstractFunctional
         $mySpreadsheet->removeSheetByIndex(0);
         $worksheet = new Worksheet($mySpreadsheet, 'addedsheet');
         self::assertSame(-1, $mySpreadsheet->getActiveSheetIndex());
-        $mySpreadsheet->addSheet($worksheet, 0);
+        $mySpreadsheet->addSheet($worksheet, $sheetNumber);
         self::assertSame('addedsheet', $mySpreadsheet->getActiveSheet()->getTitle());
         $row = 1;
         $col = 1;

--- a/tests/PhpSpreadsheetTests/Worksheet/Issue4112Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/Issue4112Test.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class Issue4112Test extends AbstractFunctional
+{
+    /**
+     * Problem deleting all sheets then adding one.
+     *
+     * @dataProvider providerSheetNumber
+     */
+    public function testIssue4112(?int $sheetNumber): void
+    {
+        $mySpreadsheet = new Spreadsheet();
+        $mySpreadsheet->removeSheetByIndex(0);
+        $worksheet = new Worksheet($mySpreadsheet, 'addedsheet');
+        self::assertSame(-1, $mySpreadsheet->getActiveSheetIndex());
+        $mySpreadsheet->addSheet($worksheet, 0);
+        self::assertSame('addedsheet', $mySpreadsheet->getActiveSheet()->getTitle());
+        $row = 1;
+        $col = 1;
+        $worksheet->getCell([$col, $row])->setValue('id_uti');
+        self::assertSame('id_uti', $worksheet->getCell([$col, $row])->getValue());
+        $mySpreadsheet->disconnectWorksheets();
+    }
+
+    public static function providerSheetNumber(): array
+    {
+        return [
+            'problem case' => [0],
+            'normal case' => [null],
+            'negative 1 (as if there were no sheets)' => [-1],
+            'diffeent negative number' => [-4],
+            'positive number' => [4],
+        ];
+    }
+}

--- a/tests/PhpSpreadsheetTests/Writer/Xls/XlsGifBmpTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/XlsGifBmpTest.php
@@ -9,6 +9,7 @@ use PhpOffice\PhpSpreadsheet\Reader\Exception as ReaderException;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\MemoryDrawing;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
 class XlsGifBmpTest extends AbstractFunctional
@@ -69,6 +70,34 @@ class XlsGifBmpTest extends AbstractFunctional
         $drawing->setPath(__DIR__ . '/../../../../samples/images/gif.gif');
         $drawing->setHeight(36);
         $drawing->setWorksheet($spreadsheet->getActiveSheet());
+        $drawing->setCoordinates('A1');
+
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Xls');
+        $spreadsheet->disconnectWorksheets();
+        $worksheet = $reloadedSpreadsheet->getActiveSheet();
+        $drawings = $worksheet->getDrawingCollection();
+        self::assertCount(1, $drawings);
+        foreach ($worksheet->getDrawingCollection() as $drawing) {
+            $mimeType = ($drawing instanceof MemoryDrawing) ? $drawing->getMimeType() : 'notmemorydrawing';
+            self::assertEquals('image/png', $mimeType);
+        }
+        $reloadedSpreadsheet->disconnectWorksheets();
+    }
+
+    public function testGifIssue4112(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->removeSheetByIndex(0);
+        $sheet = new Worksheet($spreadsheet, 'Insured List');
+        $spreadsheet->addSheet($sheet, 0);
+
+        // Add a drawing to the worksheet
+        $drawing = new Drawing();
+        $drawing->setName('Letters G, I, and G');
+        $drawing->setDescription('Handwritten G, I, and F');
+        $drawing->setPath(__DIR__ . '/../../../../samples/images/gif.gif');
+        $drawing->setHeight(36);
+        $drawing->setWorksheet($sheet);
         $drawing->setCoordinates('A1');
 
         $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Xls');


### PR DESCRIPTION
Fix #4112. Direct cause is that `applyStylesFromArray` tries to save and restore `activeSheetIndex`. However, if activeSheetIndex is -1, indicating no active sheet, the restore should not be attempted. Code is changed to test before attempting to restore.

The actual problem, however, is that user specified a sheet number for `addSheet`. That method will set activeSheetIndex most of the time, but this was a gap - when the supplied sheet number (0 in this case) is greater than activeSheetIndex (-1 in this case), it was leaving activeSheetIndex as -1. It is changed to set activeSheetIndex to 0 when activeSheetIndex is negative.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
