### PR TITLE
Remove Private Methods/Properties From Online Doc

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Build API documentation
         run: |
-          curl -LO https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.5.0/phpDocumentor.phar
-          php phpDocumentor.phar --directory src/ --target docs/api
+          curl -LO https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.8.1/phpDocumentor.phar
+          php phpDocumentor.phar --directory src/ --target docs/api --visibility=public,protected
 
       - name: Deploy to GithHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Documenting public and protected methods is useful; I don't believe it is useful to document private methods. If people really need them, they can clone the project and run PhpDocumentor against it.

As long as I'm at it, we are several releases behind in PhpDocumentor. Use the latest (3.8.1 replacing 3.5.0). I have confirmed that this works locally on my machine. There's no real way to verify the change until the next PhpSpreadsheet release. Hope it works.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] API documentation

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
