### PR TITLE
Recognize "New" Mimetype for Empty File

### DIFF
--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -605,6 +605,7 @@ class Csv extends BaseReader
             'text/csv',
             'text/plain',
             'inode/x-empty',
+            'application/x-empty', // has now replaced previous
             'text/html',
         ];
 

--- a/tests/PhpSpreadsheetTests/Issue4521Test.php
+++ b/tests/PhpSpreadsheetTests/Issue4521Test.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests;
+
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Shared\File;
+use PHPUnit\Framework\TestCase;
+
+class Issue4521Test extends TestCase
+{
+    private string $outfile = '';
+
+    protected int $weirdMimetypeMajor = 8;
+
+    protected int $weirdMimetypeMinor1 = 1;
+
+    protected int $weirdMimetypeMinor2 = 2;
+
+    protected function tearDown(): void
+    {
+        if ($this->outfile !== '') {
+            unlink($this->outfile);
+            $this->outfile = '';
+        }
+    }
+
+    public function testEmptyFile(): void
+    {
+        $this->outfile = File::temporaryFilename();
+        file_put_contents($this->outfile, '');
+        $spreadsheet = IOFactory::load($this->outfile);
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertSame('A', $sheet->getHighestColumn());
+        self::assertSame(1, $sheet->getHighestRow());
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testCrlfFile(): void
+    {
+        if (PHP_MAJOR_VERSION === $this->weirdMimetypeMajor) {
+            if (
+                PHP_MINOR_VERSION === $this->weirdMimetypeMinor1
+                || PHP_MINOR_VERSION === $this->weirdMimetypeMinor2
+            ) {
+                self::markTestSkipped('Php mimetype bug with this release');
+            }
+        }
+        $this->outfile = File::temporaryFilename();
+        file_put_contents($this->outfile, "\r\n");
+        $spreadsheet = IOFactory::load($this->outfile);
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertSame('A', $sheet->getHighestColumn());
+        self::assertSame(1, $sheet->getHighestRow());
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Fix #4521. Reader/Csv (which can be invoked by IOFactory::read), checks the mimetype of files if they don't have a csv/tsv extension. It allows empty files, whose mimetype was set to `inode/x-empty` for Php5.3.11 through Php7.3.33 (except for 5.4.0). For 5.3.1-5.3.10, 5.4.0, and 7.4.0+, the mimetype is `application/x-empty`. Reader/Csv recognizes the `inode` version but not the `application` version, which this PR adds.

The person who issued the report also noted that, for a file consisting of cr-lf, Php8.1.* and Php8.2.* report the mimetype as `application/octet-stream`, whereas all other releases report it as `text/plain`. The behavior of Php8.1/2 seems to be a bug, and I cannot possibly guess all the conditions that might lead to that bug. So I will not fix that problem. Anyone who is adversely affected by it can either add a `csv` extension to the filename, or upgrade to Php8.3+, or pre-process the file (e.g. to make it truly empty) before passing it to PhpSpreadsheet. A test case to document the problem is added for documentary purposes; the test will be skipped for Php8.1/2, but run for all other releases.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
