### PR TITLE
String Value Binder Allow Setting "Ignore Number Stored As Text"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Added
 
 - Excel Dynamic Arrays. [Issue #3901](https://github.com/PHPOffice/PhpSpreadsheet/issues/3901) [Issue #3659](https://github.com/PHPOffice/PhpSpreadsheet/issues/3659) [Issue #1834](https://github.com/PHPOffice/PhpSpreadsheet/issues/1834) [PR #3962](https://github.com/PHPOffice/PhpSpreadsheet/pull/3962)
+- String Value Binder Allow Setting "Ignore Number Stored as Text". [PR #4141](https://github.com/PHPOffice/PhpSpreadsheet/pull/4141)
 
 ### Changed
 

--- a/docs/topics/accessing-cells.md
+++ b/docs/topics/accessing-cells.md
@@ -551,6 +551,7 @@ By default, the StringValueBinder will cast any datatype passed to it into a str
 // Set value binder
 $stringValueBinder = new \PhpOffice\PhpSpreadsheet\Cell\StringValueBinder();
 $stringValueBinder->setNumericConversion(false)
+    ->setSetIgnoredErrors(true) // suppresses "number stored as text" indicators
     ->setBooleanConversion(false)
     ->setNullConversion(false)
     ->setFormulaConversion(false);

--- a/src/PhpSpreadsheet/Cell/StringValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/StringValueBinder.php
@@ -18,6 +18,15 @@ class StringValueBinder extends DefaultValueBinder implements IValueBinder
 
     protected bool $convertFormula = true;
 
+    protected bool $setIgnoredErrors = false;
+
+    public function setSetIgnoredErrors(bool $setIgnoredErrors = false): self
+    {
+        $this->setIgnoredErrors = $setIgnoredErrors;
+
+        return $this;
+    }
+
     public function setNullConversion(bool $suppressConversion = false): self
     {
         $this->convertNull = $suppressConversion;
@@ -90,6 +99,9 @@ class StringValueBinder extends DefaultValueBinder implements IValueBinder
         } elseif (is_string($value) && strlen($value) > 1 && $value[0] === '=' && $this->convertFormula === false && parent::dataTypeForValue($value) === DataType::TYPE_FORMULA) {
             $cell->setValueExplicit($value, DataType::TYPE_FORMULA);
         } else {
+            if ($this->setIgnoredErrors && is_numeric($value)) {
+                $cell->getIgnoredErrors()->setNumberStoredAsText(true);
+            }
             $cell->setValueExplicit((string) $value, DataType::TYPE_STRING);
         }
 

--- a/tests/PhpSpreadsheetTests/Cell/StringValueBinder2Test.php
+++ b/tests/PhpSpreadsheetTests/Cell/StringValueBinder2Test.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Cell;
+
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Cell\IValueBinder;
+use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+class StringValueBinder2Test extends TestCase
+{
+    private IValueBinder $valueBinder;
+
+    protected function setUp(): void
+    {
+        $this->valueBinder = Cell::getValueBinder();
+    }
+
+    protected function tearDown(): void
+    {
+        Cell::setValueBinder($this->valueBinder);
+    }
+
+    public function testStringValueBinderIgnoredErrorsDefault(): void
+    {
+        $valueBinder = new StringValueBinder();
+        Cell::setValueBinder($valueBinder);
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray([
+            [1, 'x', 3.2],
+            ['y', -5, 'z'],
+        ]);
+        $ignoredCells = [];
+        foreach ($sheet->getRowIterator() as $row) {
+            foreach ($row->getCellIterator() as $cell) {
+                $coordinate = $cell->getCoordinate();
+                self::assertSame(DataType::TYPE_STRING, $cell->getDataType(), "not string for cell $coordinate");
+                if ($cell->getIgnoredErrors()->getNumberStoredAsText()) {
+                    $ignoredCells[] = $coordinate;
+                }
+            }
+        }
+        self::assertSame([], $ignoredCells);
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testStringValueBinderIgnoredErrorsTrue(): void
+    {
+        $valueBinder = new StringValueBinder();
+        $valueBinder->setSetIgnoredErrors(true);
+        Cell::setValueBinder($valueBinder);
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray([
+            [1, 'x', 3.2],
+            ['y', -5, 'z'],
+        ]);
+        $ignoredCells = [];
+        foreach ($sheet->getRowIterator() as $row) {
+            foreach ($row->getCellIterator() as $cell) {
+                $coordinate = $cell->getCoordinate();
+                self::assertSame(DataType::TYPE_STRING, $cell->getDataType(), "not string for cell $coordinate");
+                if ($cell->getIgnoredErrors()->getNumberStoredAsText()) {
+                    $ignoredCells[] = $coordinate;
+                }
+            }
+        }
+        self::assertSame(['A1', 'C1', 'B2'], $ignoredCells);
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testStringValueBinderPreserveNumeric(): void
+    {
+        $valueBinder = new StringValueBinder();
+        $valueBinder->setNumericConversion(false);
+        $valueBinder->setSetIgnoredErrors(true);
+        Cell::setValueBinder($valueBinder);
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray([
+            [1, 'x', 3.2],
+            ['y', -5, 'z'],
+        ]);
+        $ignoredCells = [];
+        foreach ($sheet->getRowIterator() as $row) {
+            foreach ($row->getCellIterator() as $cell) {
+                $coordinate = $cell->getCoordinate();
+                $expected = is_numeric($cell->getValue()) ? DataType::TYPE_NUMERIC : DataType::TYPE_STRING;
+                self::assertSame($expected, $cell->getDataType(), "wrong type for cell $coordinate");
+                if ($cell->getIgnoredErrors()->getNumberStoredAsText()) {
+                    $ignoredCells[] = $coordinate;
+                }
+            }
+        }
+        self::assertSame([], $ignoredCells);
+        $spreadsheet->disconnectWorksheets();
+    }
+}

--- a/tests/PhpSpreadsheetTests/Cell/StringValueBinder2Test.php
+++ b/tests/PhpSpreadsheetTests/Cell/StringValueBinder2Test.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Cell;
 
+use DateTime;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Cell\IValueBinder;
 use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
+use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit\Framework\TestCase;
 
@@ -31,15 +33,24 @@ class StringValueBinder2Test extends TestCase
         Cell::setValueBinder($valueBinder);
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
+        $richText = new RichText();
+        $richText->createTextRun('6');
+        $richText2 = new RichText();
+        $richText2->createTextRun('a');
         $sheet->fromArray([
             [1, 'x', 3.2],
             ['y', -5, 'z'],
+            [new DateTime(), $richText, $richText2],
+            [new StringableObject('a'), new StringableObject(2), 'z'],
         ]);
         $ignoredCells = [];
         foreach ($sheet->getRowIterator() as $row) {
             foreach ($row->getCellIterator() as $cell) {
                 $coordinate = $cell->getCoordinate();
-                self::assertSame(DataType::TYPE_STRING, $cell->getDataType(), "not string for cell $coordinate");
+                $dataType = $cell->getDataType();
+                if ($dataType !== DataType::TYPE_INLINE) {
+                    self::assertSame(DataType::TYPE_STRING, $dataType, "not string for cell $coordinate");
+                }
                 if ($cell->getIgnoredErrors()->getNumberStoredAsText()) {
                     $ignoredCells[] = $coordinate;
                 }
@@ -56,21 +67,30 @@ class StringValueBinder2Test extends TestCase
         Cell::setValueBinder($valueBinder);
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
+        $richText = new RichText();
+        $richText->createTextRun('6');
+        $richText2 = new RichText();
+        $richText2->createTextRun('a');
         $sheet->fromArray([
             [1, 'x', 3.2],
             ['y', -5, 'z'],
+            [new DateTime(), $richText, $richText2],
+            [new StringableObject('a'), new StringableObject(2), 'z'],
         ]);
         $ignoredCells = [];
         foreach ($sheet->getRowIterator() as $row) {
             foreach ($row->getCellIterator() as $cell) {
                 $coordinate = $cell->getCoordinate();
-                self::assertSame(DataType::TYPE_STRING, $cell->getDataType(), "not string for cell $coordinate");
+                $dataType = $cell->getDataType();
+                if ($dataType !== DataType::TYPE_INLINE) {
+                    self::assertSame(DataType::TYPE_STRING, $dataType, "not string for cell $coordinate");
+                }
                 if ($cell->getIgnoredErrors()->getNumberStoredAsText()) {
                     $ignoredCells[] = $coordinate;
                 }
             }
         }
-        self::assertSame(['A1', 'C1', 'B2'], $ignoredCells);
+        self::assertSame(['A1', 'C1', 'B2', 'B3', 'B4'], $ignoredCells);
         $spreadsheet->disconnectWorksheets();
     }
 
@@ -82,22 +102,28 @@ class StringValueBinder2Test extends TestCase
         Cell::setValueBinder($valueBinder);
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
+        $richText = new RichText();
+        $richText->createTextRun('6');
+        $richText2 = new RichText();
+        $richText2->createTextRun('a');
         $sheet->fromArray([
             [1, 'x', 3.2],
             ['y', -5, 'z'],
+            [new DateTime(), $richText, $richText2],
+            [new StringableObject('a'), new StringableObject(2), 'z'],
         ]);
         $ignoredCells = [];
         foreach ($sheet->getRowIterator() as $row) {
             foreach ($row->getCellIterator() as $cell) {
                 $coordinate = $cell->getCoordinate();
-                $expected = is_numeric($cell->getValue()) ? DataType::TYPE_NUMERIC : DataType::TYPE_STRING;
+                $expected = (is_int($cell->getValue()) || is_float($cell->getValue())) ? DataType::TYPE_NUMERIC : (($cell->getValue() instanceof RichText) ? DataType::TYPE_INLINE : DataType::TYPE_STRING);
                 self::assertSame($expected, $cell->getDataType(), "wrong type for cell $coordinate");
                 if ($cell->getIgnoredErrors()->getNumberStoredAsText()) {
                     $ignoredCells[] = $coordinate;
                 }
             }
         }
-        self::assertSame([], $ignoredCells);
+        self::assertSame(['B3', 'B4'], $ignoredCells);
         $spreadsheet->disconnectWorksheets();
     }
 }

--- a/tests/PhpSpreadsheetTests/Cell/StringableObject.php
+++ b/tests/PhpSpreadsheetTests/Cell/StringableObject.php
@@ -6,8 +6,15 @@ namespace PhpOffice\PhpSpreadsheetTests\Cell;
 
 class StringableObject
 {
+    private int|string $value;
+
+    public function __construct(int|string $value = 'abc')
+    {
+        $this->value = $value;
+    }
+
     public function __toString(): string
     {
-        return 'abc';
+        return (string) $this->value;
     }
 }


### PR DESCRIPTION
When String Value Binder converts a numeric value to text, the resulting spreadsheet will be full of little green triangles to indicate to the end user that something might be wrong. It is unlikely that a spreadsheet created in this manner needs that visual clutter. This PR adds a property and setter (I can't really think of a good use case for a getter) to suppress it. Suppression should arguably be the default, but, for now, I will avoid any BC problems by leaving non-suppression as the default.

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [x] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
