### PR TITLE
Create Uninitialized Cell If Used in Calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- Nothing yet.
+- Create uninitialized cell if used in calculation. [Issue #4558](https://github.com/PHPOffice/PhpSpreadsheet/issues/4558) [Issue #4530](https://github.com/PHPOffice/PhpSpreadsheet/issues/4530) [PR #4565](https://github.com/PHPOffice/PhpSpreadsheet/pull/4565)
 
 ## 2025-07-23 - 4.5.0
 

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -1999,6 +1999,9 @@ class Calculation extends CalculationLocale
                             $this->debugLog->writeDebugLog('Evaluating Cell %s in worksheet %s', $cellRef, $matches[2]);
                             if ($pCellParent !== null && $this->spreadsheet !== null) {
                                 $cellSheet = $this->spreadsheet->getSheetByName($matches[2]);
+                                if ($cellSheet && !$cellSheet->cellExists($cellRef)) {
+                                    $cellSheet->setCellValue($cellRef, null);
+                                }
                                 if ($cellSheet && $cellSheet->cellExists($cellRef)) {
                                     $cellValue = $this->extractCellRange($cellRef, $this->spreadsheet->getSheetByName($matches[2]), false);
                                     $cell->attach($pCellParent);
@@ -2503,7 +2506,7 @@ class Calculation extends CalculationLocale
      *
      * @return mixed[] Array of values in range if range contains more than one element. Otherwise, a single value is returned.
      */
-    public function extractCellRange(string &$range = 'A1', ?Worksheet $worksheet = null, bool $resetLog = true): array
+    public function extractCellRange(string &$range = 'A1', ?Worksheet $worksheet = null, bool $resetLog = true, bool $createCell = false): array
     {
         // Return value
         /** @var mixed[][] */
@@ -2525,6 +2528,9 @@ class Calculation extends CalculationLocale
             if (!isset($aReferences[1])) {
                 //    Single cell in range
                 sscanf($aReferences[0], '%[A-Z]%d', $currentCol, $currentRow);
+                if ($createCell && $worksheet !== null && !$worksheet->cellExists($aReferences[0])) {
+                    $worksheet->setCellValue($aReferences[0], null);
+                }
                 if ($worksheet !== null && $worksheet->cellExists($aReferences[0])) {
                     $temp = $worksheet->getCell($aReferences[0])->getCalculatedValue($resetLog);
                     if ($this->getInstanceArrayReturnType() === self::RETURN_ARRAY_AS_ARRAY) {
@@ -2541,6 +2547,9 @@ class Calculation extends CalculationLocale
                 foreach ($aReferences as $reference) {
                     // Extract range
                     sscanf($reference, '%[A-Z]%d', $currentCol, $currentRow);
+                    if ($createCell && $worksheet !== null && !$worksheet->cellExists($reference)) {
+                        $worksheet->setCellValue($reference, null);
+                    }
                     if ($worksheet !== null && $worksheet->cellExists($reference)) {
                         $temp = $worksheet->getCell($reference)->getCalculatedValue($resetLog);
                         if ($this->getInstanceArrayReturnType() === self::RETURN_ARRAY_AS_ARRAY) {

--- a/src/PhpSpreadsheet/Calculation/Financial/Amortization.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Amortization.php
@@ -54,9 +54,7 @@ class Amortization
         $salvage = Functions::flattenSingleValue($salvage);
         $period = Functions::flattenSingleValue($period);
         $rate = Functions::flattenSingleValue($rate);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $cost = FinancialValidations::validateFloat($cost);
@@ -141,9 +139,7 @@ class Amortization
         $salvage = Functions::flattenSingleValue($salvage);
         $period = Functions::flattenSingleValue($period);
         $rate = Functions::flattenSingleValue($rate);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $cost = FinancialValidations::validateFloat($cost);

--- a/src/PhpSpreadsheet/Calculation/Financial/CashFlow/Constant/Periodic.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/CashFlow/Constant/Periodic.php
@@ -38,9 +38,9 @@ class Periodic
     ): string|float {
         $rate = Functions::flattenSingleValue($rate);
         $numberOfPeriods = Functions::flattenSingleValue($numberOfPeriods);
-        $payment = ($payment === null) ? 0.0 : Functions::flattenSingleValue($payment);
-        $presentValue = ($presentValue === null) ? 0.0 : Functions::flattenSingleValue($presentValue);
-        $type = ($type === null) ? FinancialConstants::PAYMENT_END_OF_PERIOD : Functions::flattenSingleValue($type);
+        $payment = Functions::flattenSingleValue($payment) ?? 0.0;
+        $presentValue = Functions::flattenSingleValue($presentValue) ?? 0.0;
+        $type = Functions::flattenSingleValue($type) ?? FinancialConstants::PAYMENT_END_OF_PERIOD;
 
         try {
             $rate = CashFlowValidations::validateRate($rate);
@@ -77,9 +77,9 @@ class Periodic
     ): string|float {
         $rate = Functions::flattenSingleValue($rate);
         $numberOfPeriods = Functions::flattenSingleValue($numberOfPeriods);
-        $payment = ($payment === null) ? 0.0 : Functions::flattenSingleValue($payment);
-        $futureValue = ($futureValue === null) ? 0.0 : Functions::flattenSingleValue($futureValue);
-        $type = ($type === null) ? FinancialConstants::PAYMENT_END_OF_PERIOD : Functions::flattenSingleValue($type);
+        $payment = Functions::flattenSingleValue($payment) ?? 0.0;
+        $futureValue = Functions::flattenSingleValue($futureValue) ?? 0.0;
+        $type = Functions::flattenSingleValue($type) ?? FinancialConstants::PAYMENT_END_OF_PERIOD;
 
         try {
             $rate = CashFlowValidations::validateRate($rate);
@@ -122,8 +122,8 @@ class Periodic
         $rate = Functions::flattenSingleValue($rate);
         $payment = Functions::flattenSingleValue($payment);
         $presentValue = Functions::flattenSingleValue($presentValue);
-        $futureValue = ($futureValue === null) ? 0.0 : Functions::flattenSingleValue($futureValue);
-        $type = ($type === null) ? FinancialConstants::PAYMENT_END_OF_PERIOD : Functions::flattenSingleValue($type);
+        $futureValue = Functions::flattenSingleValue($futureValue) ?? 0.0;
+        $type = Functions::flattenSingleValue($type) ?? FinancialConstants::PAYMENT_END_OF_PERIOD;
 
         try {
             $rate = CashFlowValidations::validateRate($rate);

--- a/src/PhpSpreadsheet/Calculation/Financial/CashFlow/Constant/Periodic/Cumulative.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/CashFlow/Constant/Periodic/Cumulative.php
@@ -41,7 +41,7 @@ class Cumulative
         $presentValue = Functions::flattenSingleValue($presentValue);
         $start = Functions::flattenSingleValue($start);
         $end = Functions::flattenSingleValue($end);
-        $type = ($type === null) ? FinancialConstants::PAYMENT_END_OF_PERIOD : Functions::flattenSingleValue($type);
+        $type = Functions::flattenSingleValue($type) ?? FinancialConstants::PAYMENT_END_OF_PERIOD;
 
         try {
             $rate = CashFlowValidations::validateRate($rate);
@@ -104,7 +104,7 @@ class Cumulative
         $presentValue = Functions::flattenSingleValue($presentValue);
         $start = Functions::flattenSingleValue($start);
         $end = Functions::flattenSingleValue($end);
-        $type = ($type === null) ? FinancialConstants::PAYMENT_END_OF_PERIOD : Functions::flattenSingleValue($type);
+        $type = Functions::flattenSingleValue($type) ?? FinancialConstants::PAYMENT_END_OF_PERIOD;
 
         try {
             $rate = CashFlowValidations::validateRate($rate);

--- a/src/PhpSpreadsheet/Calculation/Financial/CashFlow/Constant/Periodic/Interest.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/CashFlow/Constant/Periodic/Interest.php
@@ -43,7 +43,7 @@ class Interest
         $numberOfPeriods = Functions::flattenSingleValue($numberOfPeriods);
         $presentValue = Functions::flattenSingleValue($presentValue);
         $futureValue = ($futureValue === null) ? 0.0 : Functions::flattenSingleValue($futureValue);
-        $type = ($type === null) ? FinancialConstants::PAYMENT_END_OF_PERIOD : Functions::flattenSingleValue($type);
+        $type = Functions::flattenSingleValue($type) ?? FinancialConstants::PAYMENT_END_OF_PERIOD;
 
         try {
             $interestRate = CashFlowValidations::validateRate($interestRate);
@@ -160,9 +160,9 @@ class Interest
         $numberOfPeriods = Functions::flattenSingleValue($numberOfPeriods);
         $payment = Functions::flattenSingleValue($payment);
         $presentValue = Functions::flattenSingleValue($presentValue);
-        $futureValue = ($futureValue === null) ? 0.0 : Functions::flattenSingleValue($futureValue);
-        $type = ($type === null) ? FinancialConstants::PAYMENT_END_OF_PERIOD : Functions::flattenSingleValue($type);
-        $guess = ($guess === null) ? 0.1 : Functions::flattenSingleValue($guess);
+        $futureValue = Functions::flattenSingleValue($futureValue) ?? 0.0;
+        $type = Functions::flattenSingleValue($type) ?? FinancialConstants::PAYMENT_END_OF_PERIOD;
+        $guess = Functions::flattenSingleValue($guess) ?? 0.1;
 
         try {
             $numberOfPeriods = CashFlowValidations::validateFloat($numberOfPeriods);

--- a/src/PhpSpreadsheet/Calculation/Financial/CashFlow/Constant/Periodic/Payments.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/CashFlow/Constant/Periodic/Payments.php
@@ -27,14 +27,14 @@ class Payments
         mixed $interestRate,
         mixed $numberOfPeriods,
         mixed $presentValue,
-        mixed $futureValue = 0,
+        mixed $futureValue = 0.0,
         mixed $type = FinancialConstants::PAYMENT_END_OF_PERIOD
     ): string|float {
         $interestRate = Functions::flattenSingleValue($interestRate);
         $numberOfPeriods = Functions::flattenSingleValue($numberOfPeriods);
         $presentValue = Functions::flattenSingleValue($presentValue);
-        $futureValue = ($futureValue === null) ? 0.0 : Functions::flattenSingleValue($futureValue);
-        $type = ($type === null) ? FinancialConstants::PAYMENT_END_OF_PERIOD : Functions::flattenSingleValue($type);
+        $futureValue = Functions::flattenSingleValue($futureValue) ?? 0.0;
+        $type = Functions::flattenSingleValue($type) ?? FinancialConstants::PAYMENT_END_OF_PERIOD;
 
         try {
             $interestRate = CashFlowValidations::validateRate($interestRate);
@@ -83,7 +83,7 @@ class Payments
         $numberOfPeriods = Functions::flattenSingleValue($numberOfPeriods);
         $presentValue = Functions::flattenSingleValue($presentValue);
         $futureValue = ($futureValue === null) ? 0.0 : Functions::flattenSingleValue($futureValue);
-        $type = ($type === null) ? FinancialConstants::PAYMENT_END_OF_PERIOD : Functions::flattenSingleValue($type);
+        $type = Functions::flattenSingleValue($type) ?? FinancialConstants::PAYMENT_END_OF_PERIOD;
 
         try {
             $interestRate = CashFlowValidations::validateRate($interestRate);

--- a/src/PhpSpreadsheet/Calculation/Financial/Coupons.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Coupons.php
@@ -49,9 +49,7 @@ class Coupons
         $settlement = Functions::flattenSingleValue($settlement);
         $maturity = Functions::flattenSingleValue($maturity);
         $frequency = Functions::flattenSingleValue($frequency);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = FinancialValidations::validateSettlementDate($settlement);
@@ -110,9 +108,7 @@ class Coupons
         $settlement = Functions::flattenSingleValue($settlement);
         $maturity = Functions::flattenSingleValue($maturity);
         $frequency = Functions::flattenSingleValue($frequency);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = FinancialValidations::validateSettlementDate($settlement);
@@ -179,9 +175,7 @@ class Coupons
         $settlement = Functions::flattenSingleValue($settlement);
         $maturity = Functions::flattenSingleValue($maturity);
         $frequency = Functions::flattenSingleValue($frequency);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = FinancialValidations::validateSettlementDate($settlement);
@@ -244,9 +238,7 @@ class Coupons
         $settlement = Functions::flattenSingleValue($settlement);
         $maturity = Functions::flattenSingleValue($maturity);
         $frequency = Functions::flattenSingleValue($frequency);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = FinancialValidations::validateSettlementDate($settlement);
@@ -296,9 +288,7 @@ class Coupons
         $settlement = Functions::flattenSingleValue($settlement);
         $maturity = Functions::flattenSingleValue($maturity);
         $frequency = Functions::flattenSingleValue($frequency);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = FinancialValidations::validateSettlementDate($settlement);
@@ -355,9 +345,7 @@ class Coupons
         $settlement = Functions::flattenSingleValue($settlement);
         $maturity = Functions::flattenSingleValue($maturity);
         $frequency = Functions::flattenSingleValue($frequency);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = FinancialValidations::validateSettlementDate($settlement);

--- a/src/PhpSpreadsheet/Calculation/Financial/Securities/AccruedInterest.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Securities/AccruedInterest.php
@@ -60,12 +60,8 @@ class AccruedInterest
         $settlement = Functions::flattenSingleValue($settlement);
         $rate = Functions::flattenSingleValue($rate);
         $parValue = ($parValue === null) ? 1000 : Functions::flattenSingleValue($parValue);
-        $frequency = ($frequency === null)
-            ? FinancialConstants::FREQUENCY_ANNUAL
-            : Functions::flattenSingleValue($frequency);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $frequency = Functions::flattenSingleValue($frequency) ?? FinancialConstants::FREQUENCY_ANNUAL;
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $issue = SecurityValidations::validateIssueDate($issue);
@@ -126,9 +122,7 @@ class AccruedInterest
         $settlement = Functions::flattenSingleValue($settlement);
         $rate = Functions::flattenSingleValue($rate);
         $parValue = ($parValue === null) ? 1000 : Functions::flattenSingleValue($parValue);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $issue = SecurityValidations::validateIssueDate($issue);

--- a/src/PhpSpreadsheet/Calculation/Financial/Securities/Price.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Securities/Price.php
@@ -53,9 +53,7 @@ class Price
         $yield = Functions::flattenSingleValue($yield);
         $redemption = Functions::flattenSingleValue($redemption);
         $frequency = Functions::flattenSingleValue($frequency);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = SecurityValidations::validateSettlementDate($settlement);
@@ -120,9 +118,7 @@ class Price
         $maturity = Functions::flattenSingleValue($maturity);
         $discount = Functions::flattenSingleValue($discount);
         $redemption = Functions::flattenSingleValue($redemption);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = SecurityValidations::validateSettlementDate($settlement);
@@ -179,9 +175,7 @@ class Price
         $issue = Functions::flattenSingleValue($issue);
         $rate = Functions::flattenSingleValue($rate);
         $yield = Functions::flattenSingleValue($yield);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = SecurityValidations::validateSettlementDate($settlement);
@@ -255,9 +249,7 @@ class Price
         $maturity = Functions::flattenSingleValue($maturity);
         $investment = Functions::flattenSingleValue($investment);
         $discount = Functions::flattenSingleValue($discount);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = SecurityValidations::validateSettlementDate($settlement);

--- a/src/PhpSpreadsheet/Calculation/Financial/Securities/Rates.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Securities/Rates.php
@@ -44,9 +44,7 @@ class Rates
         $maturity = Functions::flattenSingleValue($maturity);
         $price = Functions::flattenSingleValue($price);
         $redemption = Functions::flattenSingleValue($redemption);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = SecurityValidations::validateSettlementDate($settlement);
@@ -105,9 +103,7 @@ class Rates
         $maturity = Functions::flattenSingleValue($maturity);
         $investment = Functions::flattenSingleValue($investment);
         $redemption = Functions::flattenSingleValue($redemption);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = SecurityValidations::validateSettlementDate($settlement);

--- a/src/PhpSpreadsheet/Calculation/Financial/Securities/Yields.php
+++ b/src/PhpSpreadsheet/Calculation/Financial/Securities/Yields.php
@@ -43,9 +43,7 @@ class Yields
         $maturity = Functions::flattenSingleValue($maturity);
         $price = Functions::flattenSingleValue($price);
         $redemption = Functions::flattenSingleValue($redemption);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = SecurityValidations::validateSettlementDate($settlement);
@@ -107,9 +105,7 @@ class Yields
         $issue = Functions::flattenSingleValue($issue);
         $rate = Functions::flattenSingleValue($rate);
         $price = Functions::flattenSingleValue($price);
-        $basis = ($basis === null)
-            ? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD
-            : Functions::flattenSingleValue($basis);
+        $basis = Functions::flattenSingleValue($basis) ?? FinancialConstants::BASIS_DAYS_PER_YEAR_NASD;
 
         try {
             $settlement = SecurityValidations::validateSettlementDate($settlement);

--- a/src/PhpSpreadsheet/Calculation/LookupRef/Indirect.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/Indirect.php
@@ -107,7 +107,7 @@ class Indirect
     private static function extractRequiredCells(?Worksheet $worksheet, string $cellAddress): array
     {
         return Calculation::getInstance($worksheet !== null ? $worksheet->getParent() : null)
-            ->extractCellRange($cellAddress, $worksheet, false);
+            ->extractCellRange($cellAddress, $worksheet, false, createCell: true);
     }
 
     private static function handleRowColumnRanges(?Worksheet $worksheet, string $start, string $end): string

--- a/src/PhpSpreadsheet/Calculation/Statistical/Conditional.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Conditional.php
@@ -40,6 +40,7 @@ class Conditional
             throw new CalcException('Must specify range of cells, not any kind of literal');
         }
         $database = self::databaseFromRangeAndValue($range, $averageRange);
+        $condition = Functions::flattenSingleValue($condition);
         $condition = [[self::CONDITION_COLUMN_NAME, self::VALUE_COLUMN_NAME], [$condition, null]];
 
         return DAverage::evaluate($database, self::VALUE_COLUMN_NAME, $condition);
@@ -105,6 +106,7 @@ class Conditional
         );
 
         $range = array_merge([[self::CONDITION_COLUMN_NAME]], array_chunk($range, 1));
+        $condition = Functions::flattenSingleValue($condition);
         $condition = array_merge([[self::CONDITION_COLUMN_NAME]], [[$condition]]);
 
         return DCount::evaluate($range, null, $condition, false);
@@ -205,6 +207,7 @@ class Conditional
             throw new CalcException('Must specify range of cells, not any kind of literal');
         }
         $database = self::databaseFromRangeAndValue($range, $sumRange);
+        $condition = Functions::flattenSingleValue($condition);
         $condition = [[self::CONDITION_COLUMN_NAME, self::VALUE_COLUMN_NAME], [$condition, null]];
 
         return DSum::evaluate($database, self::VALUE_COLUMN_NAME, $condition);

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndirectMissingCellTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndirectMissingCellTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
+
+class IndirectMissingCellTest extends AllSetupTeardown
+{
+    public function testIssue4330(): void
+    {
+        $sheet = $this->getSheet();
+        $sheet->getCell('A1')->setValue(5); // used in INDIRECT
+        $sheet->getCell('A2')->setValue(1);
+
+        $sheet->getCell('B1')->setValue(2);
+        $sheet->getCell('B2')->setValue(4);
+        $sheet->getCell('B3')->setValue(6);
+        $sheet->getCell('B4')->setValue(8);
+        $sheet->getCell('B5')->setValue(10);
+        $sheet->getCell('B6')->setValue(12);
+        $sheet->getCell('C1')->setValue('=SUM(B1:INDIRECT("B"&A1))');
+        self::assertSame(
+            30,
+            $sheet->getCell('C1')->getCalculatedValue(),
+            'end cell initialized'
+        );
+
+        $sheet->getCell('D1')->setValue(30);
+        $sheet->getCell('D2')->setValue(60);
+        $sheet->getCell('D3')->setValue(90);
+        $sheet->getCell('D4')->setValue(120);
+        $sheet->getCell('E1')->setValue('=SUM(D1:INDIRECT("D"&A1))');
+        self::assertSame(
+            300,
+            $sheet->getCell('E1')->getCalculatedValue(),
+            'end cell not initialized'
+        );
+
+        //$sheet->getCell('F1')->setValue(30);
+        //$sheet->getCell('F2')->setValue(60);
+        $sheet->getCell('F3')->setValue(90);
+        $sheet->getCell('F4')->setValue(120);
+        $sheet->getCell('G1')->setValue(
+            '=SUM(INDIRECT("F"&A2&":F"&A1))'
+        );
+        self::assertSame(
+            210,
+            $sheet->getCell('G1')->getCalculatedValue(),
+            'range with uninitialized cells as INDIRECT argument'
+        );
+    }
+}

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountATest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Statistical;
 
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+
 class CountATest extends AllSetupTeardown
 {
     #[\PHPUnit\Framework\Attributes\DataProvider('providerCOUNTA')]
@@ -15,5 +17,18 @@ class CountATest extends AllSetupTeardown
     public static function providerCOUNTA(): array
     {
         return require 'tests/data/Calculation/Statistical/COUNTA.php';
+    }
+
+    public function testNull(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', '=COUNTA(B1,B2,B3,B4)');
+        $sheet->setCellValue('A2', '=COUNTA(B1,,B3,B4)');
+        $sheet->setCellValue('A3', '=COUNTA(B1,B2,B3,B4)');
+        self::assertSame(0, $sheet->getCell('A1')->getCalculatedValue(), 'empty cells not counted');
+        self::assertSame(1, $sheet->getCell('A2')->getCalculatedValue(), 'null argument is counted');
+        self::assertSame(0, $sheet->getCell('A3')->getCalculatedValue(), 'empty cells still not counted');
+        $spreadsheet->disconnectWorksheets();
     }
 }

--- a/tests/PhpSpreadsheetTests/Worksheet/MergeBehaviourTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/MergeBehaviourTest.php
@@ -139,13 +139,14 @@ class MergeBehaviourTest extends AbstractFunctional
                     [null, null, null],
                 ],
             ],
-            [
+            'A2 referenced and therefore created' => [
                 [
                     [12, '=5+1', '=A1/A2'],
                 ],
                 'A1:C1',
                 [
                     ['12 6 #DIV/0!', null, null],
+                    [null, null, null],
                 ],
             ],
         ];


### PR DESCRIPTION
Fix #4558. Fix #4530. 4558 deals with a problem with COUNTA. Excel does not count empty cells, but it does count literal nulls (usually empty parameters) in the argument list. PhpSpreadsheet has till now not created empty cells during calculation, and so winds up treating them as literals. It is changed to create the cell when appropriate.

4530 has a similar problem. When INDIRECT winds up evaluating an uninitialized cell, it treats it as a null literal, leading to incorrect results. It is now changed to create the missing cell.

A number of functions, almost all of them Financial, have a related problem. They test for a null literal when initializing some of their parameters, but they should be testing for null literal or cell containing null. They are changed to do the right thing.

SUMIF and related functions are slightly affected by this change, and are changed so that they are no longer affected.

New tests have been added. Only one existing test had to change. MergeBehaviorTest for `[12, '=5+1', '=A1/A2']`, where cell A2 was uninitialized formerly returned one row, but now returns a second all-null row because A2, by virtue of being used in a calculation, now winds up defined. I do not consider this a significant difference.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

