### PR TITLE
BIN2DEC, OCT2DEC, HEX2DEC Return Numbers Rather than Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
-- Nothing yet.
+- Phpstan Version 2. [PR #4384](https://github.com/PHPOffice/PhpSpreadsheet/pull/4384)
 
 ### Moved
 
@@ -29,14 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- Nothing yet.
+- BIN2DEC, OCT2DEC, and HEX2DEC return numbers rather than strings. [Issue #4383](https://github.com/PHPOffice/PhpSpreadsheet/issues/4383) [PR #4389](https://github.com/PHPOffice/PhpSpreadsheet/pull/4389)
 
 ## 2025-03-02 - 4.1.0
 
 ### Added
 
 - Support Justify Last Line. [Issue #4374](https://github.com/PHPOffice/PhpSpreadsheet/issues/4374) [PR #4373](https://github.com/PHPOffice/PhpSpreadsheet/pull/4373)
-- Allow Spreadsheet clone. [PR #437-](https://github.com/PHPOffice/PhpSpreadsheet/pull/4370)
+- Allow Spreadsheet clone. [PR #4370](https://github.com/PHPOffice/PhpSpreadsheet/pull/4370)
 
 ### Changed
 

--- a/src/PhpSpreadsheet/Calculation/Engineering/ConvertBinary.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/ConvertBinary.php
@@ -23,7 +23,7 @@ class ConvertBinary extends ConvertBase
      *                                10 characters (10 bits), BIN2DEC returns the #NUM! error value.
      *                      Or can be an array of values
      *
-     * @return array|string Result, or an error
+     * @return array|float|int|string Result, or an error
      *         If an array of numbers is passed as an argument, then the returned result will also be an array
      *            with the same dimensions
      */
@@ -44,10 +44,10 @@ class ConvertBinary extends ConvertBase
             //    Two's Complement
             $value = substr($value, -9);
 
-            return '-' . (512 - bindec($value));
+            return -(512 - bindec($value));
         }
 
-        return (string) bindec($value);
+        return bindec($value);
     }
 
     /**

--- a/src/PhpSpreadsheet/Calculation/Engineering/ConvertHex.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/ConvertHex.php
@@ -74,7 +74,7 @@ class ConvertHex extends ConvertBase
      *                          #NUM! error value.
      *                      Or can be an array of values
      *
-     * @return array|string Result, or an error
+     * @return array|float|int|string Result, or an error
      *         If an array of numbers is passed as an argument, then the returned result will also be an array
      *            with the same dimensions
      */
@@ -104,10 +104,10 @@ class ConvertHex extends ConvertBase
                 $binX[$i] = ($binX[$i] == '1' ? '0' : '1');
             }
 
-            return (string) ((bindec($binX) + 1) * -1);
+            return (bindec($binX) + 1) * -1;
         }
 
-        return (string) bindec($binX);
+        return bindec($binX);
     }
 
     /**

--- a/src/PhpSpreadsheet/Calculation/Engineering/ConvertOctal.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/ConvertOctal.php
@@ -78,7 +78,7 @@ class ConvertOctal extends ConvertBase
      *                          #NUM! error value.
      *                      Or can be an array of values
      *
-     * @return array|string Result, or an error
+     * @return array|float|int|string Result, or an error
      *         If an array of numbers is passed as an argument, then the returned result will also be an array
      *            with the same dimensions
      */
@@ -104,10 +104,10 @@ class ConvertOctal extends ConvertBase
                 $binX[$i] = ($binX[$i] == '1' ? '0' : '1');
             }
 
-            return (string) ((bindec($binX) + 1) * -1);
+            return (bindec($binX) + 1) * -1;
         }
 
-        return (string) bindec($binX);
+        return bindec($binX);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2DecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2DecTest.php
@@ -11,6 +11,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class Bin2DecTest extends TestCase
@@ -27,19 +28,14 @@ class Bin2DecTest extends TestCase
         Functions::setCompatibilityMode($this->compatibilityMode);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerBIN2DEC')]
