### PR TITLE
Minor Breaking Change - Move Some BaseWriter Properties

### DIFF
--- a/src/PhpSpreadsheet/Writer/BaseWriter.php
+++ b/src/PhpSpreadsheet/Writer/BaseWriter.php
@@ -2,8 +2,6 @@
 
 namespace PhpOffice\PhpSpreadsheet\Writer;
 
-use PhpOffice\PhpSpreadsheet\Exception as PhpSpreadsheetException;
-
 abstract class BaseWriter implements IWriter
 {
     /**
@@ -18,18 +16,6 @@ abstract class BaseWriter implements IWriter
      * immediately available to MS Excel or other office spreadsheet viewer when opening the file.
      */
     protected bool $preCalculateFormulas = true;
-
-    /**
-     * Table formats
-     * Enables table formats in writer, disabled here, must be enabled in writer via a setter.
-     */
-    protected bool $tableFormats = false;
-
-    /**
-     * Conditional Formatting
-     * Enables conditional formatting in writer, disabled here, must be enabled in writer via a setter.
-     */
-    protected bool $conditionalFormatting = false;
 
     /**
      * Use disk caching where possible?
@@ -68,34 +54,6 @@ abstract class BaseWriter implements IWriter
     public function setPreCalculateFormulas(bool $precalculateFormulas): self
     {
         $this->preCalculateFormulas = $precalculateFormulas;
-
-        return $this;
-    }
-
-    public function getTableFormats(): bool
-    {
-        return $this->tableFormats;
-    }
-
-    public function setTableFormats(bool $tableFormats): self
-    {
-        if ($tableFormats) {
-            throw new PhpSpreadsheetException('Table formatting not implemented for this writer');
-        }
-
-        return $this;
-    }
-
-    public function getConditionalFormatting(): bool
-    {
-        return $this->conditionalFormatting;
-    }
-
-    public function setConditionalFormatting(bool $conditionalFormatting): self
-    {
-        if ($conditionalFormatting) {
-            throw new PhpSpreadsheetException('Conditional Formatting not implemented for this writer');
-        }
 
         return $this;
     }

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -159,6 +159,18 @@ class Html extends BaseWriter
     private string $getFalse = 'FALSE';
 
     /**
+     * Table formats
+     * Enables table formats in writer, disabled here, must be enabled in writer via a setter.
+     */
+    protected bool $tableFormats = false;
+
+    /**
+     * Conditional Formatting
+     * Enables conditional formatting in writer, disabled here, must be enabled in writer via a setter.
+     */
+    protected bool $conditionalFormatting = false;
+
+    /**
      * Create a new HTML.
      */
     public function __construct(Spreadsheet $spreadsheet)
@@ -1849,11 +1861,21 @@ class Html extends BaseWriter
         return $this;
     }
 
+    public function getTableFormats(): bool
+    {
+        return $this->tableFormats;
+    }
+
     public function setTableFormats(bool $tableFormats): self
     {
         $this->tableFormats = $tableFormats;
 
         return $this;
+    }
+
+    public function getConditionalFormatting(): bool
+    {
+        return $this->conditionalFormatting;
     }
 
     public function setConditionalFormatting(bool $conditionalFormatting): self


### PR DESCRIPTION
When Conditional and Table Formatting were added to Html Writer, properties, getters, and setters were added to Base Writer. They should have been added to Html Writer instead, and this PR moves them from one to the other. It is technically a breaking change, but, since there is no reason to use them with any writer other than Html, I don't anticipate anyone seeing any adverse effects.

This is:

- [ ] a bugfix
- [ ] a new feature
- [x] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

