### PR TITLE
Update XMLWriter.php: htmlspecialchars use Settings::htmlEntityFlags

### DIFF
--- a/src/PhpSpreadsheet/Shared/XMLWriter.php
+++ b/src/PhpSpreadsheet/Shared/XMLWriter.php
@@ -91,6 +91,6 @@ class XMLWriter extends \XMLWriter
             $rawTextData = implode("\n", $rawTextData);
         }
 
-        return $this->writeRaw(htmlspecialchars($rawTextData ?? ''));
+        return $this->writeRaw(htmlspecialchars($rawTextData ?? '', \PhpOffice\PhpSpreadsheet\Settings::htmlEntityFlags()));
     }
 }


### PR DESCRIPTION
XLSX files are now saved cell content with apros as >>'<< and not longer as &#39;

This is:

- [ x ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ x ] Code style is respected
- [ x ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Export XLSX and use this in R, than the content of the cells are wrong, becaues &#39; and not ' is used. See Issue #4537
