### PR TITLE
Shared/Date::isDateTime Handle Cells Which Calculate as Arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- Nothing yet.
+- Shared/Date::isDateTime handle cells which calculate as arrays. [Issue #4557](https://github.com/PHPOffice/PhpSpreadsheet/issues/4557) [PR #4562](https://github.com/PHPOffice/PhpSpreadsheet/pull/4562)
 
 ## 2025-07-23 - 4.5.0
 

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -207,10 +207,7 @@ class Calculation extends CalculationLocale
     public static function getInstance(?Spreadsheet $spreadsheet = null): self
     {
         if ($spreadsheet !== null) {
-            $instance = $spreadsheet->getCalculationEngine();
-            if (isset($instance)) {
-                return $instance;
-            }
+            return $spreadsheet->getCalculationEngine();
         }
 
         if (!self::$instance) {
@@ -218,6 +215,20 @@ class Calculation extends CalculationLocale
         }
 
         return self::$instance;
+    }
+
+    /**
+     * Intended for use only via a destructor.
+     *
+     * @internal
+     */
+    public static function getInstanceOrNull(?Spreadsheet $spreadsheet = null): ?self
+    {
+        if ($spreadsheet !== null) {
+            return $spreadsheet->getCalculationEngineOrNull();
+        }
+
+        return null;
     }
 
     /**

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2,7 +2,6 @@
 
 namespace PhpOffice\PhpSpreadsheet\Reader;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
@@ -452,10 +451,7 @@ class Xlsx extends BaseReader
             switch ($rel['Type']) {
                 case "$xmlNamespaceBase/sheetMetadata":
                     if ($this->fileExistsInArchive($zip, "xl/{$relTarget}")) {
-                        $excel->getCalculationEngine()
-                            ?->setInstanceArrayReturnType(
-                                Calculation::RETURN_ARRAY_AS_ARRAY
-                            );
+                        $excel->returnArrayAsArray();
                     }
 
                     break;

--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -374,7 +374,12 @@ class Date
             $selected = $worksheet->getSelectedCells();
 
             try {
-                $result = is_numeric($value ?? $cell->getCalculatedValue())
+                if ($value === null) {
+                    $value = Functions::flattenSingleValue(
+                        $cell->getCalculatedValue()
+                    );
+                }
+                $result = is_numeric($value)
                     && self::isDateTimeFormat(
                         $worksheet->getStyle(
                             $cell->getCoordinate()

--- a/src/PhpSpreadsheet/Shared/Date.php
+++ b/src/PhpSpreadsheet/Shared/Date.php
@@ -172,10 +172,7 @@ class Date
             throw new Exception("Invalid string $value supplied for datatype Date");
         }
 
-        $newValue = self::PHPToExcel($date);
-        if ($newValue === false) {
-            throw new Exception("Invalid string $value supplied for datatype Date");
-        }
+        $newValue = self::dateTimeToExcel($date);
 
         if (preg_match('/^\s*\d?\d:\d\d(:\d\d([.]\d+)?)?\s*(am|pm)?\s*$/i', $value) == 1) {
             $newValue = fmod($newValue, 1.0);

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -373,7 +373,8 @@ class Worksheet
      */
     public function __destruct()
     {
-        Calculation::getInstance($this->parent)->clearCalculationCacheForWorksheet($this->title);
+        Calculation::getInstanceOrNull($this->parent)
+            ?->clearCalculationCacheForWorksheet($this->title);
 
         $this->disconnectCells();
         unset($this->rowDimensions, $this->columnDimensions, $this->tableCollection, $this->drawingCollection, $this->chartCollection, $this->autoFilter);
@@ -909,7 +910,7 @@ class Worksheet
         // Set title
         $this->title = $title;
 
-        if ($this->parent && $this->parent->getIndex($this, true) >= 0 && $this->parent->getCalculationEngine()) {
+        if ($this->parent && $this->parent->getIndex($this, true) >= 0) {
             // New title
             $newTitle = $this->getTitle();
             $this->parent->getCalculationEngine()

--- a/tests/PhpSpreadsheetTests/Calculation/StructuredReferenceFormulaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/StructuredReferenceFormulaTest.php
@@ -39,7 +39,7 @@ class StructuredReferenceFormulaTest extends TestCase
         $result = $spreadsheet->getActiveSheet()->getCell($cellAddress)->getCalculatedValue();
         self::assertSame('Region', $result);
 
-        $spreadsheet->getCalculationEngine()?->flushInstance();
+        $spreadsheet->getCalculationEngine()->flushInstance();
         $table->setShowHeaderRow(false);
 
         $result = $spreadsheet->getActiveSheet()->getCell($cellAddress)->getCalculatedValue();

--- a/tests/PhpSpreadsheetTests/Reader/Ods/DefinedNamesTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Ods/DefinedNamesTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Ods;
 
-use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Reader\Ods;
 use PHPUnit\Framework\TestCase;
 
@@ -15,10 +14,7 @@ class DefinedNamesTest extends TestCase
         $filename = 'tests/data/Reader/Ods/DefinedNames.ods';
         $reader = new Ods();
         $spreadsheet = $reader->load($filename);
-        $calculation = Calculation::getInstance($spreadsheet);
-        $calculation->setInstanceArrayReturnType(
-            Calculation::RETURN_ARRAY_AS_VALUE
-        );
+        $spreadsheet->returnArrayAsValue();
         $worksheet = $spreadsheet->getActiveSheet();
 
         $firstDefinedNameValue = $worksheet->getCell('First')->getValue();
@@ -36,10 +32,7 @@ class DefinedNamesTest extends TestCase
         $filename = 'tests/data/Reader/Ods/DefinedNames.apostrophe.ods';
         $reader = new Ods();
         $spreadsheet = $reader->load($filename);
-        $calculation = Calculation::getInstance($spreadsheet);
-        $calculation->setInstanceArrayReturnType(
-            Calculation::RETURN_ARRAY_AS_VALUE
-        );
+        $spreadsheet->returnArrayAsValue();
         $worksheet = $spreadsheet->getActiveSheet();
         self::assertSame("apo'strophe", $worksheet->getTitle());
 
@@ -58,10 +51,7 @@ class DefinedNamesTest extends TestCase
         $filename = 'tests/data/Reader/Ods/DefinedNames.ods';
         $reader = new Ods();
         $spreadsheet = $reader->load($filename);
-        $calculation = Calculation::getInstance($spreadsheet);
-        $calculation->setInstanceArrayReturnType(
-            Calculation::RETURN_ARRAY_AS_ARRAY
-        );
+        $spreadsheet->returnArrayAsArray();
         $worksheet = $spreadsheet->getActiveSheet();
 
         $firstDefinedNameValue = $worksheet->getCell('First')->getValue();

--- a/tests/PhpSpreadsheetTests/Shared/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/DateTest.php
@@ -39,10 +39,15 @@ class DateTest extends TestCase
             Date::CALENDAR_WINDOWS_1900,
         ];
 
+        $spreadsheet = new Spreadsheet();
         foreach ($calendarValues as $calendarValue) {
             $result = Date::setExcelCalendar($calendarValue);
             self::assertTrue($result);
+            $result = $spreadsheet->setExcelCalendar($calendarValue);
+            self::assertTrue($result);
         }
+        self::assertFalse($spreadsheet->setExcelCalendar(0));
+        $spreadsheet->disconnectWorksheets();
     }
 
     public function testSetExcelCalendarWithInvalidValue(): void

--- a/tests/PhpSpreadsheetTests/Shared/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/DateTest.php
@@ -11,6 +11,7 @@ use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class DateTest extends TestCase
@@ -51,7 +52,7 @@ class DateTest extends TestCase
         self::assertFalse($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerDateTimeExcelToTimestamp1900')]
+    #[DataProvider('providerDateTimeExcelToTimestamp1900')]
     public function testDateTimeExcelToTimestamp1900(float|int $expectedResult, float|int $excelDateTimeValue): void
     {
         if ($expectedResult > PHP_INT_MAX || $expectedResult < PHP_INT_MIN) {
@@ -68,7 +69,7 @@ class DateTest extends TestCase
         return require 'tests/data/Shared/Date/ExcelToTimestamp1900.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerDateTimeTimestampToExcel1900')]
+    #[DataProvider('providerDateTimeTimestampToExcel1900')]
     public function testDateTimeTimestampToExcel1900(float|int $expectedResult, float|int|string $unixTimestamp): void
     {
         Date::setExcelCalendar(Date::CALENDAR_WINDOWS_1900);
@@ -82,7 +83,7 @@ class DateTest extends TestCase
         return require 'tests/data/Shared/Date/TimestampToExcel1900.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerDateTimeDateTimeToExcel')]
+    #[DataProvider('providerDateTimeDateTimeToExcel')]
     public function testDateTimeDateTimeToExcel(float|int $expectedResult, DateTimeInterface $dateTimeObject): void
     {
         Date::setExcelCalendar(Date::CALENDAR_WINDOWS_1900);
@@ -99,7 +100,7 @@ class DateTest extends TestCase
     /**
      * @param array{0: int, 1: int, 2: int, 3: int, 4: int, 5: float|int} $args Array containing year/month/day/hours/minutes/seconds
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerDateTimeFormattedPHPToExcel1900')]
+    #[DataProvider('providerDateTimeFormattedPHPToExcel1900')]
     public function testDateTimeFormattedPHPToExcel1900(mixed $expectedResult, ...$args): void
     {
         Date::setExcelCalendar(Date::CALENDAR_WINDOWS_1900);
@@ -113,7 +114,7 @@ class DateTest extends TestCase
         return require 'tests/data/Shared/Date/FormattedPHPToExcel1900.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerDateTimeExcelToTimestamp1904')]
+    #[DataProvider('providerDateTimeExcelToTimestamp1904')]
     public function testDateTimeExcelToTimestamp1904(float|int $expectedResult, float|int $excelDateTimeValue): void
     {
         if ($expectedResult > PHP_INT_MAX || $expectedResult < PHP_INT_MIN) {
@@ -130,7 +131,7 @@ class DateTest extends TestCase
         return require 'tests/data/Shared/Date/ExcelToTimestamp1904.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerDateTimeTimestampToExcel1904')]
+    #[DataProvider('providerDateTimeTimestampToExcel1904')]
     public function testDateTimeTimestampToExcel1904(mixed $expectedResult, float|int|string $unixTimestamp): void
     {
         Date::setExcelCalendar(Date::CALENDAR_MAC_1904);
@@ -144,7 +145,7 @@ class DateTest extends TestCase
         return require 'tests/data/Shared/Date/TimestampToExcel1904.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsDateTimeFormatCode')]
+    #[DataProvider('providerIsDateTimeFormatCode')]
     public function testIsDateTimeFormatCode(mixed $expectedResult, string $format): void
     {
         $result = Date::isDateTimeFormatCode($format);
@@ -156,7 +157,7 @@ class DateTest extends TestCase
         return require 'tests/data/Shared/Date/FormatCodes.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerDateTimeExcelToTimestamp1900Timezone')]
+    #[DataProvider('providerDateTimeExcelToTimestamp1900Timezone')]
     public function testDateTimeExcelToTimestamp1900Timezone(float|int $expectedResult, float|int $excelDateTimeValue, string $timezone): void
     {
         if ($expectedResult > PHP_INT_MAX || $expectedResult < PHP_INT_MIN) {
@@ -237,6 +238,27 @@ class DateTest extends TestCase
             ->getNumberFormat()
             ->setFormatCode('yyyy-mm-dd');
         self::assertFalse(Date::isDateTime($cella4));
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testArray(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->returnArrayAsArray();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 45000);
+        $sheet->setCellValue('A2', 44000);
+        $sheet->setCellValue('A3', 46000);
+        $sheet->setCellValue('C1', '=SORT(A1:A3)');
+        $sheet->setCellValue('D1', '=SORT(A1:A3)');
+        $sheet->getStyle('C1')
+            ->getNumberFormat()
+            ->setFormatCode('yyyy-mm-dd');
+        self::assertTrue(Date::isDateTime($sheet->getCell('C1')));
+        self::assertFalse(Date::isDateTime($sheet->getCell('D1')));
+        self::assertIsArray(
+            $sheet->getCell('C1')->getCalculatedValue()
+        );
         $spreadsheet->disconnectWorksheets();
     }
 

--- a/tests/PhpSpreadsheetTests/Shared/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/DateTest.php
@@ -204,6 +204,9 @@ class DateTest extends TestCase
 
         $date = Date::PHPToExcel('2020-01-01');
         self::assertEquals(43831.0, $date);
+        $phpDate = new DateTime('2020-01-02T00:00Z');
+        $date = Date::PHPToExcel($phpDate);
+        self::assertEquals(43832.0, $date);
 
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();

--- a/tests/PhpSpreadsheetTests/SpreadsheetCopyCloneTest.php
+++ b/tests/PhpSpreadsheetTests/SpreadsheetCopyCloneTest.php
@@ -49,8 +49,8 @@ class SpreadsheetCopyCloneTest extends TestCase
         } else {
             $spreadsheet2 = $this->spreadsheet2 = clone $spreadsheet;
         }
-        self::assertSame($spreadsheet, $spreadsheet->getCalculationEngine()?->getSpreadsheet());
-        self::assertSame($spreadsheet2, $spreadsheet2->getCalculationEngine()?->getSpreadsheet());
+        self::assertSame($spreadsheet, $spreadsheet->getCalculationEngine()->getSpreadsheet());
+        self::assertSame($spreadsheet2, $spreadsheet2->getCalculationEngine()->getSpreadsheet());
         self::assertSame('A3', $sheet->getSelectedCells());
         $copysheet = $spreadsheet2->getActiveSheet();
         self::assertSame('A3', $copysheet->getSelectedCells());
@@ -132,7 +132,6 @@ class SpreadsheetCopyCloneTest extends TestCase
     {
         $spreadsheet = $this->spreadsheet = new Spreadsheet();
         $calc = $spreadsheet->getCalculationEngine();
-        self::assertNotNull($calc);
         $calc->setSuppressFormulaErrors($suppress);
         $calc->setCalculationCacheEnabled($cache);
         $calc->setBranchPruningEnabled($pruning);
@@ -143,7 +142,6 @@ class SpreadsheetCopyCloneTest extends TestCase
             $spreadsheet2 = $this->spreadsheet2 = clone $spreadsheet;
         }
         $calc2 = $spreadsheet2->getCalculationEngine();
-        self::assertNotNull($calc2);
         self::assertSame($suppress, $calc2->getSuppressFormulaErrors());
         self::assertSame($cache, $calc2->getCalculationCacheEnabled());
         self::assertSame($pruning, $calc2->getBranchPruningEnabled());


### PR DESCRIPTION
In issue #4557, the user complains, with some justification, about the way Excel handles certain calculations. We are not able to help with that problem. However, the user also notes a problem in Shared/Date when `isDateTime` has to evaluate a cell whose calculated value is an array. This is solved by flattening the calculated result to a single value.

It became obvious while working on this change that the code to set `instanceArrayReturnType` was kind of awkward. Simpler methods `returnArrayAsArray` and `returnArrayAsValue` are added to `Spreadsheet`. Even these started out a bit awkward because `Spreadsheet::calculationEngine` was defined as nullable, which really isn't true. It is allocated by the constructor, and never freed except in the destructor. It is no longer nullable.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

