### PR TITLE
Copy Cell Adjusting Formula

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -3984,4 +3984,22 @@ class Worksheet
 
         return true;
     }
+
+    public function copyFormula(string $fromCell, string $toCell): void
+    {
+        $formula = $this->getCell($fromCell)->getValue();
+        $newFormula = $formula;
+        if (is_string($formula) && $this->getCell($fromCell)->getDataType() === DataType::TYPE_FORMULA) {
+            [$fromColInt, $fromRow] = Coordinate::indexesFromString($fromCell);
+            [$toColInt, $toRow] = Coordinate::indexesFromString($toCell);
+            $helper = ReferenceHelper::getInstance();
+            $newFormula = $helper->updateFormulaReferences(
+                $formula,
+                'A1',
+                $toColInt - $fromColInt,
+                $toRow - $fromRow
+            );
+        }
+        $this->setCellValue($toCell, $newFormula);
+    }
 }

--- a/tests/PhpSpreadsheetTests/Worksheet/Issue1203Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/Issue1203Test.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+class Issue1203Test extends TestCase
+{
+    public static function testCopyFormula(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 1);
+        $sheet->setCellValue('A5', 5);
+        $sheet->setCellValue('E5', '=A5+$A$1');
+        $sheet->insertNewRowBefore(5, 1);
+        $e5 = $sheet->getCell('E5')->getValue();
+        self::assertNull($e5);
+        self::assertSame('=A6+$A$1', $sheet->getCell('E6')->getValue());
+        $sheet->copyFormula('E6', 'E5');
+        self::assertSame('=A5+$A$1', $sheet->getCell('E5')->getValue());
+        $sheet->copyFormula('E6', 'H9');
+        self::assertSame('=D9+$A$1', $sheet->getCell('H9')->getValue());
+        $sheet->copyFormula('A6', 'Z9');
+        self::assertSame(5, $sheet->getCell('Z9')->getValue());
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Fix #1203. The issue actually complains about the documentation, but I think it wants documented functionality that doesn't yet exist. This PR adds a method for copying a formula from one cell to another, adjusting cell references in the formula as Excel would. For a non-formula, it copies the value without making any adjustments.

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

