### PR TITLE
Clean Up Some Engineering Tests

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/ArrayFormulaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/ArrayFormulaTest.php
@@ -6,14 +6,15 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ArrayFormulaTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerArrayFormulae')]
+    #[DataProvider('providerArrayFormulae')]
     public function testArrayFormula(string $formula, mixed $expectedResult): void
     {
-        $result = Calculation::getInstance()->_calculateFormulaValue($formula);
+        $result = Calculation::getInstance()->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationErrorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationErrorTest.php
@@ -15,7 +15,7 @@ class CalculationErrorTest extends TestCase
         $calculation = Calculation::getInstance();
         self::assertFalse($calculation->getSuppressFormulaErrors());
         $calculation->setSuppressFormulaErrors(true);
-        $result = $calculation->_calculateFormulaValue('=SUM(');
+        $result = $calculation->calculateFormula('=SUM(');
         $calculation->setSuppressFormulaErrors(false);
         self::assertFalse($result);
     }
@@ -26,7 +26,7 @@ class CalculationErrorTest extends TestCase
         self::assertFalse($calculation->getSuppressFormulaErrors());
         $this->expectException(CalcException::class);
         $this->expectExceptionMessage("Formula Error: Expecting ')'");
-        $result = $calculation->_calculateFormulaValue('=SUM(');
+        $result = $calculation->calculateFormula('=SUM(');
         self::assertFalse($result);
     }
 }

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -32,11 +32,11 @@ class CalculationTest extends TestCase
     public function testBinaryComparisonOperation(string $formula, mixed $expectedResultExcel, mixed $expectedResultOpenOffice): void
     {
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        $resultExcel = Calculation::getInstance()->_calculateFormulaValue($formula);
+        $resultExcel = Calculation::getInstance()->calculateFormula($formula);
         self::assertEquals($expectedResultExcel, $resultExcel, 'should be Excel compatible');
 
         Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
-        $resultOpenOffice = Calculation::getInstance()->_calculateFormulaValue($formula);
+        $resultOpenOffice = Calculation::getInstance()->calculateFormula($formula);
         self::assertEquals($expectedResultOpenOffice, $resultOpenOffice, 'should be OpenOffice compatible');
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/AllSetupTeardown.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
+
+use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalcException;
+use PhpOffice\PhpSpreadsheet\Calculation\Functions;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PHPUnit\Framework\TestCase;
+
+class AllSetupTeardown extends TestCase
+{
+    private string $compatibilityMode;
+
+    private ?Spreadsheet $spreadsheet = null;
+
+    private ?Worksheet $sheet = null;
+
+    protected function setUp(): void
+    {
+        $this->compatibilityMode = Functions::getCompatibilityMode();
+    }
+
+    protected function tearDown(): void
+    {
+        Functions::setCompatibilityMode($this->compatibilityMode);
+        $this->sheet = null;
+        if ($this->spreadsheet !== null) {
+            $this->spreadsheet->disconnectWorksheets();
+            $this->spreadsheet = null;
+        }
+    }
+
+    protected static function setExcel(): void
+    {
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_EXCEL
+        );
+    }
+
+    protected static function setOpenOffice(): void
+    {
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_OPENOFFICE
+        );
+    }
+
+    protected static function setGnumeric(): void
+    {
+        Functions::setCompatibilityMode(
+            Functions::COMPATIBILITY_GNUMERIC
+        );
+    }
+
+    protected function mightHaveException(mixed $expectedResult): void
+    {
+        if ($expectedResult === 'exception') {
+            $this->expectException(CalcException::class);
+        }
+    }
+
+    protected function getSpreadsheet(): Spreadsheet
+    {
+        if ($this->spreadsheet !== null) {
+            return $this->spreadsheet;
+        }
+        $this->spreadsheet = new Spreadsheet();
+
+        return $this->spreadsheet;
+    }
+
+    protected function getSheet(): Worksheet
+    {
+        if ($this->sheet !== null) {
+            return $this->sheet;
+        }
+        $this->sheet = $this->getSpreadsheet()->getActiveSheet();
+
+        return $this->sheet;
+    }
+}

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselITest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselITest.php
@@ -31,7 +31,7 @@ class BesselITest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BESSELI({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::BESSEL_PRECISION);
     }
 
@@ -92,7 +92,7 @@ class BesselITest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=BESSELI({$value}, {$ord})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::BESSEL_PRECISION);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselJTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselJTest.php
@@ -31,7 +31,7 @@ class BesselJTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BESSELJ({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::BESSEL_PRECISION);
     }
 
@@ -92,7 +92,7 @@ class BesselJTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=BESSELJ({$value}, {$ord})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselKTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselKTest.php
@@ -31,7 +31,7 @@ class BesselKTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BESSELK({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::BESSEL_PRECISION);
     }
 
