### PR TITLE
Fix incorrect versions error (ForbiddenThisUseContexts)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "check": [
             "./bin/check-phpdoc-types",
             "phpcs samples/ src/ tests/ --report=checkstyle",
-            "phpcs samples/ src/ tests/ --standard=PHPCompatibility --runtime-set testVersion 8.0- -n",
+            "phpcs samples/ src/ tests/ --standard=PHPCompatibility --runtime-set testVersion 8.0- --exclude=PHPCompatibility.Variables.ForbiddenThisUseContexts -n",
             "php-cs-fixer fix --ansi --dry-run --diff",
             "phpunit --color=always",
             "phpstan analyse --ansi --memory-limit=2048M"
@@ -61,7 +61,7 @@
             "php-cs-fixer fix"
         ],
         "versions": [
-            "phpcs samples/ src/ tests/ --standard=PHPCompatibility --runtime-set testVersion 8.0- -n"
+            "phpcs samples/ src/ tests/ --standard=PHPCompatibility --runtime-set testVersion 8.0- --exclude=PHPCompatibility.Variables.ForbiddenThisUseContexts -n"
         ]
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -45,12 +45,12 @@
     ],
     "scripts": {
         "check": [
-            "./bin/check-phpdoc-types",
+            "php ./bin/check-phpdoc-types",
             "phpcs samples/ src/ tests/ --report=checkstyle",
             "phpcs samples/ src/ tests/ --standard=PHPCompatibility --runtime-set testVersion 8.0- --exclude=PHPCompatibility.Variables.ForbiddenThisUseContexts -n",
             "php-cs-fixer fix --ansi --dry-run --diff",
-            "phpunit --color=always",
-            "phpstan analyse --ansi --memory-limit=2048M"
+            "phpstan analyse --ansi --memory-limit=2048M",
+            "phpunit --color=always"
         ],
         "style": [
             "phpcs samples/ src/ tests/ --report=checkstyle",


### PR DESCRIPTION
PHPCompatibility erroneously flags the use of $this in enumerations. Commit 5e248cf moved disabling of this error check to .github/workflows/main.yml. Hence, `composer versions` and `composer check` should also exclude this check.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Fixes #4220 
