### PR TITLE
Xlsx Reader Use Dynamic Arrays if Spreadsheet Did So

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Reader;
 
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
@@ -449,6 +450,15 @@ class Xlsx extends BaseReader
                 $relTarget = substr($relTarget, 4);
             }
             switch ($rel['Type']) {
+                case "$xmlNamespaceBase/sheetMetadata":
+                    if ($this->fileExistsInArchive($zip, "xl/{$relTarget}")) {
+                        $excel->getCalculationEngine()
+                            ?->setInstanceArrayReturnType(
+                                Calculation::RETURN_ARRAY_AS_ARRAY
+                            );
+                    }
+
+                    break;
                 case "$xmlNamespaceBase/theme":
                     if (!$this->fileExistsInArchive($zip, "xl/{$relTarget}")) {
                         break; // issue3770

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/ReadDynamTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/ReadDynamTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class ReadDynamTest extends AbstractFunctional
+{
+    public function writeCse(XlsxWriter $writer): void
+    {
+        $writer->setUseCSEArrays(true);
+    }
+
+    public function testCse(): void
+    {
+        $spreadsheetOld = new Spreadsheet();
+        $sheetOld = $spreadsheetOld->getActiveSheet();
+        $calcOld = Calculation::getInstance($spreadsheetOld);
+        $calcOld->setInstanceArrayReturnType(
+            Calculation::RETURN_ARRAY_AS_ARRAY
+        );
+        $sheetOld->fromArray(
+            [1, 2, 2, 4, 3, 2, 1, 3, 3, 3, 5],
+            null,
+            'A14',
+            true
+        );
+        $sheetOld->setCellValue('A15', '=UNIQUE(A14:K14, TRUE)');
+        /** @var callable */
+        $callableWriter = [$this, 'writeCse'];
+        $spreadsheet = $this->writeAndReload($spreadsheetOld, 'Xlsx', null, $callableWriter);
+        $spreadsheetOld->disconnectWorksheets();
+        $calc = Calculation::getInstance($spreadsheet);
+        self::assertSame(
+            Calculation::RETURN_ARRAY_AS_VALUE,
+            $calc->getInstanceArrayReturnType()
+        );
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testDynam(): void
+    {
+        $spreadsheetOld = new Spreadsheet();
+        $sheetOld = $spreadsheetOld->getActiveSheet();
+        $calcOld = Calculation::getInstance($spreadsheetOld);
+        $calcOld->setInstanceArrayReturnType(
+            Calculation::RETURN_ARRAY_AS_ARRAY
+        );
+        $sheetOld->fromArray(
+            [1, 2, 2, 4, 3, 2, 1, 3, 3, 3, 5],
+            null,
+            'A14',
+            true
+        );
+        $sheetOld->setCellValue('A15', '=UNIQUE(A14:K14, TRUE)');
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheetOld, 'Xlsx');
+        $spreadsheet = $this->writeAndReload($spreadsheetOld, 'Xlsx');
+        $spreadsheetOld->disconnectWorksheets();
+        $calc = Calculation::getInstance($spreadsheet);
+        self::assertSame(
+            Calculation::RETURN_ARRAY_AS_ARRAY,
+            $calc->getInstanceArrayReturnType()
+        );
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
By default, when an Xlsx spreadsheet is read, its calculation engine is set to `RETURN_ARRAY_AS_VALUE` for array formulas. The user does have the option to change this. However, the presence of certain metadata in the file indicates that it was saved as if `RETURN_ARRAY_AS_ARRAY` was in use. This PR tests for the metadata, and, if present, sets `...ARRAY` rather than `...VALUE`. This eliminates the need for any extra action on the user's part.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

