### PR TITLE
Fix typo in reading-and-writing-to-file.md

### DIFF
--- a/docs/topics/reading-and-writing-to-file.md
+++ b/docs/topics/reading-and-writing-to-file.md
@@ -1099,7 +1099,7 @@ $secondHtmlString = '<table>
 $reader = new \PhpOffice\PhpSpreadsheet\Reader\Html();
 $spreadsheet = $reader->loadFromString($firstHtmlString);
 $reader->setSheetIndex(1);
-$spreadhseet = $reader->loadFromString($secondHtmlString, $spreadsheet);
+$spreadsheet = $reader->loadFromString($secondHtmlString, $spreadsheet);
 
 $writer = \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($spreadsheet, 'Xls');
 $writer->save('write.xls');


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [x] Documentation is updated as necessary

### Why this change is needed?
I found a typo in the following document and fix it.
https://phpspreadsheet.readthedocs.io/en/latest/topics/reading-and-writing-to-file/#generating-excel-files-from-html-content

This PR fixes documentation typos only. No code changes included.