### PR TITLE
Allow php-cs-fixer to Handle Implicit Backslashes

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -221,7 +221,7 @@ $config
         'standardize_not_equals' => true,
         'static_lambda' => false, // Risky if we can't guarantee nobody use `bindTo()`
         'strict_comparison' => false, // No, too dangerous to change that
-        'string_implicit_backslashes' => false, // was escape_implicit_backslashes, too confusing
+        'string_implicit_backslashes' => ['single_quoted' => 'unescape', 'double_quoted' => 'escape', 'heredoc' => 'escape'], // was escape_implicit_backslashes
         'strict_param' => false, // No, too dangerous to change that
         'string_length_to_empty' => true,
         'string_line_ending' => true,

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "platform": {
             "php" : "8.1.99"
         },
+        "process-timeout": 600,
         "sort-packages": true,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -52,7 +52,7 @@ class Calculation
     //    Defined Names: Named Range of cells, or Named Formulae
     const CALCULATION_REGEXP_DEFINEDNAME = '((([^\s,!&%^\/\*\+<>=-]*)|(\'(?:[^\']|\'[^!])+?\')|(\"(?:[^\"]|\"[^!])+?\"))!)?([_\p{L}][_\p{L}\p{N}\.]*)';
     // Structured Reference (Fully Qualified and Unqualified)
-    const CALCULATION_REGEXP_STRUCTURED_REFERENCE = '([\p{L}_\\\\][\p{L}\p{N}\._]+)?(\[(?:[^\d\]+-])?)';
+    const CALCULATION_REGEXP_STRUCTURED_REFERENCE = '([\p{L}_\\\][\p{L}\p{N}\._]+)?(\[(?:[^\d\]+-])?)';
     //    Error
     const CALCULATION_REGEXP_ERROR = '\#[A-Z][A-Z0_\/]*[!\?]?';
 

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/DateValue.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/DateValue.php
@@ -47,7 +47,7 @@ class DateValue
         }
 
         // try to parse as date iff there is at least one digit
-        if (is_string($dateValue) && preg_match('/\\d/', $dateValue) !== 1) {
+        if (is_string($dateValue) && preg_match('/\d/', $dateValue) !== 1) {
             return ExcelError::VALUE();
         }
 

--- a/src/PhpSpreadsheet/Calculation/DateTimeExcel/TimeValue.php
+++ b/src/PhpSpreadsheet/Calculation/DateTimeExcel/TimeValue.php
@@ -43,7 +43,7 @@ class TimeValue
         }
 
         // try to parse as time iff there is at least one digit
-        if (is_string($timeValue) && preg_match('/\\d/', $timeValue) !== 1) {
+        if (is_string($timeValue) && preg_match('/\d/', $timeValue) !== 1) {
             return ExcelError::VALUE();
         }
 

--- a/src/PhpSpreadsheet/Calculation/Engine/Operands/StructuredReference.php
+++ b/src/PhpSpreadsheet/Calculation/Engine/Operands/StructuredReference.php
@@ -29,7 +29,7 @@ final class StructuredReference implements Operand, Stringable
         self::ITEM_SPECIFIER_TOTALS,
     ];
 
-    private const TABLE_REFERENCE = '/([\p{L}_\\\\][\p{L}\p{N}\._]+)?(\[(?:[^\]\[]+|(?R))*+\])/miu';
+    private const TABLE_REFERENCE = '/([\p{L}_\\\][\p{L}\p{N}\._]+)?(\[(?:[^\]\[]+|(?R))*+\])/miu';
 
     private string $value;
 