-    public function testDirectCallToBIN2DEC(string $expectedResult, bool|int|string $arg1): void
+    #[DataProvider('providerBIN2DEC')]
+    public function testDirectCallToBIN2DEC(float|int|string $expectedResult, bool|int|string $arg1): void
     {
         $result = ConvertBinary::toDecimal($arg1);
         self::assertSame($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerBIN2DEC')]
+    #[DataProvider('providerBIN2DEC')]
     public function testBIN2DECAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -48,11 +44,11 @@ class Bin2DecTest extends TestCase
         $formula = "=BIN2DEC({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerBIN2DEC')]
+    #[DataProvider('providerBIN2DEC')]
     public function testBIN2DECInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -75,7 +71,7 @@ class Bin2DecTest extends TestCase
         return require 'tests/data/Calculation/Engineering/BIN2DEC.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyBIN2DEC')]
+    #[DataProvider('providerUnhappyBIN2DEC')]
     public function testBIN2DECUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -101,10 +97,12 @@ class Bin2DecTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerBIN2DECOds')]
-    public function testBIN2DECOds(string $expectedResult, bool $arg1): void
+    #[DataProvider('providerBIN2DECOds')]
+    public function testBIN2DECOds(float|int|string $expectedResult, bool $arg1): void
     {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_OPENOFFICE
+        );
 
         $result = ConvertBinary::toDecimal($arg1);
         self::assertSame($expectedResult, $result);
@@ -120,29 +118,35 @@ class Bin2DecTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = '=BIN2DEC(101.1)';
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_GNUMERIC
+        );
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('5', $this->trimIfQuoted((string) $result), 'Gnumeric');
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(5, $result, 'Gnumeric');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_OPENOFFICE
+        );
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(ExcelError::NAN(), $result, 'OpenOffice');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_EXCEL
+        );
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(ExcelError::NAN(), $result, 'Excel');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerBin2DecArray')]
+    #[DataProvider('providerBin2DecArray')]
     public function testBin2DecArray(array $expectedResult, string $value): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=BIN2DEC({$value})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2DecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2DecTest.php
@@ -11,6 +11,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class Hex2DecTest extends TestCase
@@ -27,19 +28,14 @@ class Hex2DecTest extends TestCase
         Functions::setCompatibilityMode($this->compatibilityMode);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerHEX2DEC')]
+    #[DataProvider('providerHEX2DEC')]
     public function testDirectCallToHEX2DEC(mixed $expectedResult, bool|float|int|string $value): void
     {
         $result = ConvertHex::toDecimal($value);
         self::assertSame($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerHEX2DEC')]
+    #[DataProvider('providerHEX2DEC')]
     public function testHEX2DECAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -48,11 +44,11 @@ class Hex2DecTest extends TestCase
         $formula = "=HEX2DEC({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerHEX2DEC')]
+    #[DataProvider('providerHEX2DEC')]
     public function testHEX2DECInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -75,7 +71,7 @@ class Hex2DecTest extends TestCase
         return require 'tests/data/Calculation/Engineering/HEX2DEC.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyHEX2DEC')]
+    #[DataProvider('providerUnhappyHEX2DEC')]
     public function testHEX2DECUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -101,10 +97,12 @@ class Hex2DecTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerHEX2DECOds')]
+    #[DataProvider('providerHEX2DECOds')]
     public function testHEX2DECOds(mixed $expectedResult, bool|float|int|string $value): void
     {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_OPENOFFICE
+        );
 
         $result = ConvertHex::toDecimal($value);
         self::assertSame($expectedResult, $result);
@@ -120,29 +118,35 @@ class Hex2DecTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = '=HEX2DEC(10.1)';
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_GNUMERIC
+        );
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('16', $this->trimIfQuoted((string) $result), 'Gnumeric');
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(16, $result, 'Gnumeric');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_OPENOFFICE
+        );
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(ExcelError::NAN(), $result, 'OpenOffice');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_EXCEL
+        );
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(ExcelError::NAN(), $result, 'Excel');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerHex2DecArray')]
+    #[DataProvider('providerHex2DecArray')]
     public function testHex2DecArray(array $expectedResult, string $value): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=HEX2DEC({$value})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2DecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2DecTest.php
@@ -11,6 +11,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class Oct2DecTest extends TestCase
@@ -27,19 +28,14 @@ class Oct2DecTest extends TestCase
         Functions::setCompatibilityMode($this->compatibilityMode);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerOCT2DEC')]
