### PR TITLE
Ods Writer Horizontal Alignment

### DIFF
--- a/src/PhpSpreadsheet/Writer/Ods/Cell/Style.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Cell/Style.php
@@ -20,6 +20,7 @@ class Style
     public const COLUMN_STYLE_PREFIX = 'co';
     public const ROW_STYLE_PREFIX = 'ro';
     public const TABLE_STYLE_PREFIX = 'ta';
+    public const INDENT_TO_INCHES = 0.1043; // undocumented, used trial and error
 
     private XMLWriter $writer;
 
@@ -28,12 +29,13 @@ class Style
         $this->writer = $writer;
     }
 
-    private function mapHorizontalAlignment(string $horizontalAlignment): string
+    private function mapHorizontalAlignment(?string $horizontalAlignment): string
     {
         return match ($horizontalAlignment) {
             Alignment::HORIZONTAL_CENTER, Alignment::HORIZONTAL_CENTER_CONTINUOUS, Alignment::HORIZONTAL_DISTRIBUTED => 'center',
             Alignment::HORIZONTAL_RIGHT => 'end',
             Alignment::HORIZONTAL_FILL, Alignment::HORIZONTAL_JUSTIFY => 'justify',
+            Alignment::HORIZONTAL_GENERAL, '', null => '',
             default => 'start',
         };
     }
