### PR TITLE
Micro-optimization for excelToDateTimeObject

### DIFF
--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -214,6 +214,13 @@ class Date
             $baseDate = new DateTime('1899-12-30', $timeZone);
         }
 
+        if (is_int($excelTimestamp)) {
+            if ($excelTimestamp >= 0) {
+                return $baseDate->modify("+ $excelTimestamp days");
+            }
+
+            return $baseDate->modify("$excelTimestamp days");
+        }
         $days = floor($excelTimestamp);
         $partDay = $excelTimestamp - $days;
         $hms = 86400 * $partDay;

--- a/tests/PhpSpreadsheetTests/Style/NumberFormatTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormatTest.php
@@ -4,17 +4,22 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Style;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat\NumberFormatter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class NumberFormatTest extends TestCase
 {
+    private string $compatibilityMode;
+
     protected function setUp(): void
     {
         StringHelper::setDecimalSeparator('.');
         StringHelper::setThousandsSeparator(',');
+        $this->compatibilityMode = Functions::getCompatibilityMode();
     }
 
     protected function tearDown(): void
@@ -22,12 +27,13 @@ class NumberFormatTest extends TestCase
         StringHelper::setCurrencyCode(null);
         StringHelper::setDecimalSeparator(null);
         StringHelper::setThousandsSeparator(null);
+        Functions::setCompatibilityMode($this->compatibilityMode);
     }
 
     /**
      * @param null|bool|float|int|string $args string to be formatted
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerNumberFormat')]
+    #[DataProvider('providerNumberFormat')]
     public function testFormatValueWithMask(mixed $expectedResult, mixed ...$args): void
     {
         $result = NumberFormat::toFormattedString(...$args);
@@ -42,7 +48,7 @@ class NumberFormatTest extends TestCase
     /**
      * @param null|bool|float|int|string $args string to be formatted
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerNumberFormatFractions')]
+    #[DataProvider('providerNumberFormatFractions')]
     public function testFormatValueWithMaskFraction(mixed $expectedResult, mixed ...$args): void
     {
         $result = NumberFormat::toFormattedString(...$args);
@@ -57,7 +63,7 @@ class NumberFormatTest extends TestCase
     /**
      * @param null|bool|float|int|string $args string to be formatted
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerNumberFormatDates')]
+    #[DataProvider('providerNumberFormatDates')]
     public function testFormatValueWithMaskDate(mixed $expectedResult, mixed ...$args): void
     {
         $result = NumberFormat::toFormattedString(...$args);
@@ -67,6 +73,23 @@ class NumberFormatTest extends TestCase
     public static function providerNumberFormatDates(): array
     {
         return require 'tests/data/Style/NumberFormatDates.php';
+    }
+
+    public function testDatesOpenOfficeGnumericNonPositive(): void
+    {
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_OPENOFFICE
+        );
+        $fmt1 = 'yyyy-mm-dd';
+        $rslt = NumberFormat::toFormattedString(0, $fmt1);
+        self::assertSame('1899-12-30', $rslt);
+        $rslt = NumberFormat::toFormattedString(-2, $fmt1);
+        self::assertSame('1899-12-28', $rslt);
+        $rslt = NumberFormat::toFormattedString(-2.4, $fmt1);
+        self::assertSame('1899-12-27', $rslt);
+        $fmt2 = 'yyyy-mm-dd hh:mm:ss AM/PM';
+        $rslt = NumberFormat::toFormattedString(-2.4, $fmt2);
+        self::assertSame('1899-12-27 02:24:00 PM', $rslt);
     }
 
     public function testCurrencyCode(): void
@@ -83,7 +106,7 @@ class NumberFormatTest extends TestCase
         StringHelper::setCurrencyCode($cur);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerNoScientific')]
+    #[DataProvider('providerNoScientific')]
     public function testNoScientific(string $expectedResult, string $numericString): void
     {
         $result = NumberFormatter::floatStringConvertScientific($numericString);


### PR DESCRIPTION
Fix #4438. Do some optimization if Excel value is an integer. This is unlikely to make much of a difference, but the use case seems pretty common (cell represents a date rather than date-time), so we may as well do it. There had been no tests for negative integer values, because Excel does not handle those well, but OpenOffice and Gnumeric handle them just fine, so add some tests for them.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] performance optimization

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

