### PR TITLE
All Readers - Allow or Forbid Fetching of External Images Release210

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com)
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+# TBD - 2.1.11
+
+### Added
+
+- Add to all readers the option to allow or forbid fetching external images. This is unconditionally allowed now. The default will be set to "allow", so no code changes are necessary. However, we are giving consideration to changing the default.
+
 # 2025-06-22 - 2.1.10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com)
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-# TBD - 2.1.11
+# 2025-07-23 - 2.1.11
 
 ### Added
 
-- Add to all readers the option to allow or forbid fetching external images. This is unconditionally allowed now. The default will be set to "allow", so no code changes are necessary. However, we are giving consideration to changing the default.
+- Add to all readers the option to allow or forbid fetching external images. This is unconditionally allowed now. The default will be set to "allow", so no code changes are necessary. However, we are giving consideration to changing the default. [PR #4546](https://github.com/PHPOffice/PhpSpreadsheet/pull/4546)
 
 # 2025-06-22 - 2.1.10
 

--- a/src/PhpSpreadsheet/Reader/BaseReader.php
+++ b/src/PhpSpreadsheet/Reader/BaseReader.php
@@ -40,6 +40,13 @@ abstract class BaseReader implements IReader
     protected ?array $loadSheetsOnly = null;
 
     /**
+     * Allow external images. Use with caution.
+     * Improper specification of these within a spreadsheet
+     * can subject the caller to security exploits.
+     */
+    protected bool $allowExternalImages = true;
+
+    /**
      * IReadFilter instance.
      */
     protected IReadFilter $readFilter;
@@ -125,6 +132,23 @@ abstract class BaseReader implements IReader
         return $this;
     }
 
+    /**
+     * Allow external images. Use with caution.
+     * Improper specification of these within a spreadsheet
+     * can subject the caller to security exploits.
+     */
+    public function setAllowExternalImages(bool $allowExternalImages): self
+    {
+        $this->allowExternalImages = $allowExternalImages;
+
+        return $this;
+    }
+
+    public function getAllowExternalImages(): bool
+    {
+        return $this->allowExternalImages;
+    }
+
     public function getSecurityScanner(): ?XmlScanner
     {
         return $this->securityScanner;
@@ -149,6 +173,12 @@ abstract class BaseReader implements IReader
         }
         if (((bool) ($flags & self::SKIP_EMPTY_CELLS) || (bool) ($flags & self::IGNORE_EMPTY_CELLS)) === true) {
             $this->setReadEmptyCells(false);
+        }
+        if (((bool) ($flags & self::ALLOW_EXTERNAL_IMAGES)) === true) {
+            $this->setAllowExternalImages(true);
+        }
+        if (((bool) ($flags & self::DONT_ALLOW_EXTERNAL_IMAGES)) === true) {
+            $this->setAllowExternalImages(false);
         }
     }
 

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -1031,7 +1031,7 @@ class Html extends BaseReader
         $name = $attributes['alt'] ?? null;
 
         $drawing = new Drawing();
-        $drawing->setPath($src, false);
+        $drawing->setPath($src, false, allowExternal: $this->allowExternalImages);
         if ($drawing->getPath() === '') {
             return;
         }

--- a/src/PhpSpreadsheet/Reader/IReader.php
+++ b/src/PhpSpreadsheet/Reader/IReader.php
@@ -13,6 +13,14 @@ interface IReader
     public const SKIP_EMPTY_CELLS = 4;
     public const IGNORE_EMPTY_CELLS = 4;
 
