### PR TITLE
Xlsx Writer Eliminate xml:space From Non-Text Nodes

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheet\Writer;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\HashTable;
+use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Borders;
 use PhpOffice\PhpSpreadsheet\Style\Conditional;
@@ -284,6 +285,19 @@ class Xlsx extends BaseWriter
     }
 
     /**
+     * @return (RichText|string)[] $stringTable
+     */
+    public function createStringTable(): array
+    {
+        $this->stringTable = [];
+        for ($i = 0; $i < $this->spreadSheet->getSheetCount(); ++$i) {
+            $this->stringTable = $this->getWriterPartStringTable()->createStringTable($this->spreadSheet->getSheet($i), $this->stringTable);
+        }
+
+        return $this->stringTable;
+    }
+
+    /**
      * Save PhpSpreadsheet to file.
      *
      * @param resource|string $filename
@@ -303,10 +317,7 @@ class Xlsx extends BaseWriter
         Functions::setReturnDateType(Functions::RETURNDATE_EXCEL);
 
         // Create string lookup table
-        $this->stringTable = [];
-        for ($i = 0; $i < $this->spreadSheet->getSheetCount(); ++$i) {
-            $this->stringTable = $this->getWriterPartStringTable()->createStringTable($this->spreadSheet->getSheet($i), $this->stringTable);
-        }
+        $this->createStringTable();
 
         // Create styles dictionaries
         $this->createStyleDictionaries();

--- a/src/PhpSpreadsheet/Writer/Xlsx/Style.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Style.php
@@ -37,7 +37,6 @@ class Style extends WriterPart
 
         // styleSheet
         $objWriter->startElement('styleSheet');
-        $objWriter->writeAttribute('xml:space', 'preserve');
         $objWriter->writeAttribute('xmlns', Namespaces::MAIN);
 
         // numFmts

--- a/src/PhpSpreadsheet/Writer/Xlsx/Table.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Table.php
@@ -34,7 +34,6 @@ class Table extends WriterPart
         $range = $table->getRange();
 
         $objWriter->startElement('table');
-        $objWriter->writeAttribute('xml:space', 'preserve');
         $objWriter->writeAttribute('xmlns', Namespaces::MAIN);
         $objWriter->writeAttribute('id', (string) $tableRef);
         $objWriter->writeAttribute('name', $name);

--- a/src/PhpSpreadsheet/Writer/Xlsx/Workbook.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Workbook.php
@@ -33,7 +33,6 @@ class Workbook extends WriterPart
 
         // workbook
         $objWriter->startElement('workbook');
-        $objWriter->writeAttribute('xml:space', 'preserve');
         $objWriter->writeAttribute('xmlns', Namespaces::MAIN);
         $objWriter->writeAttribute('xmlns:r', Namespaces::SCHEMA_OFFICE_DOCUMENT);
 

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -68,7 +68,6 @@ class Worksheet extends WriterPart
 
         // Worksheet
         $objWriter->startElement('worksheet');
-        $objWriter->writeAttribute('xml:space', 'preserve');
         $objWriter->writeAttribute('xmlns', Namespaces::MAIN);
         $objWriter->writeAttribute('xmlns:r', Namespaces::SCHEMA_OFFICE_DOCUMENT);
 
@@ -1436,13 +1435,16 @@ class Worksheet extends WriterPart
         $objWriter->writeAttribute('t', $mappedType);
         if (!$cellValue instanceof RichText) {
             $objWriter->startElement('is');
-            $objWriter->writeElement(
-                't',
-                StringHelper::controlCharacterPHP2OOXML(
-                    $cellValue
-                )
+            $objWriter->startElement('t');
+            $textToWrite = StringHelper::controlCharacterPHP2OOXML(
+                $cellValue
             );
-            $objWriter->endElement();
+            if ($textToWrite !== trim($textToWrite)) {
+                $objWriter->writeAttribute('xml:space', 'preserve');
+            }
+            $objWriter->writeRawData($textToWrite);
+            $objWriter->endElement(); // t
+            $objWriter->endElement(); // is
         } else {
             $objWriter->startElement('is');
             $this->getParentWriter()

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue4542Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue4542Test.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Table;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PHPUnit\Framework\TestCase;
+
+class Issue4542Test extends TestCase
+{
+    public function testXmlSpace(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $string = ' Ye&ar ';
+        $trimString = trim($string);
+        $sheet->getCell('A1')->setValue($string);
+        $sheet->getCell('A2')->setValueExplicit($string, DataType::TYPE_INLINE);
+        $sheet->getCell('B1')->setValue($trimString);
+        $sheet->getCell('B2')->setValueExplicit($trimString, DataType::TYPE_INLINE);
+        $writer = new XlsxWriter($spreadsheet);
+
+        $writer->createStyleDictionaries();
+        $writerStyle = new XlsxWriter\Style($writer);
+        $data = $writerStyle->writeStyles($spreadsheet);
+        self::assertStringContainsString(
+            '<styleSheet',
+            $data
+        );
+        self::assertStringNotContainsString(
+            'xml:space',
+            $data
+        );
+
+        $writerWorkbook = new XlsxWriter\Workbook($writer);
+        $data = $writerWorkbook->writeWorkbook($spreadsheet);
+        self::assertStringContainsString(
+            '<workbook',
+            $data
+        );
+        self::assertStringNotContainsString(
+            'xml:space',
+            $data
+        );
+
+        $stringTable = $writer->createStringTable();
+        $writerStringTable = new XlsxWriter\StringTable($writer);
+        $data = $writerStringTable->writeStringTable($stringTable);
+        self::assertStringContainsString(
+            '<si><t xml:space="preserve"> Ye&amp;ar </t></si>',
+            $data
+        );
+        self::assertStringContainsString(
+            '<si><t>Ye&amp;ar</t></si>',
+            $data
+        );
+
+        $writerWorksheet = new XlsxWriter\Worksheet($writer);
+        $data = $writerWorksheet->writeWorksheet($sheet, []);
+        self::assertStringContainsString(
+            '<c r="A2" t="inlineStr"><is><t xml:space="preserve"> Ye&amp;ar </t></is></c>',
+            $data
+        );
+        self::assertStringContainsString(
+            '<c r="B2" t="inlineStr"><is><t>Ye&amp;ar</t></is></c>',
+            $data
+        );
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testTable(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray(
+            [
+                ['MyCol', 'Colonne2', 'Colonne3'],
+                [10, 20],
+                [2],
+                [3],
+                [4],
+            ],
+            null,
+            'B1',
+            true
+        );
+        $table = new Table('B1:D5', 'Tableau1');
+        $sheet->addTable($table);
+
+        $writer = new XlsxWriter($spreadsheet);
+        $writerTable = new XlsxWriter\Table($writer);
+        $data = $writerTable->writeTable($table, 1);
+
+        self::assertStringContainsString(
+            '<table ',
+            $data
+        );
+        self::assertStringNotContainsString(
+            'xml:space',
+            $data
+        );
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Fix #4542. PhpSpreadsheet has been writing attribute `xml:space="preserve"` to the `table` tag when writing a Table. According to the issue, Excel 2016 is treating the resulting file as corrupt. I do not have access to a version of Excel 2016 to confirm. This seems to be a bug with that release. Nevertheless, the OOXML spec, with over 100 references to `xml:space` does not indicate that it is a permitted attribute for `table`. It should only be specified for text nodes. This PR eliminates the undocumented, and unneeded, usage.

Investigating further, PhpSpreadsheet also writes this attribute for `workbook`, `styleSheet`, and `worksheet` tags. It is again undocumented and unneeded in those cases. Although all Excel releases, including 2016, apparently tolerate such usage, this PR also eliminates those.

Finally, there is one case where PhpSpreadsheet omits this tag when it is needed. When writing a cell whose data type is an inline string, and the string contains leading or trailing whitespace, the text tag needs to specify `xml:space`, and is now changed to do so.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