--- a/src/PhpSpreadsheet/Calculation/FormulaParser.php
+++ b/src/PhpSpreadsheet/Calculation/FormulaParser.php
@@ -213,7 +213,7 @@ class FormulaParser
             // scientific notation check
             if (str_contains(self::OPERATORS_SN, $this->formula[$index])) {
                 if (strlen($value) > 1) {
-                    if (preg_match('/^[1-9]{1}(\\.\\d+)?E{1}$/', $this->formula[$index]) != 0) {
+                    if (preg_match('/^[1-9]{1}(\.\d+)?E{1}$/', $this->formula[$index]) != 0) {
                         $value .= $this->formula[$index];
                         ++$index;
 

--- a/src/PhpSpreadsheet/Calculation/Functions.php
+++ b/src/PhpSpreadsheet/Calculation/Functions.php
@@ -338,7 +338,7 @@ class Functions
 
     public static function trimTrailingRange(string $coordinate): string
     {
-        return (string) preg_replace('/:[\\w\$]+$/', '', $coordinate);
+        return (string) preg_replace('/:[\w\$]+$/', '', $coordinate);
     }
 
     public static function trimSheetFromCellReference(string $coordinate): string

--- a/src/PhpSpreadsheet/Calculation/Internal/WildcardMatch.php
+++ b/src/PhpSpreadsheet/Calculation/Internal/WildcardMatch.php
@@ -6,10 +6,10 @@ class WildcardMatch
 {
     private const SEARCH_SET = [
         '~~', // convert double tilde to unprintable value
-        '~\\*', // convert tilde backslash asterisk to [*] (matches literal asterisk in regexp)
-        '\\*', // convert backslash asterisk to .* (matches string of any length in regexp)
-        '~\\?', // convert tilde backslash question to [?] (matches literal question mark in regexp)
-        '\\?', // convert backslash question to . (matches one character in regexp)
+        '~\*', // convert tilde backslash asterisk to [*] (matches literal asterisk in regexp)
+        '\*', // convert backslash asterisk to .* (matches string of any length in regexp)
+        '~\?', // convert tilde backslash question to [?] (matches literal question mark in regexp)
+        '\?', // convert backslash question to . (matches one character in regexp)
         "\x1c", // convert original double tilde to single tilde
     ];
 

--- a/src/PhpSpreadsheet/Calculation/TextData/Trim.php
+++ b/src/PhpSpreadsheet/Calculation/TextData/Trim.php
@@ -25,7 +25,7 @@ class Trim
 
         $stringValue = Helpers::extractString($stringValue);
 
-        return (string) preg_replace('/[\\x00-\\x1f]/', '', "$stringValue");
+        return (string) preg_replace('/[\x00-\x1f]/', '', "$stringValue");
     }
 
     /**

--- a/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
@@ -89,7 +89,7 @@ class DefaultValueBinder implements IValueBinder
 
             return DataType::TYPE_FORMULA;
         }
-        if (preg_match('/^[\+\-]?(\d+\\.?\d*|\d*\\.?\d+)([Ee][\-\+]?[0-2]?\d{1,3})?$/', $value)) {
+        if (preg_match('/^[\+\-]?(\d+\.?\d*|\d*\.?\d+)([Ee][\-\+]?[0-2]?\d{1,3})?$/', $value)) {
             $tValue = ltrim($value, '+-');
             if (strlen($tValue) > 1 && $tValue[0] === '0' && $tValue[1] !== '.') {
                 return DataType::TYPE_STRING;

--- a/src/PhpSpreadsheet/Document/Properties.php
+++ b/src/PhpSpreadsheet/Document/Properties.php
@@ -149,8 +149,8 @@ class Properties
                 $timestamp = (float) $timestamp;
             } else {
                 $timestamp = (string) preg_replace('/[.][0-9]*$/', '', $timestamp);
-                $timestamp = (string) preg_replace('/^(\\d{4})- (\\d)/', '$1-0$2', $timestamp);
-                $timestamp = (string) preg_replace('/^(\\d{4}-\\d{2})- (\\d)/', '$1-0$2', $timestamp);
+                $timestamp = (string) preg_replace('/^(\d{4})- (\d)/', '$1-0$2', $timestamp);
+                $timestamp = (string) preg_replace('/^(\d{4}-\d{2})- (\d)/', '$1-0$2', $timestamp);
                 $timestamp = (float) (new DateTime($timestamp))->format('U');
             }
         }

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -35,7 +35,7 @@ class Html extends BaseReader
 
     private const STARTS_WITH_BOM = '/^(?:\xfe\xff|\xff\xfe|\xEF\xBB\xBF)/';
 
-    private const DECLARES_CHARSET = '/\\bcharset=/i';
+    private const DECLARES_CHARSET = '/\bcharset=/i';
 
     /**
      * Input encoding.
@@ -373,7 +373,7 @@ class Html extends BaseReader
                 }
                 if (isset($attributeArray['style'])) {
                     $alignStyle = $attributeArray['style'];
-                    if (preg_match('/\\btext-align:\\s*(left|right|center|justify)\\b/', $alignStyle, $matches) === 1) {
+                    if (preg_match('/\btext-align:\s*(left|right|center|justify)\b/', $alignStyle, $matches) === 1) {
                         $sheet->getComment($column . $row)->setAlignment($matches[1]);
                     }
                 }

--- a/src/PhpSpreadsheet/Reader/Ods/FormulaTranslator.php
+++ b/src/PhpSpreadsheet/Reader/Ods/FormulaTranslator.php
@@ -34,7 +34,7 @@ class FormulaTranslator
                 '/\$?([^\.]+)\.([^\.]+)/miu', // Cell reference in another sheet
                 '/\.([^\.]+):\.([^\.]+)/miu', // Cell range reference
                 '/\.([^\.]+)/miu', // Simple cell reference
-                '/\\x{FFFE}/miu', // restore quoted periods
+                '/\x{FFFE}/miu', // restore quoted periods
             ],
             [
                 '$1!$2:$4',
@@ -68,7 +68,7 @@ class FormulaTranslator
                         '/\[\$?([^\.]+)\.([^\.]+)\]/miu', // Cell reference in another sheet
                         '/\[\.([^\.]+):\.([^\.]+)\]/miu', // Cell range reference
                         '/\[\.([^\.]+)\]/miu', // Simple cell reference
-                        '/\\x{FFFE}/miu', // restore quoted periods
+                        '/\x{FFFE}/miu', // restore quoted periods
                     ],
                     [
                         '$1!$2:$3',

--- a/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
+++ b/src/PhpSpreadsheet/Reader/Security/XmlScanner.php
@@ -6,8 +6,8 @@ use PhpOffice\PhpSpreadsheet\Reader;
 
 class XmlScanner
 {
-    private const ENCODING_PATTERN = '/encoding\\s*=\\s*(["\'])(.+?)\\1/s';
-    private const ENCODING_UTF7 = '/encoding\\s*=\\s*(["\'])UTF-7\\1/si';
+    private const ENCODING_PATTERN = '/encoding\s*=\s*(["\'])(.+?)\1/s';
+    private const ENCODING_UTF7 = '/encoding\s*=\s*(["\'])UTF-7\1/si';
 
     private string $pattern;
 
@@ -41,7 +41,7 @@ class XmlScanner
         $charset = $this->findCharSet($xml);
         $foundUtf7 = $charset === 'UTF-7';
         if ($charset !== 'UTF-8') {
-            $testStart = '/^.{0,4}\\s*<?xml/s';
+            $testStart = '/^.{0,4}\s*<?xml/s';
             $startWithXml1 = preg_match($testStart, $xml);
             $xml = self::forceString(mb_convert_encoding($xml, 'UTF-8', $charset));
             if ($startWithXml1 === 1 && preg_match($testStart, $xml) !== 1) {
@@ -87,7 +87,7 @@ class XmlScanner
     public function scan($xml): string
     {
         // Don't rely purely on libxml_disable_entity_loader()
-        $pattern = '/\\0*' . implode('\\0*', str_split($this->pattern)) . '\\0*/';
+        $pattern = '/\0*' . implode('\0*', str_split($this->pattern)) . '\0*/';
 
         $xml = "$xml";
         if (preg_match($pattern, $xml)) {

--- a/src/PhpSpreadsheet/Reader/Slk.php
+++ b/src/PhpSpreadsheet/Reader/Slk.php
@@ -361,7 +361,7 @@ class Slk extends BaseReader
             } elseif ($char == 'S') {
                 $styleData['fill']['fillType'] = Fill::FILL_PATTERN_GRAY125;
             } elseif ($char == 'M') {
-                if (preg_match('/M([1-9]\\d*)/', $styleSettings, $matches)) {
+                if (preg_match('/M([1-9]\d*)/', $styleSettings, $matches)) {
                     $fontStyle = $matches[1];
                 }
             }
@@ -449,7 +449,7 @@ class Slk extends BaseReader
 
     private function processPColors(string $rowDatum, array &$formatArray): void
     {
-        if (preg_match('/L([1-9]\\d*)/', $rowDatum, $matches)) {
+        if (preg_match('/L([1-9]\d*)/', $rowDatum, $matches)) {
             $fontColor = ((int) $matches[1]) % 8;
             $formatArray['font']['color']['argb'] = self::COLOR_ARRAY[$fontColor];
         }

--- a/src/PhpSpreadsheet/Reader/Xlsx/DataValidations.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/DataValidations.php
@@ -27,7 +27,7 @@ class DataValidations
             $range = strtoupper((string) $dataValidation['sqref']);
             $rangeSet = explode(' ', $range);
             foreach ($rangeSet as $range) {
-                if (preg_match('/^[A-Z]{1,3}\\d{1,7}/', $range, $matches) === 1) {
+                if (preg_match('/^[A-Z]{1,3}\d{1,7}/', $range, $matches) === 1) {
                     // Ensure left/top row of range exists, thereby
                     // adjusting high row/column.
                     $this->worksheet->getCell($matches[0]);

--- a/src/PhpSpreadsheet/Reader/Xml/DataValidations.php
+++ b/src/PhpSpreadsheet/Reader/Xml/DataValidations.php
@@ -83,7 +83,7 @@ class DataValidations
                                 $this->thisColumn = (int) $selectionMatches[2];
                                 $combinedCells .= "$separator$cell";
                                 $separator = ' ';
-                            } elseif (preg_match('/^C(\d+)(:C(]\\d+))?$/', (string) $range, $selectionMatches) === 1) {
+                            } elseif (preg_match('/^C(\d+)(:C(]\d+))?$/', (string) $range, $selectionMatches) === 1) {
                                 // column
                                 $firstCol = $selectionMatches[1];
                                 $firstColString = Coordinate::stringFromColumnIndex((int) $firstCol);
@@ -95,7 +95,7 @@ class DataValidations
                                 $sheet->getCell($firstCell);
                                 $combinedCells .= "$separator$cell";
                                 $separator = ' ';
-                            } elseif (preg_match('/^R(\\d+)(:R(]\\d+))?$/', (string) $range, $selectionMatches)) {
+                            } elseif (preg_match('/^R(\d+)(:R(]\d+))?$/', (string) $range, $selectionMatches)) {
                                 // row
                                 $firstRow = $selectionMatches[1];
                                 $lastRow = $selectionMatches[3] ?? $firstRow;

--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -177,7 +177,7 @@ class Date
             throw new Exception("Invalid string $value supplied for datatype Date");
         }
 
-        if (preg_match('/^\\s*\\d?\\d:\\d\\d(:\\d\\d([.]\\d+)?)?\\s*(am|pm)?\\s*$/i', $value) == 1) {
+        if (preg_match('/^\s*\d?\d:\d\d(:\d\d([.]\d+)?)?\s*(am|pm)?\s*$/i', $value) == 1) {
             $newValue = fmod($newValue, 1.0);
         }
 

--- a/src/PhpSpreadsheet/Shared/Font.php
+++ b/src/PhpSpreadsheet/Shared/Font.php
@@ -563,7 +563,7 @@ class Font
         if (mb_strlen(self::$trueTypeFontPath) > 1 && mb_substr(self::$trueTypeFontPath, -1) !== '/' && mb_substr(self::$trueTypeFontPath, -1) !== '\\') {
             $separator = DIRECTORY_SEPARATOR;
         }
-        $fontFileAbsolute = preg_match('~^([A-Za-z]:)?[/\\\\]~', $fontFile) === 1;
+        $fontFileAbsolute = preg_match('~^([A-Za-z]:)?[/\\\]~', $fontFile) === 1;
         if (!$fontFileAbsolute) {
             $fontFile = self::findFontFile(self::$trueTypeFontPath, $fontFile) ?? self::$trueTypeFontPath . $separator . $fontFile;
         }

--- a/src/PhpSpreadsheet/Style/NumberFormat/DateFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/DateFormatter.php
@@ -164,7 +164,7 @@ class DateFormatter
         // If the colon preceding minute had been quoted, as happens in
         // Excel 2003 XML formats, m will not have been changed to i above.
         // Change it now.
-        $format = (string) \preg_replace('/\\\\:m/', ':i', $format);
+        $format = (string) \preg_replace('/\\\:m/', ':i', $format);
         $microseconds = (int) $dateObj->format('u');
         if (str_contains($format, ':s.000')) {
             $milliseconds = (int) round($microseconds / 1000.0);

--- a/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
@@ -55,8 +55,8 @@ class Formatter extends BaseFormatter
         //   4 sections:  [POSITIVE] [NEGATIVE] [ZERO] [TEXT]
         $sectionCount = count($sections);
         // Colour could be a named colour, or a numeric index entry in the colour-palette
-        $color_regex = '/\\[(' . implode('|', Color::NAMED_COLORS) . '|color\\s*(\\d+))\\]/mui';
-        $cond_regex = '/\\[(>|>=|<|<=|=|<>)([+-]?\\d+([.]\\d+)?)\\]/';
+        $color_regex = '/\[(' . implode('|', Color::NAMED_COLORS) . '|color\s*(\d+))\]/mui';
+        $cond_regex = '/\[(>|>=|<|<=|=|<>)([+-]?\d+([.]\d+)?)\]/';
         $colors = ['', '', '', '', ''];
         $conditionOperations = ['', '', '', '', ''];
         $conditionComparisonValues = [0, 0, 0, 0, 0];
@@ -126,7 +126,7 @@ class Formatter extends BaseFormatter
         }
         // For now we do not treat strings in sections, although section 4 of a format code affects strings
         // Process a single block format code containing @ for text substitution
-        $formatx = str_replace('\\"', self::QUOTE_REPLACEMENT, $format);
+        $formatx = str_replace('\"', self::QUOTE_REPLACEMENT, $format);
         if (preg_match(self::SECTION_SPLIT, $format) === 0 && preg_match(self::SYMBOL_AT, $formatx) === 1) {
             if (!str_contains($format, '"')) {
                 return str_replace('@', $value, $format);
@@ -134,7 +134,7 @@ class Formatter extends BaseFormatter
             //escape any dollar signs on the string, so they are not replaced with an empty value
             $value = str_replace(
                 ['$', '"'],
-                ['\\$', self::QUOTE_REPLACEMENT],
+                ['\$', self::QUOTE_REPLACEMENT],
                 (string) $value
             );
 
@@ -160,7 +160,7 @@ class Formatter extends BaseFormatter
         $format = (string) preg_replace('/^\[\$-[^\]]*\]/', '', $format);
 
         $format = (string) preg_replace_callback(
-            '/(["])(?:(?=(\\\\?))\\2.)*?\\1/u',
+            '/(["])(?:(?=(\\\?))\2.)*?\1/u',
             fn (array $matches): string => str_replace('.', chr(0x00), $matches[0]),
             $format
         );

--- a/src/PhpSpreadsheet/Style/NumberFormat/FractionFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/FractionFormatter.php
@@ -61,7 +61,7 @@ class FractionFormatter extends BaseFormatter
     private static function getDecimal(string $value): string
     {
         $decimalPart = '0';
-        if (preg_match('/^\\d*[.](\\d*[1-9])0*$/', $value, $matches) === 1) {
+        if (preg_match('/^\d*[.](\d*[1-9])0*$/', $value, $matches) === 1) {
             $decimalPart = $matches[1];
         }
 

--- a/src/PhpSpreadsheet/Style/NumberFormat/NumberFormatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/NumberFormatter.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 
 class NumberFormatter extends BaseFormatter
 {
-    private const NUMBER_REGEX = '/(0+)(\\.?)(0*)/';
+    private const NUMBER_REGEX = '/(0+)(\.?)(0*)/';
 
     private static function mergeComplexNumberFormatMasks(array $numbers, array $masks): array
     {
@@ -212,11 +212,11 @@ class NumberFormatter extends BaseFormatter
             $paddingPlaceholder = (str_contains($format, '?'));
 
             // Replace # or ? with 0
-            $format = self::pregReplace('/[\\#\?](?=(?:[^"]*"[^"]*")*[^"]*\Z)/', '0', $format);
+            $format = self::pregReplace('/[\#\?](?=(?:[^"]*"[^"]*")*[^"]*\Z)/', '0', $format);
             // Remove locale code [$-###] for an LCID
             $format = self::pregReplace('/\[\$\-.*\]/', '', $format);
 
-            $n = '/\\[[^\\]]+\\]/';
+            $n = '/\[[^\]]+\]/';
             $m = self::pregReplace($n, '', $format);
 
             // Some non-number strings are quoted, so we'll get rid of the quotes, likewise any positional * symbols
@@ -236,7 +236,7 @@ class NumberFormatter extends BaseFormatter
 
         if (preg_match('/\[\$(.*)\]/u', $format, $m)) {
             //  Currency or Accounting
-            $value = preg_replace('/-0+(( |\\xc2\\xa0))?\\[/', '- [', (string) $value) ?? $value;
+            $value = preg_replace('/-0+(( |\xc2\xa0))?\[/', '- [', (string) $value) ?? $value;
             $currencyCode = $m[1];
             [$currencyCode] = explode('-', $currencyCode);
             if ($currencyCode == '') {

--- a/src/PhpSpreadsheet/Style/NumberFormat/Wizard/CurrencyBase.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Wizard/CurrencyBase.php
@@ -173,7 +173,7 @@ class CurrencyBase extends Number
             if ($symbolWithSpacing) {
                 $format .= '*' . $this->spaceOrNbsp;
             }
-            if ($negativeStart === '\\(' || ($symbolWithSpacing && $negativeStart === '-')) {
+            if ($negativeStart === '\(' || ($symbolWithSpacing && $negativeStart === '-')) {
                 $format .= $negativeStart;
             }
         } else {

--- a/src/PhpSpreadsheet/Style/NumberFormat/Wizard/CurrencyNegative.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Wizard/CurrencyNegative.php
@@ -13,7 +13,7 @@ enum CurrencyNegative
     {
         return match ($this) {
             self::minus, self::redMinus => '-',
-            self::parentheses, self::redParentheses => '\\(',
+            self::parentheses, self::redParentheses => '\(',
         };
     }
 
@@ -21,7 +21,7 @@ enum CurrencyNegative
     {
         return match ($this) {
             self::minus, self::redMinus => '',
-            self::parentheses, self::redParentheses => '\\)',
+            self::parentheses, self::redParentheses => '\)',
         };
     }
 

--- a/src/PhpSpreadsheet/Worksheet/AutoFilter.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter.php
@@ -145,7 +145,7 @@ class AutoFilter implements Stringable
         $this->evaluated = false;
         if ($this->workSheet !== null) {
             $thisrange = $this->range;
-            $range = (string) preg_replace('/\\d+$/', (string) $this->workSheet->getHighestRow(), $thisrange);
+            $range = (string) preg_replace('/\d+$/', (string) $this->workSheet->getHighestRow(), $thisrange);
             if ($range !== $thisrange) {
                 $this->setRange($range);
             }

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -103,7 +103,7 @@ class Drawing extends BaseDrawing
 
         $this->path = '';
         // Check if a URL has been passed. https://stackoverflow.com/a/2058596/1252979
-        if (filter_var($path, FILTER_VALIDATE_URL) || (preg_match('/^([\\w\\s\\x00-\\x1f]+):/u', $path) && !preg_match('/^([\\w]+):/u', $path))) {
+        if (filter_var($path, FILTER_VALIDATE_URL) || (preg_match('/^([\w\s\x00-\x1f]+):/u', $path) && !preg_match('/^([\w]+):/u', $path))) {
             if (!preg_match('/^(http|https|file|ftp|s3):/', $path)) {
                 throw new PhpSpreadsheetException('Invalid protocol for linked drawing');
             }

--- a/src/PhpSpreadsheet/Worksheet/Table.php
+++ b/src/PhpSpreadsheet/Worksheet/Table.php
@@ -117,10 +117,10 @@ class Table implements Stringable
             ) {
                 throw new PhpSpreadsheetException('The table name can\'t be the same as a cell reference');
             }
-            if (!preg_match('/^[\p{L}_\\\\]/iu', $name)) {
+            if (!preg_match('/^[\p{L}_\\\]/iu', $name)) {
                 throw new PhpSpreadsheetException('The table name must begin a name with a letter, an underscore character (_), or a backslash (\)');
             }
-            if (!preg_match('/^[\p{L}_\\\\][\p{L}\p{M}0-9\._]+$/iu', $name)) {
+            if (!preg_match('/^[\p{L}_\\\][\p{L}\p{M}0-9\._]+$/iu', $name)) {
                 throw new PhpSpreadsheetException('The table name contains invalid characters');
             }
 
@@ -318,7 +318,7 @@ class Table implements Stringable
     {
         if ($this->workSheet !== null) {
             $thisrange = $this->range;
-            $range = (string) preg_replace('/\\d+$/', (string) $this->workSheet->getHighestRow(), $thisrange);
+            $range = (string) preg_replace('/\d+$/', (string) $this->workSheet->getHighestRow(), $thisrange);
             if ($range !== $thisrange) {
                 $this->setRange($range);
             }

--- a/src/PhpSpreadsheet/Worksheet/Validations.php
+++ b/src/PhpSpreadsheet/Worksheet/Validations.php
@@ -63,7 +63,7 @@ class Validations
     public static function convertWholeRowColumn(?string $addressRange): string
     {
         return (string) preg_replace(
-            ['/^([A-Z]+):([A-Z]+)$/i', '/^(\\d+):(\\d+)$/'],
+            ['/^([A-Z]+):([A-Z]+)$/i', '/^(\d+):(\d+)$/'],
             [self::SETMAXROW, self::SETMAXCOL],
             $addressRange ?? ''
         );

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -49,7 +49,7 @@ class Worksheet
     public const MERGE_CELL_CONTENT_HIDE = 'hide';
     public const MERGE_CELL_CONTENT_MERGE = 'merge';
 
-    public const FUNCTION_LIKE_GROUPBY = '/\\b(groupby|_xleta)\\b/i'; // weird new syntax
+    public const FUNCTION_LIKE_GROUPBY = '/\b(groupby|_xleta)\b/i'; // weird new syntax
 
     protected const SHEET_NAME_REQUIRES_NO_QUOTES = '/^[_\p{L}][_\p{L}\p{N}]*$/mui';
 
@@ -1740,7 +1740,7 @@ class Worksheet
             $range .= ":{$range}";
         }
 
-        if (preg_match('/^([A-Z]+)(\\d+):([A-Z]+)(\\d+)$/', $range, $matches) !== 1) {
+        if (preg_match('/^([A-Z]+)(\d+):([A-Z]+)(\d+)$/', $range, $matches) !== 1) {
             throw new Exception('Merge must be on a valid range of cells.');
         }
 

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -1405,7 +1405,7 @@ class Html extends BaseWriter
 
             // Converts the cell content so that spaces occuring at beginning of each new line are replaced by &nbsp;
             // Example: "  Hello\n to the world" is converted to "&nbsp;&nbsp;Hello\n&nbsp;to the world"
-            $cellData = Preg::replace('/(?m)(?:^|\\G) /', '&nbsp;', $cellData);
+            $cellData = Preg::replace('/(?m)(?:^|\G) /', '&nbsp;', $cellData);
 
             // convert newline "\n" to '<br>'
             $cellData = nl2br($cellData);
@@ -1593,8 +1593,8 @@ class Html extends BaseWriter
             if ($worksheet->hyperlinkExists($coordinate) && !$worksheet->getHyperlink($coordinate)->isInternal()) {
                 $url = $worksheet->getHyperlink($coordinate)->getUrl();
                 $urlDecode1 = html_entity_decode($url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
-                $urlTrim = Preg::replace('/^\\s+/u', '', $urlDecode1);
-                $parseScheme = Preg::isMatch('/^([\\w\\s\\x00-\\x1f]+):/u', strtolower($urlTrim), $matches);
+                $urlTrim = Preg::replace('/^\s+/u', '', $urlDecode1);
+                $parseScheme = Preg::isMatch('/^([\w\s\x00-\x1f]+):/u', strtolower($urlTrim), $matches);
                 if ($parseScheme && !in_array($matches[1], ['http', 'https', 'file', 'ftp', 'mailto', 's3'], true)) {
                     $cellData = htmlspecialchars($url, Settings::htmlEntityFlags());
                     $cellData = self::replaceControlChars($cellData);
@@ -1660,7 +1660,7 @@ class Html extends BaseWriter
     private static function replaceControlChars(string $convert): string
     {
         return (string) preg_replace_callback(
-            '/[\\x00-\\x1f]/',
+            '/[\x00-\x1f]/',
             [self::class, 'replaceNonAscii'],
             $convert
         );
@@ -1763,7 +1763,7 @@ class Html extends BaseWriter
         $color = null; // initialize
         $matches = [];
 
-        $color_regex = '/^\\[[a-zA-Z]+\\]/';
+        $color_regex = '/^\[[a-zA-Z]+\]/';
         if (Preg::isMatch($color_regex, $format, $matches)) {
             $color = str_replace(['[', ']'], '', $matches[0]);
             $color = strtolower($color);

--- a/src/PhpSpreadsheet/Writer/Xls/Parser.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Parser.php
@@ -49,22 +49,22 @@ class Parser
     // Former value for this constant led to "catastrophic backtracking",
     //     unable to handle double apostrophes.
     //     (*COMMIT) should prevent this.
-    const REGEX_SHEET_TITLE_QUOTED = "([^*:/\\\\?\[\]']|'')+";
+    const REGEX_SHEET_TITLE_QUOTED = "([^*:/\\\\?\\[\\]']|'')+";
 
     const REGEX_CELL_TITLE_QUOTED = "~^'"
         . self::REGEX_SHEET_TITLE_QUOTED
         . '(:' . self::REGEX_SHEET_TITLE_QUOTED . ')?'
         . "'!(*COMMIT)"
-        . '[$]?[A-Ia-i]?[A-Za-z][$]?(\\d+)'
+        . '[$]?[A-Ia-i]?[A-Za-z][$]?(\d+)'
         . '$~u';
 
     const REGEX_RANGE_TITLE_QUOTED = "~^'"
         . self::REGEX_SHEET_TITLE_QUOTED
         . '(:' . self::REGEX_SHEET_TITLE_QUOTED . ')?'
         . "'!(*COMMIT)"
-        . '[$]?[A-Ia-i]?[A-Za-z][$]?(\\d+)'
+        . '[$]?[A-Ia-i]?[A-Za-z][$]?(\d+)'
         . ':'
-        . '[$]?[A-Ia-i]?[A-Za-z][$]?(\\d+)'
+        . '[$]?[A-Ia-i]?[A-Za-z][$]?(\d+)'
         . '$~u';
 
     private const UTF8 = 'UTF-8';
@@ -511,7 +511,7 @@ class Parser
             return $this->convertRef2d($token);
         }
         // match external references like Sheet1!A1 or Sheet1:Sheet2!A1 or Sheet1!$A$1 or Sheet1:Sheet2!$A$1
-        if (Preg::isMatch('/^' . self::REGEX_SHEET_TITLE_UNQUOTED . '(\\:' . self::REGEX_SHEET_TITLE_UNQUOTED . ')?\\!\$?[A-Ia-i]?[A-Za-z]\$?(\\d+)$/u', $token)) {
+        if (Preg::isMatch('/^' . self::REGEX_SHEET_TITLE_UNQUOTED . '(\:' . self::REGEX_SHEET_TITLE_UNQUOTED . ')?\!\$?[A-Ia-i]?[A-Za-z]\$?(\d+)$/u', $token)) {
             return $this->convertRef3d($token);
         }
         // match external references like 'Sheet1'!A1 or 'Sheet1:Sheet2'!A1 or 'Sheet1'!$A$1 or 'Sheet1:Sheet2'!$A$1
@@ -523,7 +523,7 @@ class Parser
             return $this->convertRange2d($token);
         }
         // match external ranges like Sheet1!A1:B2 or Sheet1:Sheet2!A1:B2 or Sheet1!$A$1:$B$2 or Sheet1:Sheet2!$A$1:$B$2
-        if (Preg::isMatch('/^' . self::REGEX_SHEET_TITLE_UNQUOTED . '(\\:' . self::REGEX_SHEET_TITLE_UNQUOTED . ')?\\!\$?([A-Ia-i]?[A-Za-z])?\$?(\\d+)\\:\$?([A-Ia-i]?[A-Za-z])?\$?(\\d+)$/u', $token)) {
+        if (Preg::isMatch('/^' . self::REGEX_SHEET_TITLE_UNQUOTED . '(\:' . self::REGEX_SHEET_TITLE_UNQUOTED . ')?\!\$?([A-Ia-i]?[A-Za-z])?\$?(\d+)\:\$?([A-Ia-i]?[A-Za-z])?\$?(\d+)$/u', $token)) {
             return $this->convertRange3d($token);
         }
         // match external ranges like 'Sheet1'!A1:B2 or 'Sheet1:Sheet2'!A1:B2 or 'Sheet1'!$A$1:$B$2 or 'Sheet1:Sheet2'!$A$1:$B$2
@@ -535,7 +535,7 @@ class Parser
             return pack('C', $this->ptg[$token]);
         }
         // match error codes
-        if (Preg::isMatch('/^#[A-Z0\\/]{3,5}[!?]{1}$/', $token) || $token == '#N/A') {
+        if (Preg::isMatch('/^#[A-Z0\/]{3,5}[!?]{1}$/', $token) || $token == '#N/A') {
             return $this->convertError($token);
         }
         if (Preg::isMatch('/^' . Calculation::CALCULATION_REGEXP_DEFINEDNAME . '$/mui', $token) && $this->spreadsheet->getDefinedName($token) !== null) {
@@ -569,7 +569,7 @@ class Parser
     private function convertNumber(mixed $num): string
     {
         // Integer in the range 0..2**16-1
-        if ((Preg::isMatch('/^\\d+$/', (string) $num)) && ($num <= 65535)) {
+        if ((Preg::isMatch('/^\d+$/', (string) $num)) && ($num <= 65535)) {
             return pack('Cv', $this->ptg['ptgInt'], $num);
         }
 
@@ -680,7 +680,7 @@ class Parser
         [$cell1, $cell2] = explode(':', $range ?? '');
 
         // Convert the cell references
-        if (Preg::isMatch('/^(\$)?[A-Ia-i]?[A-Za-z](\$)?(\\d+)$/', $cell1)) {
+        if (Preg::isMatch('/^(\$)?[A-Ia-i]?[A-Za-z](\$)?(\d+)$/', $cell1)) {
             [$row1, $col1] = $this->cellToPackedRowcol($cell1);
             [$row2, $col2] = $this->cellToPackedRowcol($cell2);
         } else { // It's a rows range (like 26:27)
@@ -1087,7 +1087,7 @@ class Parser
         }
         // If it's an external reference (Sheet1!A1 or Sheet1:Sheet2!A1 or Sheet1!$A$1 or Sheet1:Sheet2!$A$1)
         if (
-            Preg::isMatch('/^' . self::REGEX_SHEET_TITLE_UNQUOTED . '(\\:' . self::REGEX_SHEET_TITLE_UNQUOTED . ')?\\!\$?[A-Ia-i]?[A-Za-z]\$?\\d+$/u', $token)
+            Preg::isMatch('/^' . self::REGEX_SHEET_TITLE_UNQUOTED . '(\:' . self::REGEX_SHEET_TITLE_UNQUOTED . ')?\!\$?[A-Ia-i]?[A-Za-z]\$?\d+$/u', $token)
             && !Preg::isMatch('/\d/', $this->lookAhead)
             && ($this->lookAhead !== ':')
             && ($this->lookAhead !== '.')
@@ -1097,7 +1097,7 @@ class Parser
         // If it's an external reference ('Sheet1'!A1 or 'Sheet1:Sheet2'!A1 or 'Sheet1'!$A$1 or 'Sheet1:Sheet2'!$A$1)
         if (
             self::matchCellSheetnameQuoted($token)
-            && !Preg::isMatch('/\\d/', $this->lookAhead)
+            && !Preg::isMatch('/\d/', $this->lookAhead)
             && ($this->lookAhead !== ':') && ($this->lookAhead !== '.')
         ) {
             return $token;
@@ -1117,8 +1117,8 @@ class Parser
             Preg::isMatch(
                 '/^'
                 . self::REGEX_SHEET_TITLE_UNQUOTED
-                . '(\\:' . self::REGEX_SHEET_TITLE_UNQUOTED
-                . ')?\\!\$?([A-Ia-i]?[A-Za-z])?\$?\\d+:\$?([A-Ia-i]?[A-Za-z])?\$?\\d+$/u',
+                . '(\:' . self::REGEX_SHEET_TITLE_UNQUOTED
+                . ')?\!\$?([A-Ia-i]?[A-Za-z])?\$?\d+:\$?([A-Ia-i]?[A-Za-z])?\$?\d+$/u',
                 $token
             )
             && !Preg::isMatch('/\d/', $this->lookAhead)
@@ -1128,7 +1128,7 @@ class Parser
         // If it's an external range like 'Sheet1'!A1:B2 or 'Sheet1:Sheet2'!A1:B2 or 'Sheet1'!$A$1:$B$2 or 'Sheet1:Sheet2'!$A$1:$B$2
         if (
             self::matchRangeSheetnameQuoted($token)
-            && !Preg::isMatch('/\\d/', $this->lookAhead)
+            && !Preg::isMatch('/\d/', $this->lookAhead)
         ) {
             return $token;
         }
@@ -1146,7 +1146,7 @@ class Parser
         }
         // If it's an error code
         if (
-            Preg::isMatch('/^#[A-Z0\\/]{3,5}[!?]{1}$/', $token)
+            Preg::isMatch('/^#[A-Z0\/]{3,5}[!?]{1}$/', $token)
             || $token === '#N/A'
         ) {
             return $token;
@@ -1272,7 +1272,7 @@ class Parser
             return $result;
         }
         if (
-            Preg::isMatch('/^#[A-Z0\\/]{3,5}[!?]{1}$/', $this->currentToken)
+            Preg::isMatch('/^#[A-Z0\/]{3,5}[!?]{1}$/', $this->currentToken)
             || $this->currentToken == '#N/A'
         ) { // error code
             $result = $this->createTree($this->currentToken, 'ptgErr', '');
@@ -1396,8 +1396,8 @@ class Parser
             Preg::isMatch(
                 '/^'
                 . self::REGEX_SHEET_TITLE_UNQUOTED
-                . '(\\:' . self::REGEX_SHEET_TITLE_UNQUOTED
-                . ')?\\!\$?[A-Ia-i]?[A-Za-z]\$?\\d+$/u',
+                . '(\:' . self::REGEX_SHEET_TITLE_UNQUOTED
+                . ')?\!\$?[A-Ia-i]?[A-Za-z]\$?\d+$/u',
                 $this->currentToken
             )
         ) {
@@ -1435,9 +1435,9 @@ class Parser
             Preg::isMatch(
                 '/^'
                 . self::REGEX_SHEET_TITLE_UNQUOTED
-                . '(\\:'
+                . '(\:'
                 . self::REGEX_SHEET_TITLE_UNQUOTED
-                . ')?\\!\$?([A-Ia-i]?[A-Za-z])?\$?\\d+:\$?([A-Ia-i]?[A-Za-z])?\$?\\d+$/u',
+                . ')?\!\$?([A-Ia-i]?[A-Za-z])?\$?\d+:\$?([A-Ia-i]?[A-Za-z])?\$?\d+$/u',
                 $this->currentToken
             )
         ) {
@@ -1613,7 +1613,7 @@ class Parser
             Preg::isMatch("/^[A-Z0-9\xc0-\xdc\\.]+$/", $tree['value'])
             && !Preg::isMatch('/^([A-Ia-i]?[A-Za-z])(\d+)$/', $tree['value'])
             && !Preg::isMatch(
-                '/^[A-Ia-i]?[A-Za-z](\\d+)\\.\\.[A-Ia-i]?[A-Za-z](\\d+)$/',
+                '/^[A-Ia-i]?[A-Za-z](\d+)\.\.[A-Ia-i]?[A-Za-z](\d+)$/',
                 $tree['value']
             )
             && !is_numeric($tree['value'])

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -464,7 +464,7 @@ class Worksheet extends BIFFwriter
                 $url = str_replace('sheet://', 'internal:', $url);
             } elseif (Preg::isMatch('/^(http:|https:|ftp:|mailto:)/', $url)) {
                 // URL
-            } elseif (!empty($hyperlinkbase) && !Preg::isMatch('~^([A-Za-z]:)?[/\\\\]~', $url)) {
+            } elseif (!empty($hyperlinkbase) && !Preg::isMatch('~^([A-Za-z]:)?[/\\\]~', $url)) {
                 $url = "$hyperlinkbase$url";
                 if (!Preg::isMatch('/^(http:|https:|ftp:|mailto:)/', $url)) {
                     $url = 'external:' . $url;
@@ -1060,7 +1060,7 @@ class Worksheet extends BIFFwriter
     {
         // Network drives are different. We will handle them separately
         // MS/Novell network drives and shares start with \\
-        if (Preg::isMatch('[^external:\\\\]', $url)) {
+        if (Preg::isMatch('[^external:\\\]', $url)) {
             return;
         }
 
@@ -1085,7 +1085,7 @@ class Worksheet extends BIFFwriter
         // parameters accordingly.
         // Split the dir name and sheet name (if it exists)
         $dir_long = $url;
-        if (Preg::isMatch('/\\#/', $url)) {
+        if (Preg::isMatch('/\#/', $url)) {
             $link_type |= 0x08;
         }
 
@@ -1093,11 +1093,11 @@ class Worksheet extends BIFFwriter
         $link_type = pack('V', $link_type);
 
         // Calculate the up-level dir count e.g.. (..\..\..\ == 3)
-        $up_count = Preg::isMatchAll('/\\.\\.\\\\/', $dir_long, $useless);
+        $up_count = Preg::isMatchAll('/\.\.\\\/', $dir_long, $useless);
         $up_count = pack('v', $up_count);
 
         // Store the short dos dir name (null terminated)
-        $dir_short = Preg::replace('/\\.\\.\\\\/', '', $dir_long) . "\0";
+        $dir_short = Preg::replace('/\.\.\\\/', '', $dir_long) . "\0";
 
         // Store the long dir name as a wchar string (non-null terminated)
         //$dir_long = $dir_long . "\0";

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCscTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCscTest.php
@@ -119,12 +119,12 @@ class ImCscTest extends TestCase
         // Avoid testing for excess precision
         foreach ($expectedResult as &$array) {
             foreach ($array as &$string) {
-                $string = preg_replace('/(\\d{8})\\d+/', '$1', $string);
+                $string = preg_replace('/(\d{8})\d+/', '$1', $string);
             }
         }
         foreach ($result as &$array) {
             foreach ($array as &$string) {
-                $string = preg_replace('/(\\d{8})\\d+/', '$1', $string);
+                $string = preg_replace('/(\d{8})\d+/', '$1', $string);
             }
         }
 

--- a/tests/PhpSpreadsheetTests/IOFactoryTest.php
+++ b/tests/PhpSpreadsheetTests/IOFactoryTest.php
@@ -191,21 +191,21 @@ class IOFactoryTest extends TestCase
     {
         $filename = 'samples/Reader2/sampleData/example1.tsv';
         $reader = IOFactory::createReaderForFile($filename);
-        self::assertEquals('PhpOffice\\PhpSpreadsheet\\Reader\\Csv', $reader::class);
+        self::assertEquals('PhpOffice\PhpSpreadsheet\Reader\Csv', $reader::class);
     }
 
     public function testCreateReaderCsvExtension(): void
     {
         $filename = 'samples/Reader2/sampleData/example1.csv';
         $reader = IOFactory::createReaderForFile($filename);
-        self::assertEquals('PhpOffice\\PhpSpreadsheet\\Reader\\Csv', $reader::class);
+        self::assertEquals('PhpOffice\PhpSpreadsheet\Reader\Csv', $reader::class);
     }
 
     public function testCreateReaderNoExtension(): void
     {
         $filename = 'samples/Reader/sampleData/example1xls';
         $reader = IOFactory::createReaderForFile($filename);
-        self::assertEquals('PhpOffice\\PhpSpreadsheet\\Reader\\Xls', $reader::class);
+        self::assertEquals('PhpOffice\PhpSpreadsheet\Reader\Xls', $reader::class);
     }
 
     public function testCreateReaderNotSpreadsheet(): void

--- a/tests/PhpSpreadsheetTests/Reader/Gnumeric/GnumericLoadTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Gnumeric/GnumericLoadTest.php
@@ -31,10 +31,10 @@ class GnumericLoadTest extends TestCase
         $props = $spreadsheet->getProperties();
         self::assertEquals('Mark Baker', $props->getCreator());
         $creationDate = $props->getCreated();
-        $result = Date::formattedDateTimeFromTimestamp("$creationDate", 'Y-m-d\\TH:i:s\\Z', new DateTimeZone('UTC'));
+        $result = Date::formattedDateTimeFromTimestamp("$creationDate", 'Y-m-d\TH:i:s\Z', new DateTimeZone('UTC'));
         self::assertEquals('2010-09-02T20:48:39Z', $result);
         $creationDate = $props->getModified();
-        $result = Date::formattedDateTimeFromTimestamp("$creationDate", 'Y-m-d\\TH:i:s\\Z', new DateTimeZone('UTC'));
+        $result = Date::formattedDateTimeFromTimestamp("$creationDate", 'Y-m-d\TH:i:s\Z', new DateTimeZone('UTC'));
         self::assertEquals('2020-06-05T05:15:21Z', $result);
 
         $sheet = $spreadsheet->getSheet(0);

--- a/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
@@ -31,7 +31,7 @@ class XmlScannerTest extends TestCase
             $expectedResult = (string) file_get_contents($file);
             if (preg_match('/UTF-16(LE|BE)?/', $file, $matches) == 1) {
                 $expectedResult = (string) mb_convert_encoding($expectedResult, 'UTF-8', $matches[0]);
-                $expectedResult = preg_replace('/encoding\\s*=\\s*[\'"]UTF-\\d+(LE|BE)?[\'"]/', '', $expectedResult) ?? $expectedResult;
+                $expectedResult = preg_replace('/encoding\s*=\s*[\'"]UTF-\d+(LE|BE)?[\'"]/', '', $expectedResult) ?? $expectedResult;
             }
             $tests[basename($file)] = [$filename, $expectedResult];
         }

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/Issue3730Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/Issue3730Test.php
@@ -14,7 +14,7 @@ class Issue3730Test extends \PHPUnit\Framework\TestCase
     {
         $file = 'zip://';
         $file .= self::$testbook;
-        $file .= '#xl\\_rels\\workbook.xml.rels'; // no idea why backslash
+        $file .= '#xl\_rels\workbook.xml.rels'; // no idea why backslash
         $data = file_get_contents($file);
         // confirm that file contains expected absolute reference
         if ($data === false) {

--- a/tests/PhpSpreadsheetTests/Reader/Xml/XmlLoadTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/XmlLoadTest.php
@@ -58,16 +58,16 @@ class XmlLoadTest extends TestCase
         $props = $spreadsheet->getProperties();
         self::assertEquals('Mark Baker', $props->getCreator());
         $creationDate = $props->getCreated();
-        $result = Date::formattedDateTimeFromTimestamp("$creationDate", 'Y-m-d\\TH:i:s\\Z', new DateTimeZone('UTC'));
+        $result = Date::formattedDateTimeFromTimestamp("$creationDate", 'Y-m-d\TH:i:s\Z', new DateTimeZone('UTC'));
         self::assertEquals('2010-09-02T20:48:39Z', $result);
         $creationDate = $props->getModified();
-        $result = Date::formattedDateTimeFromTimestamp("$creationDate", 'Y-m-d\\TH:i:s\\Z', new DateTimeZone('UTC'));
+        $result = Date::formattedDateTimeFromTimestamp("$creationDate", 'Y-m-d\TH:i:s\Z', new DateTimeZone('UTC'));
         self::assertEquals('2010-09-03T21:48:39Z', $result);
         self::assertEquals('AbCd1234', $props->getCustomPropertyValue('my_API_Token'));
         self::assertEquals('2', $props->getCustomPropertyValue('myאInt'));
         /** @var string */
         $creationDate = $props->getCustomPropertyValue('my_API_Token_Expiry');
-        $result = Date::formattedDateTimeFromTimestamp("$creationDate", 'Y-m-d\\TH:i:s\\Z', new DateTimeZone('UTC'));
+        $result = Date::formattedDateTimeFromTimestamp("$creationDate", 'Y-m-d\TH:i:s\Z', new DateTimeZone('UTC'));
         self::assertEquals('2019-01-31T07:00:00Z', $result);
 
         $sheet = $spreadsheet->getSheet(0);

--- a/tests/PhpSpreadsheetTests/Writer/Csv/CsvEnclosureTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Csv/CsvEnclosureTest.php
@@ -43,7 +43,7 @@ class CsvEnclosureTest extends Functional\AbstractFunctional
         $filename = File::temporaryFilename();
         $writer->save($filename);
         $filedata = self::getFileData($filename);
-        $filedata = preg_replace('/\\r?\\n/', $delimiter, $filedata);
+        $filedata = preg_replace('/\r?\n/', $delimiter, $filedata);
         $reader = new CsvReader();
         $reader->setDelimiter($delimiter);
         $reader->setEnclosure($enclosure);
@@ -76,7 +76,7 @@ class CsvEnclosureTest extends Functional\AbstractFunctional
         $filename = File::temporaryFilename();
         $writer->save($filename);
         $filedata = self::getFileData($filename);
-        $filedata = preg_replace('/\\r?\\n/', $delimiter, $filedata);
+        $filedata = preg_replace('/\r?\n/', $delimiter, $filedata);
         $reader = new CsvReader();
         $reader->setDelimiter($delimiter);
         $reader->setEnclosure($enclosure);
@@ -109,7 +109,7 @@ class CsvEnclosureTest extends Functional\AbstractFunctional
         $filename = File::temporaryFilename();
         $writer->save($filename);
         $filedata = self::getFileData($filename);
-        $filedata = preg_replace('/\\r?\\n/', $delimiter, $filedata);
+        $filedata = preg_replace('/\r?\n/', $delimiter, $filedata);
         $reader = new CsvReader();
         $reader->setDelimiter($delimiter);
         $reader->setEnclosure($enclosure);
@@ -170,7 +170,7 @@ class CsvEnclosureTest extends Functional\AbstractFunctional
         $filename = File::temporaryFilename();
         $writer->save($filename);
         $filedata = self::getFileData($filename);
-        $filedata = preg_replace('/\\r/', '', $filedata);
+        $filedata = preg_replace('/\r/', '', $filedata);
         $reader = new CsvReader();
         $reader->setDelimiter($delimiter);
         $reader->setEnclosure($enclosure);
@@ -229,7 +229,7 @@ class CsvEnclosureTest extends Functional\AbstractFunctional
         $filename = File::temporaryFilename();
         $writer->save($filename);
         $filedata = self::getFileData($filename);
-        $filedata = preg_replace('/\\r/', '', $filedata);
+        $filedata = preg_replace('/\r/', '', $filedata);
         $reader = new CsvReader();
         $reader->setDelimiter($delimiter);
         $reader->setEnclosure($enclosure);

--- a/tests/PhpSpreadsheetTests/Writer/Dompdf/HideMergeTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Dompdf/HideMergeTest.php
@@ -82,8 +82,8 @@ class HideMergeTest extends TestCase
         $worksheet->getColumnDimension('A')->setVisible(false);
         $Dompdf = new Dompdf($spreadsheet);
         $html = $Dompdf->generateHtmlAll();
-        $html = preg_replace('/^\\s+/m', '', $html) ?? $html;
-        $html = preg_replace('/[\\n\\r]/', '', $html) ?? $html;
+        $html = preg_replace('/^\s+/m', '', $html) ?? $html;
+        $html = preg_replace('/[\n\r]/', '', $html) ?? $html;
         self::assertStringContainsString(
             'table.sheet0 .column0 { display:none }',
             $html

--- a/tests/PhpSpreadsheetTests/Writer/Html/HideMergeTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/HideMergeTest.php
@@ -82,8 +82,8 @@ class HideMergeTest extends TestCase
         $worksheet->getColumnDimension('A')->setVisible(false);
         $Dompdf = new Html($spreadsheet);
         $html = $Dompdf->generateHtmlAll();
-        $html = preg_replace('/^\\s+/m', '', $html) ?? $html;
-        $html = preg_replace('/[\\n\\r]/', '', $html) ?? $html;
+        $html = preg_replace('/^\s+/m', '', $html) ?? $html;
+        $html = preg_replace('/[\n\r]/', '', $html) ?? $html;
         self::assertStringContainsString(
             'table.sheet0 .column0 { display:none }',
             $html

--- a/tests/PhpSpreadsheetTests/Writer/Html/InvalidFileNameTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/InvalidFileNameTest.php
@@ -57,7 +57,7 @@ class InvalidFileNameTest extends Functional\AbstractFunctional
 
     public function testWinFileNames(): void
     {
-        self::assertEquals('file:///C:/temp/filename.xlsx', Html::winFileToUrl('C:\\temp\filename.xlsx'));
+        self::assertEquals('file:///C:/temp/filename.xlsx', Html::winFileToUrl('C:\temp\filename.xlsx'));
         self::assertEquals('/tmp/filename.xlsx', Html::winFileToUrl('/tmp/filename.xlsx'));
         self::assertEquals('a:bfile', Html::winFileToUrl('a:bfile'));
     }

--- a/tests/PhpSpreadsheetTests/Writer/Html/VisibilityTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/VisibilityTest.php
@@ -28,13 +28,13 @@ class VisibilityTest extends Functional\AbstractFunctional
         $sheet->getRowDimension(2)->setVisible(false);
         $writer = new Html($spreadsheet);
         $html = $writer->generateHTMLAll();
-        $reg = '/^\\s*table[.]sheet0 tr { display:none; visibility:hidden }\\s*$/m';
+        $reg = '/^\s*table[.]sheet0 tr { display:none; visibility:hidden }\s*$/m';
         $rowsrch = preg_match($reg, $html);
         self::assertEquals($rowsrch, 0);
-        $reg = '/^\\s*table[.]sheet0 tr[.]row1 { display:none; visibility:hidden }\\s*$/m';
+        $reg = '/^\s*table[.]sheet0 tr[.]row1 { display:none; visibility:hidden }\s*$/m';
         $rowsrch = preg_match($reg, $html);
         self::assertEquals($rowsrch, 1);
-        $reg = '/^\\s*table[.]sheet0 [.]column1 [{] display:none [}]\\s*$/m';
+        $reg = '/^\s*table[.]sheet0 [.]column1 [{] display:none [}]\s*$/m';
         $colsrch = preg_match($reg, $html);
         self::assertEquals($colsrch, 1);
 
@@ -61,13 +61,13 @@ class VisibilityTest extends Functional\AbstractFunctional
 
         $writer = new Html($spreadsheet);
         $html = $writer->generateHTMLAll();
-        $reg = '/^\\s*table[.]sheet0 tr { height:15pt; display:none; visibility:hidden }\\s*$/m';
+        $reg = '/^\s*table[.]sheet0 tr { height:15pt; display:none; visibility:hidden }\s*$/m';
         $rowsrch = preg_match($reg, $html);
         self::assertEquals($rowsrch, 1);
-        $reg = '/^\\s*table[.]sheet0 tr[.]row1 { display:none; visibility:hidden }\\s*$/m';
+        $reg = '/^\s*table[.]sheet0 tr[.]row1 { display:none; visibility:hidden }\s*$/m';
         $rowsrch = preg_match($reg, $html);
         self::assertEquals($rowsrch, 0);
-        $reg = '/^\\s*table[.]sheet0 [.]column1 [{] display:none [}]\\s*$/m';
+        $reg = '/^\s*table[.]sheet0 [.]column1 [{] display:none [}]\s*$/m';
         $colsrch = preg_match($reg, $html);
         self::assertEquals($colsrch, 1);
 
@@ -97,15 +97,15 @@ class VisibilityTest extends Functional\AbstractFunctional
         $html = $writer->generateHTMLAll();
         self::assertEquals(1, substr_count($html, 'height:20pt'));
         self::assertEquals(1, substr_count($html, 'height:25pt'));
-        $rowsrch = preg_match('/^\\s*table[.]sheet0 tr [{] height:20pt [}]\\s*$/m', $html);
+        $rowsrch = preg_match('/^\s*table[.]sheet0 tr [{] height:20pt [}]\s*$/m', $html);
         self::assertEquals(1, $rowsrch);
-        $rowsrch = preg_match('/^\\s*table[.]sheet0 tr[.]row1 [{] height:25pt [}]\\s*$/m', $html);
+        $rowsrch = preg_match('/^\s*table[.]sheet0 tr[.]row1 [{] height:25pt [}]\s*$/m', $html);
         self::assertEquals(1, $rowsrch);
-        $rowsrch = preg_match('/^\\s*td[.]style1, th[.]style1 [{].*text-decoration:line-through;.*[}]\\s*$/m', $html);
+        $rowsrch = preg_match('/^\s*td[.]style1, th[.]style1 [{].*text-decoration:line-through;.*[}]\s*$/m', $html);
         self::assertEquals(1, $rowsrch);
-        $rowsrch = preg_match('/^\\s*td[.]style2, th[.]style2 [{].*text-decoration:underline line-through;.*[}]\\s*$/m', $html);
+        $rowsrch = preg_match('/^\s*td[.]style2, th[.]style2 [{].*text-decoration:underline line-through;.*[}]\s*$/m', $html);
         self::assertEquals(1, $rowsrch);
-        $rowsrch = preg_match('/^\\s*td[.]style3, th[.]style3 [{].*text-decoration:underline;.*[}]\\s*$/m', $html);
+        $rowsrch = preg_match('/^\s*td[.]style3, th[.]style3 [{].*text-decoration:underline;.*[}]\s*$/m', $html);
         self::assertEquals(1, $rowsrch);
 
         $this->writeAndReload($spreadsheet, 'Html');

--- a/tests/PhpSpreadsheetTests/Writer/Html/XssVulnerabilityTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/XssVulnerabilityTest.php
@@ -20,7 +20,7 @@ class XssVulnerabilityTest extends Functional\AbstractFunctional
             'script tag with quotes' => ['Hello, I am trying to <script>alert("Hack");</script> your site', 'Hello, I am trying to &lt;script&gt;alert(&quot;Hack&quot;);&lt;/script&gt; your site'],
             'javascript tag no hex' => ["<a href='javascript:alert(1)'>CLICK</a>", "&lt;a href='javascript:alert(1)'&gt;CLICK&lt;/a&gt;"],
             'javascript tag' => ["<a href='&#x2000;javascript:alert(1)'>CLICK</a>", "&lt;a href='&amp;#x2000;javascript:alert(1)'&gt;CLICK&lt;/a&gt;"],
-            'with unicode' => ['<a href="\\u0001java\\u0003script:alert(1)">CLICK</a>', '&lt;a href=&quot;\\u0001java\\u0003script:alert(1)&quot;&gt;CLICK&lt;/a&gt;'],
+            'with unicode' => ['<a href="\u0001java\u0003script:alert(1)">CLICK</a>', '&lt;a href=&quot;\u0001java\u0003script:alert(1)&quot;&gt;CLICK&lt;/a&gt;'],
             'inline css' => ['<li style="list-style-image: url(javascript:alert(0))">', '&lt;li style=&quot;list-style-image: url(javascript:alert(0))&quot;&gt;'],
             'char value chevron' => ["\x3cscript src=http://www.example.com/malicious-code.js\x3e\x3c/script\x3e", '&lt;script src=http://www.example.com/malicious-code.js&gt;&lt;/script&gt;'],
             'hexadecimal html' => ['<IMG SRC=&#106&#x61&#x76&#x61&#x73&#109&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x58&#x53&#x53&#x27&#x29>', '&lt;IMG SRC=&amp;#106&amp;#x61&amp;#x76&amp;#x61&amp;#x73&amp;#109&amp;#x72&amp;#x69&amp;#x70&amp;#x74&amp;#x3A&amp;#x61&amp;#x6C&amp;#x65&amp;#x72&amp;#x74&amp;#x28&amp;#x27&amp;#x58&amp;#x53&amp;#x53&amp;#x27&amp;#x29&gt;'],

--- a/tests/PhpSpreadsheetTests/Writer/Mpdf/HideMergeTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Mpdf/HideMergeTest.php
@@ -82,8 +82,8 @@ class HideMergeTest extends TestCase
         $worksheet->getColumnDimension('A')->setVisible(false);
         $mpdf = new Mpdf($spreadsheet);
         $html = $mpdf->generateHtmlAll();
-        $html = preg_replace('/^\\s+/m', '', $html) ?? $html;
-        $html = preg_replace('/[\\n\\r]/', '', $html) ?? $html;
+        $html = preg_replace('/^\s+/m', '', $html) ?? $html;
+        $html = preg_replace('/[\n\r]/', '', $html) ?? $html;
         self::assertStringContainsString(
             '<tr class="row0">'
                 . '<td class="column1 style0 s" style="width:42pt; height:17pt">B</td>'

--- a/tests/PhpSpreadsheetTests/Writer/Tcpdf/HideMergeTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Tcpdf/HideMergeTest.php
@@ -82,8 +82,8 @@ class HideMergeTest extends TestCase
         $worksheet->getColumnDimension('A')->setVisible(false);
         $Tcpdf = new Tcpdf($spreadsheet);
         $html = $Tcpdf->generateHtmlAll();
-        $html = preg_replace('/^\\s+/m', '', $html) ?? $html;
-        $html = preg_replace('/[\\n\\r]/', '', $html) ?? $html;
+        $html = preg_replace('/^\s+/m', '', $html) ?? $html;
+        $html = preg_replace('/[\n\r]/', '', $html) ?? $html;
         self::assertStringContainsString(
             '<tbody><tr style="height:17pt">'
                 . '<td></td>'

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue4179Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue4179Test.php
@@ -52,7 +52,7 @@ class Issue4179Test extends TestCase
             self::assertSame(1, $subCount);
             for ($i = 0; $i < $zip->numFiles; ++$i) {
                 $filename = (string) $zip->getNameIndex($i);
-                if (preg_match('~^xl/media/\\w+[.]png$~', $filename) === 1) {
+                if (preg_match('~^xl/media/\w+[.]png$~', $filename) === 1) {
                     ++$pngCount;
                 }
             }

--- a/tests/data/Calculation/TextData/TEXTJOIN.php
+++ b/tests/data/Calculation/TextData/TEXTJOIN.php
@@ -54,7 +54,7 @@ return [
         ['-', false, 'Boolean', '', true],
     ],
     [
-        'C:\\Users\\Mark\\Documents\\notes.doc',
+        'C:\Users\Mark\Documents\notes.doc',
         ['\\', true, 'C:', 'Users', 'Mark', 'Documents', 'notes.doc'],
     ],
     'no argument' => ['exception', []],

--- a/tests/data/Style/NumberFormat.php
+++ b/tests/data/Style/NumberFormat.php
@@ -1725,6 +1725,6 @@ return [
     'issue 4242 escaped quote in format' => [
         '"Hello"',
         'Hello',
-        '\\"@\\"',
+        '\"@\"',
     ],
 ];

--- a/tests/data/Style/NumberFormatDates.php
+++ b/tests/data/Style/NumberFormatDates.php
@@ -18,13 +18,13 @@ return [
     [
         '1960-12-19T01:30:00',
         22269.0625,
-        'yyyy-mm-dd\\Thh:mm:ss',
+        'yyyy-mm-dd\Thh:mm:ss',
     ],
     // Date with plaintext in quotes
     [
         '1960-12-19T01:30:00 Z',
         22269.0625,
-        'yyyy-mm-dd"T"hh:mm:ss \\Z',
+        'yyyy-mm-dd"T"hh:mm:ss \Z',
     ],
     // Date with quoted formatting characters
     [


### PR DESCRIPTION
Its defaults are to unescape within single quotes, and escape within double quotes and here-docs. Right now, it leaves everything as-is, which means our code is inconsistent and need not be. Further, although dealing with complex regular expressions will never be easy, I find it much easier to figure out what's going on when superfluous back-slashes are removed.

These changes were all made automatically using the "fix" script, so should be reliable. They, of course, pass all unit tests.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] more consistent code base 

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary