### PR TITLE
Ignore Coverage for SimpleCache1, ZipStream2

### DIFF
--- a/src/PhpSpreadsheet/Collection/Memory/SimpleCache1.php
+++ b/src/PhpSpreadsheet/Collection/Memory/SimpleCache1.php
@@ -9,6 +9,11 @@ use Psr\SimpleCache\CacheInterface;
  *
  * Alternative implementation should leverage off-memory, non-volatile storage
  * to reduce overall memory usage.
+ *
+ * Either SimpleCache1 or SimpleCache3, but not both, may be used.
+ * For code coverage testing, it will always be SimpleCache3.
+ *
+ * @codeCoverageIgnore
  */
 class SimpleCache1 implements CacheInterface
 {

--- a/src/PhpSpreadsheet/Writer/ZipStream2.php
+++ b/src/PhpSpreadsheet/Writer/ZipStream2.php
@@ -5,6 +5,12 @@ namespace PhpOffice\PhpSpreadsheet\Writer;
 use ZipStream\Option\Archive;
 use ZipStream\ZipStream;
 
+/**
+ * Either ZipStream2 or ZipStream3, but not both, may be used.
+ * For code coverage testing, it will always be ZipStream3.
+ *
+ * @codeCoverageIgnore
+ */
 class ZipStream2
 {
     /**


### PR DESCRIPTION
PhpSpreadsheet will use either SimpleCache1/3 (but not both). Likewise for ZipStream2/3. However, only SimpleCache3/Zipstream3 are used while processing code coverage. Indicate this with appropriate annotations.

No executable code is changed.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] more accurate code coverage

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
