### PR TITLE
Xlsx Style Writer Minor Refactoring

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -249,6 +249,40 @@ class Xlsx extends BaseWriter
         return $this->writerPartWorksheet;
     }
 
+    public function createStyleDictionaries(): void
+    {
+        $this->styleHashTable->addFromSource(
+            $this->getWriterPartStyle()->allStyles(
+                $this->spreadSheet
+            )
+        );
+        $this->stylesConditionalHashTable->addFromSource(
+            $this->getWriterPartStyle()->allConditionalStyles(
+                $this->spreadSheet
+            )
+        );
+        $this->fillHashTable->addFromSource(
+            $this->getWriterPartStyle()->allFills(
+                $this->spreadSheet
+            )
+        );
+        $this->fontHashTable->addFromSource(
+            $this->getWriterPartStyle()->allFonts(
+                $this->spreadSheet
+            )
+        );
+        $this->bordersHashTable->addFromSource(
+            $this->getWriterPartStyle()->allBorders(
+                $this->spreadSheet
+            )
+        );
+        $this->numFmtHashTable->addFromSource(
+            $this->getWriterPartStyle()->allNumberFormats(
+                $this->spreadSheet
+            )
+        );
+    }
+
     /**
      * Save PhpSpreadsheet to file.
      *
@@ -275,12 +309,7 @@ class Xlsx extends BaseWriter
         }
 
         // Create styles dictionaries
-        $this->styleHashTable->addFromSource($this->getWriterPartStyle()->allStyles($this->spreadSheet));
-        $this->stylesConditionalHashTable->addFromSource($this->getWriterPartStyle()->allConditionalStyles($this->spreadSheet));
-        $this->fillHashTable->addFromSource($this->getWriterPartStyle()->allFills($this->spreadSheet));
-        $this->fontHashTable->addFromSource($this->getWriterPartStyle()->allFonts($this->spreadSheet));
-        $this->bordersHashTable->addFromSource($this->getWriterPartStyle()->allBorders($this->spreadSheet));
-        $this->numFmtHashTable->addFromSource($this->getWriterPartStyle()->allNumberFormats($this->spreadSheet));
+        $this->createStyleDictionaries();
 
         // Create drawing dictionary
         $this->drawingHashTable->addFromSource($this->getWriterPartDrawing()->allDrawings($this->spreadSheet));

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/StylesWriterTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/StylesWriterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PHPUnit\Framework\TestCase;
+
+class StylesWriterTest extends TestCase
+{
+    public function testStylesWriter(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        $writer = new XlsxWriter($spreadsheet);
+        $writer->createStyleDictionaries();
+        $writerStyle = new XlsxWriter\Style($writer);
+        $data = $writerStyle->writeStyles($spreadsheet);
+        self::assertStringContainsString(
+            '<fonts count="1"><font><b val="0"/><i val="0"/><strike val="0"/><u val="none"/><sz val="11"/><color rgb="FF000000"/><name val="Calibri"/></font></fonts>',
+            $data
+        );
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
In our unit tests, we can test the Worksheet Xml which PhpSpreadsheet will generate without having to actually write the spreadsheet to and read it from disk. This refactoring allows us to do the same for Styles, as demonstrated in the new StylesWriterTest.

This is:

- [ ] a bugfix
- [ ] a new feature
- [x] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

