### PR TITLE
Disable 2 Tests

### DIFF
--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlImage2Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlImage2Test.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class HtmlImage2Test extends TestCase
 {
-    public function testCanInsertImageGoodProtocol(): void
+    public function xtestCanInsertImageGoodProtocol(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');
@@ -31,7 +31,7 @@ class HtmlImage2Test extends TestCase
         self::assertEquals('A1', $drawing->getCoordinates());
     }
 
-    public function testCantInsertImageNotFound(): void
+    public function xtestCantInsertImageNotFound(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class URLImageTest extends TestCase
 {
-    public function testURLImageSource(): void
+    public function xtestURLImageSource(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');
@@ -37,7 +37,7 @@ class URLImageTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function testURLImageSourceNotFound(): void
+    public function xtestURLImageSourceNotFound(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');


### PR DESCRIPTION
For the second time in recent months, some tests are failing/erring because https file_get_contents is not working on github (cannot reproduce locally on Windows or Linux). Filed an issue with Php when this first happened, and their suggested code change worked till now. If they come up with another successful code change, I will implement it and restore these tests.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
