### PR TITLE
AutoColor for LibreOffice Dark Mode

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -136,6 +136,12 @@ class Styles extends BaseParserClass
             $attr = $this->getStyleAttributes($fontStyleXml->scheme);
             $fontStyle->setScheme((string) $attr['val']);
         }
+        if (isset($fontStyleXml->auto)) {
+            $attr = $this->getStyleAttributes($fontStyleXml->auto);
+            if (isset($attr['val'])) {
+                $fontStyle->setAutoColor(self::boolean((string) $attr['val']));
+            }
+        }
     }
 
     private function readNumberFormat(NumberFormat $numfmtStyle, SimpleXMLElement $numfmtStyleXml): void

--- a/src/PhpSpreadsheet/Style/Font.php
+++ b/src/PhpSpreadsheet/Style/Font.php
@@ -85,6 +85,8 @@ class Font extends Supervisor
      */
     protected Color $color;
 
+    protected bool $autoColor = false;
+
     public ?int $colorIndex = null;
 
     protected string $scheme = '';
@@ -166,7 +168,7 @@ class Font extends Supervisor
      * );
      * </code>
      *
-     * @param array{name?: string, latin?: string, eastAsian?: string, complexScript?: string, bold?: bool, italic?: bool, superscript?: bool, subscript?: bool, underline?: bool|string, strikethrough?: bool, color?: string[], size?: ?int, chartColor?: ChartColor, scheme?: string, cap?: string} $styleArray Array containing style information
+     * @param array{name?: string, latin?: string, eastAsian?: string, complexScript?: string, bold?: bool, italic?: bool, superscript?: bool, subscript?: bool, underline?: bool|string, strikethrough?: bool, color?: string[], size?: ?int, chartColor?: ChartColor, scheme?: string, cap?: string, autoColor?: bool} $styleArray Array containing style information
      *
      * @return $this
      */
@@ -185,7 +187,9 @@ class Font extends Supervisor
                 $this->setEastAsian($styleArray['eastAsian']);
             }
             if (isset($styleArray['complexScript'])) {
-                $this->setComplexScript($styleArray['complexScript']);
+                $this->setComplexScript(
+                    $styleArray['complexScript']
+                );
             }
             if (isset($styleArray['bold'])) {
                 $this->setBold($styleArray['bold']);
@@ -203,7 +207,9 @@ class Font extends Supervisor
                 $this->setUnderline($styleArray['underline']);
             }
             if (isset($styleArray['strikethrough'])) {
-                $this->setStrikethrough($styleArray['strikethrough']);
+                $this->setStrikethrough(
+                    $styleArray['strikethrough']
+                );
             }
             if (isset($styleArray['color'])) {
                 /** @var array{rgb?: string, argb?: string, theme?: int} */
@@ -222,6 +228,9 @@ class Font extends Supervisor
             }
             if (isset($styleArray['cap'])) {
                 $this->setCap($styleArray['cap']);
+            }
+            if (isset($styleArray['autoColor'])) {
+                $this->setAutoColor($styleArray['autoColor']);
             }
         }
 
@@ -736,6 +745,7 @@ class Font extends Supervisor
             . ($this->subscript ? 't' : 'f')
             . $this->underline
             . ($this->strikethrough ? 't' : 'f')
+            . ($this->autoColor ? 't' : 'f')
             . $this->color->getHashCode()
             . $this->scheme
             . implode(
@@ -777,6 +787,7 @@ class Font extends Supervisor
         $this->exportArray2($exportedArray, 'superscript', $this->getSuperscript());
         $this->exportArray2($exportedArray, 'underline', $this->getUnderline());
         $this->exportArray2($exportedArray, 'underlineColor', $this->getUnderlineColor());
+        $this->exportArray2($exportedArray, 'autoColor', $this->getAutoColor());
 
         return $exportedArray;
     }
@@ -829,6 +840,29 @@ class Font extends Supervisor
         $this->setUnderline(self::UNDERLINE_SINGLE);
 
         return $this;
+    }
+
+    public function setAutoColor(bool $autoColor): self
+    {
+        if ($this->isSupervisor) {
+            $styleArray = $this->getStyleArray(['autoColor' => $autoColor]);
+            $this->getActiveSheet()
+                ->getStyle($this->getSelectedCells())
+                ->applyFromArray($styleArray);
+        } else {
+            $this->autoColor = $autoColor;
+        }
+
+        return $this;
+    }
+
+    public function getAutoColor(): bool
+    {
+        if ($this->isSupervisor) {
+            return $this->getSharedComponent()->getAutoColor();
+        }
+
+        return $this->autoColor;
     }
 
     /**

--- a/src/PhpSpreadsheet/Writer/Ods/Cell/Style.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Cell/Style.php
@@ -204,15 +204,26 @@ class Style
 
         if ($font->getBold()) {
             $this->writer->writeAttribute('fo:font-weight', 'bold');
-            $this->writer->writeAttribute('style:font-weight-complex', 'bold');
-            $this->writer->writeAttribute('style:font-weight-asian', 'bold');
+            $this->writer->writeAttribute(
+                'style:font-weight-complex',
+                'bold'
+            );
+            $this->writer->writeAttribute(
+                'style:font-weight-asian',
+                'bold'
+            );
         }
 
         if ($font->getItalic()) {
             $this->writer->writeAttribute('fo:font-style', 'italic');
         }
 
-        $this->writer->writeAttribute('fo:color', sprintf('#%s', $font->getColor()->getRGB()));
+        if ($font->getAutoColor()) {
+            $this->writer
+                ->writeAttribute('style:use-window-font-color', 'true');
+        } else {
+            $this->writer->writeAttribute('fo:color', sprintf('#%s', $font->getColor()->getRGB()));
+        }
 
         if ($family = $font->getName()) {
             $this->writer->writeAttribute('fo:font-family', $family);

--- a/src/PhpSpreadsheet/Writer/Xlsx/Style.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Style.php
@@ -347,7 +347,12 @@ class Style extends WriterPart
         }
 
         // Foreground color
-        if ($font->getColor()->getTheme() >= 0) {
+        if ($font->getAutoColor()) {
+            $this->startFont($objWriter, $fontStarted);
+            $objWriter->startElement('auto');
+            $objWriter->writeAttribute('val', '1');
+            $objWriter->endElement();
+        } elseif ($font->getColor()->getTheme() >= 0) {
             $this->startFont($objWriter, $fontStarted);
             $objWriter->startElement('color');
             $objWriter->writeAttribute('theme', (string) $font->getColor()->getTheme());

--- a/tests/PhpSpreadsheetTests/Writer/Ods/AutoColorTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Ods/AutoColorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\ODS;
+
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Ods as OdsWriter;
+use PHPUnit\Framework\TestCase;
+
+class AutoColorTest extends TestCase
+{
+    private string $outputFile = '';
+
+    protected function tearDown(): void
+    {
+        if ($this->outputFile !== '') {
+            unlink($this->outputFile);
+            $this->outputFile = '';
+        }
+    }
+
+    public function testAutoColor(): void
+    {
+        // It's not clear to me what AutoColor does in Excel.
+        // However, LibreOffice Dark Mode
+        // can make use of a spreadsheet which uses it.
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->getDefaultStyle()->getFont()
+            ->setAutoColor(true);
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'Hello World!');
+        $sheet->setCellValue('A2', 'Hello World!');
+        $sheet->getStyle('A2')->getFont()
+            ->setBold(true);
+        $sheet->setCellValue('A3', 'Hello World!');
+        $sheet->getStyle('A3')->getFont()
+            ->setItalic(true);
+        $sheet->setCellValue('B1', 'Hello World!');
+
+        $writer = new OdsWriter($spreadsheet);
+        $outputFile = $this->outputFile = File::temporaryFilename();
+        $writer->save($outputFile);
+        $spreadsheet->disconnectWorksheets();
+        $zipfile = "zip://$outputFile#content.xml";
+        $contents = file_get_contents($zipfile);
+        if ($contents === false) {
+            self::fail('Unable to open file');
+        } else {
+            self::assertStringContainsString('<style:text-properties style:use-window-font-color="true" fo:font-family="Calibri" fo:font-size="11.0pt"/>', $contents);
+            self::assertStringContainsString('<style:text-properties fo:font-weight="bold" style:font-weight-complex="bold" style:font-weight-asian="bold" style:use-window-font-color="true" fo:font-family="Calibri" fo:font-size="11.0pt"/>', $contents);
+            self::assertStringContainsString('<style:text-properties fo:font-style="italic" style:use-window-font-color="true" fo:font-family="Calibri" fo:font-size="11.0pt"/>', $contents);
+        }
+    }
+}

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/AutoColorTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/AutoColorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Reader\Xlsx as XlsxReader;
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PHPUnit\Framework\TestCase;
+
+class AutoColorTest extends TestCase
+{
+    private string $outputFile = '';
+
+    protected function tearDown(): void
+    {
+        if ($this->outputFile !== '') {
+            unlink($this->outputFile);
+            $this->outputFile = '';
+        }
+    }
+
+    public function testAutoColor(): void
+    {
+        // It's not clear to me what AutoColor does in Excel.
+        // However, LibreOffice Dark Mode
+        // can make use of a spreadsheet which uses it.
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->getDefaultStyle()->getFont()
+            ->setAutoColor(true);
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'Hello World!');
+        $sheet->setCellValue('A2', 'Hello World!');
+        $sheet->getStyle('A2')->getFont()
+            ->setBold(true);
+        $sheet->setCellValue('A3', 'Hello World!');
+        $sheet->getStyle('A3')->getFont()
+            ->setItalic(true);
+        $sheet->setCellValue('B1', 'Hello World!');
+
+        $writer = new XlsxWriter($spreadsheet);
+        $outputFile = $this->outputFile = File::temporaryFilename();
+        $writer->save($outputFile);
+        $spreadsheet->disconnectWorksheets();
+        $zipfile = "zip://$outputFile#xl/styles.xml";
+        $contents = file_get_contents($zipfile);
+        if ($contents === false) {
+            self::fail('Unable to open file');
+        } else {
+            self::assertStringContainsString('<fonts count="3">', $contents);
+            self::assertStringContainsString('<font><b val="0"/><i val="0"/><strike val="0"/><u val="none"/><sz val="11"/><auto val="1"/><name val="Calibri"/></font>', $contents);
+            self::assertStringContainsString('<font><b val="1"/><i val="0"/><strike val="0"/><u val="none"/><sz val="11"/><auto val="1"/><name val="Calibri"/></font>', $contents);
+            self::assertStringContainsString('<font><b val="0"/><i val="1"/><strike val="0"/><u val="none"/><sz val="11"/><auto val="1"/><name val="Calibri"/></font>', $contents);
+        }
+
+        $reader = new XlsxReader();
+        $spreadsheet2 = $reader->load($outputFile);
+        $sheet2 = $spreadsheet2->getActiveSheet();
+        self::assertTrue(
+            $sheet2->getStyle('A1')
+                ->getFont()
+                ->getAutoColor()
+        );
+        $spreadsheet2->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
See discussion #4502. I am not sure of what needs to be involved here. This is especially so because Excel also offers AutoColor, but its dark mode looks significantly different than LibreOffice's.

So here's what I've come up with thus far.
- Add boolean autoColor with setter and getter to Font.
- If autoColor is true, ODS writer and XLSX Writer will record it in the xml, and will not write a font color. It is possible that both can co-exist; I'm just not sure how they are supposed to interact if that is the case.
- It makes most sense to me if the spreadsheet's default font specifies autoColor, but PhpSpreadsheet will not insist on that.
- Xlsx Reader will process autoColor. Like most other styles, Ods Reader is not yet set up to handle it.
- LibreOffice Calc should follow the autoColor declarations when it reads either an Xlsx or Ods spreadsheet created by PhpSpreadsheet.

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

