### PR TITLE
fix: data loss for numeric value greater than excel supported max value

### DIFF
--- a/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
+++ b/src/PhpSpreadsheet/Cell/DefaultValueBinder.php
@@ -64,7 +64,7 @@ class DefaultValueBinder implements IValueBinder
             return DataType::TYPE_INLINE;
         }
         if ($value instanceof Stringable) {
-            $value = (string)$value;
+            $value = (string) $value;
         }
         if (!is_string($value)) {
             $gettype = is_object($value) ? get_class($value) : gettype($value);


### PR DESCRIPTION
This is:

- [ *] a bugfix


Checklist:

- [*] Changes are covered by unit tests
  - [*] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ *] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

This change is necessary because PHP_INT_MAX represents the maximum integer value supported by PHP on the current platform, which can be larger than what Excel or JavaScript can safely handle (specifically, numbers above 2^53 lose precision in JavaScript and Excel). By switching to self::EXCEL_MAX_INT (2^53), the code ensures that any integer value larger than what Excel can safely represent is treated as a string, preventing precision loss and data corruption when exporting to Excel. This makes the behavior consistent and safe across different platforms and environments.

Reference issue #4522
