### PR TITLE
VLOOKUP Handling of Strings and Number

### DIFF
--- a/src/PhpSpreadsheet/Calculation/LookupRef/VLookup.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/VLookup.php
@@ -88,8 +88,8 @@ class VLookup extends LookupBase
 
         $rowNumber = null;
         foreach ($lookupArray as $rowKey => $rowData) {
-            $bothNumeric = is_numeric($lookupValue) && is_numeric($rowData[$column]);
-            $bothNotNumeric = !is_numeric($lookupValue) && !is_numeric($rowData[$column]);
+            $bothNumeric = self::numeric($lookupValue) && self::numeric($rowData[$column]);
+            $bothNotNumeric = !self::numeric($lookupValue) && !self::numeric($rowData[$column]);
             $cellDataLower = StringHelper::strToLower((string) $rowData[$column]);
 
             // break if we have passed possible keys
@@ -113,5 +113,10 @@ class VLookup extends LookupBase
         }
 
         return $rowNumber;
+    }
+
+    private static function numeric(mixed $value): bool
+    {
+        return is_int($value) || is_float($value);
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/VLookupTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/VLookupTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit\Framework\TestCase;
 
@@ -77,5 +78,25 @@ class VLookupTest extends TestCase
                 '{2,3,2}',
             ],
         ];
+    }
+
+    public function testIssue1402(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $worksheet = $spreadsheet->getActiveSheet();
+
+        $worksheet->setCellValueExplicit('A1', 1, DataType::TYPE_STRING);
+        $worksheet->setCellValue('B1', 'Text Nr 1');
+        $worksheet->setCellValue('A2', 2);
+        $worksheet->setCellValue('B2', 'Numeric result');
+        $worksheet->setCellValueExplicit('A3', 2, DataType::TYPE_STRING);
+        $worksheet->setCellValue('B3', 'Text Nr 2');
+        $worksheet->setCellValueExplicit('A4', 2, DataType::TYPE_STRING);
+        $worksheet->setCellValue('B4', '=VLOOKUP(A4,$A$1:$B$3,2,0)');
+        self::assertSame('Text Nr 2', $worksheet->getCell('B4')->getCalculatedValue());
+        $worksheet->setCellValue('A5', 2);
+        $worksheet->setCellValue('B5', '=VLOOKUP(A5,$A$1:$B$3,2,0)');
+        self::assertSame('Numeric result', $worksheet->getCell('B5')->getCalculatedValue());
+        $spreadsheet->disconnectWorksheets();
     }
 }


### PR DESCRIPTION
Fix #1402, another in our "better late than never" series. Stalebot closed it in May 2020, and I have reopened it. @ljcag submitted the issue, and PR #1403 to resolve it, also marked stale. That change is more complicated than this one. Since there were no tests in that PR, and since this PR solves the original problem (test added), I will stick with this version, but will continue to study 1403 before merging.

This is also another in the "Excel doesn't believe in complete documentation" series. (See issue #3802 for a similar example.) Nothing that I have seen in the documentation suggests that a number will not match a numeric string, but that seems clearly to be the case. Despite the lack of complete documentation, PhpSpreadsheet implemented VLOOKUP with that in mind. Unfortunately, it did so by using `is_numeric` on its comparands, and so treats numeric strings as if they were numbers. This PR replaces those tests with `is_int() || is_float()`. The earlier PR used `is_string()` instead as a proxy for "not numeric" but that required other changes.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
