### PR TITLE
Better Definitions for Mixed Parameters and Values Part 4 of Many

### DIFF
--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -191,7 +191,7 @@ class Cell implements Stringable
         $currentCalendar = SharedDate::getExcelCalendar();
         SharedDate::setExcelCalendar($this->getWorksheet()->getParent()?->getExcelCalendar());
         $formattedValue = (string) NumberFormat::toFormattedString(
-            $this->getCalculatedValue(),
+            $this->getCalculatedValueString(),
             (string) $this->getStyle()->getNumberFormat()->getFormatCode(true)
         );
         SharedDate::setExcelCalendar($currentCalendar);
@@ -920,7 +920,7 @@ class Cell implements Stringable
      *
      * @return $this
      */
-    public function setFormulaAttributes(mixed $attributes): self
+    public function setFormulaAttributes(?array $attributes): self
     {
         $this->formulaAttributes = $attributes;
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TruncTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TruncTest.php
@@ -60,8 +60,8 @@ class TruncTest extends AllSetupTeardown
         $sheet = $this->getSheet();
         $sheet->getCell('E1')->setValue($value);
         $sheet->getCell('E2')->setValue("=TRUNC(E1,$digits)");
-        $result = $sheet->getCell('E2')->getCalculatedValue();
-        self::assertSame($expectedResult, (string) $result);
+        $result = $sheet->getCell('E2')->getCalculatedValueString();
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerTooMuchPrecision(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ConcatenateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ConcatenateTest.php
@@ -30,6 +30,7 @@ class ConcatenateTest extends AllSetupTeardown
                 $finalArg .= 'A3';
                 $sheet->getCell('A3')->setValue(str_repeat('Ԁ', DataType::MAX_STRING_LENGTH - 5));
             } else {
+                self::assertTrue($arg === null || is_scalar($arg));
                 $finalArg .= '"' . (string) $arg . '"';
             }
         }

--- a/tests/PhpSpreadsheetTests/Reader/Gnumeric/ArrayFormula2Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Gnumeric/ArrayFormula2Test.php
@@ -26,7 +26,7 @@ class ArrayFormula2Test extends TestCase
         $cell = $worksheet->getCell($cellAddress);
         self::assertSame(DataType::TYPE_FORMULA, $cell->getDataType());
         self::assertSame(['t' => 'array', 'ref' => $expectedRange], $cell->getFormulaAttributes());
-        self::assertSame($expectedFormula, strtoupper($cell->getValue()));
+        self::assertSame($expectedFormula, strtoupper($cell->getValueString()));
         Calculation::getInstance($spreadsheet)->setInstanceArrayReturnType(Calculation::RETURN_ARRAY_AS_ARRAY);
         $worksheet->calculateArrays();
         $cell = $worksheet->getCell($cellAddress);

--- a/tests/PhpSpreadsheetTests/Reader/Gnumeric/ArrayFormulaTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Gnumeric/ArrayFormulaTest.php
@@ -30,7 +30,7 @@ class ArrayFormulaTest extends TestCase
         } else {
             self::assertEmpty($cell->getFormulaAttributes());
         }
-        self::assertSame($expectedFormula, strtoupper($cell->getValue()));
+        self::assertSame($expectedFormula, strtoupper($cell->getValueString()));
         Calculation::getInstance($spreadsheet)->setInstanceArrayReturnType(Calculation::RETURN_ARRAY_AS_ARRAY);
         $worksheet->calculateArrays();
         $cell = $worksheet->getCell($cellAddress);

--- a/tests/PhpSpreadsheetTests/Reader/Ods/ArrayFormulaTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Ods/ArrayFormulaTest.php
@@ -26,7 +26,7 @@ class ArrayFormulaTest extends TestCase
         $cell = $worksheet->getCell($cellAddress);
         self::assertSame(DataType::TYPE_FORMULA, $cell->getDataType());
         self::assertSame(['t' => 'array', 'ref' => $expectedRange], $cell->getFormulaAttributes());
-        self::assertSame($expectedFormula, strtoupper($cell->getValue()));
+        self::assertSame($expectedFormula, strtoupper($cell->getValueString()));
         Calculation::getInstance($spreadsheet)->setInstanceArrayReturnType(Calculation::RETURN_ARRAY_AS_ARRAY);
         $worksheet->calculateArrays();
         $cell = $worksheet->getCell($cellAddress);

--- a/tests/PhpSpreadsheetTests/Reader/Xml/ArrayFormulaTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/ArrayFormulaTest.php
@@ -17,7 +17,7 @@ class ArrayFormulaTest extends TestCase
 
         self::assertSame(DataType::TYPE_FORMULA, $sheet->getCell('B1')->getDataType());
         self::assertSame(['t' => 'array', 'ref' => 'B1:B3'], $sheet->getCell('B1')->getFormulaAttributes());
-        self::assertSame('=CONCATENATE(A1:A3,"-",C1:C3)', strtoupper($sheet->getCell('B1')->getValue()));
+        self::assertSame('=CONCATENATE(A1:A3,"-",C1:C3)', strtoupper($sheet->getCell('B1')->getValueString()));
         self::assertSame('a-1', $sheet->getCell('B1')->getOldCalculatedValue());
         self::assertSame('b-2', $sheet->getCell('B2')->getValue());
         self::assertSame('c-3', $sheet->getCell('B3')->getValue());

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/ArrayFunctions2Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/ArrayFunctions2Test.php
@@ -268,7 +268,9 @@ class ArrayFunctions2Test extends TestCase
     {
         $json = file_get_contents('tests/data/Writer/XLSX/ArrayFunctions2.json');
         self::assertNotFalse($json);
-        $this->trn = json_decode($json, true);
+        $trn = json_decode($json, true);
+        self::assertIsArray($trn);
+        $this->trn = $trn;
         $spreadsheet = new Spreadsheet();
         Calculation::getInstance($spreadsheet)->setInstanceArrayReturnType(Calculation::RETURN_ARRAY_AS_ARRAY);
 


### PR DESCRIPTION
Continuing work started with PR #4016, PR #4026, and PR #4060. Improve documentation within program by making explicit what types of values are allowed for variables described as "mixed". In order to avoid broken functionality, this is done mainly through doc-blocks. This will get us closer to Phpstan Level 9, but many changes will be needed before we can consider that.

After this PR, 231 changes remain, all in src/Calculation.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] code quality

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
