### PR TITLE
Get Us Closer to Csv Not Autodetect By Default

### DIFF
--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -84,10 +84,13 @@ class Csv extends BaseReader
      */
     private static $constructorCallback;
 
+    /** Will be changed to false in next major release */
+    public const DEFAULT_TEST_AUTODETECT = true;
+
     /**
      * Attempt autodetect line endings (deprecated after PHP8.1)?
      */
-    private bool $testAutodetect = true;
+    private bool $testAutodetect = self::DEFAULT_TEST_AUTODETECT;
 
     protected bool $castFormattedNumberToNumeric = false;
 

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvLineEndingTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvLineEndingTest.php
@@ -12,6 +12,8 @@ class CsvLineEndingTest extends TestCase
 {
     private string $tempFile = '';
 
+    private static bool $alwaysFalse = false;
+
     protected function tearDown(): void
     {
         if ($this->tempFile !== '') {
@@ -32,6 +34,9 @@ class CsvLineEndingTest extends TestCase
         $data = ['123', '456', '789'];
         file_put_contents($filename, implode($ending, $data));
         $reader = new Csv();
+        if (Csv::DEFAULT_TEST_AUTODETECT === self::$alwaysFalse) {
+            $reader->setTestAutoDetect(true);
+        }
         $spreadsheet = $reader->load($filename);
         $sheet = $spreadsheet->getActiveSheet();
         self::assertEquals($data[0], $sheet->getCell('A1')->getValue());


### PR DESCRIPTION
This has been requested a few times, most recently issue #4092. Because it's a breaking change, I haven't proceeded with it. But, because I have a breaking change PR #4240 already in the queue, this gives a plan for getting where we want to go (under the extremely likely assumption that most users don't deal with Csv files with Mac line endings). This PR doesn't change the current behavior, but it gets us to a state where a single-line change will be sufficient when the time comes for a new major release.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] prep work for a future change

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
