### PR TITLE
Additional Floating Point Precision Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org). Thia is a
 ### Fixed
 
 - Xlsx Writer eliminate xml:space from non-text nodes. [Issue #4542](https://github.com/PHPOffice/PhpSpreadsheet/issues/4542) [PR #4556](https://github.com/PHPOffice/PhpSpreadsheet/pull/4556)
+- Xlsx Writer eliminate xml:space from non-text nodes. [Issue #1324](https://github.com/PHPOffice/PhpSpreadsheet/issues/1324) [PR #4575](https://github.com/PHPOffice/PhpSpreadsheet/pull/4575)
 
 ## 2025-07-23 - 4.5.0
 

--- a/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
+++ b/src/PhpSpreadsheet/Style/NumberFormat/Formatter.php
@@ -159,7 +159,9 @@ class Formatter extends BaseFormatter
         // For 'General' format code, we just pass the value although this is not entirely the way Excel does it,
         // it seems to round numbers to a total of 10 digits.
         if (($format === NumberFormat::FORMAT_GENERAL) || ($format === NumberFormat::FORMAT_TEXT)) {
-            return self::adjustSeparators((string) $value);
+            return self::adjustSeparators(
+                StringHelper::convertToString($value)
+            );
         }
 
         // Ignore square-$-brackets prefix in format string, like "[$-411]ge.m.d", "[$-010419]0%", etc

--- a/tests/PhpSpreadsheetTests/Shared/Issue1324Test.php
+++ b/tests/PhpSpreadsheetTests/Shared/Issue1324Test.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Shared;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Csv as CsvWriter;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class Issue1324Test extends AbstractFunctional
+{
+    protected static int $version = 80400;
+
+    public function testPrecision(): void
+    {
+        $string1 = '753.149999999999';
+        $s1 = (float) $string1;
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->getCell('A1')->setValue($s1);
+        self::assertNotSame(753.15, $sheet->getCell('A1')->getValue());
+        $formats = ['Csv', 'Xlsx', 'Xls', 'Ods', 'Html'];
+        foreach ($formats as $format) {
+            $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, $format);
+            $rsheet = $reloadedSpreadsheet->getActiveSheet();
+            $s2 = $rsheet->getCell('A1')->getValue();
+            self::assertSame($s1, $s2, "difference for $format");
+            $reloadedSpreadsheet->disconnectWorksheets();
+        }
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testCsv(): void
+    {
+        $string1 = '753.149999999999';
+        $s1 = (float) $string1;
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->getCell('A1')->setValue($s1);
+        $writer = new CsvWriter($spreadsheet);
+        ob_start();
+        $writer->save('php://output');
+        $output = (string) ob_get_clean();
+        self::assertStringContainsString($string1, $output);
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Fix #1324, which went stale many years ago, and is now re-opened. It can be considered a follow-on to PR #4479 which was installed in May. The user complains of a *very* small loss of precision. This can be corrected by using `StringHelper::convertToString` in lieu of a simple cast from float to string in two places. `Style\NumberFormat\Formatter` is quite straightforward. `Writer\Csv` is a bit more complicated. If you put a float with more than 15 digits precision in a Csv, on opening it Excel will give a pop-up, saying something inaccurate like "We've corrected this for you - is that okay?" Better to avoid that by making sure to avoid too much precision when writing to Csv.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
