### PR TITLE
Catch Phpstan Up

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1789,16 +1789,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.0",
+            "version": "1.12.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "384af967d35b2162f69526c7276acadce534d0e1"
+                "reference": "ceb937fb39a92deabc02d20709cf14b2c452502c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/384af967d35b2162f69526c7276acadce534d0e1",
-                "reference": "384af967d35b2162f69526c7276acadce534d0e1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ceb937fb39a92deabc02d20709cf14b2c452502c",
+                "reference": "ceb937fb39a92deabc02d20709cf14b2c452502c",
                 "shasum": ""
             },
             "require": {
@@ -1843,7 +1843,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-27T09:18:05+00:00"
+            "time": "2024-11-10T17:10:04+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -4149,9 +4149,9 @@ class Calculation
                     $expectedArgumentCountString = null;
                     if (is_numeric($expectedArgumentCount)) {
                         if ($expectedArgumentCount < 0) {
-                            if ($argumentCount > abs($expectedArgumentCount)) {
+                            if ($argumentCount > abs($expectedArgumentCount + 0)) {
                                 $argumentCountError = true;
-                                $expectedArgumentCountString = 'no more than ' . abs($expectedArgumentCount);
+                                $expectedArgumentCountString = 'no more than ' . abs($expectedArgumentCount + 0);
                             }
                         } else {
                             if ($argumentCount != $expectedArgumentCount) {
@@ -4236,7 +4236,7 @@ class Calculation
                 // do we now have a function/variable/number?
                 $expectingOperator = true;
                 $expectingOperand = false;
-                $val = $match[1] ?? '';
+                $val = $match[1] ?? ''; //* @phpstan-ignore-line
                 $length = strlen($val);
 
                 if (preg_match('/^' . self::CALCULATION_REGEXP_FUNCTION . '$/miu', $val, $matches)) {

--- a/src/PhpSpreadsheet/Calculation/Engineering/BitWise.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/BitWise.php
@@ -221,7 +221,7 @@ class BitWise
         $value = self::nullFalseTrueToNumber($value);
 
         if (is_numeric($value)) {
-            if (abs($value) > 53) {
+            if (abs($value + 0) > 53) {
                 throw new Exception(ExcelError::NAN());
             }
 

--- a/src/PhpSpreadsheet/Calculation/Financial/CashFlow/Variable/NonPeriodic.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/CashFlow/Variable/NonPeriodic.php
@@ -239,6 +239,7 @@ class NonPeriodic
         return $rslt;
     }
 
+    /** @param array<int,float|int|numeric-string> $values> */
     private static function xnpvOrdered(mixed $rate, mixed $values, mixed $dates, bool $ordered = true, bool $capAtNegative1 = false): float|string
     {
         $rate = Functions::flattenSingleValue($rate);
@@ -276,7 +277,7 @@ class NonPeriodic
                 return $dif;
             }
             if ($rate <= -1.0) {
-                $xnpv += -abs($values[$i]) / (-1 - $rate) ** ($dif / 365);
+                $xnpv += -abs($values[$i] + 0) / (-1 - $rate) ** ($dif / 365);
             } else {
                 $xnpv += $values[$i] / (1 + $rate) ** ($dif / 365);
             }

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -234,7 +234,7 @@ class Xls extends XlsBase
      * The current MD5 context state.
      * It is never set in the program, so code which uses it is suspect.
      */
-    private string $md5Ctxt; // @phpstan-ignore-line
+    private string $md5Ctxt = '';
 
     protected int $textObjRef;
 

--- a/src/PhpSpreadsheet/Shared/OLE/ChainedBlockStream.php
+++ b/src/PhpSpreadsheet/Shared/OLE/ChainedBlockStream.php
@@ -85,7 +85,7 @@ class ChainedBlockStream
             }
         }
         if (isset($this->params['size'])) {
-            $this->data = substr($this->data, 0, $this->params['size']);
+            $this->data = substr($this->data, 0, $this->params['size']); //* @phpstan-ignore-line
         }
 
         if ($options & STREAM_USE_PATH) {

--- a/src/PhpSpreadsheet/Shared/Trend/PolynomialBestFit.php
+++ b/src/PhpSpreadsheet/Shared/Trend/PolynomialBestFit.php
@@ -159,7 +159,7 @@ class PolynomialBestFit extends BestFit
         $coefficients = [];
         for ($i = 0; $i < $C->rows; ++$i) {
             $r = $C->getValue($i + 1, 1); // row and column are origin-1
-            if (!is_numeric($r) || abs($r) <= 10 ** (-9)) {
+            if (!is_numeric($r) || abs($r + 0) <= 10 ** (-9)) {
                 $r = 0;
             } else {
                 $r += 0;

--- a/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
@@ -42,7 +42,7 @@ class Formatter extends BaseFormatter
         };
     }
 
-    /** @param float|int|string $value value to be formatted */
+    /** @param float|int|numeric-string $value value to be formatted */
     private static function splitFormatForSectionSelection(array $sections, mixed $value): array
     {
         // Extract the relevant section depending on whether number is positive, negative, or zero?
@@ -79,7 +79,7 @@ class Formatter extends BaseFormatter
         $absval = $value;
         switch ($sectionCount) {
             case 2:
-                $absval = abs($value);
+                $absval = abs($value + 0);
                 if (!self::splitFormatComparison($value, $conditionOperations[0], $conditionComparisonValues[0], '>=', 0)) {
                     $color = $colors[1];
                     $format = $sections[1];
@@ -88,7 +88,7 @@ class Formatter extends BaseFormatter
                 break;
             case 3:
             case 4:
-                $absval = abs($value);
+                $absval = abs($value + 0);
                 if (!self::splitFormatComparison($value, $conditionOperations[0], $conditionComparisonValues[0], '>', 0)) {
                     if (self::splitFormatComparison($value, $conditionOperations[1], $conditionComparisonValues[1], '<', 0)) {
                         $color = $colors[1];

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -2362,7 +2362,7 @@ class Worksheet extends BIFFwriter
      *
      * @param GdImage $image The image to process
      *
-     * @return array Array with data and properties of the bitmap
+     * @return array{0: float, 1: float, 2: int, 3: string} Data and properties of the bitmap
      */
     public function processBitmapGd(GdImage $image): array
     {
@@ -2372,9 +2372,9 @@ class Worksheet extends BIFFwriter
         $data = pack('Vvvvv', 0x000C, $width, $height, 0x01, 0x18);
         for ($j = $height; --$j;) {
             for ($i = 0; $i < $width; ++$i) {
-                /** @phpstan-ignore-next-line */
-                $color = imagecolorsforindex($image, imagecolorat($image, $i, $j));
-                if ($color !== false) {
+                $colorAt = imagecolorat($image, $i, $j);
+                if ($colorAt !== false) {
+                    $color = imagecolorsforindex($image, $colorAt);
                     foreach (['red', 'green', 'blue'] as $key) {
                         $color[$key] = $color[$key] + (int) round((255 - $color[$key]) * $color['alpha'] / 127);
                     }
@@ -2385,8 +2385,11 @@ class Worksheet extends BIFFwriter
                 $data .= str_repeat("\x00", 4 - 3 * $width % 4);
             }
         }
+        // Phpstan says this always throws an exception before getting here.
+        // I don't see why, but I think this is code is never exercised
+        // in unit tests, so I can't say for sure it's wrong.
 
-        return [$width, $height, strlen($data), $data];
+        return [$width, $height, strlen($data), $data]; //* @phpstan-ignore-line
     }
 
     /**


### PR DESCRIPTION
Its last few updates have been irksome. I need to eliminate more of the new problems with annotations rather than code because I can't figure out what it's objecting to. Nevertheless, it provides a very valuable service, so ...

Its latest release is flagging calling abs with a string, even when the string is defined as numeric-string in a doc block. Php generally allows it, though not with strict types. Changed to add 0 in those situations.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] code quality

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
