### PR TITLE
Upgrade mitoteam/jpgraph

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1221,16 +1221,16 @@
         },
         {
             "name": "mitoteam/jpgraph",
-            "version": "10.4.3",
+            "version": "10.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mitoteam/jpgraph.git",
-                "reference": "f0db97108aec23a3bbb34721365931af992b83b3"
+                "reference": "9ad8e2fcc30f765c788a28543e9705fb541d499f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mitoteam/jpgraph/zipball/f0db97108aec23a3bbb34721365931af992b83b3",
-                "reference": "f0db97108aec23a3bbb34721365931af992b83b3",
+                "url": "https://api.github.com/repos/mitoteam/jpgraph/zipball/9ad8e2fcc30f765c788a28543e9705fb541d499f",
+                "reference": "9ad8e2fcc30f765c788a28543e9705fb541d499f",
                 "shasum": ""
             },
             "require": {
@@ -1270,9 +1270,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mitoteam/jpgraph/issues",
-                "source": "https://github.com/mitoteam/jpgraph/tree/10.4.3"
+                "source": "https://github.com/mitoteam/jpgraph/tree/10.4.4"
             },
-            "time": "2024-12-01T06:36:31+00:00"
+            "time": "2025-01-01T05:39:20+00:00"
         },
         {
             "name": "mpdf/mpdf",

--- a/tests/PhpSpreadsheetTests/Chart/ChartsDynamicTitleTest.php
+++ b/tests/PhpSpreadsheetTests/Chart/ChartsDynamicTitleTest.php
@@ -34,7 +34,6 @@ class ChartsDynamicTitleTest extends AbstractFunctional
         $writer->setIncludeCharts(true);
     }
 
-    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testDynamicTitle(): void
     {
         // based on samples/templates/issue.3797.2007.xlsx


### PR DESCRIPTION
They have made a change at our request to help us eliminate runInSeparateProcess for one or more tests. This will be helpful when we get to PhpUnit 11 (not imminent, since it doesn't support Php8.1, but it will happen eventually).

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] upgrade required software

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
