### PR TITLE
Redo ComplexAssert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /analysis
 /vendor/
 /phpunit.xml
+.phpunit.result.cache
 
 ## IDE support
 *.buildpath

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ComplexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ComplexTest.php
@@ -20,11 +20,6 @@ class ComplexTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
     #[DataProvider('providerCOMPLEX')]
     public function testCOMPLEXAsFormula(mixed $expectedResult, mixed ...$args): void
     {
@@ -34,8 +29,8 @@ class ComplexTest extends TestCase
         $formula = "=COMPLEX({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     #[DataProvider('providerCOMPLEX')]
@@ -68,7 +63,7 @@ class ComplexTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=COMPLEX({$real}, {$imaginary})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImConjugateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImConjugateTest.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImConjugateTest extends TestCase
+class ImConjugateTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCONJUGATE')]
+    #[DataProvider('providerIMCONJUGATE')]
     public function testDirectCallToIMCONJUGATE(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMCONJUGATE($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCONJUGATE')]
+    #[DataProvider('providerIMCONJUGATE')]
     public function testIMCONJUGATEAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImConjugateTest extends TestCase
         $formula = "=IMCONJUGATE({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCONJUGATE')]
+    #[DataProvider('providerIMCONJUGATE')]
     public function testIMCONJUGATEInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImConjugateTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImConjugateTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMCONJUGATE.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMCONJUGATE')]
+    #[DataProvider('providerUnhappyIMCONJUGATE')]
     public function testIMCONJUGATEUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +83,13 @@ class ImConjugateTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImConjugateArray')]
+    #[DataProvider('providerImConjugateArray')]
     public function testImConjugateArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMCONJUGATE({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCosTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCosTest.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImCosTest extends TestCase
+class ImCosTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCOS')]
+    #[DataProvider('providerIMCOS')]
     public function testDirectCallToIMCOS(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMCOS($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCOS')]
+    #[DataProvider('providerIMCOS')]
     public function testIMCOSAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImCosTest extends TestCase
         $formula = "=IMCOS({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCOS')]
+    #[DataProvider('providerIMCOS')]
     public function testIMCOSInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImCosTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImCosTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMCOS.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMCOS')]
+    #[DataProvider('providerUnhappyIMCOS')]
     public function testIMCOSUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +83,13 @@ class ImCosTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImCosArray')]
+    #[DataProvider('providerImCosArray')]
     public function testImCosArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMCOS({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCoshTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCoshTest.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImCoshTest extends TestCase
+class ImCoshTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCOSH')]
+    #[DataProvider('providerIMCOSH')]
     public function testDirectCallToIMCOSH(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMCOSH($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCOSH')]
+    #[DataProvider('providerIMCOSH')]
     public function testIMCOSHAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImCoshTest extends TestCase
         $formula = "=IMCOSH({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCOSH')]
+    #[DataProvider('providerIMCOSH')]
     public function testIMCOSHInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImCoshTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImCoshTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMCOSH.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMCOSH')]
+    #[DataProvider('providerUnhappyIMCOSH')]
     public function testIMCOSHUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +83,13 @@ class ImCoshTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImCoshArray')]
+    #[DataProvider('providerImCoshArray')]
     public function testImCoshArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMCOSH({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCotTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCotTest.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImCotTest extends TestCase
+class ImCotTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCOT')]
+    #[DataProvider('providerIMCOT')]
     public function testDirectCallToIMCOT(float|string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMCOT($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCOT')]
+    #[DataProvider('providerIMCOT')]
     public function testIMCOTAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImCotTest extends TestCase
         $formula = "=IMCOT({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCOT')]
+    #[DataProvider('providerIMCOT')]
     public function testIMCOTInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImCotTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImCotTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMCOT.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMCOT')]
+    #[DataProvider('providerUnhappyIMCOT')]
     public function testIMCOTUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +83,13 @@ class ImCotTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImCotArray')]
+    #[DataProvider('providerImCotArray')]
     public function testImCotArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMCOT({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCscTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCscTest.php
@@ -7,38 +7,18 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class ImCscTest extends TestCase
+class ImCscTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
     #[DataProvider('providerIMCSC')]
     public function testDirectCallToIMCSC(float|string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMCSC($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
-    }
-
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
     #[DataProvider('providerIMCSC')]
@@ -50,11 +30,8 @@ class ImCscTest extends TestCase
         $formula = "=IMCSC({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
     #[DataProvider('providerIMCSC')]
@@ -70,10 +47,7 @@ class ImCscTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -117,7 +91,7 @@ class ImCscTest extends TestCase
 
         $formula = "=IMCSC({$complex})";
         /** @var array<string, array<string, string>> */
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         // Avoid testing for excess precision
         foreach ($expectedResult as &$array) {
             foreach ($array as &$string) {

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCschTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCschTest.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImCschTest extends TestCase
+class ImCschTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCSCH')]
+    #[DataProvider('providerIMCSCH')]
     public function testDirectCallToIMCSCH(float|string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMCSCH($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCSCH')]
+    #[DataProvider('providerIMCSCH')]
     public function testIMCSCHAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImCschTest extends TestCase
         $formula = "=IMCSCH({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMCSCH')]
+    #[DataProvider('providerIMCSCH')]
     public function testIMCSCHInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImCschTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImCschTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMCSCH.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMCSCH')]
+    #[DataProvider('providerUnhappyIMCSCH')]
     public function testIMCSCHUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +83,13 @@ class ImCschTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImCschArray')]
+    #[DataProvider('providerImCschArray')]
     public function testImCschArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMCSCH({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImDivTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImDivTest.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexOperations;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImDivTest extends TestCase
+class ImDivTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMDIV')]
+    #[DataProvider('providerIMDIV')]
     public function testDirectCallToIMDIV(string $expectedResult, string $dividend, string $divisor): void
     {
         $result = ComplexOperations::IMDIV($dividend, $divisor);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMDIV')]
+    #[DataProvider('providerIMDIV')]
     public function testIMDIVAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImDivTest extends TestCase
         $formula = "=IMDIV({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMDIV')]
+    #[DataProvider('providerIMDIV')]
     public function testIMDIVInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImDivTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImDivTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMDIV.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMDIV')]
+    #[DataProvider('providerUnhappyIMDIV')]
     public function testIMDIVUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -109,13 +84,13 @@ class ImDivTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImDivArray')]
+    #[DataProvider('providerImDivArray')]
     public function testImDivArray(array $expectedResult, string $dividend, string $divisor): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMDIV({$dividend}, {$divisor})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImExpTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImExpTest.php
@@ -7,40 +7,23 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImExpTest extends TestCase
+class ImExpTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = (PHP_INT_SIZE > 4) ? 1E-12 : 1E-9;
+    protected float $complexPrecision = (PHP_INT_SIZE > 4) ? 1E-12 : 1E-9;
 
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMEXP')]
+    #[DataProvider('providerIMEXP')]
     public function testDirectCallToIMEXP(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMEXP($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMEXP')]
+    #[DataProvider('providerIMEXP')]
     public function testIMEXPAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +32,11 @@ class ImExpTest extends TestCase
         $formula = "=IMEXP({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMEXP')]
+    #[DataProvider('providerIMEXP')]
     public function testIMEXPInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +49,7 @@ class ImExpTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +59,7 @@ class ImExpTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMEXP.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMEXP')]
+    #[DataProvider('providerUnhappyIMEXP')]
     public function testIMEXPUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +85,13 @@ class ImExpTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImExpArray')]
+    #[DataProvider('providerImExpArray')]
     public function testImExpArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMEXP({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLnTest.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImLnTest extends TestCase
+class ImLnTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMLN')]
+    #[DataProvider('providerIMLN')]
     public function testDirectCallToIMLN(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMLN($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMLN')]
+    #[DataProvider('providerIMLN')]
     public function testIMLNAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImLnTest extends TestCase
         $formula = "=IMLN({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMLN')]
+    #[DataProvider('providerIMLN')]
     public function testIMLNInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImLnTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImLnTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMLN.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMLN')]
+    #[DataProvider('providerUnhappyIMLN')]
     public function testIMLNUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +83,13 @@ class ImLnTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImLnArray')]
+    #[DataProvider('providerImLnArray')]
     public function testImLnArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMLN({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog10Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog10Test.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImLog10Test extends TestCase
+class ImLog10Test extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMLOG10')]
+    #[DataProvider('providerIMLOG10')]
     public function testDirectCallToIMLOG10(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMLOG10($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMLOG10')]
+    #[DataProvider('providerIMLOG10')]
     public function testIMLOG10AsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImLog10Test extends TestCase
         $formula = "=IMLOG10({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMLOG10')]
+    #[DataProvider('providerIMLOG10')]
     public function testIMLOG10InWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImLog10Test extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImLog10Test extends TestCase
         return require 'tests/data/Calculation/Engineering/IMLOG10.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMLOG10')]
+    #[DataProvider('providerUnhappyIMLOG10')]
     public function testIMLOG10UnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +83,13 @@ class ImLog10Test extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImLog10Array')]
+    #[DataProvider('providerImLog10Array')]
     public function testImLog10Array(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMLOG10({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog2Test.php
@@ -7,40 +7,23 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImLog2Test extends TestCase
+class ImLog2Test extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-8;
+    protected float $complexPrecision = 1E-8;
 
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMLOG2')]
+    #[DataProvider('providerIMLOG2')]
     public function testDirectCallToIMLOG2(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMLOG2($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMLOG2')]
+    #[DataProvider('providerIMLOG2')]
     public function testIMLOG2AsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +32,11 @@ class ImLog2Test extends TestCase
         $formula = "=IMLOG2({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMLOG2')]
+    #[DataProvider('providerIMLOG2')]
     public function testIMLOG2InWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +49,7 @@ class ImLog2Test extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +59,7 @@ class ImLog2Test extends TestCase
         return require 'tests/data/Calculation/Engineering/IMLOG2.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMLOG2')]
+    #[DataProvider('providerUnhappyIMLOG2')]
     public function testIMLOG2UnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +85,13 @@ class ImLog2Test extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImLog2Array')]
+    #[DataProvider('providerImLog2Array')]
     public function testImLog2Array(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMLOG2({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImPowerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImPowerTest.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImPowerTest extends TestCase
+class ImPowerTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMPOWER')]
+    #[DataProvider('providerIMPOWER')]
     public function testDirectCallToIMPOWER(float|int|string $expectedResult, string $arg1, float|int|string $arg2): void
     {
         $result = ComplexFunctions::IMPOWER($arg1, $arg2);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMPOWER')]
+    #[DataProvider('providerIMPOWER')]
     public function testIMPOWERAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImPowerTest extends TestCase
         $formula = "=IMPOWER({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMPOWER')]
+    #[DataProvider('providerIMPOWER')]
     public function testIMPOWERInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImPowerTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImPowerTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMPOWER.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMPOWER')]
+    #[DataProvider('providerUnhappyIMPOWER')]
     public function testIMPOWERUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +83,13 @@ class ImPowerTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImPowerArray')]
+    #[DataProvider('providerImPowerArray')]
     public function testImPowerArray(array $expectedResult, string $complex, string $real): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMPOWER({$complex}, {$real})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImProductTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImProductTest.php
@@ -7,43 +7,24 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexOperations;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImProductTest extends TestCase
+class ImProductTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
     /**
      * @param string ...$args variadic arguments
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMPRODUCT')]
+    #[DataProvider('providerIMPRODUCT')]
     public function testDirectCallToIMPRODUCT(mixed $expectedResult, ...$args): void
     {
         $result = ComplexOperations::IMPRODUCT(...$args);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMPRODUCT')]
+    #[DataProvider('providerIMPRODUCT')]
     public function testIMPRODUCTAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -52,14 +33,11 @@ class ImProductTest extends TestCase
         $formula = "=IMPRODUCT({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMPRODUCT')]
+    #[DataProvider('providerIMPRODUCT')]
     public function testIMPRODUCTInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -72,10 +50,7 @@ class ImProductTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -85,7 +60,7 @@ class ImProductTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMPRODUCT.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMPRODUCT')]
+    #[DataProvider('providerUnhappyIMPRODUCT')]
     public function testIMPRODUCTUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSecTest.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImSecTest extends TestCase
+class ImSecTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMSEC')]
+    #[DataProvider('providerIMSEC')]
     public function testDirectCallToIMSEC(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMSEC($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMSEC')]
+    #[DataProvider('providerIMSEC')]
     public function testIMSECAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImSecTest extends TestCase
         $formula = "=IMSEC({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMSEC')]
+    #[DataProvider('providerIMSEC')]
     public function testIMSECInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImSecTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImSecTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMSEC.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMSEC')]
+    #[DataProvider('providerUnhappyIMSEC')]
     public function testIMSECUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +83,13 @@ class ImSecTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImSecArray')]
+    #[DataProvider('providerImSecArray')]
     public function testImSecArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMSEC({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSechTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSechTest.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImSechTest extends TestCase
+class ImSechTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMSECH')]
+    #[DataProvider('providerIMSECH')]
     public function testDirectCallToIMSECH(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMSECH($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMSECH')]
+    #[DataProvider('providerIMSECH')]
     public function testIMSECHAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImSechTest extends TestCase
         $formula = "=IMSECH({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMSECH')]
+    #[DataProvider('providerIMSECH')]
     public function testIMSECHInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImSechTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImSechTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMSECH.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMSECH')]
+    #[DataProvider('providerUnhappyIMSECH')]
     public function testIMSECHUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +83,13 @@ class ImSechTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImSecHArray')]
+    #[DataProvider('providerImSecHArray')]
     public function testImSecHArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMSECH({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinTest.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImSinTest extends TestCase
+class ImSinTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMSIN')]
+    #[DataProvider('providerIMSIN')]
     public function testDirectCallToIMSIN(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMSIN($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMSIN')]
+    #[DataProvider('providerIMSIN')]
     public function testIMSINAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImSinTest extends TestCase
         $formula = "=IMSIN({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMSIN')]
+    #[DataProvider('providerIMSIN')]
     public function testIMSINInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImSinTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImSinTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMSIN.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMSIN')]
+    #[DataProvider('providerUnhappyIMSIN')]
     public function testIMSINUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +83,13 @@ class ImSinTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImSinArray')]
+    #[DataProvider('providerImSinArray')]
     public function testImSinArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMSIN({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinhTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinhTest.php
@@ -7,40 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImSinhTest extends TestCase
+class ImSinhTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMSINH')]
+    #[DataProvider('providerIMSINH')]
     public function testDirectCallToIMSINH(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMSINH($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMSINH')]
+    #[DataProvider('providerIMSINH')]
     public function testIMSINHAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -49,14 +30,11 @@ class ImSinhTest extends TestCase
         $formula = "=IMSINH({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMSINH')]
+    #[DataProvider('providerIMSINH')]
     public function testIMSINHInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -69,10 +47,7 @@ class ImSinhTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -82,7 +57,7 @@ class ImSinhTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMSINH.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMSINH')]
+    #[DataProvider('providerUnhappyIMSINH')]
     public function testIMSINHUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -108,13 +83,13 @@ class ImSinhTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImSinHArray')]
+    #[DataProvider('providerImSinHArray')]
     public function testImSinHArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMSINH({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSqrtTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSqrtTest.php
@@ -7,38 +7,18 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class ImSqrtTest extends TestCase
+class ImSqrtTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
     #[DataProvider('providerIMSQRT')]
     public function testDirectCallToIMSQRT(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMSQRT($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
-    }
-
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
     #[DataProvider('providerIMSQRT')]
@@ -50,11 +30,8 @@ class ImSqrtTest extends TestCase
         $formula = "=IMSQRT({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
     #[DataProvider('providerIMSQRT')]
@@ -70,10 +47,7 @@ class ImSqrtTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -116,7 +90,7 @@ class ImSqrtTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=IMSQRT({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSubTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSubTest.php
@@ -7,38 +7,18 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexOperations;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class ImSubTest extends TestCase
+class ImSubTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
     #[DataProvider('providerIMSUB')]
     public function testDirectCallToIMSUB(string $expectedResult, string $arg1, string $arg2): void
     {
         $result = ComplexOperations::IMSUB($arg1, $arg2);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
-    }
-
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
     #[DataProvider('providerIMSUB')]
@@ -50,11 +30,8 @@ class ImSubTest extends TestCase
         $formula = "=IMSUB({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
     #[DataProvider('providerIMSUB')]
@@ -70,10 +47,7 @@ class ImSubTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -117,7 +91,7 @@ class ImSubTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=IMSUB({$subidend}, {$subisor})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSumTest.php
@@ -7,25 +7,13 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexOperations;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class ImSumTest extends TestCase
+class ImSumTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
     /**
      * @param string ...$args variadic arguments
      */
@@ -33,15 +21,7 @@ class ImSumTest extends TestCase
     public function testDirectCallToIMSUM(mixed $expectedResult, ...$args): void
     {
         $result = ComplexOperations::IMSUM(...$args);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
-    }
-
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
     #[DataProvider('providerIMSUM')]
@@ -53,11 +33,8 @@ class ImSumTest extends TestCase
         $formula = "=IMSUM({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
     #[DataProvider('providerIMSUM')]
@@ -73,10 +50,7 @@ class ImSumTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImTanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImTanTest.php
@@ -7,38 +7,18 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PhpOffice\PhpSpreadsheetTests\Custom\ComplexAssert;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class ImTanTest extends TestCase
+class ImTanTest extends ComplexAssert
 {
-    const COMPLEX_PRECISION = 1E-12;
-
-    private ComplexAssert $complexAssert;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $this->complexAssert = new ComplexAssert();
-    }
-
     #[DataProvider('providerIMTAN')]
     public function testDirectCallToIMTAN(string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMTAN($arg);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
-    }
-
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
     #[DataProvider('providerIMTAN')]
@@ -50,11 +30,8 @@ class ImTanTest extends TestCase
         $formula = "=IMTAN({$arguments})";
 
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $this->trimIfQuoted((string) $result), self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $result = $calculation->calculateFormula($formula);
+        $this->assertComplexEquals($expectedResult, $result);
     }
 
     #[DataProvider('providerIMTAN')]
@@ -70,10 +47,7 @@ class ImTanTest extends TestCase
         $result = $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-        self::assertTrue(
-            $this->complexAssert->assertComplexEquals($expectedResult, $result, self::COMPLEX_PRECISION),
-            $this->complexAssert->getErrorMessage()
-        );
+        $this->assertComplexEquals($expectedResult, $result);
 
         $spreadsheet->disconnectWorksheets();
     }
@@ -116,7 +90,7 @@ class ImTanTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=IMTAN({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/IrrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/IrrTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Financial;
 
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
+
 class IrrTest extends AllSetupTeardown
 {
     #[\PHPUnit\Framework\Attributes\DataProvider('providerIRR')]
-    public function testIRR(mixed $expectedResult, mixed $values = null): void
+    public function testIRR(mixed $expectedResult, mixed $values = null, mixed $guess = null): void
     {
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();
@@ -31,6 +33,9 @@ class IrrTest extends AllSetupTeardown
                 $sheet->getCell('A1')->setValue($values);
                 $formula .= 'A1';
             }
+        }
+        if ($guess !== null) {
+            $formula .= ',' . StringHelper::convertToString($guess);
         }
         $formula .= ')';
         $sheet->getCell('D1')->setValue($formula);

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/MidTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/MidTest.php
@@ -116,7 +116,7 @@ class MidTest extends AllSetupTeardown
     }
 
     #[DataProvider('providerCalculationTypeMIDFalse')]
-    public function testCalculationTypeFalse(string $type, string $resultB1, string $resultB2): void
+    public function testCalculationTypeFalse(string $type, string $resultB1, string $resultB2, string $resultB3): void
     {
         Functions::setCompatibilityMode($type);
         $sheet = $this->getSheet();
@@ -127,6 +127,7 @@ class MidTest extends AllSetupTeardown
         $this->setCell('B3', '=MID(A2, 2, A1)');
         self::assertEquals($resultB1, $sheet->getCell('B1')->getCalculatedValue());
         self::assertEquals($resultB2, $sheet->getCell('B2')->getCalculatedValue());
+        self::assertEquals($resultB3, $sheet->getCell('B3')->getCalculatedValue());
     }
 
     public static function providerCalculationTypeMIDFalse(): array

--- a/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
@@ -219,8 +219,8 @@ class AdvancedValueBinderTest extends TestCase
     public static function stringProvider(): array
     {
         return [
-            ['Hello World', false],
-            ["Hello\nWorld", true],
+            ['Hello World'],
+            ["Hello\nWorld"],
         ];
     }
 

--- a/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
@@ -250,7 +250,7 @@ class StringValueBinderTest extends TestCase
             ['-.123', '-.123', DataType::TYPE_STRING],
             ['1.23e-4', '1.23e-4', DataType::TYPE_STRING],
             ['ABC', 'ABC', DataType::TYPE_STRING],
-            ['=SUM(A1:C3)', '=SUM(A1:C3)', DataType::TYPE_FORMULA, false],
+            ['=SUM(A1:C3)', '=SUM(A1:C3)', DataType::TYPE_FORMULA],
             [123, 123, DataType::TYPE_NUMERIC],
             [123.456, 123.456, DataType::TYPE_NUMERIC],
             [0.123, 0.123, DataType::TYPE_NUMERIC],

--- a/tests/PhpSpreadsheetTests/Functional/ReadBlankCellsTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/ReadBlankCellsTest.php
@@ -73,8 +73,11 @@ class ReadBlankCellsTest extends AbstractFunctional
      * Test generate file with some empty cells.
      */
     #[\PHPUnit\Framework\Attributes\DataProvider('providerSheetFormat')]
-    public function testLoadAndSaveDontReadEmpty(string $format): void
+    public function testLoadAndSaveDontReadEmpty(string $format, mixed $expected): void
     {
+        if (!is_bool($expected)) {
+            self::fail('unexpected unused arg');
+        }
         $filename = 'tests/data/Reader/XLSX/blankcell.xlsx';
         $reader = new Xlsx();
         $reader->setReadEmptyCells(false);

--- a/tests/PhpSpreadsheetTests/Helper/SampleCoverageTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/SampleCoverageTest.php
@@ -32,8 +32,7 @@ class SampleCoverageTest extends TestCase
             ->getMock();
         $helper->expects(self::once())
             ->method('isDirOrMkdir')
-            ->with(self::isType('string'))
             ->willReturn(false);
-        self::assertSame('', $helper->getFilename('a.xlsx'));
+        $helper->getFilename('a.xlsx');
     }
 }

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnCellIterator2Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnCellIterator2Test.php
@@ -83,8 +83,11 @@ class ColumnCellIterator2Test extends TestCase
     }
 
     #[DataProvider('providerNullOrCreate')]
-    public function testNullOrCreateOption(?bool $existingBehaviour, int $expectedCreatedResult): void
+    public function testNullOrCreateOption(?bool $existingBehaviour, int $expectedCreatedResult, mixed $expectedNullResult): void
     {
+        if (!is_int($expectedNullResult)) {
+            self::fail('unexpected unused arg');
+        }
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
         $iterator = new ColumnCellIterator($sheet, 'F');

--- a/tests/PhpSpreadsheetTests/Worksheet/RowCellIterator2Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/RowCellIterator2Test.php
@@ -83,8 +83,11 @@ class RowCellIterator2Test extends TestCase
     }
 
     #[DataProvider('providerNullOrCreate')]
-    public function testNullOrCreateOption(?bool $existingBehaviour, int $expectedCreatedResult): void
+    public function testNullOrCreateOption(?bool $existingBehaviour, int $expectedCreatedResult, mixed $expectedNullResult): void
     {
+        if (!is_int($expectedNullResult)) {
+            self::fail('unexpected unused arg');
+        }
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
         $iterator = new RowCellIterator($sheet, 2);


### PR DESCRIPTION
Its use is already causes an issue with Phpstan. It uses interfaces marked as internal by Phpunit, and it will not work with Phpunit 12. It is more complicated than needed. This PR corrects all these problems. It also corrects a handful of other problems that will show up with Phpunit 12. Only tests are changed - no source code.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