+    #[DataProvider('providerOCT2DEC')]
     public function testDirectCallToOCT2DEC(mixed $expectedResult, bool|string $value): void
     {
         $result = ConvertOctal::toDecimal($value);
         self::assertSame($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerOCT2DEC')]
+    #[DataProvider('providerOCT2DEC')]
     public function testOCT2DECAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -48,11 +44,11 @@ class Oct2DecTest extends TestCase
         $formula = "=OCT2DEC({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerOCT2DEC')]
+    #[DataProvider('providerOCT2DEC')]
     public function testOCT2DECInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -75,7 +71,7 @@ class Oct2DecTest extends TestCase
         return require 'tests/data/Calculation/Engineering/OCT2DEC.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyOCT2DEC')]
+    #[DataProvider('providerUnhappyOCT2DEC')]
     public function testOCT2DECUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -101,10 +97,12 @@ class Oct2DecTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerOCT2DECOds')]
+    #[DataProvider('providerOCT2DECOds')]
     public function testOCT2DECOds(mixed $expectedResult, bool|string $value): void
     {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_OPENOFFICE
+        );
 
         $result = ConvertOctal::toDecimal($value);
         self::assertSame($expectedResult, $result);
@@ -120,29 +118,35 @@ class Oct2DecTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = '=OCT2DEC(10.1)';
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_GNUMERIC
+        );
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('8', $this->trimIfQuoted((string) $result), 'Gnumeric');
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(8, $result, 'Gnumeric');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_OPENOFFICE
+        );
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(ExcelError::NAN(), $result, 'OpenOffice');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_EXCEL
+        );
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(ExcelError::NAN(), $result, 'Excel');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerOct2DecArray')]
+    #[DataProvider('providerOct2DecArray')]
     public function testOct2DecArray(array $expectedResult, string $value): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=OCT2DEC({$value})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/data/Calculation/Engineering/BIN2DEC.php
+++ b/tests/data/Calculation/Engineering/BIN2DEC.php
@@ -5,25 +5,25 @@ declare(strict_types=1);
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
 
 return [
-    ['178', 10110010],
-    ['178', '10110010'],
-    ['100', '1100100'],
+    [178, 10110010],
+    [178, '10110010'],
+    [100, '1100100'],
     [ExcelError::NAN(), '111001010101'], // Too large
-    ['5', '101'],
-    ['2', '10'],
-    ['0', '0'],
-    ['5', '101'],
-    ['100', '1100100'],
+    [5, '101'],
+    [2, '10'],
+    [0, '0'],
+    [5, '101'],
+    [100, '1100100'],
     [ExcelError::NAN(), '21'], // Invalid binary number
     [ExcelError::VALUE(), true], // Boolean okay for ODS, not for Excel/Gnumeric
     [ExcelError::VALUE(), false], // Boolean okay for ODS, not for Excel/Gnumeric
-    ['-107', '1110010101'], // 2's Complement
-    ['-1', '1111111111'], // 2's Complement
-    ['-512', '1000000000'], // lowest negative
-    ['511', '111111111'], // highest positive
-    ['0', '0000000000'],
-    ['1', '000000001'],
-    ['256', '0100000000'],
-    ['256', '100000000'],
-    ['-256', '1100000000'],
+    [-107, '1110010101'], // 2's Complement
+    [-1, '1111111111'], // 2's Complement
+    [-512, '1000000000'], // lowest negative
+    [511, '111111111'], // highest positive
+    [0, '0000000000'],
+    [1, '000000001'],
+    [256, '0100000000'],
+    [256, '100000000'],
+    [-256, '1100000000'],
 ];

--- a/tests/data/Calculation/Engineering/BIN2DECOpenOffice.php
+++ b/tests/data/Calculation/Engineering/BIN2DECOpenOffice.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 return [
-    ['1', true], // Boolean okay for ODS, not for Excel/Gnumeric
-    ['0', false], // Boolean okay for ODS, not for Excel/Gnumeric
+    [1, true], // Boolean okay for ODS, not for Excel/Gnumeric
+    [0, false], // Boolean okay for ODS, not for Excel/Gnumeric
 ];

