### PR TITLE
Eliminate Deprecated Constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Breaking Changes
 
-- Nothing yet.
+- Deletion of items deprecated in Release 4. See "removed" below.
 
 ### Added
 
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Removed
 
-- Nothing yet.
+- Theme public constants COLOR_SCHEME_2013_PLUS_NAME (use COLOR_SCHEME_2013_2022_NAME) and COLOR_SCHEME_2013_PLUS (use COLOR_SCHEME_2013_2022).
 
 ### Changed
 

--- a/src/PhpSpreadsheet/Theme.php
+++ b/src/PhpSpreadsheet/Theme.php
@@ -24,10 +24,7 @@ class Theme
         'hlink' => '0563C1',
         'folHlink' => '954F72',
     ];
-    /** @deprecated 4.4.0 Use COLOR_SCHEME_2013_2022_NAME */
-    public const COLOR_SCHEME_2013_PLUS_NAME = 'Office 2013+';
-    /** @deprecated 4.4.0 Use COLOR_SCHEME_2013_2022 */
-    public const COLOR_SCHEME_2013_PLUS = self::COLOR_SCHEME_2013_2022;
+    private const COLOR_SCHEME_2013_PLUS_NAME = 'Office 2013+';
 
     public const COLOR_SCHEME_2007_2010_NAME = 'Office 2007-2010';
     public const COLOR_SCHEME_2007_2010 = [
@@ -177,15 +174,15 @@ class Theme
     /** @param null|string[] $themeColors */
     public function setThemeColorName(string $name, ?array $themeColors = null, ?Spreadsheet $spreadsheet = null): self
     {
+        if ($name === self::COLOR_SCHEME_2013_PLUS_NAME) {
+            // Ensure against this value being found in
+            // spreadsheets created while constant was public.
+            $name = self::COLOR_SCHEME_2013_2022_NAME;
+        }
         $this->themeColorName = $name;
         if ($name === self::COLOR_SCHEME_2007_2010_NAME) {
             $themeColors = $themeColors ?? self::COLOR_SCHEME_2007_2010;
             $this->majorFontLatin = 'Cambria';
-            $this->minorFontLatin = 'Calibri';
-        } elseif ($name === self::COLOR_SCHEME_2013_PLUS_NAME) { //* @phpstan-ignore-line
-            // delete this block when deprecated constants removed
-            $themeColors = $themeColors ?? self::COLOR_SCHEME_2013_PLUS; //* @phpstan-ignore-line
-            $this->majorFontLatin = 'Calibri Light';
             $this->minorFontLatin = 'Calibri';
         } elseif ($name === self::COLOR_SCHEME_2013_2022_NAME) {
             $themeColors = $themeColors ?? self::COLOR_SCHEME_2013_2022;

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/ThemeColorsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/ThemeColorsTest.php
@@ -12,17 +12,19 @@ use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
 class ThemeColorsTest extends AbstractFunctional
 {
+    private const COLOR_SCHEME_2013_PLUS_NAME = 'Office 2013+';
+
     public function testOffice2013Theme(): void
     {
         $spreadsheet = new Spreadsheet();
         $spreadsheet->getTheme()
             ->setThemeColorName(
-                SpreadsheetTheme::COLOR_SCHEME_2013_PLUS_NAME //* @phpstan-ignore-line
+                self::COLOR_SCHEME_2013_PLUS_NAME
             );
         $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Xlsx');
         $spreadsheet->disconnectWorksheets();
         self::assertSame(
-            SpreadsheetTheme::COLOR_SCHEME_2013_PLUS_NAME, //* @phpstan-ignore-line
+            SpreadsheetTheme::COLOR_SCHEME_2013_2022_NAME,
             $reloadedSpreadsheet->getTheme()->getThemeColorName()
         );
         self::assertSame('FFC000', $reloadedSpreadsheet->getTheme()->getThemeColors()['accent4']);


### PR DESCRIPTION
In Theme, change COLOR_SCHEME_2013_PLUS_NAME to private (use COLOR_SCHEME_2013_2022_NAME instead), and delete COLOR_SCHEME_2013_PLUS (use COLOR_SCHEME_2013_2022).

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] cleanup for new major release 

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

