### PR TITLE
Phpstan and Samples

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -28,5 +28,4 @@ parameters:
     ignoreErrors:
         # Accept a bit anything for assert methods
         - '~^Parameter \#2 .* of static method PHPUnit\\Framework\\Assert\:\:assert\w+\(\) expects .*, .* given\.$~'
-        - '~^Variable \$helper might not be defined\.$~'
         - identifier: missingType.iterableValue

--- a/samples/Autofilter/10_Autofilter.php
+++ b/samples/Autofilter/10_Autofilter.php
@@ -3,6 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Autofilter/10_Autofilter_dynamic_dates.php
+++ b/samples/Autofilter/10_Autofilter_dynamic_dates.php
@@ -67,6 +67,7 @@ function createSheet(Sample $helper, Spreadsheet $spreadsheet, string $rule, boo
 }
 
 // Create new Spreadsheet object
+/** @var Sample $helper */
 $helper->log('Create new Spreadsheet object');
 $spreadsheet = new Spreadsheet();
 

--- a/samples/Autofilter/10_Autofilter_selection_1.php
+++ b/samples/Autofilter/10_Autofilter_selection_1.php
@@ -7,6 +7,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column;
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column\Rule;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Autofilter/10_Autofilter_selection_2.php
+++ b/samples/Autofilter/10_Autofilter_selection_2.php
@@ -7,6 +7,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column;
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column\Rule;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Autofilter/10_Autofilter_selection_display.php
+++ b/samples/Autofilter/10_Autofilter_selection_display.php
@@ -7,6 +7,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column;
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column\Rule;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic/01_Simple.php
+++ b/samples/Basic/01_Simple.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Create new Spreadsheet object');
 $spreadsheet = new Spreadsheet();
 

--- a/samples/Basic/02_Types.php
+++ b/samples/Basic/02_Types.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpSpreadsheet\Style\Color;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic/03_Formulas.php
+++ b/samples/Basic/03_Formulas.php
@@ -3,6 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic/04_Printing.php
+++ b/samples/Basic/04_Printing.php
@@ -6,6 +6,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\HeaderFooterDrawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic/05_Feature_demo.php
+++ b/samples/Basic/05_Feature_demo.php
@@ -1,6 +1,7 @@
 <?php
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 
 // Save

--- a/samples/Basic/05_UnexpectedCharacters.php
+++ b/samples/Basic/05_UnexpectedCharacters.php
@@ -1,6 +1,7 @@
 <?php
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet2.php';
 
 // Save

--- a/samples/Basic/06_Largescale.php
+++ b/samples/Basic/06_Largescale.php
@@ -1,7 +1,7 @@
 <?php
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/largeSpreadsheet.php';
 
 // Save

--- a/samples/Basic/07_Reader.php
+++ b/samples/Basic/07_Reader.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create temporary file that will be read
 $sampleSpreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';

--- a/samples/Basic/08_Conditional_formatting.php
+++ b/samples/Basic/08_Conditional_formatting.php
@@ -7,6 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic/08_Conditional_formatting_2.php
+++ b/samples/Basic/08_Conditional_formatting_2.php
@@ -6,6 +6,7 @@ use PhpOffice\PhpSpreadsheet\Style\Conditional;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic/09_Pagebreaks.php
+++ b/samples/Basic/09_Pagebreaks.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic1/11_Documentsecurity.php
+++ b/samples/Basic1/11_Documentsecurity.php
@@ -3,6 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic1/12_CellProtection.php
+++ b/samples/Basic1/12_CellProtection.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Protection;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic1/13_Calculation.php
+++ b/samples/Basic1/13_Calculation.php
@@ -6,6 +6,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 mt_srand(1234567890);
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // List functions
 $helper->log('List implemented functions');

--- a/samples/Basic1/13_CalculationCyclicFormulae.php
+++ b/samples/Basic1/13_CalculationCyclicFormulae.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic1/14_Xls.php
+++ b/samples/Basic1/14_Xls.php
@@ -3,6 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 
 $filename = $helper->getFilename(__FILE__, 'xls');

--- a/samples/Basic1/15_Datavalidation.php
+++ b/samples/Basic1/15_Datavalidation.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Cell\DataValidation;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic1/16_Csv.php
+++ b/samples/Basic1/16_Csv.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Reader\Csv as CsvReader;
 use PhpOffice\PhpSpreadsheet\Writer\Csv as CsvWriter;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 
 $helper->log('Write to CSV format');

--- a/samples/Basic1/17_Html.php
+++ b/samples/Basic1/17_Html.php
@@ -1,6 +1,7 @@
 <?php
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 $spreadsheet->getProperties()->setTitle('Non-embedded images');
 

--- a/samples/Basic1/17a_Html.php
+++ b/samples/Basic1/17a_Html.php
@@ -3,6 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Writer\Html;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 $spreadsheet->getProperties()->setTitle('Embedded images');
 

--- a/samples/Basic1/17b_Html.php
+++ b/samples/Basic1/17b_Html.php
@@ -3,6 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Writer\Html;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 
 function changeGridlines(string $html): string

--- a/samples/Basic1/18_Extendedcalculation.php
+++ b/samples/Basic1/18_Extendedcalculation.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // List functions
 $helper->log('List implemented functions');

--- a/samples/Basic1/19_Namedrange.php
+++ b/samples/Basic1/19_Namedrange.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic2/20_Read_Excel2003XML.php
+++ b/samples/Basic2/20_Read_Excel2003XML.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $filename = __DIR__ . '/../templates/excel2003.xml';
 $callStartTime = microtime(true);
 $spreadsheet = IOFactory::load($filename);

--- a/samples/Basic2/20_Read_Gnumeric.php
+++ b/samples/Basic2/20_Read_Gnumeric.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $filename = __DIR__ . '/../templates/GnumericTest.gnumeric';
 $callStartTime = microtime(true);
 $spreadsheet = IOFactory::load($filename);

--- a/samples/Basic2/20_Read_Ods.php
+++ b/samples/Basic2/20_Read_Ods.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $filename = __DIR__ . '/../templates/OOCalcTest.ods';
 $callStartTime = microtime(true);
 $spreadsheet = IOFactory::load($filename);

--- a/samples/Basic2/20_Read_Sylk.php
+++ b/samples/Basic2/20_Read_Sylk.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $filename = __DIR__ . '/../templates/SylkTest.slk';
 $callStartTime = microtime(true);
 $spreadsheet = IOFactory::load($filename);

--- a/samples/Basic2/20_Read_Xls.php
+++ b/samples/Basic2/20_Read_Xls.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 
 // Write temporary file

--- a/samples/Basic2/22_Heavily_formatted.php
+++ b/samples/Basic2/22_Heavily_formatted.php
@@ -5,6 +5,7 @@ use PhpOffice\PhpSpreadsheet\Style\Border;
 use PhpOffice\PhpSpreadsheet\Style\Fill;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic2/23_Sharedstyles.php
+++ b/samples/Basic2/23_Sharedstyles.php
@@ -6,6 +6,7 @@ use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic2/24_Readfilter.php
+++ b/samples/Basic2/24_Readfilter.php
@@ -7,6 +7,7 @@ use PhpOffice\PhpSpreadsheet\Reader\Xlsx as XlsxReader;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
 require __DIR__ . '/../Header.php';
+/** @var Helper\Sample $helper */
 
 // Write temporary file
 $largeSpreadsheet = require __DIR__ . '/../templates/largeSpreadsheet.php';

--- a/samples/Basic2/25_In_memory_image.php
+++ b/samples/Basic2/25_In_memory_image.php
@@ -5,6 +5,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\MemoryDrawing;
 use PhpOffice\PhpSpreadsheet\Writer\BaseWriter;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic2/26_Utf8.php
+++ b/samples/Basic2/26_Utf8.php
@@ -5,6 +5,7 @@ use PhpOffice\PhpSpreadsheet\Writer\Csv;
 use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Read from Xlsx (.xlsx) template
 $helper->log('Load Xlsx template file');

--- a/samples/Basic2/27_Images_Html_Pdf.php
+++ b/samples/Basic2/27_Images_Html_Pdf.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Read from Xls (.xls) template
 $helper->log('Load Xlsx template file');

--- a/samples/Basic2/27_Images_Xls.php
+++ b/samples/Basic2/27_Images_Xls.php
@@ -3,6 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Read from Xls (.xls) template
 $helper->log('Load Xls template file');

