### PR TITLE
Disable 2 Tests

### DIFF
--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
@@ -12,7 +12,8 @@ use PHPUnit\Framework\TestCase;
 
 class URLImageTest extends TestCase
 {
-    public function testURLImageSource(): void
+    // https://github.com/readthedocs/readthedocs.org/issues/11615
+    public function xtestURLImageSource(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');
@@ -43,7 +44,7 @@ class URLImageTest extends TestCase
         }
     }
 
-    public function testURLImageSourceNotFound(): void
+    public function xtestURLImageSourceNotFound(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');


### PR DESCRIPTION
Test for url image used file_get_contents on file which we have read successfully for years. Today it started returning error 403. Disable tests while I study whether there is a suitable replacement.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] environment change

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
