### PR TITLE
Add format number with thousands separator and no decimal 

### DIFF
--- a/src/PhpSpreadsheet/Style/NumberFormat.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat.php
@@ -16,6 +16,7 @@ class NumberFormat extends Supervisor
     const FORMAT_NUMBER_00 = '0.00';
     const FORMAT_NUMBER_COMMA_SEPARATED1 = '#,##0.00';
     const FORMAT_NUMBER_COMMA_SEPARATED2 = '#,##0.00_-';
+    const FORMAT_NUMBER_COMMA_SEPARATED3 = '#,##0';
 
     const FORMAT_PERCENTAGE = '0%';
     const FORMAT_PERCENTAGE_0 = '0.0%';


### PR DESCRIPTION
Add format number with thousands separator and no decimal "#,##0'"

This is:

- [X ] a new feature

### Why this change is needed?

Because I can't format a number wihtout decimal places.

Fixes Github #4443 
