### PR TITLE
refactor: cleanup code twice calling

### DIFF
--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -608,7 +608,7 @@ class Spreadsheet implements JsonSerializable
      */
     public function removeSheetByIndex(int $sheetIndex): void
     {
-        $numSheets = count($this->workSheetCollection);
+        $numSheets = $this->getSheetCount();
         if ($sheetIndex > $numSheets - 1) {
             throw new Exception(
                 "You tried to remove a sheet by the out of bounds index: {$sheetIndex}. The actual number of sheets is {$numSheets}."
@@ -660,10 +660,9 @@ class Spreadsheet implements JsonSerializable
      */
     public function getSheetByName(string $worksheetName): ?Worksheet
     {
-        $worksheetCount    = count($this->workSheetCollection);
         $trimWorksheetName = trim($worksheetName, "'");
 
-        for ($i = 0; $i < $worksheetCount; ++$i) {
+        for ($i = 0; $i < $this->getSheetCount(); ++$i) {
             if (strcasecmp($this->workSheetCollection[$i]->getTitle(), $trimWorksheetName) === 0) {
                 return $this->workSheetCollection[$i];
             }
@@ -792,8 +791,8 @@ class Spreadsheet implements JsonSerializable
     public function getSheetNames(): array
     {
         $returnValue = [];
-        $worksheetCount = $this->getSheetCount();
-        for ($i = 0; $i < $worksheetCount; ++$i) {
+
+        for ($i = 0; $i < $this->getSheetCount(); ++$i) {
             $returnValue[] = $this->getSheet($i)->getTitle();
         }
 

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -608,7 +608,7 @@ class Spreadsheet implements JsonSerializable
      */
     public function removeSheetByIndex(int $sheetIndex): void
     {
-        $numSheets = $this->getSheetCount();
+        $numSheets = count($this->workSheetCollection);
         if ($sheetIndex > $numSheets - 1) {
             throw new Exception(
                 "You tried to remove a sheet by the out of bounds index: {$sheetIndex}. The actual number of sheets is {$numSheets}."
@@ -660,9 +660,10 @@ class Spreadsheet implements JsonSerializable
      */
     public function getSheetByName(string $worksheetName): ?Worksheet
     {
+        $worksheetCount = count($this->workSheetCollection);
         $trimWorksheetName = trim($worksheetName, "'");
 
-        for ($i = 0; $i < $this->getSheetCount(); ++$i) {
+        for ($i = 0; $i < $wroksheetCount; ++$i) {
             if (strcasecmp($this->workSheetCollection[$i]->getTitle(), $trimWorksheetName) === 0) {
                 return $this->workSheetCollection[$i];
             }
@@ -791,8 +792,8 @@ class Spreadsheet implements JsonSerializable
     public function getSheetNames(): array
     {
         $returnValue = [];
-
-        for ($i = 0; $i < $this->getSheetCount(); ++$i) {
+        $worksheetCount = $this->getSheetCount();
+        for ($i = 0; $i < $worksheetCount; ++$i) {
             $returnValue[] = $this->getSheet($i)->getTitle();
         }
 

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -660,12 +660,10 @@ class Spreadsheet implements JsonSerializable
      */
     public function getSheetByName(string $worksheetName): ?Worksheet
     {
-        $worksheetCount = count($this->workSheetCollection);
         $trimWorksheetName = trim($worksheetName, "'");
-
-        for ($i = 0; $i < $worksheetCount; ++$i) {
-            if (strcasecmp($this->workSheetCollection[$i]->getTitle(), $trimWorksheetName) === 0) {
-                return $this->workSheetCollection[$i];
+        foreach ($this->workSheetCollection as $worksheet) {
+            if (strcasecmp($worksheet->getTitle(), $trimWorksheetName) === 0) {
+                return $worksheet;
             }
         }
 

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -663,7 +663,7 @@ class Spreadsheet implements JsonSerializable
         $worksheetCount = count($this->workSheetCollection);
         $trimWorksheetName = trim($worksheetName, "'");
 
-        for ($i = 0; $i < $wroksheetCount; ++$i) {
+        for ($i = 0; $i < $worksheetCount; ++$i) {
             if (strcasecmp($this->workSheetCollection[$i]->getTitle(), $trimWorksheetName) === 0) {
                 return $this->workSheetCollection[$i];
             }

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -660,9 +660,11 @@ class Spreadsheet implements JsonSerializable
      */
     public function getSheetByName(string $worksheetName): ?Worksheet
     {
-        $worksheetCount = count($this->workSheetCollection);
+        $worksheetCount    = count($this->workSheetCollection);
+        $trimWorksheetName = trim($worksheetName, "'");
+
         for ($i = 0; $i < $worksheetCount; ++$i) {
-            if (strcasecmp($this->workSheetCollection[$i]->getTitle(), trim($worksheetName, "'")) === 0) {
+            if (strcasecmp($this->workSheetCollection[$i]->getTitle(), $trimWorksheetName) === 0) {
                 return $this->workSheetCollection[$i];
             }
         }


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [ ] a new feature
- [x] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Just refactoring trimming twice.