--- a/samples/Basic2/27_Images_Xlsx.php
+++ b/samples/Basic2/27_Images_Xlsx.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Read from Xlsx (.xls) template
 $helper->log('Load Xlsx template file');

--- a/samples/Basic2/28_Iterator.php
+++ b/samples/Basic2/28_Iterator.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Reader\Xlsx as XlsxReader;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $sampleSpreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 $filename = $helper->getTemporaryFilename();
 $writer = new XlsxWriter($sampleSpreadsheet);

--- a/samples/Basic2/29_Advanced_value_binder.php
+++ b/samples/Basic2/29_Advanced_value_binder.php
@@ -5,6 +5,7 @@ use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Set timezone
 $helper->log('Set timezone');

--- a/samples/Basic3/30_Template.php
+++ b/samples/Basic3/30_Template.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Load from Xls template');
 $reader = IOFactory::createReader('Xls');
 $spreadsheet = $reader->load(__DIR__ . '/../templates/30template.xls');

--- a/samples/Basic3/30_Templatebiff5.php
+++ b/samples/Basic3/30_Templatebiff5.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Load from Xls template');
 $reader = IOFactory::createReader('Xls');
 $spreadsheet = $reader->load(__DIR__ . '/../templates/30templatebiff5.xls');

--- a/samples/Basic3/31_Document_properties_write.php
+++ b/samples/Basic3/31_Document_properties_write.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Document\Properties;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xlsx';
 $inputFileName = __DIR__ . '/../templates/31docproperties.xlsx';
 

--- a/samples/Basic3/31_Document_properties_write_xls.php
+++ b/samples/Basic3/31_Document_properties_write_xls.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Document\Properties;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/../templates/31docproperties.xls';
 

--- a/samples/Basic3/37_Page_layout_view.php
+++ b/samples/Basic3/37_Page_layout_view.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\SheetView;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic3/38_Clone_worksheet.php
+++ b/samples/Basic3/38_Clone_worksheet.php
@@ -3,6 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic3/39_Dropdown.php
+++ b/samples/Basic3/39_Dropdown.php
@@ -5,6 +5,7 @@ use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic4/40_Duplicate_style.php
+++ b/samples/Basic4/40_Duplicate_style.php
@@ -5,7 +5,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Create new Spreadsheet object');
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();

--- a/samples/Basic4/41_Password.php
+++ b/samples/Basic4/41_Password.php
@@ -1,6 +1,7 @@
 <?php
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 
 // Set password against the spreadsheet file

--- a/samples/Basic4/42_RichText.php
+++ b/samples/Basic4/42_RichText.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Helper\Html as HtmlHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Basic4/43_Merge_workbooks.php
+++ b/samples/Basic4/43_Merge_workbooks.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Load MergeBook1 from Xlsx file');
 $filename1 = __DIR__ . '/../templates/43mergeBook1.xlsx';
 $callStartTime = microtime(true);

--- a/samples/Basic4/44_Worksheet_info.php
+++ b/samples/Basic4/44_Worksheet_info.php
@@ -5,6 +5,7 @@ use PhpOffice\PhpSpreadsheet\Reader\Xlsx as Reader;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx as Writer;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create temporary file that will be read
 $sampleSpreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';

--- a/samples/Basic4/45_Quadratic_equation_solver.php
+++ b/samples/Basic4/45_Quadratic_equation_solver.php
@@ -5,7 +5,7 @@ use PhpOffice\PhpSpreadsheet\Helper\Sample;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 
 require __DIR__ . '/../Header.php';
-
+/** @var Sample $helper */
 $helper = new Sample();
 if ($helper->isCli()) {
     $helper->log('This example should only be run from a Web Browser' . PHP_EOL);

--- a/samples/Basic4/46_ReadHtml.php
+++ b/samples/Basic4/46_ReadHtml.php
@@ -6,7 +6,7 @@ error_reporting(0);
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $html = __DIR__ . '/../templates/46readHtml.html';
 $callStartTime = microtime(true);
 

--- a/samples/Basic4/47_xlsfill.php
+++ b/samples/Basic4/47_xlsfill.php
@@ -1,6 +1,7 @@
 <?php
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 use PhpOffice\PhpSpreadsheet\Reader\Xls;
 

--- a/samples/Basic4/47_xlsxfill.php
+++ b/samples/Basic4/47_xlsxfill.php
@@ -1,6 +1,7 @@
 <?php
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 

--- a/samples/Basic4/48_Image_move_size_with_cells.php
+++ b/samples/Basic4/48_Image_move_size_with_cells.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Create new Spreadsheet object');
 $spreadsheet = new Spreadsheet();
 $sheet = $spreadsheet->getActiveSheet();

--- a/samples/Basic4/49_alignment.php
+++ b/samples/Basic4/49_alignment.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Create new Spreadsheet object');
 $spreadsheet = new Spreadsheet();
 $spreadsheet->getProperties()->setTitle('Alignment');

--- a/samples/Basic4/50_xlsverticalbreak.php
+++ b/samples/Basic4/50_xlsverticalbreak.php
@@ -1,6 +1,7 @@
 <?php
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 use PhpOffice\PhpSpreadsheet\Reader\Xls;
 

--- a/samples/Basic4/51_ProtectedSort.php
+++ b/samples/Basic4/51_ProtectedSort.php
@@ -1,6 +1,7 @@
 <?php
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\RichText\TextElement;

--- a/samples/Basic4/52_Currency.php
+++ b/samples/Basic4/52_Currency.php
@@ -1,6 +1,7 @@
 <?php
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;

--- a/samples/Basic4/53_ImageOpacity.php
+++ b/samples/Basic4/53_ImageOpacity.php
@@ -1,6 +1,7 @@
 <?php
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;

--- a/samples/Bitwise/BITAND.php
+++ b/samples/Bitwise/BITAND.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'BITAND';
 $description = "Returns a bitwise 'AND' of two numbers";

--- a/samples/Bitwise/BITLSHIFT.php
+++ b/samples/Bitwise/BITLSHIFT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'BITLSHIFT';
 $description = 'Returns a number shifted left by the specified number of bits';

--- a/samples/Bitwise/BITOR.php
+++ b/samples/Bitwise/BITOR.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'BITOR';
 $description = "Returns a bitwise 'OR' of two numbers";

--- a/samples/Bitwise/BITRSHIFT.php
+++ b/samples/Bitwise/BITRSHIFT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'BITRSHIFT';
 $description = 'Returns a number shifted right by the specified number of bits';

--- a/samples/Bitwise/BITXOR.php
+++ b/samples/Bitwise/BITXOR.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'BITXOR';
 $description = "Returns a bitwise 'XOR' of two numbers";

--- a/samples/Chart/32_Chart_read_write.php
+++ b/samples/Chart/32_Chart_read_write.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xlsx';
 $inputFileNames = __DIR__ . '/../templates/32readwrite*[0-9].xlsx';
 

--- a/samples/Chart/32_Chart_read_write_HTML.php
+++ b/samples/Chart/32_Chart_read_write_HTML.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Settings;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Change these values to select the Rendering library that you wish to use
 //Settings::setChartRenderer(\PhpOffice\PhpSpreadsheet\Chart\Renderer\JpGraph::class);

--- a/samples/Chart/32_Chart_read_write_PDF.php
+++ b/samples/Chart/32_Chart_read_write_PDF.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Settings;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 IOFactory::registerWriter('Pdf', PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf::class);
 
 // Change these values to select the Rendering library that you wish to use

--- a/samples/Chart/34_Chart_update.php
+++ b/samples/Chart/34_Chart_update.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Reader\Xlsx as XlsxReader;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create temporary file that will be read
 $sampleSpreadsheet = require __DIR__ . '/../templates/chartSpreadsheet.php';

--- a/samples/Chart/35_Chart_render.php
+++ b/samples/Chart/35_Chart_render.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Settings;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Change these values to select the Rendering library that you wish to use
 //Settings::setChartRenderer(\PhpOffice\PhpSpreadsheet\Chart\Renderer\JpGraph::class);

--- a/samples/Chart/35_Chart_render33.php
+++ b/samples/Chart/35_Chart_render33.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Settings;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Change these values to select the Rendering library that you wish to use
 //Settings::setChartRenderer(\PhpOffice\PhpSpreadsheet\Chart\Renderer\JpGraph::class);

--- a/samples/Chart/37_Chart_dynamic_title.php
+++ b/samples/Chart/37_Chart_dynamic_title.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Settings;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xlsx';
 $inputFileName = __DIR__ . '/../templates/37dynamictitle.xlsx';
 var_dump($inputFileName);

--- a/samples/Chart33a/33_Chart_create_area.php
+++ b/samples/Chart33a/33_Chart_create_area.php
@@ -9,7 +9,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33a/33_Chart_create_area_2.php
+++ b/samples/Chart33a/33_Chart_create_area_2.php
@@ -10,7 +10,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Theme as SpreadsheetTheme;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 // same as 33_Chart_create_area, but with 2013+ schemes
 $spreadsheet->getTheme()->setThemeColorName(SpreadsheetTheme::COLOR_SCHEME_2013_PLUS_NAME);

--- a/samples/Chart33a/33_Chart_create_bar.php
+++ b/samples/Chart33a/33_Chart_create_bar.php
@@ -1,7 +1,7 @@
 <?php
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/chartSpreadsheet.php';
 
 // Save Excel 2007 file

--- a/samples/Chart33a/33_Chart_create_bar_custom_colors.php
+++ b/samples/Chart33a/33_Chart_create_bar_custom_colors.php
@@ -10,7 +10,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33a/33_Chart_create_bar_labels_lines.php
+++ b/samples/Chart33a/33_Chart_create_bar_labels_lines.php
@@ -13,7 +13,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33a/33_Chart_create_bar_stacked.php
+++ b/samples/Chart33a/33_Chart_create_bar_stacked.php
@@ -9,7 +9,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33a/33_Chart_create_bubble.php
+++ b/samples/Chart33a/33_Chart_create_bubble.php
@@ -8,7 +8,7 @@ use PhpOffice\PhpSpreadsheet\Chart\PlotArea;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33a/33_Chart_create_column.php
+++ b/samples/Chart33a/33_Chart_create_column.php
@@ -9,7 +9,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33a/33_Chart_create_column_2.php
+++ b/samples/Chart33a/33_Chart_create_column_2.php
@@ -9,7 +9,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33a/33_Chart_create_composite.alternate.php
+++ b/samples/Chart33a/33_Chart_create_composite.alternate.php
@@ -9,7 +9,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33a/33_Chart_create_composite.php
+++ b/samples/Chart33a/33_Chart_create_composite.php
@@ -9,7 +9,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33a/33_Chart_create_line.php
+++ b/samples/Chart33a/33_Chart_create_line.php
@@ -10,7 +10,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33a/33_Chart_create_line_dateaxis.php
+++ b/samples/Chart33a/33_Chart_create_line_dateaxis.php
@@ -8,7 +8,7 @@ use PhpOffice\PhpSpreadsheet\Shared\Date as SharedDate;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var \PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $dataSheet = $spreadsheet->getActiveSheet();
 $dataSheet->setTitle('Data');

--- a/samples/Chart33b/33_Chart_create_multiple_charts.php
+++ b/samples/Chart33b/33_Chart_create_multiple_charts.php
@@ -9,7 +9,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33b/33_Chart_create_pie.php
+++ b/samples/Chart33b/33_Chart_create_pie.php
@@ -10,7 +10,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33b/33_Chart_create_pie_custom_colors.php
+++ b/samples/Chart33b/33_Chart_create_pie_custom_colors.php
@@ -10,7 +10,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33b/33_Chart_create_radar.php
+++ b/samples/Chart33b/33_Chart_create_radar.php
@@ -10,7 +10,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33b/33_Chart_create_scatter.php
+++ b/samples/Chart33b/33_Chart_create_scatter.php
@@ -9,7 +9,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33b/33_Chart_create_scatter2.php
+++ b/samples/Chart33b/33_Chart_create_scatter2.php
@@ -13,7 +13,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 // changed data to simulate a trend chart - Xaxis are dates; Yaxis are 3 meausurements from each date

--- a/samples/Chart33b/33_Chart_create_scatter3.php
+++ b/samples/Chart33b/33_Chart_create_scatter3.php
@@ -12,7 +12,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 // changed data to simulate a trend chart - Xaxis are dates; Yaxis are 3 meausurements from each date

--- a/samples/Chart33b/33_Chart_create_scatter4.php
+++ b/samples/Chart33b/33_Chart_create_scatter4.php
@@ -10,7 +10,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33b/33_Chart_create_scatter5_trendlines.php
+++ b/samples/Chart33b/33_Chart_create_scatter5_trendlines.php
@@ -13,7 +13,7 @@ use PhpOffice\PhpSpreadsheet\Chart\TrendLine;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $dataSheet = $spreadsheet->getActiveSheet();
 $dataSheet->setTitle('Data');

--- a/samples/Chart33b/33_Chart_create_scatter6_value_xaxis.php
+++ b/samples/Chart33b/33_Chart_create_scatter6_value_xaxis.php
@@ -12,7 +12,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $dataSheet = $spreadsheet->getActiveSheet();
 $dataSheet->setTitle('Data');

--- a/samples/Chart33b/33_Chart_create_scatter7_blanks.php
+++ b/samples/Chart33b/33_Chart_create_scatter7_blanks.php
@@ -9,7 +9,7 @@ use PhpOffice\PhpSpreadsheet\Chart\Title;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33b/33_Chart_create_stock.php
+++ b/samples/Chart33b/33_Chart_create_stock.php
@@ -12,7 +12,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/Chart33b/33_Chart_create_stock2.php
+++ b/samples/Chart33b/33_Chart_create_stock2.php
@@ -12,7 +12,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->getActiveSheet();
 $worksheet->fromArray(

--- a/samples/ComplexNumbers1/COMPLEX.php
+++ b/samples/ComplexNumbers1/COMPLEX.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'COMPLEX';
 $description = 'Converts real and imaginary coefficients into a complex number of the form x + yi or x + yj';

--- a/samples/ComplexNumbers1/IMABS.php
+++ b/samples/ComplexNumbers1/IMABS.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMABS';
 $description = 'Returns the absolute value (modulus) of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers1/IMAGINARY.php
+++ b/samples/ComplexNumbers1/IMAGINARY.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMAGINARY';
 $description = 'Returns the imaginary coefficient of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers1/IMARGUMENT.php
+++ b/samples/ComplexNumbers1/IMARGUMENT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMARGUMENT';
 $description = 'Returns the argument Theta, an angle expressed in radians';

--- a/samples/ComplexNumbers1/IMCONJUGATE.php
+++ b/samples/ComplexNumbers1/IMCONJUGATE.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMCONJUGATE';
 $description = 'Returns the complex conjugate of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers1/IMREAL.php
+++ b/samples/ComplexNumbers1/IMREAL.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMREAL';
 $description = 'Returns the real coefficient of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers2/IMCOS.php
+++ b/samples/ComplexNumbers2/IMCOS.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMCOS';
 $description = 'Returns the cosine of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers2/IMCOSH.php
+++ b/samples/ComplexNumbers2/IMCOSH.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMCOSH';
 $description = 'Returns the hyperbolic cosine of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers2/IMCOT.php
+++ b/samples/ComplexNumbers2/IMCOT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMCOT';
 $description = 'Returns the cotangent of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers2/IMCSC.php
+++ b/samples/ComplexNumbers2/IMCSC.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMCSC';
 $description = 'Returns the cosecant of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers2/IMCSCH.php
+++ b/samples/ComplexNumbers2/IMCSCH.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMCSCH';
 $description = 'Returns the hyperbolic cosecant of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers2/IMDIV.php
+++ b/samples/ComplexNumbers2/IMDIV.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMDIV';
 $description = 'Returns the quotient of two complex numbers in x + yi or x + yj text format';

--- a/samples/ComplexNumbers2/IMEXP.php
+++ b/samples/ComplexNumbers2/IMEXP.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMEXP';
 $description = 'Returns the exponential of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers2/IMLN.php
+++ b/samples/ComplexNumbers2/IMLN.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMLN';
 $description = 'Returns the natural logarithm of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers2/IMLOG10.php
+++ b/samples/ComplexNumbers2/IMLOG10.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMLOG10';
 $description = 'Returns the base-10 logarithm of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers2/IMLOG2.php
+++ b/samples/ComplexNumbers2/IMLOG2.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMLOG2';
 $description = 'Returns the base-2 logarithm of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers3/IMPOWER.php
+++ b/samples/ComplexNumbers3/IMPOWER.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMPOWER';
 $description = 'Returns a complex number in x + yi or x + yj text format raised to a power';

--- a/samples/ComplexNumbers3/IMPRODUCT.php
+++ b/samples/ComplexNumbers3/IMPRODUCT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMPRODUCT';
 $description = 'Returns the product of two or more complex numbers in x + yi or x + yj text format';

--- a/samples/ComplexNumbers3/IMSEC.php
+++ b/samples/ComplexNumbers3/IMSEC.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMSEC';
 $description = 'Returns the secant of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers3/IMSECH.php
+++ b/samples/ComplexNumbers3/IMSECH.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMSECH';
 $description = 'Returns the hyperbolic secant of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers3/IMSIN.php
+++ b/samples/ComplexNumbers3/IMSIN.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMSIN';
 $description = 'Returns the sine of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers3/IMSINH.php
+++ b/samples/ComplexNumbers3/IMSINH.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMSINH';
 $description = 'Returns the hyperbolic sine of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers3/IMSQRT.php
+++ b/samples/ComplexNumbers3/IMSQRT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMSQRT';
 $description = 'Returns the square root of a complex number in x + yi or x + yj text format';

--- a/samples/ComplexNumbers3/IMSUB.php
+++ b/samples/ComplexNumbers3/IMSUB.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMSUB';
 $description = 'Returns the difference of two complex numbers in x + yi or x + yj text format';

--- a/samples/ComplexNumbers3/IMSUM.php
+++ b/samples/ComplexNumbers3/IMSUM.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMSUM';
 $description = 'Returns the sum of two or more complex numbers in x + yi or x + yj text format';

--- a/samples/ComplexNumbers3/IMTAN.php
+++ b/samples/ComplexNumbers3/IMTAN.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'IMTAN';
 $description = 'Returns the tangent of a complex number in x + yi or x + yj text format';

--- a/samples/ConditionalFormatting/01_Basic_Comparisons.php
+++ b/samples/ConditionalFormatting/01_Basic_Comparisons.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/ConditionalFormatting/02_Text_Comparisons.php
+++ b/samples/ConditionalFormatting/02_Text_Comparisons.php
@@ -7,6 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/ConditionalFormatting/03_Blank_Comparisons.php
+++ b/samples/ConditionalFormatting/03_Blank_Comparisons.php
@@ -7,6 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/ConditionalFormatting/04_Error_Comparisons.php
+++ b/samples/ConditionalFormatting/04_Error_Comparisons.php
@@ -7,6 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/ConditionalFormatting/05_Date_Comparisons.php
+++ b/samples/ConditionalFormatting/05_Date_Comparisons.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/ConditionalFormatting/06_Duplicate_Comparisons.php
+++ b/samples/ConditionalFormatting/06_Duplicate_Comparisons.php
@@ -7,6 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/ConditionalFormatting/07_Expression_Comparisons.php
+++ b/samples/ConditionalFormatting/07_Expression_Comparisons.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/ConditionalFormatting/cond08_colorscale.php
+++ b/samples/ConditionalFormatting/cond08_colorscale.php
@@ -7,6 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\ConditionalFormatting\ConditionalColorScale;
 use PhpOffice\PhpSpreadsheet\Style\ConditionalFormatting\ConditionalFormatValueObject;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Database/DAVERAGE.php
+++ b/samples/Database/DAVERAGE.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Database';
 $functionName = 'DAVERAGE';
 $description = 'Returns the average of selected database entries that match criteria';

--- a/samples/Database/DCOUNT.php
+++ b/samples/Database/DCOUNT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Database';
 $functionName = 'DCOUNT';
 $description = 'Counts the cells that contain numbers in a set of database records that match criteria';

--- a/samples/Database/DCOUNTA.php
+++ b/samples/Database/DCOUNTA.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Database';
 $functionName = 'DCOUNTA';
 $description = 'Counts the cells in a set of database records that match criteria';

--- a/samples/Database/DGET.php
+++ b/samples/Database/DGET.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Database';
 $functionName = 'DGET';
 $description = 'Extracts a single value from a column of a list or database that matches criteria that you specify';

--- a/samples/Database/DMAX.php
+++ b/samples/Database/DMAX.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Database';
 $functionName = 'DMAX';
 $description = 'Returns the maximum value from selected database entries';

--- a/samples/Database/DMIN.php
+++ b/samples/Database/DMIN.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Database';
 $functionName = 'DMIN';
 $description = 'Returns the minimum value from selected database entries';

--- a/samples/Database/DPRODUCT.php
+++ b/samples/Database/DPRODUCT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Database';
 $functionName = 'DPRODUCT';
 $description = 'Multiplies the values in a column of a list or database that match conditions that you specify';

--- a/samples/Database/DSTDEV.php
+++ b/samples/Database/DSTDEV.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Database';
 $functionName = 'DSTDEV';
 $description = 'Estimates the standard deviation based on a sample of selected database entries';

--- a/samples/Database/DSTDEVP.php
+++ b/samples/Database/DSTDEVP.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Database';
 $functionName = 'DSTDEVP';
 $description = 'Calculates the standard deviation based on the entire population of selected database entries';

--- a/samples/Database/DSUM.php
+++ b/samples/Database/DSUM.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Database';
 $functionName = 'DSUM';
 $description = 'Returns the sum of selected database entries';

--- a/samples/Database/DVAR.php
+++ b/samples/Database/DVAR.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Database';
 $functionName = 'DVAR';
 $description = 'Estimates variance based on a sample from selected database entries';

--- a/samples/Database/DVARP.php
+++ b/samples/Database/DVARP.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Database';
 $functionName = 'DVARP';
 $description = 'Calculates variance based on the entire population of selected database entries';

--- a/samples/DateTime/DATE.php
+++ b/samples/DateTime/DATE.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'DATE';
 $description = 'Returns the Excel serial number of a particular date';

--- a/samples/DateTime/DATEDIF.php
+++ b/samples/DateTime/DATEDIF.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'DATEDIF';
 $description = 'Calculates the number of days, months, or years between two dates';

--- a/samples/DateTime/DATEVALUE.php
+++ b/samples/DateTime/DATEVALUE.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'DATEVALUE';
 $description = 'Converts a date in the form of text to an Excel serial number';

--- a/samples/DateTime/DAY.php
+++ b/samples/DateTime/DAY.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'DAY';
 $description = 'Returns the day of a date, an integer ranging from 1 to 31';

--- a/samples/DateTime/DAYS.php
+++ b/samples/DateTime/DAYS.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'DAYS';
 $description = 'Returns the number of days between two dates';

--- a/samples/DateTime/DAYS360.php
+++ b/samples/DateTime/DAYS360.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'DAYS360';
 $description = 'Returns the number of days between two dates based on a 360-day year';

--- a/samples/DateTime/EDATE.php
+++ b/samples/DateTime/EDATE.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'EDATE';
 $description = 'Returns the serial number that represents the date that is the indicated number of months before or after a specified date';

--- a/samples/DateTime/EOMONTH.php
+++ b/samples/DateTime/EOMONTH.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'EOMONTH';
 $description = 'Returns the serial number for the last day of the month that is the indicated number of months before or after start_date';

--- a/samples/DateTime/HOUR.php
+++ b/samples/DateTime/HOUR.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'HOUR';
 $description = 'Returns the hour of a time value. The hour is given as an integer, ranging from 0 (12:00 AM) to 23 (11:00 PM)';

--- a/samples/DateTime/ISOWEEKNUM.php
+++ b/samples/DateTime/ISOWEEKNUM.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'ISOWEEKNUM';
 $description = 'Returns number of the ISO week number of the year for a given date. (ISO-8601)';

--- a/samples/DateTime/MINUTE.php
+++ b/samples/DateTime/MINUTE.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'MINUTE';
 $description = 'Returns the minute of a time value. The minute is given as an integer, ranging from 0 to 59';

--- a/samples/DateTime/MONTH.php
+++ b/samples/DateTime/MONTH.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'MONTH';
 $description = 'Returns the month of a date, an integer ranging from 1 to 12';

--- a/samples/DateTime2/NETWORKDAYS.php
+++ b/samples/DateTime2/NETWORKDAYS.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'NETWORKDAYS';
 $description = 'Returns the number of whole working days between start_date and end_date. Working days exclude weekends and any dates identified in holidays';

--- a/samples/DateTime2/NOW.php
+++ b/samples/DateTime2/NOW.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'NOW';
 $description = 'Returns the serial number of the current date and time';

--- a/samples/DateTime2/SECOND.php
+++ b/samples/DateTime2/SECOND.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'SECOND';
 $description = 'Returns the second of a time value. The second is given as an integer, ranging from 0 to 59';

--- a/samples/DateTime2/TIME.php
+++ b/samples/DateTime2/TIME.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'TIME';
 $description = 'Returns the Excel serial number of a particular time';

--- a/samples/DateTime2/TIMEVALUE.php
+++ b/samples/DateTime2/TIMEVALUE.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'DATEVALUE';
 $description = 'Converts a time in the form of text to an Excel serial number';

--- a/samples/DateTime2/TODAY.php
+++ b/samples/DateTime2/TODAY.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'TODAY';
 $description = 'Returns the serial number of the current date';

--- a/samples/DateTime2/WEEKDAY.php
+++ b/samples/DateTime2/WEEKDAY.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'WEEKDAY';
 $description = 'Returns the day of the week corresponding to a date';

--- a/samples/DateTime2/WEEKNUM.php
+++ b/samples/DateTime2/WEEKNUM.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'WEEKNUM';
 $description = 'Returns the week number of a specific date';

--- a/samples/DateTime2/WORKDAY.php
+++ b/samples/DateTime2/WORKDAY.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'WORKDAY';
 $description = 'Returns a number that represents a date that is the indicated number of working days before or after a starting date. Working days exclude weekends and any dates identified as holidays';

--- a/samples/DateTime2/YEAR.php
+++ b/samples/DateTime2/YEAR.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'YEAR';
 $description = 'Returns the year of a date, an integer ranging from 1900 to 9999';

--- a/samples/DateTime2/YEARFRAC.php
+++ b/samples/DateTime2/YEARFRAC.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Date/Time';
 $functionName = 'DAYS360';
 $description = 'Returns the number of days between two dates based on a 360-day year';

--- a/samples/DefinedNames/AbsoluteNamedRange.php
+++ b/samples/DefinedNames/AbsoluteNamedRange.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->setActiveSheetIndex(0);
 

--- a/samples/DefinedNames/CrossWorksheetNamedFormula.php
+++ b/samples/DefinedNames/CrossWorksheetNamedFormula.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 require_once __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 
 $data2019 = [

--- a/samples/DefinedNames/NamedFormulaeAndRanges.php
+++ b/samples/DefinedNames/NamedFormulaeAndRanges.php
@@ -5,7 +5,7 @@ use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require_once __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->setActiveSheetIndex(0);
 

--- a/samples/DefinedNames/RelativeNamedRange.php
+++ b/samples/DefinedNames/RelativeNamedRange.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require_once __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->setActiveSheetIndex(0);
 

--- a/samples/DefinedNames/RelativeNamedRange2.php
+++ b/samples/DefinedNames/RelativeNamedRange2.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require_once __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->setActiveSheetIndex(0);
 

--- a/samples/DefinedNames/RelativeNamedRangeAsFunction.php
+++ b/samples/DefinedNames/RelativeNamedRangeAsFunction.php
@@ -5,7 +5,7 @@ use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require_once __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->setActiveSheetIndex(0);
 

--- a/samples/DefinedNames/ScopedNamedRange.php
+++ b/samples/DefinedNames/ScopedNamedRange.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require_once __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->setActiveSheetIndex(0);
 $worksheet->setTitle('Base Data');

--- a/samples/DefinedNames/ScopedNamedRange2.php
+++ b/samples/DefinedNames/ScopedNamedRange2.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require_once __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->setActiveSheetIndex(0);
 

--- a/samples/DefinedNames/SimpleNamedFormula.php
+++ b/samples/DefinedNames/SimpleNamedFormula.php
@@ -5,7 +5,7 @@ use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require_once __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->setActiveSheetIndex(0);
 

--- a/samples/DefinedNames/SimpleNamedRange.php
+++ b/samples/DefinedNames/SimpleNamedRange.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require_once __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = new Spreadsheet();
 $worksheet = $spreadsheet->setActiveSheetIndex(0);
 

--- a/samples/Engineering/BESSELI.php
+++ b/samples/Engineering/BESSELI.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'BESSELI';
 $description = 'Returns the modified Bessel function, which is equivalent to the Bessel function evaluated for purely imaginary arguments';

--- a/samples/Engineering/BESSELJ.php
+++ b/samples/Engineering/BESSELJ.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'BESSELJ';
 $description = 'Returns the Bessel function';

--- a/samples/Engineering/BESSELK.php
+++ b/samples/Engineering/BESSELK.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'BESSELK';
 $description = 'Returns the modified Bessel function, which is equivalent to the Bessel functions evaluated for purely imaginary arguments';

--- a/samples/Engineering/BESSELY.php
+++ b/samples/Engineering/BESSELY.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'BESSELY';
 $description = 'Returns the Bessel function, which is also called the Weber function or the Neumann function';

--- a/samples/Engineering/CONVERT.php
+++ b/samples/Engineering/CONVERT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'CONVERT';
 $description = 'Converts a number from one measurement system to another';

--- a/samples/Engineering/Convert-Online.php
+++ b/samples/Engineering/Convert-Online.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 
 require __DIR__ . '/../Header.php';
-
+/** @var Sample $helper */
 $helper = new Sample();
 if ($helper->isCli()) {
     $helper->log('This example should only be run from a Web Browser' . PHP_EOL);

--- a/samples/Engineering/DELTA.php
+++ b/samples/Engineering/DELTA.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'DELTA';
 $description = 'Tests whether two values are equal. Returns 1 if number1 = number2; returns 0 otherwise. This function is also known as the Kronecker Delta function';

--- a/samples/Engineering/ERF.php
+++ b/samples/Engineering/ERF.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'ERF';
 $description = 'Returns the error function integrated between lower_limit and upper_limit';

--- a/samples/Engineering/ERFC.php
+++ b/samples/Engineering/ERFC.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'ERFC';
 $description = 'Returns the complementary ERF function integrated between x and infinity';

--- a/samples/Engineering/GESTEP.php
+++ b/samples/Engineering/GESTEP.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'GESTEP';
 $description = 'Returns 1 if number ≥ step; returns 0 (zero) otherwise';

--- a/samples/Financial1/ACCRINT.php
+++ b/samples/Financial1/ACCRINT.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel\Helpers as DateHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the accrued interest for a security that pays periodic interest.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial1/ACCRINTM.php
+++ b/samples/Financial1/ACCRINTM.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel\Helpers as DateHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the accrued interest for a security that pays interest at maturity.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial1/AMORDEGRC.php
+++ b/samples/Financial1/AMORDEGRC.php
@@ -5,7 +5,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Financial\Constants as FinancialConstan
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the prorated linear depreciation of an asset for a specified accounting period.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial1/AMORLINC.php
+++ b/samples/Financial1/AMORLINC.php
@@ -5,7 +5,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Financial\Constants as FinancialConstan
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the prorated linear depreciation of an asset for a specified accounting period.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial1/COUPDAYBS.php
+++ b/samples/Financial1/COUPDAYBS.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel\Helpers as DateHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the number of days from the beginning of a coupon\'s period to the settlement date.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial1/COUPDAYS.php
+++ b/samples/Financial1/COUPDAYS.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel\Helpers as DateHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the number of days in the coupon period that contains the settlement date.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial1/COUPDAYSNC.php
+++ b/samples/Financial1/COUPDAYSNC.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel\Helpers as DateHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the number of days from the settlement date to the next coupon date.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial1/COUPNCD.php
+++ b/samples/Financial1/COUPNCD.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel\Helpers as DateHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the next coupon date, after the settlement date.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial1/COUPNUM.php
+++ b/samples/Financial1/COUPNUM.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel\Helpers as DateHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the number of coupons payable, between a security\'s settlement date and maturity date,');
 $helper->log('rounded up to the nearest whole coupon.');
 

--- a/samples/Financial1/COUPPCD.php
+++ b/samples/Financial1/COUPPCD.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel\Helpers as DateHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the previous coupon date, before the settlement date for a security.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial1/CUMIPMT.php
+++ b/samples/Financial1/CUMIPMT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the cumulative interest paid on a loan or investment, between two specified periods.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial1/CUMPRINC.php
+++ b/samples/Financial1/CUMPRINC.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the cumulative payment on the principal of a loan or investment, between two specified periods.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial2/DB.php
+++ b/samples/Financial2/DB.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the depreciation of an asset, using the Fixed Declining Balance Method,');
 $helper->log('for each period of the asset\'s lifetime.');
 

--- a/samples/Financial2/DDB.php
+++ b/samples/Financial2/DDB.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the depreciation of an asset, using the Double Declining Balance Method,');
 $helper->log('for each period of the asset\'s lifetime.');
 

--- a/samples/Financial2/DISC.php
+++ b/samples/Financial2/DISC.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel\Helpers as DateHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the Discount Rate for a security.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial2/DOLLARDE.php
+++ b/samples/Financial2/DOLLARDE.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the dollar value in fractional notation, into a dollar value expressed as a decimal.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial2/DOLLARFR.php
+++ b/samples/Financial2/DOLLARFR.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the dollar value expressed as a decimal number, into a dollar price, expressed as a fraction.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial2/EFFECT.php
+++ b/samples/Financial2/EFFECT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the effective annual interest rate for a given nominal interest rate and number of');
 $helper->log('compounding periods per year.');
 

--- a/samples/Financial2/FV.php
+++ b/samples/Financial2/FV.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the Future Value of an investment with periodic constant payments and a constant interest rate.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial2/FVSCHEDULE.php
+++ b/samples/Financial2/FVSCHEDULE.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the Future Value of an initial principal, after applying a series of compound interest rates.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial3/INTRATE.php
+++ b/samples/Financial3/INTRATE.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\DateTimeExcel\Helpers as DateHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the interest rate for a fully invested security.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial3/IPMT.php
+++ b/samples/Financial3/IPMT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the interest payment, during a specific period of a loan or investment that is paid in,');
 $helper->log('constant periodic payments, with a constant interest rate.');
 

--- a/samples/Financial3/IRR.php
+++ b/samples/Financial3/IRR.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the Internal Rate of Return for a supplied series of periodic cash flows.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial3/ISPMT.php
+++ b/samples/Financial3/ISPMT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the interest paid during a specific period of a loan or investment.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial3/MIRR.php
+++ b/samples/Financial3/MIRR.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the Modified Internal Rate of Return for a supplied series of periodic cash flows.');
 
 // Create new PhpSpreadsheet object

--- a/samples/Financial3/NOMINAL.php
+++ b/samples/Financial3/NOMINAL.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the nominal interest rate for a given effective interest rate and number of');
 $helper->log('compounding periods per year.');
 

--- a/samples/Financial3/NPER.php
+++ b/samples/Financial3/NPER.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Financial\Constants as FinancialConstan
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the number of periods required to pay off a loan, for a constant periodic payment');
 $helper->log('and a constant interest rate.');
 

--- a/samples/Financial3/NPV.php
+++ b/samples/Financial3/NPV.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the Net Present Value of an investment, based on a supplied discount rate,');
 $helper->log('and a series of future payments and income.');
 

--- a/samples/HexEtcConversions/BIN2DEC.php
+++ b/samples/HexEtcConversions/BIN2DEC.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'BIN2DEC';
 $description = 'Converts a binary number to decimal';

--- a/samples/HexEtcConversions/BIN2HEX.php
+++ b/samples/HexEtcConversions/BIN2HEX.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'BIN2HEX';
 $description = 'Converts a binary number to hexadecimal';

--- a/samples/HexEtcConversions/BIN2OCT.php
+++ b/samples/HexEtcConversions/BIN2OCT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'BIN2OCT';
 $description = 'Converts a binary number to octal';

--- a/samples/HexEtcConversions/DEC2BIN.php
+++ b/samples/HexEtcConversions/DEC2BIN.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'DEC2BIN';
 $description = 'Converts a decimal number to binary';

--- a/samples/HexEtcConversions/DEC2HEX.php
+++ b/samples/HexEtcConversions/DEC2HEX.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'DEC2HEX';
 $description = 'Converts a decimal number to hexadecimal';

--- a/samples/HexEtcConversions/DEC2OCT.php
+++ b/samples/HexEtcConversions/DEC2OCT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'DEC2OCT';
 $description = 'Converts a decimal number to octal';

--- a/samples/HexEtcConversions/HEX2BIN.php
+++ b/samples/HexEtcConversions/HEX2BIN.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'HEX2BIN';
 $description = 'Converts a hexadecimal number to binary';

--- a/samples/HexEtcConversions/HEX2DEC.php
+++ b/samples/HexEtcConversions/HEX2DEC.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'HEX2DEC';
 $description = 'Converts a hexadecimal number to decimal';

--- a/samples/HexEtcConversions/HEX2OCT.php
+++ b/samples/HexEtcConversions/HEX2OCT.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'HEX2OCT';
 $description = 'Converts a hexadecimal number to octal';

--- a/samples/HexEtcConversions/OCT2BIN.php
+++ b/samples/HexEtcConversions/OCT2BIN.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'OCT2BIN';
 $description = 'Converts an octal number to binary';

--- a/samples/HexEtcConversions/OCT2DEC.php
+++ b/samples/HexEtcConversions/OCT2DEC.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'OCT2DEC';
 $description = 'Converts an octal number to decimal';

--- a/samples/HexEtcConversions/OCT2HEX.php
+++ b/samples/HexEtcConversions/OCT2HEX.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $category = 'Engineering';
 $functionName = 'OCT2HEX';
 $description = 'Converts an octal number to hexadecimal';

--- a/samples/Html/html_01_Basic_Conditional_Formatting.php
+++ b/samples/Html/html_01_Basic_Conditional_Formatting.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Writer\Html as HtmlWriter;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = 'BasicConditionalFormatting.xlsx';
 $inputFilePath = __DIR__ . '/../templates/' . $inputFileName;
 

--- a/samples/Html/html_02_More_Conditional_Formatting.php
+++ b/samples/Html/html_02_More_Conditional_Formatting.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Writer\Html as HtmlWriter;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = 'ConditionalFormattingConditions.xlsx';
 $inputFilePath = __DIR__ . '/../templates/' . $inputFileName;
 

--- a/samples/Html/html_03_Color_Scale.php
+++ b/samples/Html/html_03_Color_Scale.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Writer\Html as HtmlWriter;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = 'ColourScale.xlsx';
 $inputFilePath = __DIR__ . '/../templates/' . $inputFileName;
 

--- a/samples/Html/html_04_Table_Format_without_Conditional.php
+++ b/samples/Html/html_04_Table_Format_without_Conditional.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Writer\Html as HtmlWriter;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = 'TableFormat.xlsx';
 $inputFilePath = __DIR__ . '/../templates/' . $inputFileName;
 

--- a/samples/Html/html_05_Table_Format_with_Conditional.php
+++ b/samples/Html/html_05_Table_Format_with_Conditional.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Writer\Html as HtmlWriter;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = 'TableFormat.xlsx';
 $inputFilePath = __DIR__ . '/../templates/' . $inputFileName;
 

--- a/samples/LookupRef/ADDRESS.php
+++ b/samples/LookupRef/ADDRESS.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns a text reference to a single cell in a worksheet.');
 
 // Create new PhpSpreadsheet object

--- a/samples/LookupRef/COLUMN.php
+++ b/samples/LookupRef/COLUMN.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the column index of a cell.');
 
 // Create new PhpSpreadsheet object

--- a/samples/LookupRef/COLUMNS.php
+++ b/samples/LookupRef/COLUMNS.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the number of columns in an array or reference.');
 
 // Create new PhpSpreadsheet object

--- a/samples/LookupRef/INDEX.php
+++ b/samples/LookupRef/INDEX.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the row index of a cell.');
 
 // Create new PhpSpreadsheet object

--- a/samples/LookupRef/INDIRECT.php
+++ b/samples/LookupRef/INDIRECT.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\NamedRange;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the cell specified by a text string.');
 
 // Create new PhpSpreadsheet object

--- a/samples/LookupRef/OFFSET.php
+++ b/samples/LookupRef/OFFSET.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns a cell range that is a specified number of rows and columns from a cell or range of cells.');
 
 // Create new PhpSpreadsheet object

--- a/samples/LookupRef/ROW.php
+++ b/samples/LookupRef/ROW.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the row index of a cell.');
 
 // Create new PhpSpreadsheet object

--- a/samples/LookupRef/ROWS.php
+++ b/samples/LookupRef/ROWS.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Returns the row index of a cell.');
 
 // Create new PhpSpreadsheet object

--- a/samples/LookupRef/VLOOKUP.php
+++ b/samples/LookupRef/VLOOKUP.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Searches for a value in the top row of a table or an array of values,
                 and then returns a value in the same column from a row you specify
                 in the table or array.');

--- a/samples/Pdf/21_Pdf_Domdf.php
+++ b/samples/Pdf/21_Pdf_Domdf.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 
 $helper->log('Hide grid lines');

--- a/samples/Pdf/21_Pdf_TCPDF.php
+++ b/samples/Pdf/21_Pdf_TCPDF.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 
 $helper->log('Hide grid lines');

--- a/samples/Pdf/21_Pdf_mPDF.php
+++ b/samples/Pdf/21_Pdf_mPDF.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 
 $helper->log('Hide grid lines');

--- a/samples/Pdf/21a_Pdf.php
+++ b/samples/Pdf/21a_Pdf.php
@@ -5,6 +5,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 
 $helper->log('Hide grid lines');

--- a/samples/Pdf/21b_Pdf.php
+++ b/samples/Pdf/21b_Pdf.php
@@ -26,6 +26,7 @@ function replaceBody(string $html): string
 }
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $spreadsheet = require __DIR__ . '/../templates/sampleSpreadsheet.php';
 
 $helper->log('Hide grid lines');

--- a/samples/Pdf/21c_Pdf.php
+++ b/samples/Pdf/21c_Pdf.php
@@ -47,6 +47,7 @@ function addHeadersFootersMpdf2000(string $html): string
 $spreadsheet = new Spreadsheet();
 $sheet = $spreadsheet->getActiveSheet();
 $counter = 0;
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Populate spreadsheet');
 for ($row = 1; $row < 1001; ++$row) {
     $sheet->getCell("A$row")->setValue(++$counter);

--- a/samples/Pdf/21d_FitToHeightPdf.php
+++ b/samples/Pdf/21d_FitToHeightPdf.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Issue 3266 - spreadsheet specified fitToHeight.
 $helper->log('Read spreadsheet');

--- a/samples/Pdf/21e_UnusualFont_mpdf.php
+++ b/samples/Pdf/21e_UnusualFont_mpdf.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf2;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 require_once __DIR__ . '/Mpdf2.php';
 
 $spreadsheet = new Spreadsheet();

--- a/samples/Pdf/21f_Drawing_mpdf.php
+++ b/samples/Pdf/21f_Drawing_mpdf.php
@@ -5,6 +5,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
 use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 require_once __DIR__ . '/Mpdf2.php';
 
 $spreadsheet = new Spreadsheet();

--- a/samples/Reader/01_Simple_file_reader_using_IOFactory.php
+++ b/samples/Reader/01_Simple_file_reader_using_IOFactory.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 $helper->log('Loading file ' . pathinfo($inputFileName, PATHINFO_BASENAME) . ' using IOFactory to identify the format');
 $spreadsheet = IOFactory::load($inputFileName);

--- a/samples/Reader/02_Simple_file_reader_using_a_specified_reader.php
+++ b/samples/Reader/02_Simple_file_reader_using_a_specified_reader.php
@@ -3,6 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Reader\Xls;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 
 $helper->log('Loading file ' . pathinfo($inputFileName, PATHINFO_BASENAME) . ' using ' . Xls::class);

--- a/samples/Reader/03_Simple_file_reader_using_the_IOFactory_to_return_a_reader.php
+++ b/samples/Reader/03_Simple_file_reader_using_the_IOFactory_to_return_a_reader.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 

--- a/samples/Reader/04_Simple_file_reader_using_the_IOFactory_to_identify_a_reader_to_use.php
+++ b/samples/Reader/04_Simple_file_reader_using_the_IOFactory_to_identify_a_reader_to_use.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 
 $inputFileType = IOFactory::identify($inputFileName);

--- a/samples/Reader/05_Simple_file_reader_using_the_read_data_only_option.php
+++ b/samples/Reader/05_Simple_file_reader_using_the_read_data_only_option.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 

--- a/samples/Reader/06_Simple_file_reader_loading_all_worksheets.php
+++ b/samples/Reader/06_Simple_file_reader_loading_all_worksheets.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 

--- a/samples/Reader/07_Simple_file_reader_loading_a_single_named_worksheet.php
+++ b/samples/Reader/07_Simple_file_reader_loading_a_single_named_worksheet.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 $sheetname = 'Data Sheet #2';

--- a/samples/Reader/08_Simple_file_reader_loading_several_named_worksheets.php
+++ b/samples/Reader/08_Simple_file_reader_loading_several_named_worksheets.php
@@ -14,6 +14,7 @@ $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 $sheetnames = getDesiredSheetNames();
 
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Loading file ' . pathinfo($inputFileName, PATHINFO_BASENAME) . ' using IOFactory with a defined reader type of ' . $inputFileType);
 $reader = IOFactory::createReader($inputFileType);
 $helper->log('Loading Sheets "' . implode('" and "', $sheetnames) . '" only');

--- a/samples/Reader/09_Simple_file_reader_using_a_read_filter.php
+++ b/samples/Reader/09_Simple_file_reader_using_a_read_filter.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
 
 require __DIR__ . '/../Header.php';
-
+/** @var \PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 $sheetname = 'Data Sheet #3';

--- a/samples/Reader/10_Simple_file_reader_using_a_configurable_read_filter.php
+++ b/samples/Reader/10_Simple_file_reader_using_a_configurable_read_filter.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
 
 require __DIR__ . '/../Header.php';
-
+/** @var \PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 $sheetname = 'Data Sheet #3';

--- a/samples/Reader/11_Reading_a_workbook_in_chunks_using_a_configurable_read_filter_(version_1).php
+++ b/samples/Reader/11_Reading_a_workbook_in_chunks_using_a_configurable_read_filter_(version_1).php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
 
 require __DIR__ . '/../Header.php';
-
+/** @var \PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/sampleData/example2.xls';
 

--- a/samples/Reader/12_Reading_a_workbook_in_chunks_using_a_configurable_read_filter_(version_2).php
+++ b/samples/Reader/12_Reading_a_workbook_in_chunks_using_a_configurable_read_filter_(version_2).php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
 
 require __DIR__ . '/../Header.php';
-
+/** @var \PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/sampleData/example2.xls';
 

--- a/samples/Reader2/13_Simple_file_reader_for_multiple_CSV_files.php
+++ b/samples/Reader2/13_Simple_file_reader_for_multiple_CSV_files.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Reader\Csv;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileNames = [__DIR__ . '/sampleData/example1.csv', __DIR__ . '/sampleData/example2.csv'];
 
 $reader = new Csv();

--- a/samples/Reader2/14_Reading_a_large_CSV_file_in_chunks_to_split_across_multiple_worksheets.php
+++ b/samples/Reader2/14_Reading_a_large_CSV_file_in_chunks_to_split_across_multiple_worksheets.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
-
+/** @var \PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = __DIR__ . '/sampleData/example2.csv';
 
 /**  Define a Read Filter class implementing IReadFilter  */

--- a/samples/Reader2/15_Simple_file_reader_for_tab_separated_value_file_using_the_Advanced_Value_Binder.php
+++ b/samples/Reader2/15_Simple_file_reader_for_tab_separated_value_file_using_the_Advanced_Value_Binder.php
@@ -5,7 +5,7 @@ use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Reader\Csv;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 Cell::setValueBinder(new AdvancedValueBinder());
 
 $inputFileName = __DIR__ . '/sampleData/example1.tsv';

--- a/samples/Reader2/16_Handling_loader_exceptions_using_TryCatch.php
+++ b/samples/Reader2/16_Handling_loader_exceptions_using_TryCatch.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\Exception as ReaderException;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = __DIR__ . '/sampleData/non-existing-file.xls';
 $helper->log('Loading file ' . pathinfo($inputFileName, PATHINFO_BASENAME) . ' using IOFactory to identify the format');
 

--- a/samples/Reader2/17_Simple_file_reader_loading_several_named_worksheets.php
+++ b/samples/Reader2/17_Simple_file_reader_loading_several_named_worksheets.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Reader\Xls;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 
 $helper->log('Loading file ' . pathinfo($inputFileName, PATHINFO_BASENAME) . ' using Xls reader');

--- a/samples/Reader2/18_Reading_list_of_worksheets_without_loading_entire_file.php
+++ b/samples/Reader2/18_Reading_list_of_worksheets_without_loading_entire_file.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Reader\Xls;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 
 $helper->log('Loading file ' . pathinfo($inputFileName, PATHINFO_BASENAME) . ' information using Xls reader');

--- a/samples/Reader2/19_Reading_worksheet_information_without_loading_entire_file.php
+++ b/samples/Reader2/19_Reading_worksheet_information_without_loading_entire_file.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\Reader\Xls;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 

--- a/samples/Reader2/20_Reader_worksheet_hyperlink_image.php
+++ b/samples/Reader2/20_Reader_worksheet_hyperlink_image.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Shared\File;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xlsx';
 
 $helper->log('Start');

--- a/samples/Reader2/21_Reader_CSV_Long_Integers_with_String_Value_Binder.php
+++ b/samples/Reader2/21_Reader_CSV_Long_Integers_with_String_Value_Binder.php
@@ -5,7 +5,7 @@ use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 Cell::setValueBinder(new StringValueBinder());
 
 $inputFileType = 'Csv';

--- a/samples/Reader2/22_Reader_formscomments.php
+++ b/samples/Reader2/22_Reader_formscomments.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Start');
 
 $inputFileType = 'Xlsx';

--- a/samples/Reader2/22_Reader_issue1767.php
+++ b/samples/Reader2/22_Reader_issue1767.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Start');
 
 $inputFileType = 'Xlsx';

--- a/samples/Reader2/23_iterateRowsYield.php
+++ b/samples/Reader2/23_iterateRowsYield.php
@@ -5,7 +5,7 @@
  */
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileName = __DIR__ . '/../Reader/sampleData/example1.xls';
 
 $spreadsheet = PhpOffice\PhpSpreadsheet\IOFactory::load(

--- a/samples/Reading_workbook_data/Custom_properties.php
+++ b/samples/Reading_workbook_data/Custom_properties.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xlsx';
 $inputFileName = __DIR__ . '/sampleData/example1.xlsx';
 

--- a/samples/Reading_workbook_data/Custom_property_names.php
+++ b/samples/Reading_workbook_data/Custom_property_names.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xlsx';
 $inputFileName = __DIR__ . '/sampleData/example1.xlsx';
 

--- a/samples/Reading_workbook_data/Properties.php
+++ b/samples/Reading_workbook_data/Properties.php
@@ -4,7 +4,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/sampleData/example1.xls';
 

--- a/samples/Reading_workbook_data/Worksheet_count_and_names.php
+++ b/samples/Reading_workbook_data/Worksheet_count_and_names.php
@@ -3,7 +3,7 @@
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $inputFileType = 'Xls';
 $inputFileName = __DIR__ . '/sampleData/example2.xls';
 

--- a/samples/Table/01_Table.php
+++ b/samples/Table/01_Table.php
@@ -6,6 +6,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Table;
 use PhpOffice\PhpSpreadsheet\Worksheet\Table\TableStyle;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Table/02_Table_Total.php
+++ b/samples/Table/02_Table_Total.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Table;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Table/03_Column_Formula.php
+++ b/samples/Table/03_Column_Formula.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Table;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Table/04_Column_Formula_with_Totals.php
+++ b/samples/Table/04_Column_Formula_with_Totals.php
@@ -4,6 +4,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Table;
 
 require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 
 // Create new Spreadsheet object
 $helper->log('Create new Spreadsheet object');

--- a/samples/Wizards/NumberFormat/Accounting.php
+++ b/samples/Wizards/NumberFormat/Accounting.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat\Wizard;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 if ($helper->isCli()) {
     $helper->log('This example should only be run from a Web Browser' . PHP_EOL);
 

--- a/samples/Wizards/NumberFormat/Currency.php
+++ b/samples/Wizards/NumberFormat/Currency.php
@@ -8,7 +8,7 @@ use PhpOffice\PhpSpreadsheet\Style\NumberFormat\Wizard\CurrencyNegative;
 use PhpOffice\PhpSpreadsheet\Writer\Html as HtmlWriter;
 
 require __DIR__ . '/../Header.php';
-
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 if ($helper->isCli()) {
     $helper->log('This example should only be run from a Web Browser' . PHP_EOL);
 

--- a/samples/Wizards/NumberFormat/Number.php
+++ b/samples/Wizards/NumberFormat/Number.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat\Wizard;
 
 require __DIR__ . '/../Header.php';
-
+/** @var Sample $helper */
 $helper = new Sample();
 if ($helper->isCli()) {
     $helper->log('This example should only be run from a Web Browser' . PHP_EOL);

--- a/samples/Wizards/NumberFormat/Percentage.php
+++ b/samples/Wizards/NumberFormat/Percentage.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat\Wizard;
 
 require __DIR__ . '/../Header.php';
-
+/** @var Sample $helper */
 $helper = new Sample();
 if ($helper->isCli()) {
     $helper->log('This example should only be run from a Web Browser' . PHP_EOL);

--- a/samples/Wizards/NumberFormat/Scientific.php
+++ b/samples/Wizards/NumberFormat/Scientific.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat\Wizard;
 
 require __DIR__ . '/../Header.php';
-
+/** @var Sample $helper */
 $helper = new Sample();
 if ($helper->isCli()) {
     $helper->log('This example should only be run from a Web Browser' . PHP_EOL);

--- a/samples/index.php
+++ b/samples/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'Header.php';
+require_once __DIR__ . '/Header.php';
 
 $requirements = [
     'PHP 8.1' => version_compare(PHP_VERSION, '8.1', '>='),
@@ -12,6 +12,7 @@ $requirements = [
     'PHP extension dom (optional)' => extension_loaded('dom'),
 ];
 
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 if (!$helper->isCli()) {
     ?>
     <div class="jumbotron">

--- a/samples/templates/chartSpreadsheet.php
+++ b/samples/templates/chartSpreadsheet.php
@@ -95,6 +95,7 @@ $chart->setBottomRightPosition('H20');
 // Add the chart to the worksheet
 $worksheet->addChart($chart);
 
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->renderChart($chart, __FILE__);
 
 return $spreadsheet;

--- a/samples/templates/largeSpreadsheet.php
+++ b/samples/templates/largeSpreadsheet.php
@@ -3,6 +3,7 @@
 // Create new Spreadsheet object
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Create new Spreadsheet object');
 $spreadsheet = new Spreadsheet();
 

--- a/samples/templates/sampleSpreadsheet.php
+++ b/samples/templates/sampleSpreadsheet.php
@@ -14,6 +14,7 @@ use PhpOffice\PhpSpreadsheet\Style\Protection;
 use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Create new Spreadsheet object');
 $spreadsheet = new Spreadsheet();
 

--- a/samples/templates/sampleSpreadsheet2.php
+++ b/samples/templates/sampleSpreadsheet2.php
@@ -14,6 +14,7 @@ use PhpOffice\PhpSpreadsheet\Style\Protection;
 use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
 $helper->log('Create new Spreadsheet object');
 $spreadsheet = new Spreadsheet();
 

--- a/src/PhpSpreadsheet/Helper/Sample.php
+++ b/src/PhpSpreadsheet/Helper/Sample.php
@@ -185,10 +185,10 @@ class Sample
         return $temporaryFilename . '.' . $extension;
     }
 
-    public function log(string $message): void
+    public function log(mixed $message): void
     {
         $eol = $this->isCli() ? PHP_EOL : '<br />';
-        echo ($this->isCli() ? date('H:i:s ') : '') . $message . $eol;
+        echo ($this->isCli() ? date('H:i:s ') : '') . StringHelper::convertToString($message) . $eol;
     }
 
     /**


### PR DESCRIPTION
Phpstan hasn't identified any errors in Samples in a long time. But, as it turns out, one particular error is suppressed:
```
Variable $helper might not be defined.
```
This error would be generated by almost all samples, and the errors that it suppresses will become problematic if we move to Level 10. We are not yet committed to doing that, but it is pretty easy to write a script to change the samples so that error no longer happens, and there isn't really any reason to delay doing so. The results of that script constitute this PR.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
