### PR TITLE
fix `Conditional formatting a cell` documentation

### DIFF
--- a/docs/topics/recipes.md
+++ b/docs/topics/recipes.md
@@ -1293,8 +1293,8 @@ style object:
 
 ```php
 $spreadsheet->getActiveSheet()
-    ->duplicateStyle(
-        $spreadsheet->getActiveSheet()->getStyle('B2'),
+    ->duplicateConditionalStyle(
+        $spreadsheet->getActiveSheet()->getConditionalStyles('B2'),
         'B3:B7'
     );
 ```


### PR DESCRIPTION
Section `Recipies / Conditional formatting a cell` after words `If you want to copy the ruleset to other cells, you can duplicate the
style object:` contained an incorrect example. I spent some time trying to figure out why it wasn't working, and through trial and error I found the correct way to duplicate conditional styles.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] documentation review



Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [x] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
