### PR TITLE
Remove Previously Announced Deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Removed
 
-- Nothing yet.
+- Worksheet::getStyles - no replacement. [PR #4330](https://github.com/PHPOffice/PhpSpreadsheet/pull/4330)
+- The following items were deprecated in release 3 and are now removed.
+- Drawing::setIsUrl - no replacement.
+- Settings::setLibXmlLoaderOptions() and Settings::getLibXmlLoaderOptions() - no replacement.
+- Worksheet::getHashCode - no replacement.
+- IReader::SKIP_EMPTY_CELLS - use its alias IGNORE_EMPTY_CELLS instead.
+- Worksheet::getProtectedCells - use getProtectedCellRanges instead.
+- Writer/Html::isMpdf property - use instanceof Mpdf instead.
 
 ### Changed
 

--- a/src/PhpSpreadsheet/Reader/IReader.php
+++ b/src/PhpSpreadsheet/Reader/IReader.php
@@ -19,11 +19,6 @@ interface IReader
     public const READ_DATA_ONLY = 2;
 
     /**
-     * @deprecated 3.4.0 use IGNORE_EMPTY_CELLS instead.
-     */
-    public const SKIP_EMPTY_CELLS = self::IGNORE_EMPTY_CELLS;
-
-    /**
      * Flag used to ignore empty cells when reading.
      *
      * The ignored cells will not be instantiated.

--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -321,14 +321,14 @@ class ReferenceHelper
      */
     protected function adjustProtectedCells(Worksheet $worksheet, int $numberOfColumns, int $numberOfRows): void
     {
-        $aProtectedCells = $worksheet->getProtectedCells();
+        $aProtectedCells = $worksheet->getProtectedCellRanges();
         ($numberOfColumns > 0 || $numberOfRows > 0)
             ? uksort($aProtectedCells, [self::class, 'cellReverseSort'])
             : uksort($aProtectedCells, [self::class, 'cellSort']);
-        foreach ($aProtectedCells as $cellAddress => $value) {
+        foreach ($aProtectedCells as $cellAddress => $protectedRange) {
             $newReference = $this->updateCellReference($cellAddress);
             if ($cellAddress !== $newReference) {
-                $worksheet->protectCells($newReference, $value, true);
+                $worksheet->protectCells($newReference, $protectedRange->getPassword(), true);
                 $worksheet->unprotectCells($cellAddress);
             }
         }

--- a/src/PhpSpreadsheet/Settings.php
+++ b/src/PhpSpreadsheet/Settings.php
@@ -21,11 +21,6 @@ class Settings
     private static ?string $chartRenderer = null;
 
     /**
-     * Default options for libxml loader.
-     */
-    private static ?int $libXmlLoaderOptions = null;
-
-    /**
      * The cache implementation to be used for cell collection.
      */
     private static ?CacheInterface $cache = null;
@@ -88,36 +83,6 @@ class Settings
     public static function htmlEntityFlags(): int
     {
         return ENT_COMPAT;
-    }
-
-    /**
-     * Set default options for libxml loader.
-     *
-     * @param ?int $options Default options for libxml loader
-     *
-     * @deprecated 3.5.0 no longer needed
-     */
-    public static function setLibXmlLoaderOptions(?int $options): int
-    {
-        if ($options === null) {
-            $options = defined('LIBXML_DTDLOAD') ? (LIBXML_DTDLOAD | LIBXML_DTDATTR) : 0;
-        }
-        self::$libXmlLoaderOptions = $options;
-
-        return $options;
-    }
-
-    /**
-     * Get default options for libxml loader.
-     * Defaults to LIBXML_DTDLOAD | LIBXML_DTDATTR when not set explicitly.
-     *
-     * @return int Default options for libxml loader
-     *
-     * @deprecated 3.5.0 no longer needed
-     */
-    public static function getLibXmlLoaderOptions(): int
-    {
-        return self::$libXmlLoaderOptions ?? (defined('LIBXML_DTDLOAD') ? (LIBXML_DTDLOAD | LIBXML_DTDATTR) : 0);
     }
 
     /**

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -193,20 +193,6 @@ class Drawing extends BaseDrawing
     }
 
     /**
-     * Set isURL.
-     *
-     * @return $this
-     *
-     * @deprecated 3.7.0 not needed, property is set by setPath
-     */
-    public function setIsURL(bool $isUrl): self
-    {
-        $this->isUrl = $isUrl;
-
-        return $this;
-    }
-
-    /**
      * Get hash code.
      *
      * @return string Hash code

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1958,24 +1958,6 @@ class Worksheet
     }
 
     /**
-     * Get password for protected cells.
-     *
-     * @return string[]
-     *
-     * @deprecated 2.0.1 use getProtectedCellRanges instead
-     * @see Worksheet::getProtectedCellRanges()
-     */
-    public function getProtectedCells(): array
-    {
-        $array = [];
-        foreach ($this->protectedCells as $key => $protectedRange) {
-            $array[$key] = $protectedRange->getPassword();
-        }
-
-        return $array;
-    }
-
-    /**
      * Get protected cells.
      *
      * @return ProtectedRange[]
@@ -3196,14 +3178,6 @@ class Worksheet
 
         // Return
         return $this;
-    }
-
-    /**
-     * @deprecated 3.5.0 use getHashInt instead.
-     */
-    public function getHashCode(): string
-    {
-        return (string) $this->hash;
     }
 
     public function getHashInt(): int

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -119,13 +119,6 @@ class Html extends BaseWriter
     protected bool $isPdf = false;
 
     /**
-     * Is the current writer creating mPDF?
-     *
-     * @deprecated 2.0.1 use instanceof Mpdf instead
-     */
-    protected bool $isMPdf = false;
-
-    /**
      * Generate the Navigation block.
      */
     private bool $generateSheetNavigationBlock = true;

--- a/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
@@ -11,13 +11,6 @@ class Mpdf extends Pdf
     private const BODY_TAG = '<body>';
 
     /**
-     * Is the current writer creating mPDF?
-     *
-     * @deprecated 2.0.1 use instanceof Mpdf instead
-     */
-    protected bool $isMPdf = true;
-
-    /**
      * Gets the implementation of external PDF library that should be used.
      *
      * @param array $config Configuration array

--- a/tests/PhpSpreadsheetTests/SettingsTest.php
+++ b/tests/PhpSpreadsheetTests/SettingsTest.php
@@ -15,21 +15,6 @@ class SettingsTest extends TestCase
         Settings::setCache(null);
     }
 
-    public function testGetXMLSettings(): void
-    {
-        $result = Settings::getLibXmlLoaderOptions();
-        self::assertTrue((bool) ((LIBXML_DTDLOAD | LIBXML_DTDATTR) & $result));
-    }
-
-    public function testSetXMLSettings(): void
-    {
-        $original = Settings::getLibXmlLoaderOptions();
-        Settings::setLibXmlLoaderOptions(LIBXML_DTDLOAD | LIBXML_DTDATTR | LIBXML_DTDVALID);
-        $result = Settings::getLibXmlLoaderOptions();
-        self::assertTrue((bool) ((LIBXML_DTDLOAD | LIBXML_DTDATTR | LIBXML_DTDVALID) & $result));
-        Settings::setLibXmlLoaderOptions($original);
-    }
-
     public function testInvalidChartRenderer(): void
     {
         $this->expectException(SpException::class);

--- a/tests/PhpSpreadsheetTests/Worksheet/ByColumnAndRowTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ByColumnAndRowTest.php
@@ -133,8 +133,6 @@ class ByColumnAndRowTest extends TestCase
         $sheet->fromArray($data, null, 'B2', true);
 
         $sheet->protectCells([2, 2, 3, 3], 'secret', false);
-        $protectedRanges = $sheet->/** @scrutinizer ignore-deprecated*/ getProtectedCells();
-        self::assertArrayHasKey('B2:C3', $protectedRanges);
         $protectedRanges2 = $sheet->getProtectedCellRanges();
         self::assertArrayHasKey('B2:C3', $protectedRanges2);
         $spreadsheet->disconnectWorksheets();

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/UnparsedDataTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/UnparsedDataTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
 
 use Exception;
-use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Shared\File;
 use PHPUnit\Framework\TestCase;
 use ZipArchive;
@@ -66,7 +65,7 @@ class UnparsedDataTest extends TestCase
         self::assertNotEmpty($resultVbaProjectRaw, 'vbaProject.bin not found!');
 
         // xl/workbook.xml
-        $xmlWorkbook = simplexml_load_string($resultWorkbookRaw ?: '', 'SimpleXMLElement', Settings::getLibXmlLoaderOptions());
+        $xmlWorkbook = simplexml_load_string($resultWorkbookRaw ?: '', 'SimpleXMLElement');
         self::assertNotFalse($xmlWorkbook);
         if (!$xmlWorkbook->workbookProtection) {
             self::fail('workbook.xml/workbookProtection not found!');
@@ -88,7 +87,7 @@ class UnparsedDataTest extends TestCase
 
         // xl/worksheets/sheet1.xml
         self::assertStringContainsString('<mc:AlternateContent', $resultSheet1Raw, 'AlternateContent at sheet1.xml not found!');
-        $xmlWorksheet = simplexml_load_string($resultSheet1Raw ?: '', 'SimpleXMLElement', Settings::getLibXmlLoaderOptions());
+        $xmlWorksheet = simplexml_load_string($resultSheet1Raw ?: '', 'SimpleXMLElement');
         self::assertNotFalse($xmlWorksheet);
         $pageSetupAttributes = $xmlWorksheet->pageSetup->attributes('http://schemas.openxmlformats.org/officeDocument/2006/relationships');
         self::assertTrue(isset($pageSetupAttributes->id), 'sheet1.xml/pageSetup[r:id] not found!');


### PR DESCRIPTION
Remove
- Worksheet::getHashCode
- Worksheet::getProtectecCells
- Worksheet::getStyles
- Drawing::setIsUrl
- IReader::SKIP_EMPTY_CELLS
- Settings:setLibXmlLoaderOptions and getLibXmlLoaderOptions
- Writer/Html::isMpdf

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] remove deprecated code 

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary
