### PR TITLE
Allow Xlsx Reader/Writer to Process Font Charset

### DIFF
--- a/docs/topics/recipes.md
+++ b/docs/topics/recipes.md
@@ -1099,6 +1099,21 @@ All cells bound to the theme fonts (via the `Font::setScheme` method) can be eas
 $spreadsheet->resetThemeFonts();
 ```
 
+### Charset for Arabic and Persian Fonts
+
+It is unknown why this should be needed. However, some Excel
+users have reported better results if the internal declaration for an
+Arabic/Persian font includes a `charset` declaration.
+This seems like a bug in Excel, but, starting with release 4.4,
+this can be accomplished at the spreadsheet level, via:
+```php
+$spreadsheet->addFontCharset('C Nazanin');
+```
+As many charsets as desired can be added in this manner.
+There is a second optional parameter specifying the charset id
+to this method, but, since this seems to be needed only for
+Arabic/Persian, that is its default value.
+
 ### Styling cell borders
 
 In PhpSpreadsheet it is easy to apply various borders on a rectangular

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -655,7 +655,11 @@ class Xlsx extends BaseReader
 
                             // add style to cellXf collection
                             $objStyle = new Style();
-                            $this->styleReader->readStyle($objStyle, $style);
+                            $this->styleReader
+                                ->readStyle($objStyle, $style);
+                            foreach ($this->styleReader->getFontCharsets() as $fontName => $charset) {
+                                $excel->addFontCharset($fontName, $charset);
+                            }
                             if ($addingFirstCellXf) {
                                 $excel->removeCellXfByIndex(0); // remove the default style
                                 $addingFirstCellXf = false;

--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -36,6 +36,15 @@ class Styles extends BaseParserClass
 
     private string $namespace = '';
 
+    /** @var array<string, int> */
+    private array $fontCharsets = [];
+
+    /** @return array<string, int> */
+    public function getFontCharsets(): array
+    {
+        return $this->fontCharsets;
+    }
+
     public function setNamespace(string $namespace): void
     {
         $this->namespace = $namespace;
@@ -84,6 +93,13 @@ class Styles extends BaseParserClass
             $attr = $this->getStyleAttributes($fontStyleXml->name);
             if (isset($attr['val'])) {
                 $fontStyle->setName((string) $attr['val']);
+            }
+            if (isset($fontStyleXml->charset)) {
+                $charsetAttr = $this->getStyleAttributes($fontStyleXml->charset);
+                if (isset($charsetAttr['val'])) {
+                    $charsetVal = (int) $charsetAttr['val'];
+                    $this->fontCharsets[$fontStyle->getName()] = $charsetVal;
+                }
             }
         }
         if (isset($fontStyleXml->sz)) {

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -183,7 +183,12 @@ class Spreadsheet implements JsonSerializable
         'B Nazanin' => SharedFont::CHARSET_ANSI_ARABIC,
     ];
 
-    public function addFontCharset(string $fontName, int $charset): void
+    /**
+     * @param int $charset uses any value from Shared\Font,
+     *    but defaults to ARABIC because that is the only known
+     *    charset for which this declaration might be needed
+     */
+    public function addFontCharset(string $fontName, int $charset = SharedFont::CHARSET_ANSI_ARABIC): void
     {
         $this->fontCharsets[$fontName] = $charset;
     }

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpSpreadsheet\Cell\IValueBinder;
 use PhpOffice\PhpSpreadsheet\Document\Properties;
 use PhpOffice\PhpSpreadsheet\Document\Security;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
+use PhpOffice\PhpSpreadsheet\Shared\Font as SharedFont;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 use PhpOffice\PhpSpreadsheet\Worksheet\Iterator;
@@ -176,6 +177,31 @@ class Spreadsheet implements JsonSerializable
     private Theme $theme;
 
     private ?IValueBinder $valueBinder = null;
+
+    /** @var array<string, int> */
+    private array $fontCharsets = [
+        'B Nazanin' => SharedFont::CHARSET_ANSI_ARABIC,
+    ];
+
+    public function addFontCharset(string $fontName, int $charset): void
+    {
+        $this->fontCharsets[$fontName] = $charset;
+    }
+
+    public function getFontCharset(string $fontName): int
+    {
+        return $this->fontCharsets[$fontName] ?? -1;
+    }
+
+    /**
+     * Return all fontCharsets.
+     *
+     * @return array<string, int>
+     */
+    public function getFontCharsets(): array
+    {
+        return $this->fontCharsets;
+    }
 
     public function getTheme(): Theme
     {

--- a/src/PhpSpreadsheet/Writer/Xlsx/Style.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Style.php
@@ -59,7 +59,7 @@ class Style extends WriterPart
         for ($i = 0; $i < $this->getParentWriter()->getFontHashTable()->count(); ++$i) {
             $thisfont = $this->getParentWriter()->getFontHashTable()->getByIndex($i);
             if ($thisfont !== null) {
-                $this->writeFont($objWriter, $thisfont);
+                $this->writeFont($objWriter, $thisfont, $spreadsheet);
             }
         }
 
@@ -145,7 +145,7 @@ class Style extends WriterPart
             /** @var ?Conditional */
             $thisstyle = $this->getParentWriter()->getStylesConditionalHashTable()->getByIndex($i);
             if ($thisstyle !== null) {
-                $this->writeCellStyleDxf($objWriter, $thisstyle->getStyle());
+                $this->writeCellStyleDxf($objWriter, $thisstyle->getStyle(), $spreadsheet);
             }
         }
 
@@ -284,7 +284,7 @@ class Style extends WriterPart
     /**
      * Write Font.
      */
-    private function writeFont(XMLWriter $objWriter, Font $font): void
+    private function writeFont(XMLWriter $objWriter, Font $font, Spreadsheet $spreadsheet): void
     {
         $fontStarted = false;
         // font
@@ -365,6 +365,12 @@ class Style extends WriterPart
             $objWriter->startElement('name');
             $objWriter->writeAttribute('val', $font->getName());
             $objWriter->endElement();
+            $charset = $spreadsheet->getFontCharset($font->getName());
+            if ($charset >= 0 && $charset <= 255) {
+                $objWriter->startElement('charset');
+                $objWriter->writeAttribute('val', "$charset");
+                $objWriter->endElement();
+            }
         }
 
         if (!empty($font->getScheme())) {
@@ -504,13 +510,13 @@ class Style extends WriterPart
     /**
      * Write Cell Style Dxf.
      */
-    private function writeCellStyleDxf(XMLWriter $objWriter, \PhpOffice\PhpSpreadsheet\Style\Style $style): void
+    private function writeCellStyleDxf(XMLWriter $objWriter, \PhpOffice\PhpSpreadsheet\Style\Style $style, Spreadsheet $spreadsheet): void
     {
         // dxf
         $objWriter->startElement('dxf');
 
         // font
-        $this->writeFont($objWriter, $style->getFont());
+        $this->writeFont($objWriter, $style->getFont(), $spreadsheet);
 
         // numFmt
         $this->writeNumFmt($objWriter, $style->getNumberFormat());

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/FontCharsetTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/FontCharsetTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class FontCharsetTest extends AbstractFunctional
+{
+    private ?Spreadsheet $spreadsheet = null;
+
+    private ?Spreadsheet $reloadedSpreadsheet = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->spreadsheet !== null) {
+            $this->spreadsheet->disconnectWorksheets();
+            $this->spreadsheet = null;
+        }
+        if ($this->reloadedSpreadsheet !== null) {
+            $this->reloadedSpreadsheet->disconnectWorksheets();
+            $this->reloadedSpreadsheet = null;
+        }
+    }
+
+    public function testFontCharset(): void
+    {
+        $spreadsheet = $this->spreadsheet = new Spreadsheet();
+        $sheet = $this->spreadsheet->getActiveSheet();
+        $sheet->getStyle('A1')->getFont()->setName('Nazanin');
+        $spreadsheet->addFontCharset('Nazanin');
+
+        $spreadsheet2 = $this->reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Xlsx');
+        $sheet2 = $spreadsheet2->getActiveSheet();
+        $sheet2->getStyle('B1')->getFont()->setName('B Nazanin');
+        $sheet2->getStyle('C1')->getFont()->setName('C Nazanin');
+        $sheet2->getStyle('D1')->getFont()->setName('D Nazanin');
+        $spreadsheet2->addFontCharset('C Nazanin');
+        // Do not add D Nazanin for this test.
+        self::assertSame(
+            [
+                'B Nazanin' => 178, // default entry
+                'Nazanin' => 178, // should have been set by Xlsx Reader
+                'C Nazanin' => 178, // explicitly set in this test
+            ],
+            $spreadsheet2->getFontCharsets()
+        );
+    }
+}


### PR DESCRIPTION
Fix #2760. Maybe. I have no real way of confirming. I am not sure why it might be needed, but a comment in the issue suggests that it helps. I have asked the submitter and another participant in the discussion to let me know if it helps before moving forward.

This is:

- [x] a bugfix (most likely workaround of an Excel bug)
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [x] Documentation is updated as necessary

