### PR TITLE
Permit Read to Class Which Extends Spreadsheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Add ability to add custom functions to Calculation. [PR #4390](https://github.com/PHPOffice/PhpSpreadsheet/pull/4390)
 - Add FormulaRange to IgnoredErrors. [PR #4393](https://github.com/PHPOffice/PhpSpreadsheet/pull/4393)
+- Permit read to class which extends Spreadsheet. [Discussion #4402](https://github.com/PHPOffice/PhpSpreadsheet/discussions/4402) [PR #4404](https://github.com/PHPOffice/PhpSpreadsheet/pull/4404)
 
 ### Removed
 

--- a/src/PhpSpreadsheet/Reader/BaseReader.php
+++ b/src/PhpSpreadsheet/Reader/BaseReader.php
@@ -257,4 +257,9 @@ abstract class BaseReader implements IReader
 
         return $this;
     }
+
+    protected function newSpreadsheet(): Spreadsheet
+    {
+        return new Spreadsheet();
+    }
 }

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -257,8 +257,7 @@ class Csv extends BaseReader
      */
     protected function loadSpreadsheetFromFile(string $filename): Spreadsheet
     {
-        // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = $this->newSpreadsheet();
         $spreadsheet->setValueBinder($this->valueBinder);
 
         // Load into this instance
@@ -270,8 +269,7 @@ class Csv extends BaseReader
      */
     public function loadSpreadsheetFromString(string $contents): Spreadsheet
     {
-        // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = $this->newSpreadsheet();
         $spreadsheet->setValueBinder($this->valueBinder);
 
         // Load into this instance

--- a/src/PhpSpreadsheet/Reader/Gnumeric.php
+++ b/src/PhpSpreadsheet/Reader/Gnumeric.php
@@ -231,8 +231,7 @@ class Gnumeric extends BaseReader
      */
     protected function loadSpreadsheetFromFile(string $filename): Spreadsheet
     {
-        // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = $this->newSpreadsheet();
         $spreadsheet->setValueBinder($this->valueBinder);
         $spreadsheet->removeSheetByIndex(0);
 

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -210,8 +210,7 @@ class Html extends BaseReader
      */
     public function loadSpreadsheetFromFile(string $filename): Spreadsheet
     {
-        // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = $this->newSpreadsheet();
         $spreadsheet->setValueBinder($this->valueBinder);
 
         // Load into this instance
@@ -826,7 +825,7 @@ class Html extends BaseReader
         if ($loaded === false) {
             throw new Exception('Failed to load content as a DOM Document', 0, $e ?? null);
         }
-        $spreadsheet = $spreadsheet ?? new Spreadsheet();
+        $spreadsheet = $spreadsheet ?? $this->newSpreadsheet();
         $spreadsheet->setValueBinder($this->valueBinder);
         self::loadProperties($dom, $spreadsheet);
 
@@ -1225,7 +1224,7 @@ class Html extends BaseReader
     public function listWorksheetInfo(string $filename): array
     {
         $info = [];
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = $this->newSpreadsheet();
         $this->loadIntoExisting($filename, $spreadsheet);
         foreach ($spreadsheet->getAllSheets() as $sheet) {
             $newEntry = ['worksheetName' => $sheet->getTitle()];

--- a/src/PhpSpreadsheet/Reader/Ods.php
+++ b/src/PhpSpreadsheet/Reader/Ods.php
@@ -229,8 +229,7 @@ class Ods extends BaseReader
      */
     protected function loadSpreadsheetFromFile(string $filename): Spreadsheet
     {
-        // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = $this->newSpreadsheet();
         $spreadsheet->setValueBinder($this->valueBinder);
         $spreadsheet->removeSheetByIndex(0);
 

--- a/src/PhpSpreadsheet/Reader/Slk.php
+++ b/src/PhpSpreadsheet/Reader/Slk.php
@@ -144,8 +144,7 @@ class Slk extends BaseReader
      */
     protected function loadSpreadsheetFromFile(string $filename): Spreadsheet
     {
-        // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = $this->newSpreadsheet();
         $spreadsheet->setValueBinder($this->valueBinder);
 
         // Load into this instance

--- a/src/PhpSpreadsheet/Reader/Xls/LoadSpreadsheet.php
+++ b/src/PhpSpreadsheet/Reader/Xls/LoadSpreadsheet.php
@@ -26,7 +26,7 @@ class LoadSpreadsheet extends Xls
         $xls->loadOLE($filename);
 
         // Initialisations
-        $xls->spreadsheet = new Spreadsheet();
+        $xls->spreadsheet = $this->newSpreadsheet();
         $xls->spreadsheet->setValueBinder($this->valueBinder);
         $xls->spreadsheet->removeSheetByIndex(0); // remove 1st sheet
         if (!$xls->readDataOnly) {

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -400,7 +400,7 @@ class Xlsx extends BaseReader
         File::assertFile($filename, self::INITIAL_FILE);
 
         // Initialisations
-        $excel = new Spreadsheet();
+        $excel = $this->newSpreadsheet();
         $excel->setValueBinder($this->valueBinder);
         $excel->removeSheetByIndex(0);
         $addingFirstCellStyleXf = true;

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -243,8 +243,7 @@ class Xml extends BaseReader
      */
     public function loadSpreadsheetFromString(string $contents): Spreadsheet
     {
-        // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = $this->newSpreadsheet();
         $spreadsheet->setValueBinder($this->valueBinder);
         $spreadsheet->removeSheetByIndex(0);
 
@@ -257,8 +256,7 @@ class Xml extends BaseReader
      */
     protected function loadSpreadsheetFromFile(string $filename): Spreadsheet
     {
-        // Create new Spreadsheet
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = $this->newSpreadsheet();
         $spreadsheet->setValueBinder($this->valueBinder);
         $spreadsheet->removeSheetByIndex(0);
 

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/MySpreadsheet.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/MySpreadsheet.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+
+class MySpreadsheet extends Spreadsheet
+{
+    public function calcSquare(string $cellAddress): float|int|string
+    {
+        $value = $this->getActiveSheet()
+            ->getCell($cellAddress)
+            ->getValue();
+        if (is_numeric($value)) {
+            return $value * $value;
+        }
+
+        return '#VALUE!';
+    }
+}

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/MyXlsxReader.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/MyXlsxReader.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Reader\Xlsx as XlsxReader;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+
+class MyXlsxReader extends XlsxReader
+{
+    protected function newSpreadsheet(): Spreadsheet
+    {
+        return new MySpreadsheet();
+    }
+}

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/MyXlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/MyXlsxTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
+
+use PHPUnit\Framework\TestCase;
+
+class MyXlsxTest extends TestCase
+{
+    public function testCustomSpreadsheetCustomLoader(): void
+    {
+        $reader = new MyXlsxReader();
+        $infile = 'tests/data/reader/XLSX/colorscale.xlsx';
+        /** @var MySpreadsheet */
+        $mySpreadsheet = $reader->load($infile);
+        self::assertSame(64, $mySpreadsheet->calcSquare('A3'));
+        $mySpreadsheet->disconnectWorksheets();
+    }
+}

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/MyXlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/MyXlsxTest.php
@@ -11,7 +11,7 @@ class MyXlsxTest extends TestCase
     public function testCustomSpreadsheetCustomLoader(): void
     {
         $reader = new MyXlsxReader();
-        $infile = 'tests/data/reader/XLSX/colorscale.xlsx';
+        $infile = 'tests/data/Reader/XLSX/colorscale.xlsx';
         /** @var MySpreadsheet */
         $mySpreadsheet = $reader->load($infile);
         self::assertSame(64, $mySpreadsheet->calcSquare('A3'));


### PR DESCRIPTION
See discussion #4402. Users can extend Spreadsheet, but the readers cannot return the extended class. This is solved pretty easily by adding a protected method in BaseReader which returns a new Spreadsheet. Users can then extend the Reader which they want, overriding that method to return the extended class.

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary
