### PR TITLE
cache the md5 sum in Style/Supervisor.php and subclasses to make getHashCode cheaper

### DIFF
--- a/src/PhpSpreadsheet/Style/Alignment.php
+++ b/src/PhpSpreadsheet/Style/Alignment.php
@@ -223,6 +223,7 @@ class Alignment extends Supervisor
                 $this->setReadOrder($styleArray['readOrder']);
             }
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -259,6 +260,7 @@ class Alignment extends Supervisor
         } else {
             $this->horizontal = $horizontalAlignment;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -288,6 +290,7 @@ class Alignment extends Supervisor
         } else {
             $this->justifyLastLine = $justifyLastLine;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -321,6 +324,7 @@ class Alignment extends Supervisor
         } else {
             $this->vertical = $verticalAlignment;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -360,6 +364,7 @@ class Alignment extends Supervisor
         } else {
             throw new PhpSpreadsheetException('Text rotation should be a value between -90 and 90.');
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -392,6 +397,7 @@ class Alignment extends Supervisor
         } else {
             $this->wrapText = $wrapped;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -424,6 +430,7 @@ class Alignment extends Supervisor
         } else {
             $this->shrinkToFit = $shrink;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -463,6 +470,7 @@ class Alignment extends Supervisor
         } else {
             $this->indent = $indent;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -495,8 +503,28 @@ class Alignment extends Supervisor
         } else {
             $this->readOrder = $readOrder;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
+    }
+
+    /**
+     * Update Hash when something changes.
+     */
+    protected function updateHash(): void
+    {
+        $this->md5Sum = md5(
+            $this->horizontal
+            . (($this->justifyLastLine === null) ? 'null' : ($this->justifyLastLine ? 't' : 'f'))
+            . $this->vertical
+            . $this->textRotation
+            . ($this->wrapText ? 't' : 'f')
+            . ($this->shrinkToFit ? 't' : 'f')
+            . $this->indent
+            . $this->readOrder
+            . __CLASS__
+        );
+        $this->updateMd5Sum = false;
     }
 
     /**
@@ -510,17 +538,11 @@ class Alignment extends Supervisor
             return $this->getSharedComponent()->getHashCode();
         }
 
-        return md5(
-            $this->horizontal
-            . (($this->justifyLastLine === null) ? 'null' : ($this->justifyLastLine ? 't' : 'f'))
-            . $this->vertical
-            . $this->textRotation
-            . ($this->wrapText ? 't' : 'f')
-            . ($this->shrinkToFit ? 't' : 'f')
-            . $this->indent
-            . $this->readOrder
-            . __CLASS__
-        );
+        if ($this->updateMd5Sum) {
+            $this->updateHash();
+        }
+
+        return $this->md5Sum;
     }
 
     protected function exportArray1(): array

--- a/src/PhpSpreadsheet/Style/Border.php
+++ b/src/PhpSpreadsheet/Style/Border.php
@@ -122,6 +122,7 @@ class Border extends Supervisor
                 $this->getColor()->applyFromArray($styleArray['color']);
             }
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -160,6 +161,7 @@ class Border extends Supervisor
         } else {
             $this->borderStyle = $style;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -188,8 +190,22 @@ class Border extends Supervisor
         } else {
             $this->color = $color;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
+    }
+
+    /**
+     * Update Hash when something changes.
+     */
+    protected function updateHash(): void
+    {
+        $this->md5Sum = md5(
+            $this->borderStyle
+            . $this->color->getHashCode()
+            . __CLASS__
+        );
+        $this->updateMd5Sum = false;
     }
 
     /**
@@ -203,11 +219,11 @@ class Border extends Supervisor
             return $this->getSharedComponent()->getHashCode();
         }
 
-        return md5(
-            $this->borderStyle
-            . $this->color->getHashCode()
-            . __CLASS__
-        );
+        if ($this->updateMd5Sum) {
+            $this->updateHash();
+        }
+
+        return $this->md5Sum;
     }
 
     protected function exportArray1(): array

--- a/src/PhpSpreadsheet/Style/Borders.php
+++ b/src/PhpSpreadsheet/Style/Borders.php
@@ -199,6 +199,7 @@ class Borders extends Supervisor
                 $this->getBottom()->applyFromArray($styleArray['allBorders']);
             }
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -330,8 +331,25 @@ class Borders extends Supervisor
         } else {
             $this->diagonalDirection = $direction;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
+    }
+
+    /**
+     * Update Hash when something changes.
+     */
+    protected function updateHash(): void
+    {
+        $this->md5Sum = md5(
+            $this->getLeft()->getHashCode()
+            . $this->getRight()->getHashCode()
+            . $this->getTop()->getHashCode()
+            . $this->getBottom()->getHashCode()
+            . $this->getDiagonal()->getHashCode()
+            . $this->getDiagonalDirection()
+            . __CLASS__
+        );
     }
 
     /**
@@ -345,15 +363,11 @@ class Borders extends Supervisor
             return $this->getSharedComponent()->getHashcode();
         }
 
-        return md5(
-            $this->getLeft()->getHashCode()
-            . $this->getRight()->getHashCode()
-            . $this->getTop()->getHashCode()
-            . $this->getBottom()->getHashCode()
-            . $this->getDiagonal()->getHashCode()
-            . $this->getDiagonalDirection()
-            . __CLASS__
-        );
+        if ($this->updateMd5Sum) {
+            $this->updateHash();
+        }
+
+        return $this->md5Sum;
     }
 
     protected function exportArray1(): array

--- a/src/PhpSpreadsheet/Style/Color.php
+++ b/src/PhpSpreadsheet/Style/Color.php
@@ -246,6 +246,7 @@ class Color extends Supervisor
         } else {
             $this->argb = $colorValue;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -385,6 +386,18 @@ class Color extends Supervisor
     }
 
     /**
+     * Update Hash when something changes.
+     */
+    protected function updateHash(): void
+    {
+        $this->md5Sum = md5(
+            $this->argb
+            . __CLASS__
+        );
+        $this->updateMd5Sum = false;
+    }
+
+    /**
      * Get hash code.
      *
      * @return string Hash code
@@ -395,10 +408,11 @@ class Color extends Supervisor
             return $this->getSharedComponent()->getHashCode();
         }
 
-        return md5(
-            $this->argb
-            . __CLASS__
-        );
+        if ($this->updateMd5Sum) {
+            $this->updateHash();
+        }
+
+        return $this->md5Sum;
     }
 
     protected function exportArray1(): array

--- a/src/PhpSpreadsheet/Style/Fill.php
+++ b/src/PhpSpreadsheet/Style/Fill.php
@@ -177,6 +177,7 @@ class Fill extends Supervisor
         } else {
             $this->fillType = $fillType;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -206,6 +207,7 @@ class Fill extends Supervisor
         } else {
             $this->rotation = $angleInDegrees;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -235,6 +237,7 @@ class Fill extends Supervisor
         } else {
             $this->startColor = $color;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -264,6 +267,7 @@ class Fill extends Supervisor
         } else {
             $this->endColor = $color;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -279,6 +283,18 @@ class Fill extends Supervisor
         return $changed || $this->startColor->getHasChanged() || $this->endColor->getHasChanged();
     }
 
+    protected function updateHash(): void
+    {
+        $this->md5Sum = md5(
+            $this->getFillType()
+            . $this->getRotation()
+            . ($this->getFillType() !== self::FILL_NONE ? $this->getStartColor()->getHashCode() : '')
+            . ($this->getFillType() !== self::FILL_NONE ? $this->getEndColor()->getHashCode() : '')
+            . ((string) $this->getColorsChanged())
+            . __CLASS__
+        );
+    }
+
     /**
      * Get hash code.
      *
@@ -290,16 +306,11 @@ class Fill extends Supervisor
             return $this->getSharedComponent()->getHashCode();
         }
 
-        // Note that we don't care about colours for fill type NONE, but could have duplicate NONEs with
-        //  different hashes if we don't explicitly prevent this
-        return md5(
-            $this->getFillType()
-            . $this->getRotation()
-            . ($this->getFillType() !== self::FILL_NONE ? $this->getStartColor()->getHashCode() : '')
-            . ($this->getFillType() !== self::FILL_NONE ? $this->getEndColor()->getHashCode() : '')
-            . ((string) $this->getColorsChanged())
-            . __CLASS__
-        );
+        if ($this->updateMd5Sum) {
+            $this->updateHash();
+        }
+
+        return $this->md5Sum;
     }
 
     protected function exportArray1(): array

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -217,6 +217,7 @@ class Font extends Supervisor
                 $this->setCap($styleArray['cap']);
             }
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -274,6 +275,7 @@ class Font extends Supervisor
         } else {
             $this->name = $fontname;
         }
+        $this->updateHashBeforeUse();
 
         return $this->setScheme('');
     }
@@ -292,6 +294,7 @@ class Font extends Supervisor
             $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($styleArray);
             // @codeCoverageIgnoreEnd
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -310,6 +313,7 @@ class Font extends Supervisor
             $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($styleArray);
             // @codeCoverageIgnoreEnd
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -328,6 +332,7 @@ class Font extends Supervisor
             $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($styleArray);
             // @codeCoverageIgnoreEnd
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -371,6 +376,7 @@ class Font extends Supervisor
         } else {
             $this->size = $sizeInPoints;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -403,6 +409,7 @@ class Font extends Supervisor
         } else {
             $this->bold = $bold;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -435,6 +442,7 @@ class Font extends Supervisor
         } else {
             $this->italic = $italic;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -467,6 +475,7 @@ class Font extends Supervisor
                 $this->subscript = false;
             }
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -499,6 +508,7 @@ class Font extends Supervisor
                 $this->superscript = false;
             }
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -523,6 +533,7 @@ class Font extends Supervisor
             $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($styleArray);
             // @codeCoverageIgnoreEnd
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -547,6 +558,7 @@ class Font extends Supervisor
             $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($styleArray);
             // @codeCoverageIgnoreEnd
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -571,6 +583,7 @@ class Font extends Supervisor
             $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($styleArray);
             // @codeCoverageIgnoreEnd
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -595,6 +608,7 @@ class Font extends Supervisor
             $this->getActiveSheet()->getStyle($this->getSelectedCells())->applyFromArray($styleArray);
             // @codeCoverageIgnoreEnd
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -602,6 +616,7 @@ class Font extends Supervisor
     public function setChartColorFromObject(?ChartColor $chartColor): self
     {
         $this->chartColor = $chartColor;
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -640,6 +655,7 @@ class Font extends Supervisor
         } else {
             $this->underline = $underlineStyle;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -673,6 +689,7 @@ class Font extends Supervisor
         } else {
             $this->strikethrough = $strikethru;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -701,6 +718,7 @@ class Font extends Supervisor
         } else {
             $this->color = $color;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -718,17 +736,11 @@ class Font extends Supervisor
     }
 
     /**
-     * Get hash code.
-     *
-     * @return string Hash code
+     * Update Hash when something changes.
      */
-    public function getHashCode(): string
+    protected function updateHash(): void
     {
-        if ($this->isSupervisor) {
-            return $this->getSharedComponent()->getHashCode();
-        }
-
-        return md5(
+        $this->md5Sum = md5(
             $this->name
             . $this->size
             . ($this->bold ? 't' : 'f')
@@ -754,6 +766,25 @@ class Font extends Supervisor
             )
             . __CLASS__
         );
+        $this->updateMd5Sum = false;
+    }
+
+    /**
+     * Get hash code.
+     *
+     * @return string Hash code
+     */
+    public function getHashCode(): string
+    {
+        if ($this->isSupervisor) {
+            return $this->getSharedComponent()->getHashCode();
+        }
+
+        if ($this->updateMd5Sum) {
+            $this->updateHash();
+        }
+
+        return $this->md5Sum;
     }
 
     protected function exportArray1(): array
@@ -800,6 +831,7 @@ class Font extends Supervisor
                 $this->scheme = $scheme;
             }
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -814,6 +846,7 @@ class Font extends Supervisor
     public function setCap(string $cap): self
     {
         $this->cap = in_array($cap, self::VALID_CAPS, true) ? $cap : null;
+        $this->updateHashBeforeUse();
 
         return $this;
     }

--- a/src/PhpSpreadsheet/Style/NumberFormat.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat.php
@@ -256,6 +256,7 @@ class NumberFormat extends Supervisor
             $this->formatCode = $formatCode;
             $this->builtInFormatCode = self::builtInFormatCodeIndex($formatCode);
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -290,6 +291,7 @@ class NumberFormat extends Supervisor
             $this->builtInFormatCode = $formatCodeIndex;
             $this->formatCode = self::builtInFormatCode($formatCodeIndex);
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -435,6 +437,19 @@ class NumberFormat extends Supervisor
     }
 
     /**
+     * Update Hash when something changes.
+     */
+    protected function updateHash(): void
+    {
+        $this->md5Sum = md5(
+            $this->formatCode
+            . $this->builtInFormatCode
+            . __CLASS__
+        );
+        $this->updateMd5Sum = false;
+    }
+
+    /**
      * Get hash code.
      *
      * @return string Hash code
@@ -445,11 +460,11 @@ class NumberFormat extends Supervisor
             return $this->getSharedComponent()->getHashCode();
         }
 
-        return md5(
-            $this->formatCode
-            . $this->builtInFormatCode
-            . __CLASS__
-        );
+        if ($this->updateMd5Sum) {
+            $this->updateHash();
+        }
+
+        return $this->md5Sum;
     }
 
     /**

--- a/src/PhpSpreadsheet/Style/Protection.php
+++ b/src/PhpSpreadsheet/Style/Protection.php
@@ -89,6 +89,7 @@ class Protection extends Supervisor
                 $this->setHidden($styleArray['hidden']);
             }
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -120,6 +121,7 @@ class Protection extends Supervisor
         } else {
             $this->locked = $lockType;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -151,8 +153,22 @@ class Protection extends Supervisor
         } else {
             $this->hidden = $hiddenType;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
+    }
+
+    /**
+     * Update Hash when something changes.
+     */
+    protected function updateHash(): void
+    {
+        $this->md5Sum = md5(
+            $this->locked
+            . $this->hidden
+            . __CLASS__
+        );
+        $this->updateMd5Sum = false;
     }
 
     /**
@@ -166,11 +182,11 @@ class Protection extends Supervisor
             return $this->getSharedComponent()->getHashCode();
         }
 
-        return md5(
-            $this->locked
-            . $this->hidden
-            . __CLASS__
-        );
+        if ($this->updateMd5Sum) {
+            $this->updateHash();
+        }
+
+        return $this->md5Sum;
     }
 
     protected function exportArray1(): array

--- a/src/PhpSpreadsheet/Style/Style.php
+++ b/src/PhpSpreadsheet/Style/Style.php
@@ -340,6 +340,7 @@ class Style extends Supervisor
 
                 // restore initial cell selection range
                 $this->getActiveSheet()->getStyle($pRange);
+                $this->updateHashBeforeUse();
 
                 return $this;
             }
@@ -485,6 +486,7 @@ class Style extends Supervisor
                 $this->quotePrefix = $styleArray['quotePrefix'];
             }
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -562,6 +564,7 @@ class Style extends Supervisor
     public function setFont(Font $font): static
     {
         $this->font = $font;
+        $this->updateHashBeforeUse();
 
         return $this;
     }
@@ -650,18 +653,17 @@ class Style extends Supervisor
         } else {
             $this->quotePrefix = (bool) $quotePrefix;
         }
+        $this->updateHashBeforeUse();
 
         return $this;
     }
 
     /**
-     * Get hash code.
-     *
-     * @return string Hash code
+     * Update Hash when something changes.
      */
-    public function getHashCode(): string
+    protected function updateHash(): void
     {
-        return md5(
+        $this->md5Sum = md5(
             $this->fill->getHashCode()
             . $this->font->getHashCode()
             . $this->borders->getHashCode()
@@ -671,6 +673,21 @@ class Style extends Supervisor
             . ($this->quotePrefix ? 't' : 'f')
             . __CLASS__
         );
+        $this->updateMd5Sum = false;
+    }
+
+    /**
+     * Get hash code.
+     *
+     * @return string Hash code
+     */
+    public function getHashCode(): string
+    {
+        if ($this->updateMd5Sum) {
+            $this->updateHash();
+        }
+
+        return $this->md5Sum;
     }
 
     /**

--- a/src/PhpSpreadsheet/Style/Supervisor.php
+++ b/src/PhpSpreadsheet/Style/Supervisor.php
@@ -21,6 +21,16 @@ abstract class Supervisor implements IComparable
     protected $parent;
 
     /**
+     * md5sum.
+     */
+    protected string $md5Sum = '';
+
+    /**
+     * do we need to recalculate the md5sum when next asked.
+     */
+    protected bool $updateMd5Sum = true;
+
+    /**
      * Parent property name.
      */
     protected ?string $parentPropertyName = null;
@@ -49,6 +59,14 @@ abstract class Supervisor implements IComparable
         $this->parentPropertyName = $parentPropertyName;
 
         return $this;
+    }
+
+    /**
+     * update the md5sum before next use.
+     */
+    public function updateHashBeforeUse(): void
+    {
+        $this->updateMd5Sum = true;
     }
 
     /**
@@ -88,6 +106,11 @@ abstract class Supervisor implements IComparable
     {
         return $this->getActiveSheet()->getActiveCell();
     }
+
+    /**
+     * Update Hash when something changes.
+     */
+    abstract protected function updateHash(): void;
 
     /**
      * Implement PHP __clone to create a deep clone, not just a shallow copy.


### PR DESCRIPTION
This pull request introduces a way to cache the md5 sum in Style/Supervisor.php and its subclasses to try and make getHashCode() less expensive to call.

This also introduces the necessity to call updateHashBeforeUse() on those classes when there is a change that affects the hash code to make the hash code update when needed.

Whether this is an acceptable trade-off will be decided by the maintainers.

I _assume_ this is tested by the existing unit tests.

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

The getHashCode function in PhpOffice\PhpSpreadsheet\Style\Supervisor and its subclasses is expensive. Conditional formatting causes new Styles to be created more than in other cases. Cacheing the md5sum of those classes and marking it to be updated upon a change makes the getHashCode function way less expensive.

Below are comparisons of execution times without and with this pull request. (the ep.xlsx contains a lot of conditional formatting (it also exits with a FormulaError)

The gain is ~15% for the conditional formatting- heavy xlsx->html and ~7.5% when all the unit tests are run.

```
git checkout HEAD^
time php test.php -f ../phpspreadsheet-test/stuff/ep.xlsx -p -c -a -t -o e.html

real	1m38,819s
user	1m38,624s
sys	0m0,077s

git checkout master
time php test.php -f ../phpspreadsheet-test/stuff/ep.xlsx -p -c -a -t -o e.html

real	1m23,607s
user	1m23,539s
sys	0m0,064s

git checkout HEAD^
time ./vendor/bin/phpunit --color=always

real	1m4,151s
user	0m55,052s
sys	0m7,844s

git checkout master
time ./vendor/bin/phpunit --color=always

real	0m59,519s
user	0m50,573s
sys	0m7,937s
```