### PR TITLE
fix(docs): Fix nested lists after paragraphs

### DIFF
--- a/docs/topics/The Dating Game.md
+++ b/docs/topics/The Dating Game.md
@@ -14,20 +14,20 @@ Open/Libre Office and Gnumeric don't have this limitation, and negative date/tim
 To write a date in a cell using PhpSpreadsheet, we need to calculate the serialized Excel datestamp for that date. Methods to do this are available in the Shared\Date class, which provides a number of methods for conversion between different date options typically used in PHP applications (Unix timestamp, PHP DateTime objects and some recognisable formatted strings) and the Excel serialized value; and vice versa.
 
  - Shared\Date::convertIsoDate()
-   - Converts a date/time in [ISO-8601 standard format](https://en.wikipedia.org/wiki/ISO_8601) to an Excel serialized timestamp
+     - Converts a date/time in [ISO-8601 standard format](https://en.wikipedia.org/wiki/ISO_8601) to an Excel serialized timestamp
  - Shared\Date::PHPToExcel()
-   - Converts a Unix timestamp, a PHP DateTime object, or a recognisable formatted string to an Excel serialized timestamp
+     - Converts a Unix timestamp, a PHP DateTime object, or a recognisable formatted string to an Excel serialized timestamp
  - Shared\Date::dateTimeToExcel()
-   - Converts a Unix timestamp to an Excel serialized timestamp
+     - Converts a Unix timestamp to an Excel serialized timestamp
  - Shared\Date::timestampToExcel()
-   - Converts a PHP DateTime object to an Excel serialized timestamp
+     - Converts a PHP DateTime object to an Excel serialized timestamp
  - Shared\Date::formattedPHPToExcel()
-   - Converts year, month, day, hour, minute, and second to an Excel serialized timestamp
+     - Converts year, month, day, hour, minute, and second to an Excel serialized timestamp
  - Shared\Date::excelToDateTimeObject()
-   - Converts an Excel serialized timestamp to a PHP DateTime object
+     - Converts an Excel serialized timestamp to a PHP DateTime object
  - Shared\Date::excelToTimestamp()
-   - Converts an Excel serialized timestamp to a Unix timestamp.
-   - The use of Unix timestamps, and therefore this function, is discouraged: they are not Y2038-safe on a 32-bit system, and have no timezone info.
+     - Converts an Excel serialized timestamp to a Unix timestamp.
+     - The use of Unix timestamps, and therefore this function, is discouraged: they are not Y2038-safe on a 32-bit system, and have no timezone info.
 
 We probably also want to set the number format mask for the cell so that it will be displayed as a human-readable date.
 ```php

--- a/docs/topics/defined-names.md
+++ b/docs/topics/defined-names.md
@@ -545,6 +545,7 @@ $this->spreadsheet->addDefinedName(
 ### Naming Names
 
 The names that you assign to Defined Name must follow the following set of rules:
+
  - The first character of a name must be one of the following characters:
    - letter (including UTF-8 letters)
    - underscore (`_`)

--- a/docs/topics/defined-names.md
+++ b/docs/topics/defined-names.md
@@ -547,16 +547,16 @@ $this->spreadsheet->addDefinedName(
 The names that you assign to Defined Name must follow the following set of rules:
 
  - The first character of a name must be one of the following characters:
-   - letter (including UTF-8 letters)
-   - underscore (`_`)
+     - letter (including UTF-8 letters)
+     - underscore (`_`)
  - Remaining characters in the name can be
-   - letters (including UTF-8 letters)
-   - numbers (including UTF-8 numbers)
-   - periods (`.`)
-   - underscore characters (`_`)
+     - letters (including UTF-8 letters)
+     - numbers (including UTF-8 numbers)
+     - periods (`.`)
+     - underscore characters (`_`)
  - The following are not allowed:
-   - Space characters are not allowed as part of a name.
-   - Names can't look like cell addresses, such as A35 or R2C2
+     - Space characters are not allowed as part of a name.
+     - Names can't look like cell addresses, such as A35 or R2C2
  - Names are not case sensitive. For example, `North` and `NORTH` are treated as the same name.
 
 ### Limitations


### PR DESCRIPTION
| GitHub | [Read _the_ Docs (before)](https://phpspreadsheet.readthedocs.io/en/latest/topics/defined-names/#naming-names) | [Read _the_ Docs (after)](https://phpspreadsheet--4520.org.readthedocs.build/en/4520/topics/defined-names/#naming-names)
| ------ | ----- | ----- |
| ![grafik](https://github.com/user-attachments/assets/bcf513cc-c359-4467-a5d3-2972880f388b) | ![grafik](https://github.com/user-attachments/assets/a81fc6bb-4e33-4de6-b816-a76255bc3ff2) | ![grafik](https://github.com/user-attachments/assets/64f0b971-8f37-4805-91e7-cc9224f0b6cc) (55294cf) ![grafik](https://github.com/user-attachments/assets/bc5bed8f-99b2-415d-9d7b-40d5926525f3) (a266911) |
| ![grafik](https://github.com/user-attachments/assets/05b6fb00-97f5-437d-ae53-360344668845) | ![grafik](https://github.com/user-attachments/assets/0dbd7171-c914-4680-a0d0-b9e7a19abe2c) | ![grafik](https://github.com/user-attachments/assets/b2252996-6e21-46f2-87c5-3e02dccaaa2a) |


This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [x] Documentation is updated as necessary

### Why this change is needed?
Read _the_ docs seems to be stricter than other markdown renderers (e.g. GitHub), which means, we have to be strict about the following:
- Lists after paragraphs need a blank line between each other to be rendered as lists
- Indent needs four spaces, not two. Otherwise, the indent is ignored and the list is rendered as flat