### PR TITLE
Dompdf and Php8.4

### DIFF
--- a/src/PhpSpreadsheet/Helper/Sample.php
+++ b/src/PhpSpreadsheet/Helper/Sample.php
@@ -9,6 +9,7 @@ use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Writer\IWriter;
+use PhpOffice\PhpSpreadsheet\Writer\Pdf\Dompdf;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RecursiveRegexIterator;
@@ -125,7 +126,11 @@ class Sample
                 $writerCallback($writer);
             }
             $callStartTime = microtime(true);
-            $writer->save($path);
+            if (PHP_VERSION_ID >= 80400 && $writer instanceof Dompdf) {
+                @$writer->save($path);
+            } else {
+                $writer->save($path);
+            }
             $this->logWrite($writer, $path, $callStartTime);
             if ($this->isCli() === false) {
                 // @codeCoverageIgnoreStart

--- a/tests/PhpSpreadsheetTests/Functional/StreamTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/StreamTest.php
@@ -8,6 +8,12 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Not clear that Dompdf will be Php8.4 compatible in time.
+ * Run in separate process and add version test till it is ready.
+ *
+ * @runTestsInSeparateProcesses
+ */
 class StreamTest extends TestCase
 {
     public static function providerFormats(): array
@@ -42,7 +48,11 @@ class StreamTest extends TestCase
         } else {
             self::assertSame(0, $stat['size']);
 
-            $writer->save($stream);
+            if ($format === 'Dompdf' && PHP_VERSION_ID >= 80400) {
+                @$writer->save($stream);
+            } else {
+                $writer->save($stream);
+            }
 
             self::assertIsResource($stream, 'should not close the stream for further usage out of PhpSpreadsheet');
             $stat = fstat($stream);

--- a/tests/PhpSpreadsheetTests/Writer/Dompdf/PaperSizeArrayTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Dompdf/PaperSizeArrayTest.php
@@ -10,6 +10,12 @@ use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 use PhpOffice\PhpSpreadsheet\Writer\Pdf\Dompdf;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Not clear that Dompdf will be Php8.4 compatible in time.
+ * Run in separate process and add version test till it is ready.
+ *
+ * @runTestsInSeparateProcesses
+ */
 class PaperSizeArrayTest extends TestCase
 {
     private string $outfile = '';
@@ -36,7 +42,11 @@ class PaperSizeArrayTest extends TestCase
         $sheet->setCellValue('A7', 'Lorem Ipsum');
         $writer = new Dompdf($spreadsheet);
         $this->outfile = File::temporaryFilename();
-        $writer->save($this->outfile);
+        if (PHP_VERSION_ID >= 80400) { // hopefully temporary
+            @$writer->save($this->outfile);
+        } else {
+            $writer->save($this->outfile);
+        }
         $spreadsheet->disconnectWorksheets();
         unset($spreadsheet);
         $contents = file_get_contents($this->outfile);
@@ -56,7 +66,11 @@ class PaperSizeArrayTest extends TestCase
         $sheet->setCellValue('A7', 'Lorem Ipsum');
         $writer = new Dompdf($spreadsheet);
         $this->outfile = File::temporaryFilename();
-        $writer->save($this->outfile);
+        if (PHP_VERSION_ID >= 80400) { // hopefully temporary
+            @$writer->save($this->outfile);
+        } else {
+            $writer->save($this->outfile);
+        }
         $spreadsheet->disconnectWorksheets();
         unset($spreadsheet);
         $contents = file_get_contents($this->outfile);


### PR DESCRIPTION
Lots of deprecation messages in nightly test suite. 8.4 is already in beta; the messages are a major distraction at this stage. Suppress them until Dompdf is fixed.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] temporary testing assistance

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
