### PR TITLE
Escape any dollar signs when formatting cell data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- Nothing yet.
+- Ignore cell formatting when the format is a single @. [Issue #4242](https://github.com/PHPOffice/PhpSpreadsheet/issues/4242) [PR #4243](https://github.com/PHPOffice/PhpSpreadsheet/pull/4243)
 
 ## 2024-11-22 - 3.5.0
 

--- a/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
@@ -126,7 +126,13 @@ class Formatter extends BaseFormatter
         // For now we do not treat strings in sections, although section 4 of a format code affects strings
         // Process a single block format code containing @ for text substitution
         if (preg_match(self::SECTION_SPLIT, $format) === 0 && preg_match(self::SYMBOL_AT, $format) === 1) {
-            return str_replace('"', '', preg_replace(self::SYMBOL_AT, (string) $value, $format) ?? '');
+            if (!str_contains($format, '"')) {
+                return str_replace('@', $value, $format);
+            }
+            //escape any dollar signs on the string, so they are not replaced with an empty value
+            $value = str_replace('$', '\\$', (string) $value);
+
+            return str_replace('"', '', preg_replace(self::SYMBOL_AT, $value, $format) ?? $value);
         }
 
         // If we have a text value, return it "as is"

--- a/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
@@ -14,6 +14,7 @@ class Formatter extends BaseFormatter
      * Matches any @ symbol that isn't enclosed in quotes.
      */
     private const SYMBOL_AT = '/@(?=(?:[^"]*"[^"]*")*[^"]*\Z)/miu';
+    private const QUOTE_REPLACEMENT = "\u{fffe}"; // invalid Unicode character
 
     /**
      * Matches any ; symbol that isn't enclosed in quotes, for a "section" split.
@@ -130,9 +131,17 @@ class Formatter extends BaseFormatter
                 return str_replace('@', $value, $format);
             }
             //escape any dollar signs on the string, so they are not replaced with an empty value
-            $value = str_replace('$', '\\$', (string) $value);
+            $value = str_replace(
+                ['$', '"'],
+                ['\\$', self::QUOTE_REPLACEMENT],
+                (string) $value
+            );
 
-            return str_replace('"', '', preg_replace(self::SYMBOL_AT, $value, $format) ?? $value);
+            return str_replace(
+                ['"', self::QUOTE_REPLACEMENT],
+                ['', '"'],
+                preg_replace(self::SYMBOL_AT, $value, $format) ?? $value
+            );
         }
 
         // If we have a text value, return it "as is"

--- a/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
@@ -126,7 +126,8 @@ class Formatter extends BaseFormatter
         }
         // For now we do not treat strings in sections, although section 4 of a format code affects strings
         // Process a single block format code containing @ for text substitution
-        if (preg_match(self::SECTION_SPLIT, $format) === 0 && preg_match(self::SYMBOL_AT, $format) === 1) {
+        $formatx = str_replace('\\"', self::QUOTE_REPLACEMENT, $format);
+        if (preg_match(self::SECTION_SPLIT, $format) === 0 && preg_match(self::SYMBOL_AT, $formatx) === 1) {
             if (!str_contains($format, '"')) {
                 return str_replace('@', $value, $format);
             }
@@ -140,7 +141,7 @@ class Formatter extends BaseFormatter
             return str_replace(
                 ['"', self::QUOTE_REPLACEMENT],
                 ['', '"'],
-                preg_replace(self::SYMBOL_AT, $value, $format) ?? $value
+                preg_replace(self::SYMBOL_AT, $value, $formatx) ?? $value
             );
         }
 

--- a/tests/data/Style/NumberFormat.php
+++ b/tests/data/Style/NumberFormat.php
@@ -1682,24 +1682,44 @@ return [
         '#,##0.00;;"---"',
     ],
     'issue 4124' => ['1 HUF', 1, '#,##0_-[$HUF]'],
-    'issue 4242-0' => [
+    'issue 4242 General with dollar sign' => [
         'General $200 - 200', // expected result
         'General $200 - 200', // cell contents
         NumberFormat::FORMAT_GENERAL, // cell style
     ],
-    'issue 4242-1' => [
+    'issue 4242 Text with dollar sign' => [
         'Text $200 - 200',
         'Text $200 - 200',
         NumberFormat::FORMAT_TEXT,
     ],
-    'issue 4242-2' => [
+    'issue 4242 Text with quotes, format without' => [
         '"Hello" she said and "Hello" I replied',
         '"Hello" she said and "Hello" I replied',
         NumberFormat::FORMAT_TEXT,
     ],
-    'issue 4242-3' => [
+    'issue 4242 Format with quotes, text without' => [
         'Text: $200 - 200',
         '$200 - 200',
+        '"Text: "' . NumberFormat::FORMAT_TEXT,
+    ],
+    'issue 4242 single quote mark' => [
+        '"',
+        '"',
+        '@',
+    ],
+    'issue 4242 dollar sign' => [
+        '$100',
+        '$100',
+        '@',
+    ],
+    'issue 4242 repeat unquoted at signs' => [
+        'xy xy xy',
+        'xy',
+        '@ @ @',
+    ],
+    'issue 4242 quotes in format and text' => [
+        'Text: "Hooray" for me',
+        '"Hooray" for me',
         '"Text: "' . NumberFormat::FORMAT_TEXT,
     ],
 ];

--- a/tests/data/Style/NumberFormat.php
+++ b/tests/data/Style/NumberFormat.php
@@ -1682,4 +1682,24 @@ return [
         '#,##0.00;;"---"',
     ],
     'issue 4124' => ['1 HUF', 1, '#,##0_-[$HUF]'],
+    'issue 4242-0' => [
+        'General $200 - 200', // expected result
+        'General $200 - 200', // cell contents
+        NumberFormat::FORMAT_GENERAL, // cell style
+    ],
+    'issue 4242-1' => [
+        'Text $200 - 200',
+        'Text $200 - 200',
+        NumberFormat::FORMAT_TEXT,
+    ],
+    'issue 4242-2' => [
+        '"Hello" she said and "Hello" I replied',
+        '"Hello" she said and "Hello" I replied',
+        NumberFormat::FORMAT_TEXT,
+    ],
+    'issue 4242-3' => [
+        'Text: $200 - 200',
+        '$200 - 200',
+        '"Text: "' . NumberFormat::FORMAT_TEXT,
+    ],
 ];

--- a/tests/data/Style/NumberFormat.php
+++ b/tests/data/Style/NumberFormat.php
@@ -1722,4 +1722,9 @@ return [
         '"Hooray" for me',
         '"Text: "' . NumberFormat::FORMAT_TEXT,
     ],
+    'issue 4242 escaped quote in format' => [
+        '"Hello"',
+        'Hello',
+        '\\"@\\"',
+    ],
 ];


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Fix #4242. When a cell is formatted as text and contains a number prefixed with dollar sign, this number is getting replaced with 0. The replacement happens due to the preg_replace function. This commit escapes any sollar signs on the cell data, so those are not replaced.