### PR TITLE
Xlsx Writer Duplicate ContentTypes Entry for Background Image

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/ContentTypes.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/ContentTypes.php
@@ -196,7 +196,7 @@ class ContentTypes extends WriterPart
             $bgImage = $spreadsheet->getSheet($i)->getBackgroundImage();
             $mimeType = $spreadsheet->getSheet($i)->getBackgroundMime();
             $extension = $spreadsheet->getSheet($i)->getBackgroundExtension();
-            if ($bgImage !== '' && !isset($aMediaContentTypes[$mimeType])) {
+            if ($bgImage !== '' && !isset($aMediaContentTypes[$extension])) {
                 $this->writeDefaultContentType($objWriter, $extension, $mimeType);
             }
         }

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/ArrayFunctionsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/ArrayFunctionsTest.php
@@ -15,6 +15,14 @@ class ArrayFunctionsTest extends TestCase
 {
     private string $outputFile = '';
 
+    protected function tearDown(): void
+    {
+        if ($this->outputFile !== '') {
+            unlink($this->outputFile);
+            $this->outputFile = '';
+        }
+    }
+
     public function testArrayOutput(): void
     {
         $spreadsheet = new Spreadsheet();

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue4179Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue4179Test.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+class Issue4179Test extends TestCase
+{
+    private string $outputFile = '';
+
+    protected function tearDown(): void
+    {
+        if ($this->outputFile !== '') {
+            unlink($this->outputFile);
+            $this->outputFile = '';
+        }
+    }
+
+    public function testIssue4179(): void
+    {
+        // duplicate entry in ContentTypes
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $imageFile = 'tests/data/Writer/XLSX/backgroundtest.png';
+        $image = (string) file_get_contents($imageFile);
+        $sheet->setBackgroundImage($image);
+        $drawing = new Drawing();
+        $drawing->setName('Blue Square');
+        $drawing->setPath('tests/data/Writer/XLSX/blue_square.png');
+        $drawing->setCoordinates('A1');
+        $drawing->setWorksheet($sheet);
+        $writer = new XlsxWriter($spreadsheet);
+        $this->outputFile = File::temporaryFilename();
+        $writer->save($this->outputFile);
+        $spreadsheet->disconnectWorksheets();
+
+        $zip = new ZipArchive();
+        $open = $zip->open($this->outputFile, ZipArchive::RDONLY);
+        $pngCount = 0;
+        if ($open !== true) {
+            self::fail("zip open failed for {$this->outputFile}");
+        } else {
+            $contents = (string) $zip->getFromName('[Content_Types].xml');
+            $subCount = substr_count($contents, '"png"');
+            self::assertSame(1, $subCount);
+            for ($i = 0; $i < $zip->numFiles; ++$i) {
+                $filename = (string) $zip->getNameIndex($i);
+                if (preg_match('~^xl/media/\\w+[.]png$~', $filename) === 1) {
+                    ++$pngCount;
+                }
+            }
+        }
+        self::assertSame(2, $pngCount);
+    }
+}


### PR DESCRIPTION
Fix #4179. Sheet has a background image, and the code is not properly accounting for the image's extension already being defined in ContentTypes, resulting in what Excel thinks is a corrupt file.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
