### PR TITLE
Add Spreadsheet Method for Duplicating Worksheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
-- Nothing yet.
+- Method for duplicating worksheet in spreadsheet. [PR #4315](https://github.com/PHPOffice/PhpSpreadsheet/pull/4315)
 
 ### Changed
 

--- a/docs/topics/worksheets.md
+++ b/docs/topics/worksheets.md
@@ -95,8 +95,12 @@ insert the clone into the workbook.
 
 ```php
 $clonedWorksheet = clone $spreadsheet->getSheetByName('Worksheet 1');
-$clonedWorksheet->setTitle('Copy of Worksheet 1');
+$clonedWorksheet->setTitle('Copy of Worksheet 1'); // must be unique
 $spreadsheet->addSheet($clonedWorksheet);
+```
+Starting with PhpSpreadsheet 3.9.0, this can be done more simply (copied sheet's title will be set to something unique):
+```php
+$copiedWorksheet = $spreadsheet->duplicateWorksheetByTitle('sheetname');
 ```
 
 You can also copy worksheets from one workbook to another, though this
@@ -104,10 +108,25 @@ is more complex as PhpSpreadsheet also has to replicate the styling
 between the two workbooks. The `addExternalSheet()` method is provided for
 this purpose.
 
-    $clonedWorksheet = clone $spreadsheet1->getSheetByName('Worksheet 1');
-    $spreadsheet->addExternalSheet($clonedWorksheet);
+```php
+$clonedWorksheet = clone $spreadsheet1->getSheetByName('Worksheet 1');
+$clonedWorksheet->setTitle('Copy of Worksheet 1'); // must be unique
+$spreadsheet1->addSheet($clonedWorksheet);
+$spreadsheet->addExternalSheet($clonedWorksheet);
+```
+Starting with PhpSpreadsheet 3.8.0, this can be simplified:
+```php
+$clonedWorksheet = clone $spreadsheet1->getSheetByName('Worksheet 1');
+$spreadsheet1->addSheet($clonedWorksheet, null, true);
+$spreadsheet->addExternalSheet($clonedWorksheet);
+```
+Starting with PhpSpreadsheet 3.9.0, this can be simplified even further:
+```php
+$clonedWorksheet = $spreadsheet1->duplicateWorksheetByTitle('sheetname');
+$spreadsheet->addExternalSheet($clonedWorksheet);
+```
 
-In both cases, it is the developer's responsibility to ensure that
+In the cases commented "must be unique", it is the developer's responsibility to ensure that
 worksheet names are not duplicated. PhpSpreadsheet will throw an
 exception if you attempt to copy worksheets that will result in a
 duplicate name.

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -529,6 +529,15 @@ class Spreadsheet implements JsonSerializable
         return $this->getSheetByName($worksheetName) !== null;
     }
 
+    public function duplicateWorksheetByTitle(string $title): Worksheet
+    {
+        $original = $this->getSheetByNameOrThrow($title);
+        $index = $this->getIndex($original) + 1;
+        $clone = clone $original;
+
+        return $this->addSheet($clone, $index, true);
+    }
+
     /**
      * Add sheet.
      *

--- a/tests/PhpSpreadsheetTests/SpreadsheetDuplicateSheetTest.php
+++ b/tests/PhpSpreadsheetTests/SpreadsheetDuplicateSheetTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+class SpreadsheetDuplicateSheetTest extends TestCase
+{
+    private ?Spreadsheet $spreadsheet = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->spreadsheet !== null) {
+            $this->spreadsheet->disconnectWorksheets();
+            $this->spreadsheet = null;
+        }
+    }
+
+    public function testDuplicate(): void
+    {
+        $this->spreadsheet = new Spreadsheet();
+        $sheet = $this->spreadsheet->getActiveSheet();
+        $sheet->setTitle('original');
+        $sheet->getCell('A1')->setValue('text1');
+        $sheet->getCell('A2')->setValue('text2');
+        $sheet->getStyle('A1')
+            ->getFont()
+            ->setBold(true);
+        $sheet3 = $this->spreadsheet->createSheet();
+        $sheet3->setTitle('added');
+        $newSheet = $this->spreadsheet
+            ->duplicateWorksheetByTitle('original');
+        $this->spreadsheet->duplicateWorksheetByTitle('added');
+        self::assertSame('original 1', $newSheet->getTitle());
+        self::assertSame(
+            'text1',
+            $newSheet->getCell('A1')->getValue()
+        );
+        self::assertSame(
+            'text2',
+            $newSheet->getCell('A2')->getValue()
+        );
+        self::assertTrue(
+            $newSheet->getStyle('A1')->getFont()->getBold()
+        );
+        self::assertFalse(
+            $newSheet->getStyle('A2')->getFont()->getBold()
+        );
+        $sheetNames = [];
+        foreach ($this->spreadsheet->getWorksheetIterator() as $worksheet) {
+            $sheetNames[] = $worksheet->getTitle();
+        }
+        $expected = ['original', 'original 1', 'added', 'added 1'];
+        self::assertSame($expected, $sheetNames);
+    }
+}


### PR DESCRIPTION
Cloning a worksheet attached to a spreadsheet creates a clone which is detached from the spreadsheet. This can have its uses, but I think it would also be useful to have the ability to duplicate the worksheet and keep the duplicate attached to the spreadsheet. You can do that in Excel and LibreOffice, and you can now do it in PhpSpreadsheet as well. The duplicated worksheet will come immediately after its source.

The worksheet being duplicated could be identified in a number of ways - by passing the worksheet itself to the new method, by passing the worksheet title, or by passing the index of the worksheet within the spreadsheet. For now, I am just implementing the one I think is most useful (title).

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [x] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
