### PR TITLE
Fix Date::roundMicroseconds() not resetting microsecond part

### DIFF
--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -537,11 +537,16 @@ class Date
         return $dtobj->format($format);
     }
 
+    /**
+     * Round the given DateTime object to seconds.
+     */
     public static function roundMicroseconds(DateTime $dti): void
     {
         $microseconds = (int) $dti->format('u');
-        if ($microseconds >= 500000) {
-            $dti->modify('+1 second');
+        $rounded = (int) round($microseconds, -6);
+        $modify = $rounded - $microseconds;
+        if ($modify !== 0) {
+            $dti->modify(($modify > 0 ? '+' : '') . $modify . ' microseconds');
         }
     }
 }

--- a/tests/PhpSpreadsheetTests/Shared/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/DateTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Shared;
 
+use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
 use PhpOffice\PhpSpreadsheet\Exception;
@@ -248,5 +249,20 @@ class DateTest extends TestCase
             ->getNumberFormat()
             ->setFormatCode('yyyy-mm-dd');
         self::assertFalse(Date::isDateTime($cella4));
+    }
+
+    public function testRoundMicroseconds(): void
+    {
+        $dti = new DateTime('2000-01-02 03:04:05.999999');
+        Date::roundMicroseconds($dti);
+        self::assertEquals(new DateTime('2000-01-02 03:04:06.000000'), $dti);
+
+        $dti = new DateTime('2000-01-02 03:04:05.500000');
+        Date::roundMicroseconds($dti);
+        self::assertEquals(new DateTime('2000-01-02 03:04:06.000000'), $dti);
+
+        $dti = new DateTime('2000-01-02 03:04:05.499999');
+        Date::roundMicroseconds($dti);
+        self::assertEquals(new DateTime('2000-01-02 03:04:05.000000'), $dti);
     }
 }


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [x] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

`Date::roundMicroseconds()` was increasing the seconds by 1 but wasn't resetting the microseconds.
I'm using the underlying DateTime object created by `Date::excelToDateTimeObject()` to not loose precision but as excel uses a floating-point number to store this value I got bitten by parsing values like `2001-02-03 04:05:06` ending up in `2001-02-03 04:05:05.999996`. As I have seen you are now rounding this value to seconds I noticed the value was still wrong as it still had the microsecond part left while the second got increased by 1.

PS 1: `Date::roundMicroseconds()` is a really weird name for a function to round to seconds
PS 2: It's great that `Date::excelToDateTimeObject()` supports microseconds now but as the underlying value is a floating point number it would be much appreciated if it could be rounded to a value not loosing precession. How does LibreOffice (I don't have excel) handle it as `2001-02-03 04:05:05.000000` just works there?