### PR TITLE
Write ignoredErrors Tag Before Drawings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Option to Write Hyperlink Rather Than Label to Csv. [Issue #1412](https://github.com/PHPOffice/PhpSpreadsheet/issues/1412) [PR #4151](https://github.com/PHPOffice/PhpSpreadsheet/pull/4151)
 - Invalid Html Due to Cached Filesize. [Issue #1107](https://github.com/PHPOffice/PhpSpreadsheet/issues/1107) [PR #4184](https://github.com/PHPOffice/PhpSpreadsheet/pull/4184)
 - Excel 2003 Allows Html Entities. [Issue #2157](https://github.com/PHPOffice/PhpSpreadsheet/issues/2157) [PR #4187](https://github.com/PHPOffice/PhpSpreadsheet/pull/4187)
+- Writer Xlsx ignoredErrors Before Drawings. [Issue #4200](https://github.com/PHPOffice/PhpSpreadsheet/issues/4200) [Issue #4145](https://github.com/PHPOffice/PhpSpreadsheet/issues/4145)  [PR #4212](https://github.com/PHPOffice/PhpSpreadsheet/pull/4212)
 
 ## 2024-09-29 - 3.3.0 (no 3.0.\*, 3.1.\*, 3.2.\*)
 

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -129,6 +129,9 @@ class Worksheet extends WriterPart
         // Breaks
         $this->writeBreaks($objWriter, $worksheet);
 
+        // IgnoredErrors
+        $this->writeIgnoredErrors($objWriter);
+
         // Drawings and/or Charts
         $this->writeDrawings($objWriter, $worksheet, $includeCharts);
 
@@ -140,9 +143,6 @@ class Worksheet extends WriterPart
 
         // AlternateContent
         $this->writeAlternateContent($objWriter, $worksheet);
-
-        // IgnoredErrors
-        $this->writeIgnoredErrors($objWriter);
 
         // BackgroundImage must come after ignored, before table
         $this->writeBackgroundImage($objWriter, $worksheet);

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue4200Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue4200Test.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\RichText\RichText;
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+class Issue4200Test extends TestCase
+{
+    private string $outputFile = '';
+
+    protected function tearDown(): void
+    {
+        if ($this->outputFile !== '') {
+            unlink($this->outputFile);
+            $this->outputFile = '';
+        }
+    }
+
+    public function testIssue4200(): void
+    {
+        // ignoredErrors came after legacyDrawing
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->getCell('A1')->setValueExplicit('01', DataType::TYPE_STRING);
+        $sheet->getCell('A1')
+            ->getIgnoredErrors()
+            ->setNumberStoredAsText(true);
+        $richText = new RichText();
+        $richText->createText('hello');
+        $sheet->getComment('C1')
+            ->setText($richText);
+        $writer = new XlsxWriter($spreadsheet);
+        $this->outputFile = File::temporaryFilename();
+        $writer->save($this->outputFile);
+        $spreadsheet->disconnectWorksheets();
+
+        $zip = new ZipArchive();
+        $open = $zip->open($this->outputFile, ZipArchive::RDONLY);
+        if ($open !== true) {
+            self::fail("zip open failed for {$this->outputFile}");
+        } else {
+            $contents = (string) $zip->getFromName('xl/worksheets/sheet1.xml');
+            self::assertStringContainsString(
+                '<ignoredErrors><ignoredError sqref="A1" numberStoredAsText="1"/></ignoredErrors><legacyDrawing r:id="rId_comments_vml1"/>',
+                $contents
+            );
+        }
+    }
+
+    public function testIssue4145(): void
+    {
+        // ignoredErrors came after drawing
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->getCell('A1')->setValueExplicit('01', DataType::TYPE_STRING);
+        $sheet->getCell('A1')
+            ->getIgnoredErrors()
+            ->setNumberStoredAsText(true);
+        $drawing = new Drawing();
+        $drawing->setName('Blue Square');
+        $drawing->setPath('tests/data/Writer/XLSX/blue_square.png');
+        $drawing->setCoordinates('C1');
+        $drawing->setWorksheet($sheet);
+        $writer = new XlsxWriter($spreadsheet);
+        $this->outputFile = File::temporaryFilename();
+        $writer->save($this->outputFile);
+        $spreadsheet->disconnectWorksheets();
+
+        $zip = new ZipArchive();
+        $open = $zip->open($this->outputFile, ZipArchive::RDONLY);
+        if ($open !== true) {
+            self::fail("zip open failed for {$this->outputFile}");
+        } else {
+            $contents = (string) $zip->getFromName('xl/worksheets/sheet1.xml');
+            self::assertStringContainsString(
+                '<ignoredErrors><ignoredError sqref="A1" numberStoredAsText="1"/></ignoredErrors><drawing r:id="rId1"/>',
+                $contents
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fix #4200. Fix #4145. Although the Xml is valid, Excel insists that worksheet.xml specifies `ignoredErrors` (introduced with 1.29.0) before `legacyDrawing` or `drawing`.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
