### PR TITLE
Performance improvement when working with large amounts of cells

### DIFF
--- a/src/PhpSpreadsheet/Collection/Cells.php
+++ b/src/PhpSpreadsheet/Collection/Cells.php
@@ -44,6 +44,25 @@ class Cells
     private array $index = [];
 
     /**
+     * Flag to avoid sorting the index every time.
+     */
+    private bool $indexSorted = false;
+
+    /**
+     * Index keys cache to avoid recalculating on large arrays.
+     *
+     * @var null|string[]
+     */
+    private ?array $indexKeysCache = null;
+
+    /**
+     * Index values cache to avoid recalculating on large arrays.
+     *
+     * @var null|int[]
+     */
+    private ?array $indexValuesCache = null;
+
+    /**
      * Prefix used to uniquely identify cache data for this worksheet.
      */
     private string $cachePrefix;
@@ -112,6 +131,10 @@ class Cells
 
         unset($this->index[$cellCoordinate]);
 
+        // Clear index caches
+        $this->indexKeysCache = null;
+        $this->indexValuesCache = null;
+
         // Delete the entry from cache
         $this->cache->delete($this->cachePrefix . $cellCoordinate);
     }
@@ -123,7 +146,12 @@ class Cells
      */
     public function getCoordinates(): array
     {
-        return array_keys($this->index);
+        // Build or rebuild index keys cache
+        if ($this->indexKeysCache === null) {
+            $this->indexKeysCache = array_keys($this->index);
+        }
+
+        return $this->indexKeysCache;
     }
 
     /**
@@ -133,9 +161,18 @@ class Cells
      */
     public function getSortedCoordinates(): array
     {
-        asort($this->index);
+        // Sort only when required
+        if (!$this->indexSorted) {
+            asort($this->index);
+            $this->indexSorted = true;
+        }
 
-        return array_keys($this->index);
+        // Build or rebuild index keys cache
+        if ($this->indexKeysCache === null) {
+            $this->indexKeysCache = array_keys($this->index);
+        }
+
+        return $this->indexKeysCache;
     }
 
     /**
@@ -145,9 +182,16 @@ class Cells
      */
     public function getSortedCoordinatesInt(): array
     {
-        asort($this->index);
+        if (!$this->indexSorted) {
+            asort($this->index);
+            $this->indexSorted = true;
+        }
 
-        return array_values($this->index);
+        if ($this->indexValuesCache === null) {
+            $this->indexValuesCache = array_values($this->index);
+        }
+
+        return $this->indexValuesCache;
     }
 
     /**
@@ -300,6 +344,11 @@ class Cells
             }
         }
 
+        // Clear index sorted flag and index caches
+        $newCollection->indexSorted = false;
+        $newCollection->indexKeysCache = null;
+        $newCollection->indexValuesCache = null;
+
         return $newCollection;
     }
 
@@ -390,6 +439,11 @@ class Cells
         /** @var int $row */
         $this->index[$cellCoordinate] = (--$row * self::MAX_COLUMN_ID) + Coordinate::columnIndexFromString((string) $column);
 
+        // Clear index sorted flag and index caches
+        $this->indexSorted = false;
+        $this->indexKeysCache = null;
+        $this->indexValuesCache = null;
+
         $this->currentCoordinate = $cellCoordinate;
         $this->currentCell = $cell;
         $this->currentCellIsDirty = true;
@@ -443,6 +497,11 @@ class Cells
         $this->__destruct();
 
         $this->index = [];
+
+        // Clear index sorted flag and index caches
+        $this->indexSorted = false;
+        $this->indexKeysCache = null;
+        $this->indexValuesCache = null;
 
         // detach ourself from the worksheet, so that it can then delete this object successfully
         $this->parent = null;

--- a/src/PhpSpreadsheet/Collection/Cells.php
+++ b/src/PhpSpreadsheet/Collection/Cells.php
@@ -165,6 +165,9 @@ class Cells
         if (!$this->indexSorted) {
             asort($this->index);
             $this->indexSorted = true;
+            // Clear unsorted cache
+            $this->indexKeysCache = null;
+            $this->indexValuesCache = null;
         }
 
         // Build or rebuild index keys cache
@@ -185,6 +188,9 @@ class Cells
         if (!$this->indexSorted) {
             asort($this->index);
             $this->indexSorted = true;
+            // Clear unsorted cache
+            $this->indexKeysCache = null;
+            $this->indexValuesCache = null;
         }
 
         if ($this->indexValuesCache === null) {

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -3104,9 +3104,30 @@ class Worksheet
 
             $index = ($row - 1) * AddressRange::MAX_COLUMN_INT + 1;
             $indexPlus = $index + AddressRange::MAX_COLUMN_INT - 1;
+
+            // Binary search to quickly approach the correct index
+            $keyIndex = intdiv($keysCount, 2);
+            $boundLow = 0;
+            $boundHigh = $keysCount - 1;
+            while ($boundLow <= $boundHigh) {
+                $keyIndex = intdiv($boundLow + $boundHigh, 2);
+                if ($keys[$keyIndex] < $index) {
+                    $boundLow = $keyIndex + 1;
+                } elseif ($keys[$keyIndex] > $index) {
+                    $boundHigh = $keyIndex - 1;
+                } else {
+                    break;
+                }
+            }
+
+            // Realign to the proper index value
+            while ($keyIndex > 0 && $keys[$keyIndex] > $index) {
+                --$keyIndex;
+            }
             while ($keyIndex < $keysCount && $keys[$keyIndex] < $index) {
                 ++$keyIndex;
             }
+
             while ($keyIndex < $keysCount && $keys[$keyIndex] <= $indexPlus) {
                 $key = $keys[$keyIndex];
                 $thisRow = intdiv($key - 1, AddressRange::MAX_COLUMN_INT) + 1;


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Related issue #4607

Improved the speed of the `rangeToArrayYield` method in `Worksheet` by:
- using a binary search algorithm first to approach the right index, before using linear search backwards and forwards to realign properly (limits the linear search iterations to about a row's worth of indices rather than the whole file's worth)
- improving the speed of the `getCoordinates`, `getSortedCoordinates`, `getSortedCoordinatesInt` method in `Collections/Cells` by adding a flag to avoid sorting the index array on every call and cache arrays to avoid using `array_keys` and `array_values` on every call to the methods