@@ -92,7 +92,7 @@ class BesselKTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=BESSELK({$value}, {$ord})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselYTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselYTest.php
@@ -31,7 +31,7 @@ class BesselYTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BESSELY({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::BESSEL_PRECISION);
     }
 
@@ -92,7 +92,7 @@ class BesselYTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=BESSELY({$value}, {$ord})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2OctTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2OctTest.php
@@ -7,37 +7,17 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ConvertBinary;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class Bin2OctTest extends TestCase
+class Bin2OctTest extends AllSetupTeardown
 {
-    private string $compatibilityMode;
-
-    protected function setUp(): void
-    {
-        $this->compatibilityMode = Functions::getCompatibilityMode();
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode($this->compatibilityMode);
-    }
-
     #[DataProvider('providerBIN2OCT')]
     public function testDirectCallToBIN2OCT(mixed $expectedResult, bool|float|int|string $value, null|float|int|string $digits = null): void
     {
         $result = ($digits === null) ? ConvertBinary::toOctal($value) : ConvertBinary::toOctal($value, $digits);
         self::assertSame($expectedResult, $result);
-    }
-
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
     }
 
     #[DataProvider('providerBIN2OCT')]
@@ -48,9 +28,8 @@ class Bin2OctTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BIN2OCT({$arguments})";
 
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     #[DataProvider('providerBIN2OCT')]
@@ -58,8 +37,7 @@ class Bin2OctTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=BIN2OCT({$argumentCells})";
 
@@ -67,8 +45,6 @@ class Bin2OctTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertSame($expectedResult, $result);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerBIN2OCT(): array
@@ -81,8 +57,7 @@ class Bin2OctTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=BIN2OCT({$argumentCells})";
 
@@ -91,8 +66,6 @@ class Bin2OctTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyBIN2OCT(): array
@@ -105,7 +78,7 @@ class Bin2OctTest extends TestCase
     #[DataProvider('providerBIN2OCTOds')]
     public function testBIN2OCTOds(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        $this->setOpenOffice();
 
         $result = ($digits === null) ? ConvertBinary::toOctal($value) : ConvertBinary::toOctal($value, $digits);
         self::assertSame($expectedResult, $result);
@@ -121,20 +94,17 @@ class Bin2OctTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = '=BIN2OCT(101.1)';
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('5', $this->trimIfQuoted((string) $result), 'Gnumeric');
+        $this->setGnumeric();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame('5', $result, 'Gnumeric');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
+        $this->setOpenOffice();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(ExcelError::NAN(), $result, 'OpenOffice');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
+        $this->setExcel();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(ExcelError::NAN(), $result, 'Excel');
     }
 
     /** @param mixed[] $expectedResult */
