### PR TITLE
Improve contributing guidelines for composer newbies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ If you would like to contribute, here are some notes and guidelines:
 
  - All new development should be on feature/fix branches, which are then merged to the `master` branch once stable and approved; so the `master` branch is always the most up-to-date, working code
  - If you are going to submit a pull request, please fork from `master`, and submit your pull request back as a fix/feature branch referencing the GitHub issue number
+ - Install (development) dependencies by running `composer install` inside your PhpSpreadsheet clone.
  - The code must work with all PHP versions that we support.
    - You can call `composer versions` to test version compatibility. 
  - Code style should be maintained.


### PR DESCRIPTION
To allow running `composer versions`, it is necessary to call `composer install` to install the (development) dependencies of this project. This may not be obvious to contributors unfamiliar with `composer'.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] documentation improvement

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [x] Documentation is updated as necessary

### Why this change is needed?

This PR helps people unfamiliar with `composer` to contribute to this project.