+    /**
+     * Allow external images. Use with caution.
+     * Improper specification of these within a spreadsheet
+     * can subject the caller to security exploits.
+     */
+    public const ALLOW_EXTERNAL_IMAGES = 16;
+    public const DONT_ALLOW_EXTERNAL_IMAGES = 32;
+
     public function __construct();
 
     /**
@@ -111,6 +119,15 @@ interface IReader
     public function setReadFilter(IReadFilter $readFilter): self;
 
     /**
+     * Allow external images. Use with caution.
+     * Improper specification of these within a spreadsheet
+     * can subject the caller to security exploits.
+     */
+    public function setAllowExternalImages(bool $allowExternalImages): self;
+
+    public function getAllowExternalImages(): bool;
+
+    /**
      * Loads PhpSpreadsheet from file.
      *
      * @param string $filename The name of the file to load
@@ -119,6 +136,8 @@ interface IReader
      *            self::READ_DATA_ONLY      Read only data, not style or structure information, from the file
      *            self::SKIP_EMPTY_CELLS    Don't read empty cells (cells that contain a null value,
      *                                      empty string, or a string containing only whitespace characters)
+     *            self::ALLOW_EXTERNAL_IMAGES    Attempt to fetch images stored outside the spreadsheet.
+     *            self::DONT_ALLOW_EXTERNAL_IMAGES    Don't attempt to fetch images stored outside the spreadsheet.
      */
     public function load(string $filename, int $flags = 0): Spreadsheet;
 }

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1441,7 +1441,7 @@ class Xlsx extends BaseReader
                                                         );
                                                         if (isset($images[$linkImageKey])) {
                                                             $url = str_replace('xl/drawings/', '', $images[$linkImageKey]);
-                                                            $objDrawing->setPath($url, false);
+                                                            $objDrawing->setPath($url, false, allowExternal: $this->allowExternalImages);
                                                         }
                                                         if ($objDrawing->getPath() === '') {
                                                             continue;
@@ -1534,7 +1534,7 @@ class Xlsx extends BaseReader
                                                         );
                                                         if (isset($images[$linkImageKey])) {
                                                             $url = str_replace('xl/drawings/', '', $images[$linkImageKey]);
-                                                            $objDrawing->setPath($url, false);
+                                                            $objDrawing->setPath($url, false, allowExternal: $this->allowExternalImages);
                                                         }
                                                         if ($objDrawing->getPath() === '') {
                                                             continue;

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -92,7 +92,7 @@ class Drawing extends BaseDrawing
      *
      * @return $this
      */
-    public function setPath(string $path, bool $verifyFile = true, ?ZipArchive $zip = null): static
+    public function setPath(string $path, bool $verifyFile = true, ?ZipArchive $zip = null, bool $allowExternal = true): static
     {
         $this->isUrl = false;
         if (preg_match('~^data:image/[a-z]+;base64,~', $path) === 1) {
@@ -106,6 +106,9 @@ class Drawing extends BaseDrawing
         if (filter_var($path, FILTER_VALIDATE_URL) || (preg_match('/^([\w\s\x00-\x1f]+):/u', $path) && !preg_match('/^([\w]+):/u', $path))) {
             if (!preg_match('/^(http|https|file|ftp|s3):/', $path)) {
                 throw new PhpSpreadsheetException('Invalid protocol for linked drawing');
+            }
+            if (!$allowExternal) {
+                return $this;
             }
             // Implicit that it is a URL, rather store info than running check above on value in other places.
             $this->isUrl = true;

--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlHelper.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlHelper.php
@@ -18,9 +18,12 @@ class HtmlHelper
         return $filename;
     }
 
-    public static function loadHtmlIntoSpreadsheet(string $filename, bool $unlink = false): Spreadsheet
+    public static function loadHtmlIntoSpreadsheet(string $filename, bool $unlink = false, ?bool $allowExternalImages = null): Spreadsheet
     {
         $html = new Html();
+        if ($allowExternalImages !== null) {
+            $html->setAllowExternalImages($allowExternalImages);
+        }
         $spreadsheet = $html->load($filename);
         if ($unlink) {
             unlink($filename);

--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlImage2Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlImage2Test.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class HtmlImage2Test extends TestCase
 {
-    public function testCanInsertImageGoodProtocol(): void
+    public function testCanInsertImageGoodProtocolAllowed(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');
@@ -23,16 +23,32 @@ class HtmlImage2Test extends TestCase
                     </tr>
                 </table>';
         $filename = HtmlHelper::createHtml($html);
-        $spreadsheet = HtmlHelper::loadHtmlIntoSpreadsheet($filename, true);
+        $spreadsheet = HtmlHelper::loadHtmlIntoSpreadsheet($filename, true, true);
         $firstSheet = $spreadsheet->getSheet(0);
 
         /** @var Drawing $drawing */
         $drawing = $firstSheet->getDrawingCollection()[0];
         self::assertEquals($imagePath, $drawing->getPath());
         self::assertEquals('A1', $drawing->getCoordinates());
+        $spreadsheet->disconnectWorksheets();
     }
 
-    public function testCantInsertImageNotFound(): void
+    public function testCanInsertImageGoodProtocolNotAllowed(): void
+    {
+        $imagePath = 'https://phpspreadsheet.readthedocs.io/en/latest/topics/images/01-03-filter-icon-1.png';
+        $html = '<table>
+                    <tr>
+                        <td><img src="' . $imagePath . '" alt="test image voilà"></td>
+                    </tr>
+                </table>';
+        $filename = HtmlHelper::createHtml($html);
+        $spreadsheet = HtmlHelper::loadHtmlIntoSpreadsheet($filename, true, false);
+        $firstSheet = $spreadsheet->getSheet(0);
+        self::assertCount(0, $firstSheet->getDrawingCollection());
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testCantInsertImageNotFoundAllowed(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');
@@ -44,10 +60,27 @@ class HtmlImage2Test extends TestCase
                     </tr>
                 </table>';
         $filename = HtmlHelper::createHtml($html);
-        $spreadsheet = HtmlHelper::loadHtmlIntoSpreadsheet($filename, true);
+        $spreadsheet = HtmlHelper::loadHtmlIntoSpreadsheet($filename, true, true);
         $firstSheet = $spreadsheet->getSheet(0);
         $drawingCollection = $firstSheet->getDrawingCollection();
         self::assertCount(0, $drawingCollection);
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testCantInsertImageNotFoundNotAllowed(): void
+    {
+        $imagePath = 'https://phpspreadsheet.readthedocs.io/en/latest/topics/images/xxx01-03-filter-icon-1.png';
+        $html = '<table>
+                    <tr>
+                        <td><img src="' . $imagePath . '" alt="test image voilà"></td>
+                    </tr>
+                </table>';
+        $filename = HtmlHelper::createHtml($html);
+        $spreadsheet = HtmlHelper::loadHtmlIntoSpreadsheet($filename, true, false);
+        $firstSheet = $spreadsheet->getSheet(0);
+        $drawingCollection = $firstSheet->getDrawingCollection();
+        self::assertCount(0, $drawingCollection);
+        $spreadsheet->disconnectWorksheets();
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/URLImageTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class URLImageTest extends TestCase
 {
-    public function testURLImageSource(): void
+    public function testURLImageSourceAllowed(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');
@@ -20,6 +20,7 @@ class URLImageTest extends TestCase
         $filename = realpath(__DIR__ . '/../../../data/Reader/XLSX/urlImage.xlsx');
         self::assertNotFalse($filename);
         $reader = IOFactory::createReader('Xlsx');
+        $reader->setAllowExternalImages(true);
         $spreadsheet = $reader->load($filename);
         $worksheet = $spreadsheet->getActiveSheet();
         $collection = $worksheet->getDrawingCollection();
@@ -37,7 +38,20 @@ class URLImageTest extends TestCase
         }
     }
 
-    public function xtestURLImageSourceNotFound(): void
+    public function testURLImageSourceNotAllowed(): void
+    {
+        $filename = realpath(__DIR__ . '/../../../data/Reader/XLSX/urlImage.xlsx');
+        self::assertNotFalse($filename);
+        $reader = IOFactory::createReader('Xlsx');
+        $reader->setAllowExternalImages(false);
+        $spreadsheet = $reader->load($filename);
+        $worksheet = $spreadsheet->getActiveSheet();
+        $collection = $worksheet->getDrawingCollection();
+        self::assertCount(0, $collection);
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testURLImageSourceNotFoundAllowed(): void
     {
         if (getenv('SKIP_URL_IMAGE_TEST') === '1') {
             self::markTestSkipped('Skipped due to setting of environment variable');
@@ -45,6 +59,20 @@ class URLImageTest extends TestCase
         $filename = realpath(__DIR__ . '/../../../data/Reader/XLSX/urlImage.notfound.xlsx');
         self::assertNotFalse($filename);
         $reader = IOFactory::createReader('Xlsx');
+        $reader->setAllowExternalImages(true);
+        $spreadsheet = $reader->load($filename);
+        $worksheet = $spreadsheet->getActiveSheet();
+        $collection = $worksheet->getDrawingCollection();
+        self::assertCount(0, $collection);
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testURLImageSourceNotFoundNotAllowed(): void
+    {
+        $filename = realpath(__DIR__ . '/../../../data/Reader/XLSX/urlImage.notfound.xlsx');
+        self::assertNotFalse($filename);
+        $reader = IOFactory::createReader('Xlsx');
+        $reader->setAllowExternalImages(false);
         $spreadsheet = $reader->load($filename);
         $worksheet = $spreadsheet->getActiveSheet();
         $collection = $worksheet->getDrawingCollection();


### PR DESCRIPTION
Add to all readers the option to allow or forbid fetching external images. This is unconditionally allowed now. The default will be set to "allow", so no code changes are necessary. However, we are giving consideration to changing the default.

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