--- a/tests/data/Calculation/Engineering/HEX2DEC.php
+++ b/tests/data/Calculation/Engineering/HEX2DEC.php
@@ -5,26 +5,26 @@ declare(strict_types=1);
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
 
 return [
-    ['427', '01AB'],
-    ['43981', 'ABCD'],
-    ['246', 'F6'],
-    ['74565', '12345'],
-    ['4886718345', '123456789'],
+    [427, '01AB'],
+    [43981, 'ABCD'],
+    [246, 'F6'],
+    [74565, '12345'],
+    [4886718345, '123456789'],
     [ExcelError::NAN(), '123.45'],
-    ['0', '0'],
-    ['0', ''],
+    [0, '0'],
+    [0, ''],
     [ExcelError::NAN(), 'G3579A'],
     [ExcelError::VALUE(), true],
     [ExcelError::VALUE(), false],
     [ExcelError::NAN(), '-107'],
-    ['165', 'A5'],
-    ['1034160313', '3DA408B9'],
-    ['-165', 'FFFFFFFF5B'], // 2's Complement
-    ['-1', 'FFFFFFFFFF'], // 2's Complement
+    [165, 'A5'],
+    [1034160313, '3DA408B9'],
+    [-165, 'FFFFFFFF5B'], // 2's Complement
+    [-1, 'FFFFFFFFFF'], // 2's Complement
     [ExcelError::NAN(), '1FFFFFFFFFF'], // Too large
-    ['549755813887', '7fffffffff'], // highest positive, succeeds even for 32-bit
-    ['-549755813888', '8000000000'], // lowest negative, succeeds even for 32-bit
-    ['-2147483648', 'ff80000000'],
-    ['2147483648', '80000000'],
-    ['2147483647', '7fffffff'],
+    [549755813887, '7fffffffff'], // highest positive, succeeds even for 32-bit
+    [-549755813888, '8000000000'], // lowest negative, succeeds even for 32-bit
+    [-2147483648, 'ff80000000'],
+    [2147483648, '80000000'],
+    [2147483647, '7fffffff'],
 ];

--- a/tests/data/Calculation/Engineering/HEX2DECOpenOffice.php
+++ b/tests/data/Calculation/Engineering/HEX2DECOpenOffice.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 return [
-    ['1', true], // ODS accepts boolean, Excel/Gnumeric don't
-    ['0', false], // ODS accepts boolean, Excel/Gnumeric don't
+    [1, true], // ODS accepts boolean, Excel/Gnumeric don't
+    [0, false], // ODS accepts boolean, Excel/Gnumeric don't
 ];

--- a/tests/data/Calculation/Engineering/OCT2DEC.php
+++ b/tests/data/Calculation/Engineering/OCT2DEC.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
 
 return [
-    ['751', '1357'],
-    ['166', '246'],
-    ['5349', '12345'],
+    [751, '1357'],
+    [166, '246'],
+    [5349, '12345'],
     [ExcelError::NAN(), '123.45'],
-    ['0', '0'],
+    [0, '0'],
     [ExcelError::VALUE(), true],
     [ExcelError::VALUE(), false],
     [ExcelError::NAN(), '3579'],
-    ['44', '54'],
-    ['-165', '7777777533'], // 2's Complement
-    ['0', ''],
+    [44, '54'],
+    [-165, '7777777533'], // 2's Complement
+    [0, ''],
     [ExcelError::NAN(), '37777777770'], // too many digits
-    ['536870911', '3777777777'], // highest positive
-    ['-536870912', '4000000000'], // lowest negative
+    [536870911, '3777777777'], // highest positive
+    [-536870912, '4000000000'], // lowest negative
 ];

--- a/tests/data/Calculation/Engineering/OCT2DECOpenOffice.php
+++ b/tests/data/Calculation/Engineering/OCT2DECOpenOffice.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 return [
-    ['1', true], // ODS accepts boolean, Excel/Gnumeric don't
-    ['0', false], // ODS accepts boolean, Excel/Gnumeric don't
+    [1, true], // ODS accepts boolean, Excel/Gnumeric don't
+    [0, false], // ODS accepts boolean, Excel/Gnumeric don't
 ];


### PR DESCRIPTION
Fix #4383.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary
