### PR TITLE
Php-cs-fixer Enforcing New Rules

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1055,16 +1055,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.60.0",
+            "version": "v3.61.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "e595e4e070d17c5d42ed8c4206f630fcc5f401a4"
+                "reference": "94a87189f55814e6cabca2d9a33b06de384a2ab8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/e595e4e070d17c5d42ed8c4206f630fcc5f401a4",
-                "reference": "e595e4e070d17c5d42ed8c4206f630fcc5f401a4",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/94a87189f55814e6cabca2d9a33b06de384a2ab8",
+                "reference": "94a87189f55814e6cabca2d9a33b06de384a2ab8",
                 "shasum": ""
             },
             "require": {
@@ -1146,7 +1146,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.60.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.61.1"
             },
             "funding": [
                 {
@@ -1154,7 +1154,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-25T09:26:51+00:00"
+            "time": "2024-07-31T14:33:15+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -69,8 +69,6 @@ class Calculation
 
     /**
      * Instance of this class.
-     *
-     * @var ?Calculation
      */
     private static ?Calculation $instance = null;
 
@@ -3272,10 +3270,8 @@ class Calculation
         return $formula;
     }
 
-    /** @var ?array */
     private static ?array $functionReplaceFromExcel;
 
-    /** @var ?array */
     private static ?array $functionReplaceToLocale;
 
     /**
@@ -3321,10 +3317,8 @@ class Calculation
         );
     }
 
-    /** @var ?array */
     private static ?array $functionReplaceFromLocale;
 
-    /** @var ?array */
     private static ?array $functionReplaceToExcel;
 
     /**

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -50,8 +50,6 @@ class Cell implements Stringable
 
     /**
      * The collection of cells that this cell belongs to (i.e. The Cell Collection for the parent Worksheet).
-     *
-     * @var ?Cells
      */
     private ?Cells $parent;
 

--- a/src/PhpSpreadsheet/Chart/Properties.php
+++ b/src/PhpSpreadsheet/Chart/Properties.php
@@ -105,7 +105,6 @@ abstract class Properties
 
     protected bool $objectState = false; // used only for minor gridlines
 
-    /** @var ?float */
     protected ?float $glowSize = null;
 
     protected ChartColor $glowColor;

--- a/src/PhpSpreadsheet/Helper/Html.php
+++ b/src/PhpSpreadsheet/Helper/Html.php
@@ -533,13 +533,10 @@ class Html
         'yellowgreen' => '9acd32',
     ];
 
-    /** @var ?string */
     private ?string $face = null;
 
-    /** @var ?string */
     private ?string $size = null;
 
-    /** @var ?string */
     private ?string $color = null;
 
     private bool $bold = false;

--- a/src/PhpSpreadsheet/Reader/Csv/Delimiter.php
+++ b/src/PhpSpreadsheet/Reader/Csv/Delimiter.php
@@ -17,7 +17,6 @@ class Delimiter
 
     protected int $numberLines = 0;
 
-    /** @var ?string */
     protected ?string $delimiter = null;
 
     /**

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -350,8 +350,6 @@ class Xls extends BaseReader
 
     /**
      * The current RC4 decryption object.
-     *
-     * @var ?Xls\RC4
      */
     private ?Xls\RC4 $rc4Key = null;
 

