### PR TITLE
Remove Styles Property From Worksheet

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -63,7 +63,7 @@ class Worksheet
     /**
      * Invalid characters in sheet title.
      */
-    private static array $invalidCharacters = ['*', ':', '/', '\\', '?', '[', ']'];
+    private const INVALID_CHARACTERS = ['*', ':', '/', '\\', '?', '[', ']'];
 
     /**
      * Parent spreadsheet.
@@ -156,13 +156,6 @@ class Worksheet
      * Protection.
      */
     private Protection $protection;
-
-    /**
-     * Collection of styles.
-     *
-     * @var Style[]
-     */
-    private array $styles = [];
 
     /**
      * Conditional styles. Indexed by cell coordinate, e.g. 'A1'.
@@ -399,7 +392,7 @@ class Worksheet
      */
     public static function getInvalidCharacters(): array
     {
-        return self::$invalidCharacters;
+        return self::INVALID_CHARACTERS;
     }
 
     /**
@@ -417,7 +410,7 @@ class Worksheet
         }
         // Some of the printable ASCII characters are invalid:  * : / \ ? [ ] and  first and last characters cannot be a "'"
         if (
-            (str_replace(self::$invalidCharacters, '', $sheetCodeName) !== $sheetCodeName)
+            (str_replace(self::INVALID_CHARACTERS, '', $sheetCodeName) !== $sheetCodeName)
             || (Shared\StringHelper::substring($sheetCodeName, -1, 1) == '\'')
             || (Shared\StringHelper::substring($sheetCodeName, 0, 1) == '\'')
         ) {
@@ -442,7 +435,7 @@ class Worksheet
     private static function checkSheetTitle(string $sheetTitle): string
     {
         // Some of the printable ASCII characters are invalid:  * : / \ ? [ ]
-        if (str_replace(self::$invalidCharacters, '', $sheetTitle) !== $sheetTitle) {
+        if (str_replace(self::INVALID_CHARACTERS, '', $sheetTitle) !== $sheetTitle) {
             throw new Exception('Invalid character found in sheet title');
         }
 
@@ -1390,16 +1383,6 @@ class Worksheet
         return $this->parent?->getCellXfByIndexOrNull(
             ($this->columnDimensions[$column] ?? null)?->getXfIndex()
         );
-    }
-
-    /**
-     * Get styles.
-     *
-     * @return Style[]
-     */
-    public function getStyles(): array
-    {
-        return $this->styles;
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Worksheet/Worksheet2Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/Worksheet2Test.php
@@ -16,9 +16,18 @@ class Worksheet2Test extends TestCase
         $invalid = Worksheet::getInvalidCharacters();
         self::assertSame(['*', ':', '/', '\\', '?', '[', ']'], $invalid);
         $worksheet = new Worksheet();
-        self::assertEmpty($worksheet->getStyles());
+        $coord1 = $worksheet->getCoordinates();
+        self::assertSame([], $coord1);
+        $worksheet->getCell('B3')->setValue(1);
+        $worksheet->getCell('G2')->setValue(2);
+        $coord2 = $worksheet->getCoordinates(false); // in order added
+        self::assertSame(['B3', 'G2'], $coord2);
+        $coord3 = $worksheet->getCoordinates(); // sorted by row then column
+        self::assertSame(['G2', 'B3'], $coord3);
+        $worksheet = new Worksheet();
         $worksheet->disconnectCells();
-        self::assertSame([], $worksheet->getCoordinates());
+        $coord4 = $worksheet->getCoordinates();
+        self::assertSame([], $coord4);
     }
 
     public function testHighestColumn(): void


### PR DESCRIPTION
Styles are a property of Spreadsheet, not Worksheet. There is a Styles property in Worksheet, initially set to an empty array and *never* updated. This PR removes the property and the getStyles method of Worksheet. This is, technically, a breaking change, so it will be installed with PhpSpreadsheet V4 (PR #4240).

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] remove unused property and method

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
