### PR TITLE
splitRange and ProtectedRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org). Thia is a
 
 ### Added
 
-- Nothing yet.
+- Add Conditional Formatting with IconSet (Xlsx only). [Issue #4560](https://github.com/PHPOffice/PhpSpreadsheet/issues/4560) [PR #4574](https://github.com/PHPOffice/PhpSpreadsheet/pull/4574)
+- Copy cell adjusting formula. [Issue #1203](https://github.com/PHPOffice/PhpSpreadsheet/issues/1203) [PR #4577](https://github.com/PHPOffice/PhpSpreadsheet/pull/4577)
+- splitRange and ProtectedRange. [Issue #1457](https://github.com/PHPOffice/PhpSpreadsheet/issues/1457) [PR #4580](https://github.com/PHPOffice/PhpSpreadsheet/pull/4580)
 
 ### Removed
 
@@ -29,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org). Thia is a
 
 ### Fixed
 
-- Nothing yet.
+- Google-only formulas exported from Google Sheets. [Issue #1637](https://github.com/PHPOffice/PhpSpreadsheet/issues/1637) [PR #4579](https://github.com/PHPOffice/PhpSpreadsheet/pull/4579)
 
 ## 2025-08-10 - 5.0.0
 

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -136,7 +136,8 @@ abstract class Coordinate
     }
 
     /**
-     * Split range into coordinate strings.
+     * Split range into coordinate strings, using comma for union
+     * and ignoring intersection (space).
      *
      * @param string $range e.g. 'B4:D9' or 'B4:D9,H2:O11' or 'B4'
      *
@@ -158,6 +159,28 @@ abstract class Coordinate
         }
 
         return $outArray;
+    }
+
+    /**
+     * Split range into coordinate strings, resolving unions and intersections.
+     *
+     * @param string $range e.g. 'B4:D9' or 'B4:D9,H2:O11' or 'B4'
+     * @param bool $unionIsComma true=comma is union, space is intersection
+     *                           false=space is union, comma is intersection
+     *
+     * @return array<array<string>> Array containing one or more arrays containing one or two coordinate strings
+     *                                e.g. ['B4','D9'] or [['B4','D9'], ['H2','O11']]
+     *                                        or ['B4']
+     */
+    public static function allRanges(string $range, bool $unionIsComma = true): array
+    {
+        if (!$unionIsComma) {
+            $range = str_replace([',', ' ', "\0"], ["\0", ',', ' '], $range);
+        }
+
+        return self::splitRange(
+            self::resolveUnionAndIntersection($range)
+        );
     }
 
     /**

--- a/src/PhpSpreadsheet/Worksheet/ProtectedRange.php
+++ b/src/PhpSpreadsheet/Worksheet/ProtectedRange.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheet\Worksheet;
 
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+
 class ProtectedRange
 {
     private string $name = '';
@@ -41,5 +43,17 @@ class ProtectedRange
     public function getSecurityDescriptor(): string
     {
         return $this->securityDescriptor;
+    }
+
+    /**
+     * Split range into coordinate strings.
+     *
+     * @return array<array<string>> Array containing one or more arrays containing one or two coordinate strings
+     *                                e.g. ['B4','D9'] or [['B4','D9'], ['H2','O11']]
+     *                                        or ['B4']
+     */
+    public function allRanges(): array
+    {
+        return Coordinate::allRanges($this->sqref, false);
     }
 }

--- a/tests/PhpSpreadsheetTests/Worksheet/Issue1457Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/Issue1457Test.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
+
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PHPUnit\Framework\TestCase;
+
+class Issue1457Test extends TestCase
+{
+    public function testIssue1457(): void
+    {
+        $sheet = new Worksheet();
+        $sheet->protectCells('C14:O15 C161:O1081 C16:H160 J16:O160 Q5');
+        $protectedRanges = $sheet->getProtectedCellRanges();
+        self::assertCount(1, $protectedRanges);
+        $range0 = reset($protectedRanges);
+        $expected = [
+            ['C14', 'O15'],
+            ['C161', 'O1081'],
+            ['C16', 'H160'],
+            ['J16', 'O160'],
+            ['Q5'],
+        ];
+        self::assertSame($expected, $range0->allRanges());
+    }
+}


### PR DESCRIPTION
Fix #1457, which had gone stale but is now re-opened. The `Coordinate::splitRange` method expects a string of cell ranges, but it is a bit limited. Excel sometimes uses comma for union and space for intersection, and sometimes vice versa. `splitRange` uses comma for union, and doesn't do anything with spaces. This PR adds a new method `Coordinate::allRanges` which handles both union and intersection, and adds a parameter to indicate whether comma means union or intersection (with space meaning the other). Also, since the issue specifically mentioned this as a problem for `ProtectedRange`, an `allRanges` method is added to that class.

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

