### PR TITLE
Fix 2 Samples

### DIFF
--- a/samples/Reading_workbook_data/Custom_properties.php
+++ b/samples/Reading_workbook_data/Custom_properties.php
@@ -38,7 +38,7 @@ foreach ($customPropertyList as $customPropertyName) {
 
             break;
         case 'd':    // date
-            $propertyValue = is_numeric($propertyValue) ? date('l, d<\s\u\p>S</\s\u\p> F Y g:i A', (int) $propertyValue) : '*****INVALID*****';
+            $propertyValue = is_numeric($propertyValue) ? date('l, j<\s\u\p>S</\s\u\p> F Y g:i A', (int) $propertyValue) : '*****INVALID*****';
             $propertyType = 'date';
 
             break;

--- a/samples/Reading_workbook_data/Properties.php
+++ b/samples/Reading_workbook_data/Properties.php
@@ -19,7 +19,7 @@ $helper->log('<b>Document Creator: </b>' . $creator);
 
 // Read the Date when the workbook was created (as a PHP timestamp value)
 $creationDatestamp = $spreadsheet->getProperties()->getCreated();
-$creationDate = Date::formattedDateTimeFromTimestamp("$creationDatestamp", 'l, d<\s\up>S</\s\up> F Y');
+$creationDate = Date::formattedDateTimeFromTimestamp("$creationDatestamp", 'l, j<\s\u\p>S</\s\u\p> F Y');
 $creationTime = Date::formattedDateTimeFromTimestamp("$creationDatestamp", 'g:i A');
 $helper->log('<b>Created On: </b>' . $creationDate . ' at ' . $creationTime);
 
@@ -30,7 +30,7 @@ $helper->log('<b>Last Modified By: </b>' . $modifiedBy);
 // Read the Date when the workbook was last modified (as a PHP timestamp value)
 $modifiedDatestamp = $spreadsheet->getProperties()->getModified();
 // Format the date and time using the standard PHP date() function
-$modifiedDate = Date::formattedDateTimeFromTimestamp("$modifiedDatestamp", 'l, d<\s\up>S</\s\up> F Y');
+$modifiedDate = Date::formattedDateTimeFromTimestamp("$modifiedDatestamp", 'l, j<\s\u\p>S</\s\u\p> F Y');
 $modifiedTime = Date::formattedDateTimeFromTimestamp("$modifiedDatestamp", 'g:i A');
 $helper->log('<b>Last Modified On: </b>' . $modifiedDate . ' at ' . $modifiedTime);
 


### PR DESCRIPTION
Custom properties would be better in this context using j (no leading 0) rather than d (leading 0) for day of month.

Properties has the same problem, and also needs backslashes before p to make it part of a <sup> tag.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
