### PR TITLE
Additional Context Options for https, Restore Disabled Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Deprecated
 
-- Nothing yet.
+- Drawing::setIsUrl is unneeded. The property is set when setPath determines whether path is a url.
 
 ### Fixed
 
-- Nothing yet.
+-  More context options may be needed for http(s) image. [Php issue 17121](https://github.com/php/php-src/issues/17121) [PR #4276](https://github.com/PHPOffice/PhpSpreadsheet/pull/4276)
 
 ## 2024-12-08 - 3.6.0
 

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -117,7 +117,7 @@ class Drawing extends BaseDrawing
                     'http' => [
                         'user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
                         'header' => [
-                            'Connection: keep-alive',
+                            //'Connection: keep-alive', // unacceptable performance
                             // accept header used by chrome without image/webp
                             'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
                         ],

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -112,7 +112,17 @@ class Drawing extends BaseDrawing
             $ctx = null;
             // https://github.com/php/php-src/issues/16023
             if (str_starts_with($path, 'https:')) {
-                $ctx = stream_context_create(['ssl' => ['crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT]]);
+                $ctx = stream_context_create([
+                    'ssl' => ['crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT],
+                    'http' => [
+                        'user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+                        'header' => [
+                            'Connection: keep-alive',
+                            // accept header used by chrome without image/webp
+                            'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+                        ],
+                    ],
+                ]);
             }
             $imageContents = @file_get_contents($path, false, $ctx);
             if ($imageContents !== false) {

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -118,8 +118,7 @@ class Drawing extends BaseDrawing
                         'user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
                         'header' => [
                             //'Connection: keep-alive', // unacceptable performance
-                            // accept header used by chrome without image/webp
-                            'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+                            'Accept: image/*;q=0.9,*/*;q=0.8',
                         ],
                     ],
                 ];

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -111,9 +111,9 @@ class Drawing extends BaseDrawing
             $this->isUrl = true;
             $ctx = null;
             // https://github.com/php/php-src/issues/16023
-            if (str_starts_with($path, 'https:')) {
-                $ctx = stream_context_create([
-                    'ssl' => ['crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT],
+            // https://github.com/php/php-src/issues/17121
+            if (str_starts_with($path, 'https:') || str_starts_with($path, 'http:')) {
+                $ctxArray = [
                     'http' => [
                         'user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
                         'header' => [
@@ -122,7 +122,11 @@ class Drawing extends BaseDrawing
                             'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
                         ],
                     ],
-                ]);
+                ];
+                if (str_starts_with($path, 'https:')) {
+                    $ctxArray['ssl'] = ['crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT];
+                }
+                $ctx = stream_context_create($ctxArray);
             }
             $imageContents = @file_get_contents($path, false, $ctx);
             if ($imageContents !== false) {
@@ -193,6 +197,8 @@ class Drawing extends BaseDrawing
      * Set isURL.
      *
      * @return $this
+     *
+     * @deprecated 3.7.0 not needed, property is set by setPath
      */
     public function setIsURL(bool $isUrl): self
     {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/XorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/XorTest.php
@@ -18,7 +18,7 @@ class XorTest extends AllSetupTeardown
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('providerXORLiteral')]
-    public function xtestXORLiteral(mixed $expectedResult, string $formula): void
+    public function testXORLiteral(mixed $expectedResult, float|string $formula): void
     {
         $sheet = $this->getSheet();
         $sheet->getCell('A1')->setValue("=XOR($formula)");

--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlImage2Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlImage2Test.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class HtmlImage2Test extends TestCase
 {
-    public function xtestCanInsertImageGoodProtocol(): void
+    public function testCanInsertImageGoodProtocol(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');
@@ -31,7 +31,7 @@ class HtmlImage2Test extends TestCase
         self::assertEquals('A1', $drawing->getCoordinates());
     }
 
-    public function xtestCantInsertImageNotFound(): void
+    public function testCantInsertImageNotFound(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class URLImageTest extends TestCase
 {
-    public function xtestURLImageSource(): void
+    public function testURLImageSource(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');
@@ -37,7 +37,7 @@ class URLImageTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function xtestURLImageSourceNotFound(): void
+    public function testURLImageSourceNotFound(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');


### PR DESCRIPTION
Additional Context Options needed, at least sometimes, to read https images.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
