### PR TITLE
Retitling Cloned Worksheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Fixed
 
 - Xlsx Reader Shared Formula with Boolean Result. Partial solution for [Issue #4280](https://github.com/PHPOffice/PhpSpreadsheet/issues/4280) [PR #4281](https://github.com/PHPOffice/PhpSpreadsheet/pull/4281)
+- Retitling cloned Worksheets. [Issue #641](https://github.com/PHPOffice/PhpSpreadsheet/issues/641) [PR #4302](https://github.com/PHPOffice/PhpSpreadsheet/pull/4302)
 
 ## 2024-12-26 - 3.7.0
 

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -515,16 +515,7 @@ class Spreadsheet implements JsonSerializable
     {
         $newSheet = new Worksheet($this);
         $title = $newSheet->getTitle();
-        if ($this->sheetNameExists($title)) {
-            $i = 1;
-            $newTitle = "$title $i";
-            while ($this->sheetNameExists($newTitle)) {
-                ++$i;
-                $newTitle = "$title $i";
-            }
-            $newSheet->setTitle($newTitle);
-        }
-        $this->addSheet($newSheet, $sheetIndex);
+        $this->addSheet($newSheet, $sheetIndex, true);
 
         return $newSheet;
     }
@@ -545,8 +536,20 @@ class Spreadsheet implements JsonSerializable
      * @param Worksheet $worksheet The worksheet to add
      * @param null|int $sheetIndex Index where sheet should go (0,1,..., or null for last)
      */
-    public function addSheet(Worksheet $worksheet, ?int $sheetIndex = null): Worksheet
+    public function addSheet(Worksheet $worksheet, ?int $sheetIndex = null, bool $retitleIfNeeded = false): Worksheet
     {
+        if ($retitleIfNeeded) {
+            $title = $worksheet->getTitle();
+            if ($this->sheetNameExists($title)) {
+                $i = 1;
+                $newTitle = "$title $i";
+                while ($this->sheetNameExists($newTitle)) {
+                    ++$i;
+                    $newTitle = "$title $i";
+                }
+                $worksheet->setTitle($newTitle);
+            }
+        }
         if ($this->sheetNameExists($worksheet->getTitle())) {
             throw new Exception(
                 "Workbook already contains a worksheet named '{$worksheet->getTitle()}'. Rename this worksheet first."

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -514,7 +514,6 @@ class Spreadsheet implements JsonSerializable
     public function createSheet(?int $sheetIndex = null): Worksheet
     {
         $newSheet = new Worksheet($this);
-        $title = $newSheet->getTitle();
         $this->addSheet($newSheet, $sheetIndex, true);
 
         return $newSheet;

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -514,6 +514,16 @@ class Spreadsheet implements JsonSerializable
     public function createSheet(?int $sheetIndex = null): Worksheet
     {
         $newSheet = new Worksheet($this);
+        $title = $newSheet->getTitle();
+        if ($this->sheetNameExists($title)) {
+            $i = 1;
+            $newTitle = "$title $i";
+            while ($this->sheetNameExists($newTitle)) {
+                ++$i;
+                $newTitle = "$title $i";
+            }
+            $newSheet->setTitle($newTitle);
+        }
         $this->addSheet($newSheet, $sheetIndex);
 
         return $newSheet;

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -321,6 +321,7 @@ class Worksheet
     {
         // Set parent and title
         $this->parent = $parent;
+        $this->hash = spl_object_id($this);
         $this->setTitle($title, false);
         // setTitle can change $pTitle
         $this->setCodeName($this->getTitle());
@@ -349,7 +350,6 @@ class Worksheet
         $this->autoFilter = new AutoFilter('', $this);
         // Table collection
         $this->tableCollection = new ArrayObject();
-        $this->hash = spl_object_id($this);
     }
 
     /**
@@ -869,7 +869,7 @@ class Worksheet
             // Syntax check
             self::checkSheetTitle($title);
 
-            if ($this->parent) {
+            if ($this->parent && $this->parent->getIndex($this, true) >= 0) {
                 // Is there already such sheet name?
                 if ($this->parent->sheetNameExists($title)) {
                     // Use name, but append with lowest possible integer
@@ -899,7 +899,7 @@ class Worksheet
         // Set title
         $this->title = $title;
 
-        if ($this->parent && $this->parent->getCalculationEngine()) {
+        if ($this->parent && $this->parent->getIndex($this, true) >= 0 && $this->parent->getCalculationEngine()) {
             // New title
             $newTitle = $this->getTitle();
             $this->parent->getCalculationEngine()

--- a/tests/PhpSpreadsheetTests/Worksheet/Issue641Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/Issue641Test.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+class Issue641Test extends TestCase
+{
+    /**
+     * Problem cloning sheet referred to in formulas.
+     */
+    public function testIssue641(): void
+    {
+        $xlsx = new Spreadsheet();
+        $xlsx->removeSheetByIndex(0);
+        $availableWs = [];
+
+        $worksheet = $xlsx->createSheet();
+        $worksheet->setTitle('Condensed A');
+        $worksheet->getCell('A1')->setValue("=SUM('Detailed A'!A1:A10)");
+        $worksheet->getCell('A2')->setValue(mt_rand(1, 30));
+        $availableWs[] = 'Condensed A';
+
+        $worksheet = $xlsx->createSheet();
+        $worksheet->setTitle('Condensed B');
+        $worksheet->getCell('A1')->setValue("=SUM('Detailed B'!A1:A10)");
+        $worksheet->getCell('A2')->setValue(mt_rand(1, 30));
+        $availableWs[] = 'Condensed B';
+
+        // at this point the value in worksheet 'Condensed B' cell A1 is
+        // =SUM('Detailed B'!A1:A10)
+
+        // worksheet in question is cloned and totals are attached
+        $totalWs1 = clone $xlsx->getSheet($xlsx->getSheetCount() - 1);
+        $totalWs1->setTitle('Condensed Total');
+        $xlsx->addSheet($totalWs1);
+        $formula = '=';
+        foreach ($availableWs as $ws) {
+            $formula .= sprintf("+'%s'!A2", $ws);
+        }
+        $totalWs1->getCell('A1')->setValue("=SUM('Detailed Total'!A1:A10)");
+        $totalWs1->getCell('A2')->setValue($formula);
+
+        $availableWs = [];
+
+        $worksheet = $xlsx->createSheet();
+        $worksheet->setTitle('Detailed A');
+        for ($step = 1; $step <= 10; ++$step) {
+            $worksheet->getCell("A{$step}")->setValue(mt_rand(1, 30));
+        }
+        $availableWs[] = 'Detailed A';
+
+        $worksheet = $xlsx->createSheet();
+        $worksheet->setTitle('Detailed B');
+        for ($step = 1; $step <= 10; ++$step) {
+            $worksheet->getCell("A{$step}")->setValue(mt_rand(1, 30));
+        }
+        $availableWs[] = 'Detailed B';
+
+        $totalWs2 = clone $xlsx->getSheet($xlsx->getSheetCount() - 1);
+        $totalWs2->setTitle('Detailed Total');
+        $xlsx->addSheet($totalWs2);
+
+        for ($step = 1; $step <= 10; ++$step) {
+            $formula = '=';
+            foreach ($availableWs as $ws) {
+                $formula .= sprintf("+'%s'!A%s", $ws, $step);
+            }
+            $totalWs2->getCell("A{$step}")->setValue($formula);
+        }
+
+        self::assertSame("=SUM('Detailed A'!A1:A10)", $xlsx->getSheetByName('Condensed A')?->getCell('A1')?->getValue());
+        self::assertSame("=SUM('Detailed B'!A1:A10)", $xlsx->getSheetByName('Condensed B')?->getCell('A1')?->getValue());
+        self::assertSame("=SUM('Detailed Total'!A1:A10)", $xlsx->getSheetByName('Condensed Total')?->getCell('A1')?->getValue());
+        self::assertSame("=+'Detailed A'!A1+'Detailed B'!A1", $xlsx->getSheetByName('Detailed Total')?->getCell('A1')?->getValue());
+
+        $xlsx->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Fix #641 (marked stale in 2018, but now reopened). When a sheet's title is changed, PhpSpreadsheet updates references to the old sheet name found in formulas. Which is a good idea when the sheet is attached to the spreadsheet, but a bad idea when it isn't (often because it has been cloned without re-attaching to the spreadsheet). This PR continues to change formulas in the former case, but will no longer do so for the latter.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
