### PR TITLE
Restore 2 Disabled Tests

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1451,7 +1451,7 @@ class Xlsx extends BaseReader
                                                         );
                                                         if (isset($images[$linkImageKey])) {
                                                             $url = str_replace('xl/drawings/', '', $images[$linkImageKey]);
-                                                            $objDrawing->setPath($url);
+                                                            $objDrawing->setPath($url, false);
                                                         }
                                                         if ($objDrawing->getPath() === '') {
                                                             continue;
@@ -1544,7 +1544,7 @@ class Xlsx extends BaseReader
                                                         );
                                                         if (isset($images[$linkImageKey])) {
                                                             $url = str_replace('xl/drawings/', '', $images[$linkImageKey]);
-                                                            $objDrawing->setPath($url);
+                                                            $objDrawing->setPath($url, false);
                                                         }
                                                         if ($objDrawing->getPath() === '') {
                                                             continue;

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -109,7 +109,12 @@ class Drawing extends BaseDrawing
             }
             // Implicit that it is a URL, rather store info than running check above on value in other places.
             $this->isUrl = true;
-            $imageContents = @file_get_contents($path);
+            $ctx = null;
+            // https://github.com/php/php-src/issues/16023
+            if (str_starts_with($path, 'https:')) {
+                $ctx = stream_context_create(['ssl' => ['crypto_method'=>STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT]]);
+            }
+            $imageContents = @file_get_contents($path, false, $ctx);
             if ($imageContents !== false) {
                 $filePath = tempnam(sys_get_temp_dir(), 'Drawing');
                 if ($filePath) {

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -112,7 +112,7 @@ class Drawing extends BaseDrawing
             $ctx = null;
             // https://github.com/php/php-src/issues/16023
             if (str_starts_with($path, 'https:')) {
-                $ctx = stream_context_create(['ssl' => ['crypto_method'=>STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT]]);
+                $ctx = stream_context_create(['ssl' => ['crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT]]);
             }
             $imageContents = @file_get_contents($path, false, $ctx);
             if ($imageContents !== false) {

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
@@ -34,6 +34,7 @@ class URLImageTest extends TestCase
             self::assertSame(84, $drawing->getWidth());
             self::assertSame(44, $drawing->getHeight());
         }
+        $spreadsheet->disconnectWorksheets();
     }
 
     public function testURLImageSourceNotFound(): void
@@ -48,6 +49,7 @@ class URLImageTest extends TestCase
         $worksheet = $spreadsheet->getActiveSheet();
         $collection = $worksheet->getDrawingCollection();
         self::assertCount(0, $collection);
+        $spreadsheet->disconnectWorksheets();
     }
 
     public function testURLImageSourceBadProtocol(): void

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
@@ -12,8 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class URLImageTest extends TestCase
 {
-    // https://github.com/readthedocs/readthedocs.org/issues/11615
-    public function xtestURLImageSource(): void
+    public function testURLImageSource(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');
@@ -31,20 +30,13 @@ class URLImageTest extends TestCase
             // Check if the source is a URL or a file path
             self::assertTrue($drawing->getIsURL());
             self::assertSame('https://phpspreadsheet.readthedocs.io/en/latest/topics/images/01-03-filter-icon-1.png', $drawing->getPath());
-            $imageContents = file_get_contents($drawing->getPath());
-            self::assertNotFalse($imageContents);
-            $filePath = tempnam(sys_get_temp_dir(), 'Drawing');
-            self::assertNotFalse($filePath);
-            self::assertNotFalse(file_put_contents($filePath, $imageContents));
-            $mimeType = mime_content_type($filePath);
-            unlink($filePath);
-            self::assertNotFalse($mimeType);
-            $extension = File::mime2ext($mimeType);
-            self::assertSame('png', $extension);
+            self::assertSame(IMAGETYPE_PNG, $drawing->getType());
+            self::assertSame(84, $drawing->getWidth());
+            self::assertSame(44, $drawing->getHeight());
         }
     }
 
-    public function xtestURLImageSourceNotFound(): void
+    public function testURLImageSourceNotFound(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');


### PR DESCRIPTION
For some https requests for file_get_contents, "context" needs to be added to function call. It is not clear why this has changed recently.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
