### PR TITLE
Remove Reflection::setAccessible From Tests

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/Issue4451Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Issue4451Test.php
@@ -20,7 +20,6 @@ class Issue4451Test extends TestCase
         // Use reflection to make the protected method accessible
         $calculation = new Calculation();
         $reflectionMethod = new ReflectionMethod(Calculation::class, 'resizeMatricesExtend');
-        $reflectionMethod->setAccessible(true);
 
         // Call the method using reflection
         $reflectionMethod->invokeArgs($calculation, [&$matrix1, &$matrix2, count($matrix1), 1, count($matrix2), 1]);

--- a/tests/PhpSpreadsheetTests/Writer/Xls/WorkbookTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/WorkbookTest.php
@@ -48,8 +48,6 @@ class WorkbookTest extends TestCase
         $workbookReflection = new ReflectionClass(Workbook::class);
         $methodAddColor = $workbookReflection->getMethod('addColor');
         $propertyPalette = $workbookReflection->getProperty('palette');
-        $methodAddColor->setAccessible(true);
-        $propertyPalette->setAccessible(true);
 
         foreach ($testColors as $testColor) {
             $methodAddColor->invoke($this->workbook, $testColor);
@@ -82,7 +80,6 @@ class WorkbookTest extends TestCase
 
         $workbookReflection = new ReflectionClass(Workbook::class);
         $propertyPalette = $workbookReflection->getProperty('palette');
-        $propertyPalette->setAccessible(true);
 
         $palette = $propertyPalette->getValue($this->workbook);
         self::assertIsArray($palette);


### PR DESCRIPTION
Method has no effect starting with Php 8.1.0, and will be deprecated in 8.5. Remove it from our test suite.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] test cleanup

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

