### PR TITLE
SUMIFS Does Not Require _xlfn

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/FunctionPrefix.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/FunctionPrefix.php
@@ -130,7 +130,6 @@ class FunctionPrefix
         . '|ifs'
         . '|maxifs'
         . '|minifs'
-        . '|sumifs'
         . '|textjoin'
         // functions added with Excel 365
         . '|anchorarray'

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/FunctionPrefixTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/FunctionPrefixTest.php
@@ -37,6 +37,7 @@ class FunctionPrefixTest extends TestCase
             'DAYS/NETWORKDAYS 4' => ['ABS(_xlfn.DAYS(DATE(2023,1,1),TODAY()))', 'ABS(_xlfn.DAYS(DATE(2023,1,1),TODAY()))'],
             'DAYS/NETWORKDAYS 5' => ['NETWORKDAYS(DATE(2023,1,1),TODAY(), C:C)', 'NETWORKDAYS(DATE(2023,1,1),TODAY(), C:C)'],
             'COUNTIFS reclassified as Legacy' => ['COUNTIFS()', 'COUNTIFS()'],
+            'SUMIFS reclassified as Legacy' => ['SUMIFS()', 'SUMIFS()'],
         ];
     }
 }


### PR DESCRIPTION
Fix #4182. It was on our list as "introduced in 2019". It was, in fact, available with Excel 2007 (https://support.microsoft.com/en-us/office/excel-functions-alphabetical-b3944572-255d-4efb-bb96-c6d90033e188#bm19), so does not require a prefix when writing it to a spreadsheet.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
