### PR TITLE
Scrutinizer Php 8.3

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -14,7 +14,7 @@ build:
         analysis:
             image: default-bionic
             environment:
-                php: 8.2
+                php: 8.3
             tests:
                 override:
                     - php-scrutinizer-run


### PR DESCRIPTION
This didn't work last time I tried it. Php 8.2 is no longer in active support (it still receives security fixes). See if Scrutinizer works with 8.3 yet.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] code quality

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