@@ -145,8 +147,10 @@ class Style
     {
         // Align
         $hAlign = $style->getAlignment()->getHorizontal();
+        $hAlign = $this->mapHorizontalAlignment($hAlign);
         $vAlign = $style->getAlignment()->getVertical();
         $wrap = $style->getAlignment()->getWrapText();
+        $indent = $style->getAlignment()->getIndent();
 
         $this->writer->startElement('style:table-cell-properties');
         if (!empty($vAlign) || $wrap) {
@@ -168,10 +172,16 @@ class Style
 
         $this->writer->endElement();
 
-        if (!empty($hAlign)) {
-            $hAlign = $this->mapHorizontalAlignment($hAlign);
-            $this->writer->startElement('style:paragraph-properties');
-            $this->writer->writeAttribute('fo:text-align', $hAlign);
+        if ($hAlign !== '' || !empty($indent)) {
+            $this->writer
+                ->startElement('style:paragraph-properties');
+            if ($hAlign !== '') {
+                $this->writer->writeAttribute('fo:text-align', $hAlign);
+            }
+            if (!empty($indent)) {
+                $indentString = sprintf('%.4f', $indent * self::INDENT_TO_INCHES) . 'in';
+                $this->writer->writeAttribute('fo:margin-left', $indentString);
+            }
             $this->writer->endElement();
         }
     }

--- a/tests/PhpSpreadsheetTests/Writer/Ods/IndentTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Ods/IndentTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Ods;
+
+use PhpOffice\PhpSpreadsheet\Calculation\Functions;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Ods;
+use PhpOffice\PhpSpreadsheet\Writer\Ods\Content;
+use PHPUnit\Framework\TestCase;
+
+class IndentTest extends TestCase
+{
+    private string $compatibilityMode;
+
+    protected function setUp(): void
+    {
+        $this->compatibilityMode = Functions::getCompatibilityMode();
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_OPENOFFICE
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Functions::setCompatibilityMode($this->compatibilityMode);
+    }
+
+    public function testWriteSpreadsheet(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'aa');
+        $sheet->setCellValue('B1', 'bb');
+        $sheet->setCellValue('A2', 'cc');
+        $sheet->setCellValue('B2', 'dd');
+        $sheet->getStyle('A1')->getAlignment()->setIndent(2);
+        $writer = new Ods($spreadsheet);
+        $content = new Content($writer);
+        $xml = $content->write();
+        self::assertStringContainsString(
+            '<style:style style:name="ce0" style:family="table-cell" style:parent-style-name="Default">'
+                . '<style:table-cell-properties style:vertical-align="bottom" style:rotation-align="none"/>'
+                . '<style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt"/>'
+                . '</style:style>',
+            $xml
+        );
+        self::assertStringContainsString(
+            '<style:style style:name="ce1" style:family="table-cell" style:parent-style-name="Default">'
+                . '<style:table-cell-properties style:vertical-align="bottom" style:rotation-align="none"/>'
+                . '<style:paragraph-properties fo:margin-left="0.2086in"/>' // fo:margin-left is what we're looking for
+                . '<style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt"/>'
+                . '</style:style>',
+            $xml
+        );
+        self::assertSame(3, substr_count($xml, 'table:style-name="ce0"'));
+        self::assertSame(1, substr_count($xml, 'table:style-name="ce1"'));
+        $spreadsheet->disconnectWorksheets();
+    }
+}

--- a/tests/data/Writer/Ods/content-arrays.xml
+++ b/tests/data/Writer/Ods/content-arrays.xml
@@ -1,2 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2"><office:scripts/><office:font-face-decls/><office:automatic-styles><style:style style:family="table" style:name="ta1"><style:table-properties table:display="true"/></style:style><style:style style:name="ce0" style:family="table-cell" style:parent-style-name="Default"><style:table-cell-properties style:vertical-align="bottom" style:rotation-align="none"/><style:paragraph-properties fo:text-align="start"/><style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt"/></style:style></office:automatic-styles><office:body><office:spreadsheet><table:calculation-settings/><table:table table:name="Worksheet" table:style-name="ta1"><office:forms/><table:table-row><table:table-cell table:style-name="ce0" office:value-type="float" office:value="1"><text:p>1</text:p></table:table-cell><table:table-cell table:style-name="ce0" table:number-matrix-columns-spanned="1" table:number-matrix-rows-spanned="2" table:formula="of:=UNIQUE([.A1:.A3])" office:value-type="float" office:value="1"><text:p>1</text:p></table:table-cell><table:table-cell table:number-columns-repeated="1022"/></table:table-row><table:table-row><table:table-cell table:style-name="ce0" office:value-type="float" office:value="1"><text:p>1</text:p></table:table-cell><table:table-cell table:style-name="ce0" office:value-type="float" office:value="3"><text:p>3</text:p></table:table-cell><table:table-cell table:number-columns-repeated="1022"/></table:table-row><table:table-row><table:table-cell table:style-name="ce0" office:value-type="float" office:value="3"><text:p>3</text:p></table:table-cell><table:table-cell table:style-name="ce0"/><table:table-cell table:number-columns-repeated="1022"/></table:table-row></table:table><table:named-expressions/></office:spreadsheet></office:body></office:document-content>
+<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2">
+<office:scripts/>
+<office:font-face-decls/>
+<office:automatic-styles>
+<style:style style:family="table" style:name="ta1">
+<style:table-properties table:display="true"/>
+</style:style>
+<style:style style:name="ce0" style:family="table-cell" style:parent-style-name="Default">
+<style:table-cell-properties style:vertical-align="bottom" style:rotation-align="none"/>
+<style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt"/>
+</style:style>
+</office:automatic-styles>
+<office:body>
+<office:spreadsheet>
+<table:calculation-settings/>
+<table:table table:name="Worksheet" table:style-name="ta1">
+<office:forms/>
+<table:table-row>
+<table:table-cell table:style-name="ce0" office:value-type="float" office:value="1">
+<text:p>1</text:p>
+</table:table-cell>
+<table:table-cell table:style-name="ce0" table:number-matrix-columns-spanned="1" table:number-matrix-rows-spanned="2" table:formula="of:=UNIQUE([.A1:.A3])" office:value-type="float" office:value="1">
+<text:p>1</text:p>
+</table:table-cell>
+<table:table-cell table:number-columns-repeated="1022"/>
+</table:table-row>
+<table:table-row>
+<table:table-cell table:style-name="ce0" office:value-type="float" office:value="1">
+<text:p>1</text:p>
+</table:table-cell>
+<table:table-cell table:style-name="ce0" office:value-type="float" office:value="3">
+<text:p>3</text:p>
+</table:table-cell>
+<table:table-cell table:number-columns-repeated="1022"/>
+</table:table-row>
+<table:table-row>
+<table:table-cell table:style-name="ce0" office:value-type="float" office:value="3">
+<text:p>3</text:p>
+</table:table-cell>
+<table:table-cell table:style-name="ce0"/>
+<table:table-cell table:number-columns-repeated="1022"/>
+</table:table-row>
+</table:table>
+<table:named-expressions/>
+</office:spreadsheet>
+</office:body>
+</office:document-content>

--- a/tests/data/Writer/Ods/content-empty.xml
+++ b/tests/data/Writer/Ods/content-empty.xml
@@ -8,7 +8,6 @@
         </style:style>
         <style:style style:name="ce0" style:family="table-cell" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" />
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt" />
         </style:style>
     </office:automatic-styles>

--- a/tests/data/Writer/Ods/content-hidden-worksheet.xml
+++ b/tests/data/Writer/Ods/content-hidden-worksheet.xml
@@ -11,7 +11,6 @@
         </style:style>
         <style:style style:name="ce0" style:family="table-cell" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" />
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt" />
         </style:style>
     </office:automatic-styles>

--- a/tests/data/Writer/Ods/content-with-data.xml
+++ b/tests/data/Writer/Ods/content-with-data.xml
@@ -11,57 +11,46 @@
         </style:style>
         <style:style style:family="table-cell" style:name="ce0" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" />
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt"/>
         </style:style>
         <style:style style:family="table-cell" style:name="ce1" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" />
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt"/>
         </style:style>
         <style:style style:family="table-cell" style:name="ce2" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" />
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties style:font-weight-asian="bold" style:font-weight-complex="bold" fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt" fo:font-weight="bold"/>
         </style:style>
         <style:style style:family="table-cell" style:name="ce3" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" />
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt" fo:font-style="italic"/>
         </style:style>
         <style:style style:family="table-cell" style:name="ce4" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" />
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties fo:color="#000000" fo:font-family="Courier" fo:font-size="11.0pt"/>
         </style:style>
         <style:style style:family="table-cell" style:name="ce5" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" />
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties fo:color="#000000" fo:font-family="Courier" fo:font-size="14.0pt"/>
         </style:style>
         <style:style style:family="table-cell" style:name="ce6" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" />
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties fo:color="#0000FF" fo:font-family="Courier" fo:font-size="14.0pt"/>
         </style:style>
         <style:style style:family="table-cell" style:name="ce7" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" fo:background-color="#ffffff"/>
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties fo:color="#0000FF" fo:font-family="Courier" fo:font-size="14.0pt"/>
         </style:style>
         <style:style style:family="table-cell" style:name="ce8" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" fo:background-color="#ff0000"/>
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties fo:color="#0000FF" fo:font-family="Courier" fo:font-size="14.0pt"/>
         </style:style>
         <style:style style:family="table-cell" style:name="ce9" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" fo:background-color="#ff0000"/>
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties style:text-underline-color="font-color" style:text-underline-style="solid" style:text-underline-type="single" style:text-underline-width="auto" fo:color="#0000FF" fo:font-family="Courier" fo:font-size="14.0pt"/>
         </style:style>
         <style:style style:family="table-cell" style:name="ce10" style:parent-style-name="Default">
             <style:table-cell-properties style:rotation-align="none" style:vertical-align="bottom" />
-            <style:paragraph-properties fo:text-align="start" />
             <style:text-properties style:text-underline-color="font-color" style:text-underline-style="solid" style:text-underline-type="double" style:text-underline-width="auto" fo:color="#000000" fo:font-family="Calibri" fo:font-size="11.0pt"/>
         </style:style>
     </office:automatic-styles>


### PR DESCRIPTION
Fix #4261. Ods does nothing with the `indent` property of Alignment. The fix is easy, but not as easy as it should be. Excel treats indent as an int in some unspecified unit. Ods, on the other hand, specifies it as a float with unit (inches, ems, etc.). Since MS does not reveal what an indent unit is, I resorted to some experimentation. It appears that 1 unit is equal to  0.1043 inches. That is not a guaranteed relationship - the conversion might be non-linear, or it might be affected by external factors like font size. I think multiplying by 0.1043 is adequate for now, and unquestionably better than what we're currently doing (ignoring the property). If it breaks down at some point, we'll look at it again. BTW, Shared\Drawing uses some conversion values of 9525, which, reciprocating and sliding the decimal point along yields a value of 0.10498..., which is close but not close enough for me to use.

The other property used in conjunction with indent is `text-align`, and here we have not been doing the right thing. If that property has the default value (`General`), it is treated as `start` (i.e. `left` on LTR docs and presumably `right` on RTL). This will align numbers as if they were text, which does no harm (they're still usable as numbers), but is not how LibreOffice handles them by default. Ods writer is changed to omit `text-align` when it is set to `General`, and let LibreOffice choose the appropriate alignment.

These changes are for Writer only. Ods Reader support for styles remains severely lacking.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