--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -19,8 +19,6 @@ class Styles extends BaseParserClass
 {
     /**
      * Theme instance.
-     *
-     * @var ?Theme
      */
     private ?Theme $theme = null;
 

--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -24,8 +24,6 @@ class ReferenceHelper
 
     /**
      * Instance of this class.
-     *
-     * @var ?ReferenceHelper
      */
     private static ?ReferenceHelper $instance = null;
 

--- a/src/PhpSpreadsheet/RichText/Run.php
+++ b/src/PhpSpreadsheet/RichText/Run.php
@@ -9,8 +9,6 @@ class Run extends TextElement implements ITextElement
 {
     /**
      * Font.
-     *
-     * @var ?Font
      */
     private ?Font $font;
 

--- a/src/PhpSpreadsheet/Settings.php
+++ b/src/PhpSpreadsheet/Settings.php
@@ -27,8 +27,6 @@ class Settings
 
     /**
      * The cache implementation to be used for cell collection.
-     *
-     * @var ?CacheInterface
      */
     private static ?CacheInterface $cache = null;
 

--- a/src/PhpSpreadsheet/Shared/Escher.php
+++ b/src/PhpSpreadsheet/Shared/Escher.php
@@ -6,15 +6,11 @@ class Escher
 {
     /**
      * Drawing Group Container.
-     *
-     * @var ?Escher\DggContainer
      */
     private ?Escher\DggContainer $dggContainer = null;
 
     /**
      * Drawing Container.
-     *
-     * @var ?Escher\DgContainer
      */
     private ?Escher\DgContainer $dgContainer = null;
 

--- a/src/PhpSpreadsheet/Shared/Escher/DggContainer.php
+++ b/src/PhpSpreadsheet/Shared/Escher/DggContainer.php
@@ -21,8 +21,6 @@ class DggContainer
 
     /**
      * BLIP Store Container.
-     *
-     * @var ?DggContainer\BstoreContainer
      */
     private ?DggContainer\BstoreContainer $bstoreContainer = null;
 

--- a/src/PhpSpreadsheet/Shared/Escher/DggContainer/BstoreContainer/BSE.php
+++ b/src/PhpSpreadsheet/Shared/Escher/DggContainer/BstoreContainer/BSE.php
@@ -25,8 +25,6 @@ class BSE
 
     /**
      * The BLIP (Big Large Image or Picture).
-     *
-     * @var ?BSE\Blip
      */
     private ?BSE\Blip $blip = null;
 

--- a/src/PhpSpreadsheet/Style/ConditionalFormatting/Wizard/WizardAbstract.php
+++ b/src/PhpSpreadsheet/Style/ConditionalFormatting/Wizard/WizardAbstract.php
@@ -9,9 +9,6 @@ use PhpOffice\PhpSpreadsheet\Style\Style;
 
 abstract class WizardAbstract
 {
-    /**
-     * @var ?Style
-     */
     protected ?Style $style = null;
 
     protected string $expression;

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -38,10 +38,8 @@ class Font extends Supervisor
 
     private string $strikeType = '';
 
-    /** @var ?ChartColor */
     private ?ChartColor $underlineColor = null;
 
-    /** @var ?ChartColor */
     private ?ChartColor $chartColor = null;
     // end of chart title items
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Database/SetupTeardownDatabases.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Database/SetupTeardownDatabases.php
@@ -14,14 +14,8 @@ class SetupTeardownDatabases extends TestCase
 {
     protected const RESULT_CELL = 'Z1';
 
-    /**
-     * @var ?Spreadsheet
-     */
     private ?Spreadsheet $spreadsheet = null;
 
-    /**
-     * @var ?Worksheet
-     */
     private ?Worksheet $sheet = null;
 
     protected function setUp(): void

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AllSetupTeardown.php
@@ -15,14 +15,8 @@ class AllSetupTeardown extends TestCase
 {
     private string $compatibilityMode;
 
-    /**
-     * @var ?Spreadsheet
-     */
     private ?Spreadsheet $spreadsheet = null;
 
-    /**
-     * @var ?Worksheet
-     */
     private ?Worksheet $sheet = null;
 
     protected function setUp(): void

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/AllSetupTeardown.php
@@ -15,14 +15,8 @@ class AllSetupTeardown extends TestCase
 {
     private string $compatibilityMode;
 
-    /**
-     * @var ?Spreadsheet
-     */
     private ?Spreadsheet $spreadsheet = null;
 
-    /**
-     * @var ?Worksheet
-     */
     private ?Worksheet $sheet = null;
 
     protected function setUp(): void

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AllSetupTeardown.php
@@ -15,14 +15,8 @@ class AllSetupTeardown extends TestCase
 {
     protected string $compatibilityMode;
 
-    /**
-     * @var ?Spreadsheet
-     */
     private ?Spreadsheet $spreadsheet = null;
 
-    /**
-     * @var ?Worksheet
-     */
     private ?Worksheet $sheet = null;
 
     protected function setUp(): void

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AllSetupTeardown.php
@@ -15,14 +15,8 @@ class AllSetupTeardown extends TestCase
 {
     private string $compatibilityMode;
 
-    /**
-     * @var ?Spreadsheet
-     */
     private ?Spreadsheet $spreadsheet = null;
 
-    /**
-     * @var ?Worksheet
-     */
     private ?Worksheet $sheet = null;
 
     protected function setUp(): void

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AllSetupTeardown.php
@@ -16,14 +16,8 @@ class AllSetupTeardown extends TestCase
 {
     private string $compatibilityMode;
 
-    /**
-     * @var ?Spreadsheet
-     */
     private ?Spreadsheet $spreadsheet = null;
 
-    /**
-     * @var ?Worksheet
-     */
     private ?Worksheet $sheet = null;
 
     protected function setUp(): void

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/AllSetupTeardown.php
@@ -18,14 +18,8 @@ class AllSetupTeardown extends TestCase
 
     private string $locale;
 
-    /**
-     * @var ?Spreadsheet
-     */
     private ?Spreadsheet $spreadsheet = null;
 
-    /**
-     * @var ?Worksheet
-     */
     private ?Worksheet $sheet = null;
 
     protected function setUp(): void

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Web/WebServiceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Web/WebServiceTest.php
@@ -15,7 +15,6 @@ use Psr\Http\Message\StreamInterface;
 
 class WebServiceTest extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     protected function tearDown(): void

--- a/tests/PhpSpreadsheetTests/Cell/CellDetachTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CellDetachTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class CellDetachTest extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     protected function tearDown(): void

--- a/tests/PhpSpreadsheetTests/NamedRange2Test.php
+++ b/tests/PhpSpreadsheetTests/NamedRange2Test.php
@@ -12,7 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 class NamedRange2Test extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     protected function setUp(): void

--- a/tests/PhpSpreadsheetTests/Reader/Xls/LoadSheetsOnlyTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xls/LoadSheetsOnlyTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class LoadSheetsOnlyTest extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     private static string $testbook = 'tests/data/Reader/XLS/HiddenSheet.xls';

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/LoadSheetsOnlyTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/LoadSheetsOnlyTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class LoadSheetsOnlyTest extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     private static string $testbook = 'tests/data/Reader/XLSX/HiddenSheet.xlsx';

--- a/tests/PhpSpreadsheetTests/Reader/Xml/PageSetupTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/PageSetupTest.php
@@ -15,9 +15,6 @@ class PageSetupTest extends TestCase
 
     private const MARGIN_UNIT_CONVERSION = 2.54; // Inches to cm
 
-    /**
-     * @var ?Spreadsheet
-     */
     private ?Spreadsheet $spreadsheet = null;
 
     private string $filename = 'tests/data/Reader/Xml/PageSetup.xml';

--- a/tests/PhpSpreadsheetTests/Reader/Xml/XmlLoadTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/XmlLoadTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\TestCase;
 
 class XmlLoadTest extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     private string $locale;

--- a/tests/PhpSpreadsheetTests/Shared/Date2Test.php
+++ b/tests/PhpSpreadsheetTests/Shared/Date2Test.php
@@ -12,7 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 class Date2Test extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     private int $calculateDateTimeType;

--- a/tests/PhpSpreadsheetTests/SpreadsheetCoverageTest.php
+++ b/tests/PhpSpreadsheetTests/SpreadsheetCoverageTest.php
@@ -10,10 +10,8 @@ use PHPUnit\Framework\TestCase;
 
 class SpreadsheetCoverageTest extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet2 = null;
 
     protected function tearDown(): void

--- a/tests/PhpSpreadsheetTests/SpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/SpreadsheetTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class SpreadsheetTest extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     protected function tearDown(): void

--- a/tests/PhpSpreadsheetTests/Style/AlignmentMiddleTest.php
+++ b/tests/PhpSpreadsheetTests/Style/AlignmentMiddleTest.php
@@ -14,7 +14,6 @@ use ZipArchive;
 
 class AlignmentMiddleTest extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     private string $outputFileName = '';

--- a/tests/PhpSpreadsheetTests/Style/AlignmentTest.php
+++ b/tests/PhpSpreadsheetTests/Style/AlignmentTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class AlignmentTest extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     protected function tearDown(): void

--- a/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/CellMatcherTest.php
+++ b/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/CellMatcherTest.php
@@ -14,9 +14,6 @@ use PHPUnit\Framework\TestCase;
 
 class CellMatcherTest extends TestCase
 {
-    /**
-     * @var ?Spreadsheet
-     */
     protected ?Spreadsheet $spreadsheet = null;
 
     protected function loadSpreadsheet(): Spreadsheet

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/SetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/SetupTeardown.php
@@ -10,14 +10,8 @@ use PHPUnit\Framework\TestCase;
 
 class SetupTeardown extends TestCase
 {
-    /**
-     * @var ?Spreadsheet
-     */
     private ?Spreadsheet $spreadsheet = null;
 
-    /**
-     * @var ?Worksheet
-     */
     private ?Worksheet $sheet = null;
 
     protected int $maxRow = 4;

--- a/tests/PhpSpreadsheetTests/Worksheet/ByColumnAndRowUndeprecatedTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ByColumnAndRowUndeprecatedTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\TestCase;
 
 class ByColumnAndRowUndeprecatedTest extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     protected function tearDown(): void

--- a/tests/PhpSpreadsheetTests/Worksheet/Table/SetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/Table/SetupTeardown.php
@@ -10,14 +10,8 @@ use PHPUnit\Framework\TestCase;
 
 class SetupTeardown extends TestCase
 {
-    /**
-     * @var ?Spreadsheet
-     */
     private ?Spreadsheet $spreadsheet = null;
 
-    /**
-     * @var ?Worksheet
-     */
     private ?Worksheet $sheet = null;
 
     protected int $maxRow = 4;

--- a/tests/PhpSpreadsheetTests/Writer/Xls/FormulaErrTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/FormulaErrTest.php
@@ -12,10 +12,8 @@ use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
 class FormulaErrTest extends AbstractFunctional
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $reloadedSpreadsheet = null;
 
     private bool $allowThrow;

--- a/tests/PhpSpreadsheetTests/Writer/Xls/ParserTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/ParserTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class ParserTest extends TestCase
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     protected function tearDown(): void

--- a/tests/PhpSpreadsheetTests/Writer/Xls/WorkbookTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/WorkbookTest.php
@@ -14,7 +14,6 @@ class WorkbookTest extends TestCase
 {
     private Workbook $workbook;
 
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
     protected function tearDown(): void

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/CalculationErrorTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/CalculationErrorTest.php
@@ -11,10 +11,8 @@ use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
 class CalculationErrorTest extends AbstractFunctional
 {
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $reloadedSpreadsheet = null;
 
     protected function tearDown(): void

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/LocaleFloatsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/LocaleFloatsTest.php
@@ -17,10 +17,8 @@ class LocaleFloatsTest extends AbstractFunctional
 
     private string $originalLocale;
 
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $spreadsheet = null;
 
-    /** @var ?Spreadsheet */
     private ?Spreadsheet $reloadedSpreadsheet = null;
 
     protected function setUp(): void


### PR DESCRIPTION
The latest release seems to not want you to give a class element both a Php type and a doc-block type. I used the "fix" operand to delete the redundant doc-block declarations, with no other changes. So there should be no change to executable code.

This is:

- [ ] a bugfix
- [x] tool changes 
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