@@ -144,7 +114,7 @@ class Bin2OctTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=BIN2OCT({$value})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitAndTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitAndTest.php
@@ -7,12 +7,10 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\BitWise;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class BitAndTest extends TestCase
+class BitAndTest extends AllSetupTeardown
 {
     #[DataProvider('providerBITAND')]
     public function testDirectCallToBITAND(float|int|string $expectedResult, null|bool|int|float|string $arg1, null|bool|int|float|string $arg2): void
@@ -29,7 +27,7 @@ class BitAndTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BITAND({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -38,8 +36,7 @@ class BitAndTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=BITAND({$argumentCells})";
 
@@ -47,8 +44,6 @@ class BitAndTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertSame($expectedResult, $result);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerBITAND(): array
@@ -61,8 +56,7 @@ class BitAndTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=BITAND({$argumentCells})";
 
@@ -71,8 +65,6 @@ class BitAndTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyBITAND(): array
@@ -90,7 +82,7 @@ class BitAndTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=BITAND({$number1}, {$number2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitLShiftTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitLShiftTest.php
@@ -7,12 +7,10 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\BitWise;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class BitLShiftTest extends TestCase
+class BitLShiftTest extends AllSetupTeardown
 {
     #[DataProvider('providerBITLSHIFT')]
     public function testDirectCallToBITLSHIFT(float|int|string $expectedResult, null|bool|int|float|string $arg1, null|bool|int|float|string $arg2): void
@@ -29,7 +27,7 @@ class BitLShiftTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BITLSHIFT({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -38,8 +36,7 @@ class BitLShiftTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=BITLSHIFT({$argumentCells})";
 
@@ -47,8 +44,6 @@ class BitLShiftTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertSame($expectedResult, $result);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerBITLSHIFT(): array
@@ -61,8 +56,7 @@ class BitLShiftTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=BITLSHIFT({$argumentCells})";
 
@@ -71,8 +65,6 @@ class BitLShiftTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyBITLSHIFT(): array
@@ -90,7 +82,7 @@ class BitLShiftTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=BITLSHIFT({$number}, {$bits})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitOrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitOrTest.php
@@ -7,12 +7,10 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\BitWise;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class BitOrTest extends TestCase
+class BitOrTest extends AllSetupTeardown
 {
     #[DataProvider('providerBITOR')]
     public function testDirectCallToBITOR(float|int|string $expectedResult, null|bool|int|float|string $arg1, null|bool|int|float|string $arg2): void
@@ -29,7 +27,7 @@ class BitOrTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BITOR({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -38,8 +36,7 @@ class BitOrTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=BITOR({$argumentCells})";
 
@@ -47,8 +44,6 @@ class BitOrTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertSame($expectedResult, $result);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerBITOR(): array
@@ -61,8 +56,7 @@ class BitOrTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=BITOR({$argumentCells})";
 
@@ -71,8 +65,6 @@ class BitOrTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyBITOR(): array
@@ -90,7 +82,7 @@ class BitOrTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=BITOR({$number1}, {$number2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitRShiftTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitRShiftTest.php
@@ -7,12 +7,10 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\BitWise;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class BitRShiftTest extends TestCase
+class BitRShiftTest extends AllSetupTeardown
 {
     #[DataProvider('providerBITRSHIFT')]
     public function testDirectCallToBITRSHIFT(float|int|string $expectedResult, null|bool|int|float|string $arg1, null|bool|int|float|string $arg2): void
@@ -29,7 +27,7 @@ class BitRShiftTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BITRSHIFT({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -38,8 +36,7 @@ class BitRShiftTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=BITRSHIFT({$argumentCells})";
 
@@ -47,8 +44,6 @@ class BitRShiftTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertSame($expectedResult, $result);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerBITRSHIFT(): array
@@ -61,8 +56,7 @@ class BitRShiftTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=BITRSHIFT({$argumentCells})";
 
@@ -71,8 +65,6 @@ class BitRShiftTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyBITRSHIFT(): array
@@ -90,7 +82,7 @@ class BitRShiftTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=BITRSHIFT({$number}, {$bits})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitXorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitXorTest.php
@@ -7,12 +7,10 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\BitWise;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class BitXorTest extends TestCase
+class BitXorTest extends AllSetupTeardown
 {
     #[DataProvider('providerBITXOR')]
     public function testDirectCallToBITXOR(float|int|string $expectedResult, null|bool|int|float|string $arg1, null|bool|int|float|string $arg2): void
@@ -29,7 +27,7 @@ class BitXorTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=BITXOR({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -38,8 +36,7 @@ class BitXorTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=BITXOR({$argumentCells})";
 
@@ -47,8 +44,6 @@ class BitXorTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertSame($expectedResult, $result);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerBITXOR(): array
@@ -61,8 +56,7 @@ class BitXorTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=BITXOR({$argumentCells})";
 
@@ -71,8 +65,6 @@ class BitXorTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyBITXOR(): array
@@ -90,7 +82,7 @@ class BitXorTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=BITXOR({$number1}, {$number2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ConvertUoMTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ConvertUoMTest.php
@@ -7,12 +7,10 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ConvertUOM;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class ConvertUoMTest extends TestCase
+class ConvertUoMTest extends AllSetupTeardown
 {
     const UOM_PRECISION = 1E-12;
 
@@ -65,7 +63,7 @@ class ConvertUoMTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=CONVERT({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::UOM_PRECISION);
     }
 
@@ -74,8 +72,7 @@ class ConvertUoMTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=CONVERT({$argumentCells})";
 
@@ -83,8 +80,6 @@ class ConvertUoMTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertEqualsWithDelta($expectedResult, $result, self::UOM_PRECISION);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     /** @return mixed[] */
@@ -101,8 +96,7 @@ class ConvertUoMTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=CONVERT({$argumentCells})";
 
@@ -111,8 +105,6 @@ class ConvertUoMTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyCONVERTUOM(): array
@@ -131,7 +123,7 @@ class ConvertUoMTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=CONVERT({$value}, {$fromUoM}, {$toUoM})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::UOM_PRECISION);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2BinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2BinTest.php
@@ -7,36 +7,16 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ConvertDecimal;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class Dec2BinTest extends TestCase
+class Dec2BinTest extends AllSetupTeardown
 {
-    private string $compatibilityMode;
-
-    protected function setUp(): void
-    {
-        $this->compatibilityMode = Functions::getCompatibilityMode();
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode($this->compatibilityMode);
-    }
-
     #[DataProvider('providerDEC2BIN')]
     public function testDirectCallToDEC2BIN(mixed $expectedResult, bool|float|int|string $value, null|float|int|string $digits = null): void
     {
         $result = ($digits === null) ? ConvertDecimal::toBinary($value) : ConvertDecimal::toBinary($value, $digits);
         self::assertSame($expectedResult, $result);
-    }
-
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
     }
 
     #[DataProvider('providerDEC2BIN')]
@@ -47,9 +27,8 @@ class Dec2BinTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DEC2BIN({$arguments})";
 
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     #[DataProvider('providerDEC2BIN')]
@@ -57,8 +36,7 @@ class Dec2BinTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=DEC2BIN({$argumentCells})";
 
@@ -66,8 +44,6 @@ class Dec2BinTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertSame($expectedResult, $result);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerDEC2BIN(): array
@@ -80,8 +56,7 @@ class Dec2BinTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=DEC2BIN({$argumentCells})";
 
@@ -90,8 +65,6 @@ class Dec2BinTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyDEC2BIN(): array
@@ -104,7 +77,7 @@ class Dec2BinTest extends TestCase
     #[DataProvider('providerDEC2BINOds')]
     public function testDEC2BINOds(mixed $expectedResult, bool|float|int|string $value, null|float|int|string $digits = null): void
     {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        $this->setOpenOffice();
 
         $result = ($digits === null) ? ConvertDecimal::toBinary($value) : ConvertDecimal::toBinary($value, $digits);
         self::assertSame($expectedResult, $result);
@@ -120,20 +93,17 @@ class Dec2BinTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = '=DEC2BIN(5.1)';
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('101', $this->trimIfQuoted((string) $result), 'Gnumeric');
+        $this->setGnumeric();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame('101', $result, 'Gnumeric');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('101', $this->trimIfQuoted((string) $result), 'OpenOffice');
+        $this->setOpenOffice();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame('101', $result, 'OpenOffice');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('101', $this->trimIfQuoted((string) $result), 'Excel');
+        $this->setExcel();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame('101', $result, 'Excel');
     }
 
     /** @param mixed[] $expectedResult */
@@ -143,7 +113,7 @@ class Dec2BinTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=DEC2BIN({$value})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2HexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2HexTest.php
@@ -7,36 +7,16 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ConvertDecimal;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class Dec2HexTest extends TestCase
+class Dec2HexTest extends AllSetupTeardown
 {
-    private string $compatibilityMode;
-
-    protected function setUp(): void
-    {
-        $this->compatibilityMode = Functions::getCompatibilityMode();
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode($this->compatibilityMode);
-    }
-
     #[DataProvider('providerDEC2HEX')]
     public function testDirectCallToDEC2HEX(mixed $expectedResult, bool|float|int|string $value, null|float|int|string $digits = null): void
     {
         $result = ($digits === null) ? ConvertDecimal::toHex($value) : ConvertDecimal::toHex($value, $digits);
         self::assertSame($expectedResult, $result);
-    }
-
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
     }
 
     #[DataProvider('providerDEC2HEX')]
@@ -47,9 +27,8 @@ class Dec2HexTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DEC2HEX({$arguments})";
 
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     #[DataProvider('providerDEC2HEX')]
@@ -57,8 +36,7 @@ class Dec2HexTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=DEC2HEX({$argumentCells})";
 
@@ -66,8 +44,6 @@ class Dec2HexTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertSame($expectedResult, $result);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerDEC2HEX(): array
@@ -80,8 +56,7 @@ class Dec2HexTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=DEC2HEX({$argumentCells})";
 
@@ -90,8 +65,6 @@ class Dec2HexTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyDEC2HEX(): array
@@ -104,7 +77,7 @@ class Dec2HexTest extends TestCase
     #[DataProvider('providerDEC2HEXOds')]
     public function testDEC2HEXOds(mixed $expectedResult, bool|float|int|string $value, null|float|int|string $digits = null): void
     {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        $this->setOpenOffice();
 
         $result = ($digits === null) ? ConvertDecimal::toHex($value) : ConvertDecimal::toHex($value, $digits);
         self::assertSame($expectedResult, $result);
@@ -120,20 +93,17 @@ class Dec2HexTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = '=DEC2HEX(17.1)';
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('11', $this->trimIfQuoted((string) $result), 'Gnumeric');
+        $this->setGnumeric();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame('11', $result, 'Gnumeric');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('11', $this->trimIfQuoted((string) $result), 'OpenOffice');
+        $this->setOpenOffice();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame('11', $result, 'OpenOffice');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('11', $this->trimIfQuoted((string) $result), 'Excel');
+        $this->setExcel();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame('11', $result, 'Excel');
     }
 
     public function test32bitHex(): void
@@ -150,7 +120,7 @@ class Dec2HexTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=DEC2HEX({$value})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2OctTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2OctTest.php
@@ -7,36 +7,16 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ConvertDecimal;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class Dec2OctTest extends TestCase
+class Dec2OctTest extends AllSetupTeardown
 {
-    private string $compatibilityMode;
-
-    protected function setUp(): void
-    {
-        $this->compatibilityMode = Functions::getCompatibilityMode();
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode($this->compatibilityMode);
-    }
-
     #[DataProvider('providerDEC2OCT')]
     public function testDirectCallToDEC2OCT(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
         $result = ($digits === null) ? ConvertDecimal::toOctal($value) : ConvertDecimal::toOctal($value, $digits);
         self::assertSame($expectedResult, $result);
-    }
-
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
     }
 
     #[DataProvider('providerDEC2OCT')]
@@ -47,9 +27,8 @@ class Dec2OctTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DEC2OCT({$arguments})";
 
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     #[DataProvider('providerDEC2OCT')]
@@ -57,8 +36,7 @@ class Dec2OctTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=DEC2OCT({$argumentCells})";
 
@@ -66,8 +44,6 @@ class Dec2OctTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertSame($expectedResult, $result);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerDEC2OCT(): array
@@ -80,8 +56,7 @@ class Dec2OctTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=DEC2OCT({$argumentCells})";
 
@@ -90,8 +65,6 @@ class Dec2OctTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyDEC2OCT(): array
@@ -104,7 +77,7 @@ class Dec2OctTest extends TestCase
     #[DataProvider('providerDEC2OCTOds')]
     public function testDEC2OCTOds(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        $this->setOpenOffice();
 
         $result = ($digits === null) ? ConvertDecimal::toOctal($value) : ConvertDecimal::toOctal($value, $digits);
         self::assertSame($expectedResult, $result);
@@ -120,20 +93,17 @@ class Dec2OctTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = '=DEC2OCT(17.1)';
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('21', $this->trimIfQuoted((string) $result), 'Gnumeric');
+        $this->setGnumeric();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame('21', $result, 'Gnumeric');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('21', $this->trimIfQuoted((string) $result), 'OpenOffice');
+        $this->setOpenOffice();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame('21', $result, 'OpenOffice');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('21', $this->trimIfQuoted((string) $result), 'Excel');
+        $this->setExcel();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame('21', $result, 'Excel');
     }
 
     /** @param mixed[] $expectedResult */
@@ -143,7 +113,7 @@ class Dec2OctTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=DEC2OCT({$value})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/DeltaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/DeltaTest.php
@@ -7,20 +7,19 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\Compare;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class DeltaTest extends TestCase
+class DeltaTest extends AllSetupTeardown
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerDELTA')]
+    #[DataProvider('providerDELTA')]
     public function testDirectCallToDELTA(mixed $expectedResult, bool|float|int|string $arg1, null|bool|float|int|string $arg2 = null): void
     {
         $result = ($arg2 === null) ? Compare::delta($arg1) : Compare::delta($arg1, $arg2);
         self::assertSame($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerDELTA')]
+    #[DataProvider('providerDELTA')]
     public function testDELTAAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -28,17 +27,16 @@ class DeltaTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DELTA({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerDELTA')]
+    #[DataProvider('providerDELTA')]
     public function testDELTAInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=DELTA({$argumentCells})";
 
@@ -46,8 +44,6 @@ class DeltaTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertSame($expectedResult, $result);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerDELTA(): array
@@ -55,13 +51,12 @@ class DeltaTest extends TestCase
         return require 'tests/data/Calculation/Engineering/DELTA.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyDELTA')]
+    #[DataProvider('providerUnhappyDELTA')]
     public function testDELTAUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=DELTA({$argumentCells})";
 
@@ -70,8 +65,6 @@ class DeltaTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyDELTA(): array
@@ -81,13 +74,13 @@ class DeltaTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerDeltaArray')]
+    #[DataProvider('providerDeltaArray')]
     public function testDeltaArray(array $expectedResult, string $a, string $b): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=DELTA({$a}, {$b})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfCTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfCTest.php
@@ -7,22 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ErfC;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ErfCTest extends TestCase
+class ErfCTest extends AllSetupTeardown
 {
     const ERF_PRECISION = 1E-14;
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerERFC')]
+    #[DataProvider('providerERFC')]
     public function testDirectCallToERFC(mixed $expectedResult, mixed ...$args): void
     {
         $result = ErfC::ERFC(...$args);
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerERFC')]
+    #[DataProvider('providerERFC')]
     public function testERFCAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -30,17 +29,16 @@ class ErfCTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=ERFC({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerERFC')]
+    #[DataProvider('providerERFC')]
     public function testERFCInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=ERFC({$argumentCells})";
 
@@ -48,8 +46,6 @@ class ErfCTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerERFC(): array
@@ -57,13 +53,12 @@ class ErfCTest extends TestCase
         return require 'tests/data/Calculation/Engineering/ERFC.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyERFC')]
+    #[DataProvider('providerUnhappyERFC')]
     public function testERFCUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=ERFC({$argumentCells})";
 
@@ -72,8 +67,6 @@ class ErfCTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyERFC(): array
@@ -83,13 +76,13 @@ class ErfCTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerErfCArray')]
+    #[DataProvider('providerErfCArray')]
     public function testErfCArray(array $expectedResult, string $lower): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ERFC({$lower})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfPreciseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfPreciseTest.php
@@ -6,22 +6,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\Erf;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ErfPreciseTest extends TestCase
+class ErfPreciseTest extends AllSetupTeardown
 {
     const ERF_PRECISION = 1E-14;
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerERFPRECISE')]
+    #[DataProvider('providerERFPRECISE')]
     public function testDirectCallToERFPRECISE(mixed $expectedResult, mixed ...$args): void
     {
         $result = Erf::ERFPRECISE(...$args);
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerERFPRECISE')]
+    #[DataProvider('providerERFPRECISE')]
     public function testERFPRECISEAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -29,17 +28,16 @@ class ErfPreciseTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=ERF.PRECISE({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerERFPRECISE')]
+    #[DataProvider('providerERFPRECISE')]
     public function testERFPRECISEInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=ERF.PRECISE({$argumentCells})";
 
@@ -47,8 +45,6 @@ class ErfPreciseTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerERFPRECISE(): array
@@ -56,13 +52,13 @@ class ErfPreciseTest extends TestCase
         return require 'tests/data/Calculation/Engineering/ERFPRECISE.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerErfPreciseArray')]
+    #[DataProvider('providerErfPreciseArray')]
     public function testErfPreciseArray(array $expectedResult, string $limit): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ERF.PRECISE({$limit})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfTest.php
@@ -7,22 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\Erf;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ErfTest extends TestCase
+class ErfTest extends AllSetupTeardown
 {
     const ERF_PRECISION = 1E-14;
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerERF')]
+    #[DataProvider('providerERF')]
     public function testDirectCallToERF(mixed $expectedResult, mixed ...$args): void
     {
         $result = Erf::erf(...$args);
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerERF')]
+    #[DataProvider('providerERF')]
     public function testERFAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -30,17 +29,16 @@ class ErfTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=ERF({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerERF')]
+    #[DataProvider('providerERF')]
     public function testERFInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=ERF({$argumentCells})";
 
@@ -48,8 +46,6 @@ class ErfTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerERF(): array
@@ -57,13 +53,12 @@ class ErfTest extends TestCase
         return require 'tests/data/Calculation/Engineering/ERF.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyERF')]
+    #[DataProvider('providerUnhappyERF')]
     public function testERFUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=ERF({$argumentCells})";
 
@@ -72,8 +67,6 @@ class ErfTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyERF(): array
@@ -83,13 +76,13 @@ class ErfTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerErfArray')]
+    #[DataProvider('providerErfArray')]
     public function testErfArray(array $expectedResult, string $lower, string $upper = 'NULL'): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ERF({$lower}, {$upper})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/GeStepTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/GeStepTest.php
@@ -7,20 +7,19 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\Compare;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class GeStepTest extends TestCase
+class GeStepTest extends AllSetupTeardown
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerGESTEP')]
+    #[DataProvider('providerGESTEP')]
     public function testDirectCallToGESTEP(int|string $expectedResult, bool|float|int|string $arg1, null|bool|float|int|string $arg2 = null): void
     {
         $result = ($arg2 === null) ? Compare::geStep($arg1) : Compare::geStep($arg1, $arg2);
         self::assertSame($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerGESTEP')]
+    #[DataProvider('providerGESTEP')]
     public function testGESTEPAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -28,17 +27,16 @@ class GeStepTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=GESTEP({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerGESTEP')]
+    #[DataProvider('providerGESTEP')]
     public function testGESTEPInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=GESTEP({$argumentCells})";
 
@@ -46,8 +44,6 @@ class GeStepTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertSame($expectedResult, $result);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerGESTEP(): array
@@ -55,13 +51,12 @@ class GeStepTest extends TestCase
         return require 'tests/data/Calculation/Engineering/GESTEP.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyGESTEP')]
+    #[DataProvider('providerUnhappyGESTEP')]
     public function testGESTEPUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=GESTEP({$argumentCells})";
 
@@ -70,8 +65,6 @@ class GeStepTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyGESTEP(): array
@@ -81,13 +74,13 @@ class GeStepTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerGeStepArray')]
+    #[DataProvider('providerGeStepArray')]
     public function testGeStepArray(array $expectedResult, string $a, string $b): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=GESTEP({$a}, {$b})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImAbsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImAbsTest.php
@@ -7,22 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImAbsTest extends TestCase
+class ImAbsTest extends AllSetupTeardown
 {
     const COMPLEX_PRECISION = 1E-12;
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMABS')]
+    #[DataProvider('providerIMABS')]
     public function testDirectCallToIMABS(float|int|string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMABS($arg);
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMABS')]
+    #[DataProvider('providerIMABS')]
     public function testIMABSAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -30,17 +29,16 @@ class ImAbsTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMABS({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMABS')]
+    #[DataProvider('providerIMABS')]
     public function testIMABSInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=IMABS({$argumentCells})";
 
@@ -48,8 +46,6 @@ class ImAbsTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerIMABS(): array
@@ -57,13 +53,12 @@ class ImAbsTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMABS.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMABS')]
+    #[DataProvider('providerUnhappyIMABS')]
     public function testIMABSUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=IMABS({$argumentCells})";
 
@@ -72,8 +67,6 @@ class ImAbsTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyIMABS(): array
@@ -83,13 +76,13 @@ class ImAbsTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImAbsArray')]
+    #[DataProvider('providerImAbsArray')]
     public function testImAbsArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMABS({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImArgumentTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImArgumentTest.php
@@ -7,28 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ComplexFunctions;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImArgumentTest extends TestCase
+class ImArgumentTest extends AllSetupTeardown
 {
     const COMPLEX_PRECISION = 1E-12;
 
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMARGUMENT')]
+    #[DataProvider('providerIMARGUMENT')]
     public function testDirectCallToIMARGUMENT(float|int|string $expectedResult, string $arg): void
     {
         $result = ComplexFunctions::IMARGUMENT($arg);
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMARGUMENT')]
+    #[DataProvider('providerIMARGUMENT')]
     public function testIMARGUMENTAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -36,17 +29,16 @@ class ImArgumentTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMARGUMENT({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMARGUMENT')]
+    #[DataProvider('providerIMARGUMENT')]
     public function testIMARGUMENTInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=IMARGUMENT({$argumentCells})";
 
@@ -54,8 +46,6 @@ class ImArgumentTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerIMARGUMENT(): array
@@ -63,13 +53,12 @@ class ImArgumentTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMARGUMENT.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMARGUMENT')]
+    #[DataProvider('providerUnhappyIMARGUMENT')]
     public function testIMARGUMENTUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=IMARGUMENT({$argumentCells})";
 
@@ -78,8 +67,6 @@ class ImArgumentTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyIMARGUMENT(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImRealTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImRealTest.php
@@ -7,28 +7,21 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\Complex;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class ImRealTest extends TestCase
+class ImRealTest extends AllSetupTeardown
 {
     const COMPLEX_PRECISION = 1E-12;
 
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-    }
-
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMREAL')]
+    #[DataProvider('providerIMREAL')]
     public function testDirectCallToIMREAL(float|int|string $expectedResult, float|int|string $arg): void
     {
         $result = Complex::IMREAL((string) $arg);
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMREAL')]
+    #[DataProvider('providerIMREAL')]
     public function testIMREALAsFormula(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
@@ -36,17 +29,16 @@ class ImRealTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMREAL({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIMREAL')]
+    #[DataProvider('providerIMREAL')]
     public function testIMREALInWorksheet(mixed $expectedResult, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=IMREAL({$argumentCells})";
 
@@ -54,8 +46,6 @@ class ImRealTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerIMREAL(): array
@@ -63,13 +53,12 @@ class ImRealTest extends TestCase
         return require 'tests/data/Calculation/Engineering/IMREAL.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerUnhappyIMREAL')]
+    #[DataProvider('providerUnhappyIMREAL')]
     public function testIMREALUnhappyPath(string $expectedException, mixed ...$args): void
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=IMREAL({$argumentCells})";
 
@@ -78,8 +67,6 @@ class ImRealTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyIMREAL(): array
@@ -89,13 +76,13 @@ class ImRealTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerImRealArray')]
+    #[DataProvider('providerImRealArray')]
     public function testImRealArray(array $expectedResult, string $complex): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IMREAL({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImaginaryTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImaginaryTest.php
@@ -7,20 +7,12 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\Complex;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class ImaginaryTest extends TestCase
+class ImaginaryTest extends AllSetupTeardown
 {
     const COMPLEX_PRECISION = 1E-12;
-
-    protected function setUp(): void
-    {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-    }
 
     #[DataProvider('providerIMAGINARY')]
     public function testDirectCallToIMAGINARY(float|int|string $expectedResult, float|int|string $arg): void
@@ -37,7 +29,7 @@ class ImaginaryTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=IMAGINARY({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
     }
 
@@ -46,8 +38,7 @@ class ImaginaryTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=IMAGINARY({$argumentCells})";
 
@@ -55,8 +46,6 @@ class ImaginaryTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertEqualsWithDelta($expectedResult, $result, self::COMPLEX_PRECISION);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerIMAGINARY(): array
@@ -69,8 +58,7 @@ class ImaginaryTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=IMAGINARY({$argumentCells})";
 
@@ -79,8 +67,6 @@ class ImaginaryTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyIMAGINARY(): array
@@ -97,7 +83,7 @@ class ImaginaryTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=IMAGINARY({$complex})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2BinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2BinTest.php
@@ -7,37 +7,17 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Engineering;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Engineering\ConvertOctal;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalculationException;
-use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
-use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheetTests\Calculation\Functions\FormulaArguments;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-class Oct2BinTest extends TestCase
+class Oct2BinTest extends AllSetupTeardown
 {
-    private string $compatibilityMode;
-
-    protected function setUp(): void
-    {
-        $this->compatibilityMode = Functions::getCompatibilityMode();
-    }
-
-    protected function tearDown(): void
-    {
-        Functions::setCompatibilityMode($this->compatibilityMode);
-    }
-
     #[DataProvider('providerOCT2BIN')]
     public function testDirectCallToOCT2BIN(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
         $result = ($digits === null) ? ConvertOctal::toBinary($value) : ConvertOctal::toBinary($value, $digits);
         self::assertSame($expectedResult, $result);
-    }
-
-    private function trimIfQuoted(string $value): string
-    {
-        return trim($value, '"');
     }
 
     #[DataProvider('providerOCT2BIN')]
@@ -48,9 +28,8 @@ class Oct2BinTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=OCT2BIN({$arguments})";
 
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame($expectedResult, $this->trimIfQuoted((string) $result));
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     #[DataProvider('providerOCT2BIN')]
@@ -58,8 +37,7 @@ class Oct2BinTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=OCT2BIN({$argumentCells})";
 
@@ -67,8 +45,6 @@ class Oct2BinTest extends TestCase
             ->getCell('A1')
             ->getCalculatedValue();
         self::assertSame($expectedResult, $result);
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerOCT2BIN(): array
@@ -81,8 +57,7 @@ class Oct2BinTest extends TestCase
     {
         $arguments = new FormulaArguments(...$args);
 
-        $spreadsheet = new Spreadsheet();
-        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet = $this->getSheet();
         $argumentCells = $arguments->populateWorksheet($worksheet);
         $formula = "=OCT2BIN({$argumentCells})";
 
@@ -91,8 +66,6 @@ class Oct2BinTest extends TestCase
         $worksheet->setCellValue('A1', $formula)
             ->getCell('A1')
             ->getCalculatedValue();
-
-        $spreadsheet->disconnectWorksheets();
     }
 
     public static function providerUnhappyOCT2BIN(): array
@@ -105,7 +78,7 @@ class Oct2BinTest extends TestCase
     #[DataProvider('providerOCT2BINOds')]
     public function testOCT2BINOds(mixed $expectedResult, bool|float|int|string $value, ?int $digits = null): void
     {
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
+        $this->setOpenOffice();
 
         $result = ($digits === null) ? ConvertOctal::toBinary($value) : ConvertOctal::toBinary($value, $digits);
         self::assertSame($expectedResult, $result);
@@ -121,20 +94,17 @@ class Oct2BinTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = '=OCT2BIN(10.1)';
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_GNUMERIC);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame('1000', $this->trimIfQuoted((string) $result), 'Gnumeric');
+        $this->setGnumeric();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame('1000', $result, 'Gnumeric');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_OPENOFFICE);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'OpenOffice');
+        $this->setOpenOffice();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(ExcelError::NAN(), $result, 'OpenOffice');
 
-        Functions::setCompatibilityMode(Functions::COMPATIBILITY_EXCEL);
-        /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertSame(ExcelError::NAN(), $this->trimIfQuoted((string) $result), 'Excel');
+        $this->setExcel();
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame(ExcelError::NAN(), $result, 'Excel');
     }
 
     /** @param mixed[] $expectedResult */
@@ -144,7 +114,7 @@ class Oct2BinTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=OCT2BIN({$value})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEquals($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/DollarDeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/DollarDeTest.php
@@ -27,7 +27,7 @@ class DollarDeTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=DollarDe({$argument1},{$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-12);
     }
 


### PR DESCRIPTION
This came to light while cleaning up ComplexAssert. Many tests are calling `_calculateFormulaValue` rather than `calculateFormula`, and, as a result, have to be trimmed before asserting. This PR changes those calls, and does a bit more to simplify the tests. There are a lot of other non-Engineering tests which call `_calculateFormulaValue`, but none of those need to manipulate the result after the call.

This PR changes only tests, no source code.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] simplify unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

