### PR TITLE
String Increments and Php8.5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ This makes it easier to see exactly what is being tested when reviewing the PR. 
 4. By default, Github removes markdown headings in the Release Notes. You can either edit to restore these, or, probably preferably, change the default comment character on your system - `git config core.commentChar ";"`.
 
 > **Note:** Tagged releases are made from the `master` branch. Only in an emergency should a tagged release be made from the `release` branch. (i.e. cherry-picked hot-fixes.) However, there are 4 branches which have been updated to apply security patches, and those may be tagged if future security updates are needed.
-- release1291
-- release210
+- release1291 (no further updates aside from security patches, including code changes needed for Php 8.5 compatibility)
+- release210 (no further updates aside from security patches, including code changes needed for Php 8.5 compatibility)
 - release222
 - release390

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # PhpSpreadsheet
 
 [![Build Status](https://github.com/PHPOffice/PhpSpreadsheet/workflows/main/badge.svg)](https://github.com/PHPOffice/PhpSpreadsheet/actions)
-[![Code Quality](https://scrutinizer-ci.com/g/PHPOffice/PhpSpreadsheet/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/PHPOffice/PhpSpreadsheet/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/PHPOffice/PhpSpreadsheet/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/PHPOffice/PhpSpreadsheet/?branch=master)
+[![Code Coverage](https://coveralls.io/repos/github/PHPOffice/PhpSpreadsheet/badge.svg?branch=master)](https://coveralls.io/github/PHPOffice/PhpSpreadsheet?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/PHPOffice/PhpSpreadsheet)](https://packagist.org/packages/phpoffice/phpspreadsheet)
 [![Latest Stable Version](https://img.shields.io/github/v/release/PHPOffice/PhpSpreadsheet)](https://packagist.org/packages/phpoffice/phpspreadsheet)
 [![License](https://img.shields.io/github/license/PHPOffice/PhpSpreadsheet)](https://packagist.org/packages/phpoffice/phpspreadsheet)
@@ -10,6 +9,17 @@
 
 PhpSpreadsheet is a library written in pure PHP and offers a set of classes that
 allow you to read and write various spreadsheet file formats such as Excel and LibreOffice Calc.
+
+This is the master branch, and is maintained for security and bug fixes.
+
+## PHP Version Support
+
+LTS: For maintained branches, support for PHP versions will only be maintained for a period of six months beyond the
+[end of life](https://www.php.net/supported-versions) of that PHP version.
+
+Currently the required PHP minimum version is PHP __8.1__, and we [will support that version](https://www.php.net/supported-versions.php) until 30th June 2026.
+
+See the `composer.json` for other requirements.
 
 ## Installation
 

--- a/docs/topics/accessing-cells.md
+++ b/docs/topics/accessing-cells.md
@@ -472,6 +472,7 @@ $highestColumnIndex = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::columnIndexFrom
 echo '<table>' . "\n";
 for ($row = 1; $row <= $highestRow; ++$row) {
     echo '<tr>' . PHP_EOL;
+    // Use StringHelper::stringIncrement($col) rather than ++$col if using Php8.5+.
     for ($col = 1; $col <= $highestColumnIndex; ++$col) {
         $value = $worksheet->getCell([$col, $row])->getValue();
         echo '<td>' . $value . '</td>' . PHP_EOL;
@@ -494,11 +495,12 @@ $worksheet = $spreadsheet->getActiveSheet();
 $highestRow = $worksheet->getHighestDataRow(); // e.g. 10
 $highestColumn = $worksheet->getHighestDataColumn(); // e.g 'F'
 // Increment the highest column letter
-++$highestColumn;
+++$highestColumn; // StringHelper::stringIncrement($highestColumn); if using Php8.5+.
 
 echo '<table>' . "\n";
 for ($row = 1; $row <= $highestRow; ++$row) {
     echo '<tr>' . PHP_EOL;
+    // Use StringHelper::stringIncrement($col) rather than ++$col if using Php8.5+.
     for ($col = 'A'; $col != $highestColumn; ++$col) {
         echo '<td>' .
              $worksheet->getCell($col . $row)

--- a/docs/topics/migration-from-PHPExcel.md
+++ b/docs/topics/migration-from-PHPExcel.md
@@ -418,6 +418,7 @@ So the code must be adapted with something like:
 // Before
 $cell = $worksheet->getCellByColumnAndRow($column, $row);
 
+// Use StringHelper::stringIncrement($column) rather than ++$column if using Php8.5+.
 for ($column = 0; $column < $max; ++$column) {
     $worksheet->setCellValueByColumnAndRow($column, $row, 'value');
 }
@@ -425,6 +426,7 @@ for ($column = 0; $column < $max; ++$column) {
 // After
 $cell = $worksheet->getCell([$column + 1, $row]);
 
+// Use StringHelper::stringIncrement($column) rather than ++$column if using Php8.5+.
 for ($column = 1; $column <= $max; ++$column) {
     $worksheet->setCellValue([$column, $row], 'value');
 }

--- a/infra/LocaleGenerator.php
+++ b/infra/LocaleGenerator.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheetInfra;
 use Exception;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
@@ -283,7 +284,7 @@ class LocaleGenerator
         $this->log("Mapping Languages for {$sheetName}:");
 
         $baseColumn = self::ENGLISH_REFERENCE_COLUMN;
-        $languagesList = $translationWorksheet->getColumnIterator(++$baseColumn);
+        $languagesList = $translationWorksheet->getColumnIterator(StringHelper::stringIncrement($baseColumn));
 
         $languageNameMap = [];
         foreach ($languagesList as $languageColumn) {

--- a/samples/Basic1/13_Calculation.php
+++ b/samples/Basic1/13_Calculation.php
@@ -1,6 +1,7 @@
 <?php
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 mt_srand(1234567890);
@@ -156,7 +157,7 @@ $spreadsheet->getActiveSheet()->setCellValue('E23', 'Mode of both ranges:')
 
 // Calculated data
 $helper->log('Calculated data');
-for ($col = 'B'; $col != 'G'; ++$col) {
+for ($col = 'B'; $col != 'G'; StringHelper::stringIncrement($col)) {
     for ($row = 14; $row <= 41; ++$row) {
         $formula = $spreadsheet->getActiveSheet()->getCell($col . $row)->getValue();
         if (

--- a/samples/Basic1/13_CalculationCyclicFormulae.php
+++ b/samples/Basic1/13_CalculationCyclicFormulae.php
@@ -1,6 +1,7 @@
 <?php
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
@@ -22,7 +23,7 @@ Calculation::getInstance($spreadsheet)->cyclicFormulaCount = 15;
 // Calculated data
 $helper->log('Calculated data');
 for ($row = 1; $row <= 2; ++$row) {
-    for ($col = 'A'; $col != 'C'; ++$col) {
+    for ($col = 'A'; $col != 'C'; StringHelper::stringIncrement($col)) {
         $formula = $spreadsheet->getActiveSheet()->getCell($col . $row)->getValue();
         if (
             is_string($formula)

--- a/samples/Basic3/39_Dropdown.php
+++ b/samples/Basic3/39_Dropdown.php
@@ -2,6 +2,7 @@
 
 use PhpOffice\PhpSpreadsheet\Cell\DataValidation;
 use PhpOffice\PhpSpreadsheet\NamedRange;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
@@ -59,7 +60,7 @@ foreach ($continents as $key => $filename) {
     $spreadsheet->getActiveSheet()
         ->setCellValue($continentColumn . ($key + 1), $continent);
 
-    ++$column;
+    StringHelper::stringIncrement($column);
 }
 
 // Hide the dropdown data

--- a/samples/ConditionalFormatting/05_Date_Comparisons.php
+++ b/samples/ConditionalFormatting/05_Date_Comparisons.php
@@ -1,5 +1,6 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Style\Color;
@@ -97,7 +98,7 @@ $spreadsheet->getActiveSheet()
     ->fromArray($dateFunctionArray, null, 'B1', true);
 $spreadsheet->getActiveSheet()
     ->fromArray($dateTitleArray, null, 'A2', true);
-for ($column = 'B'; $column !== 'L'; ++$column) {
+for ($column = 'B'; $column !== 'L'; StringHelper::stringIncrement($column)) {
     $spreadsheet->getActiveSheet()
         ->fromArray($dataArray, null, "{$column}2", true);
 }
@@ -117,7 +118,7 @@ $yellowStyle->getFont()->setColor(new Color(Color::COLOR_BLUE));
 
 // Set conditional formatting rules and styles
 $helper->log('Define conditional formatting and set styles');
-for ($column = 'B'; $column !== 'L'; ++$column) {
+for ($column = 'B'; $column !== 'L'; StringHelper::stringIncrement($column)) {
     $wizardFactory = new Wizard("{$column}2:{$column}19");
     /** @var Wizard\DateValue $dateWizard */
     $dateWizard = $wizardFactory->newRule(Wizard::DATES_OCCURRING);
@@ -141,7 +142,7 @@ for ($column = 'B'; $column !== 'L'; ++$column) {
 $helper->log('Set some additional styling for date formats');
 
 $spreadsheet->getActiveSheet()->getStyle('B:B')->getNumberFormat()->setFormatCode('ddd dd-mmm-yyyy');
-for ($column = 'A'; $column !== 'L'; ++$column) {
+for ($column = 'A'; $column !== 'L'; StringHelper::stringIncrement($column)) {
     if ($column !== 'A') {
         $spreadsheet->getActiveSheet()->getStyle("{$column}:{$column}")
             ->getNumberFormat()->setFormatCode('ddd dd-mmm-yyyy');

--- a/samples/LookupRef/VLOOKUP.php
+++ b/samples/LookupRef/VLOOKUP.php
@@ -1,5 +1,6 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
@@ -40,7 +41,7 @@ $worksheet->getCell('H5')->setValue('=VLOOKUP(H3, B3:E9, 4, FALSE)');
 $worksheet->getCell('I5')->setValue('=VLOOKUP(I3, B3:E9, 4, FALSE)');
 $worksheet->getCell('J5')->setValue('=VLOOKUP(J3, B3:E9, 4, FALSE)');
 
-for ($column = 'H'; $column !== 'K'; ++$column) {
+for ($column = 'H'; $column !== 'K'; StringHelper::stringIncrement($column)) {
     for ($row = 4; $row <= 5; ++$row) {
         $cell = $worksheet->getCell("{$column}{$row}");
         $helper->log("{$column}{$row}: " . $cell->getValueString() . ' => ' . $cell->getCalculatedValueString());

--- a/src/PhpSpreadsheet/Calculation/Engine/Operands/StructuredReference.php
+++ b/src/PhpSpreadsheet/Calculation/Engine/Operands/StructuredReference.php
@@ -6,6 +6,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Worksheet\Table;
 use Stringable;
 
@@ -174,7 +175,7 @@ final class StructuredReference implements Operand, Stringable
     }
 
     /**
-     * @param array<array<int|string>> $tableRange
+     * @param array{array{string, int}, array{string, int}} $tableRange
      *
      * @return mixed[]
      */
@@ -184,8 +185,8 @@ final class StructuredReference implements Operand, Stringable
         $cellReference = $cell->getCoordinate();
 
         $columns = [];
-        $lastColumn = ++$tableRange[1][0];
-        for ($column = $tableRange[0][0]; $column !== $lastColumn; ++$column) {
+        $lastColumn = StringHelper::stringIncrement($tableRange[1][0]);
+        for ($column = $tableRange[0][0]; $column !== $lastColumn; StringHelper::stringIncrement($column)) {
             /** @var string $column */
             $columns[$column] = $worksheet
                 ->getCell($column . ($this->headersRow ?? ($this->firstDataRow - 1)))

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -472,7 +472,7 @@ class Cell implements Stringable
                                     }
                                 }
                                 /** @var string $newColumn */
-                                ++$newColumn;
+                                StringHelper::stringIncrement($newColumn);
                             }
                             ++$newRow;
                         } else {
@@ -484,7 +484,7 @@ class Cell implements Stringable
                                     }
                                 }
                             }
-                            ++$newColumn;
+                            StringHelper::stringIncrement($newColumn);
                         }
                         if ($spill) {
                             break;
@@ -506,10 +506,10 @@ class Cell implements Stringable
                                     $minCol = $matches[1];
                                     $minRow = (int) $matches[2];
                                     $maxCol = $matches[4];
-                                    ++$maxCol;
+                                    StringHelper::stringIncrement($maxCol);
                                     $maxRow = (int) $matches[5];
                                     for ($row = $minRow; $row <= $maxRow; ++$row) {
-                                        for ($col = $minCol; $col !== $maxCol; ++$col) {
+                                        for ($col = $minCol; $col !== $maxCol; StringHelper::stringIncrement($col)) {
                                             /** @var string $col */
                                             if ("$col$row" !== $coordinate) {
                                                 $thisworksheet->getCell("$col$row")->setValue(null);
@@ -537,15 +537,14 @@ class Cell implements Stringable
                                         ->getCell($newColumn . $newRow)
                                         ->setValue($resultValue);
                                 }
-                                /** @var string $newColumn */
-                                ++$newColumn;
+                                StringHelper::stringIncrement($newColumn);
                             }
                             ++$newRow;
                         } else {
                             if ($row !== $newRow || $column !== $newColumn) {
                                 $thisworksheet->getCell($newColumn . $newRow)->setValue($resultRow);
                             }
-                            ++$newColumn;
+                            StringHelper::stringIncrement($newColumn);
                         }
                     }
                     $thisworksheet->getCell($column . $row);

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -449,7 +449,7 @@ class Csv extends BaseReader
                     // Set cell value
                     $sheet->getCell($columnLetter . $outRow)->setValue($rowDatum);
                 }
-                ++$columnLetter;
+                StringHelper::stringIncrement($columnLetter);
             }
             $rowData = self::getCsv($fileHandle, 0, $delimiter, $this->enclosure, $this->escapeCharacter);
             ++$currentRow;

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -544,7 +544,7 @@ class Html extends BaseReader
             $this->processDomElement($child, $sheet, $row, $column, $cellContent);
             $column = $this->releaseTableStartColumn();
             if ($this->tableLevel > 1) {
-                ++$column; //* @phpstan-ignore-line
+                StringHelper::stringIncrement($column);
             } else {
                 ++$row;
             }
@@ -558,7 +558,7 @@ class Html extends BaseReader
     {
         if ($child->nodeName === 'col') {
             $this->applyInlineStyle($sheet, -1, $this->currentColumn, $attributeArray);
-            ++$this->currentColumn;
+            StringHelper::stringIncrement($this->currentColumn);
         } elseif ($child->nodeName === 'tr') {
             $column = $this->getTableStartColumn();
             $cellContent = '';
@@ -644,10 +644,9 @@ class Html extends BaseReader
     {
         while (isset($this->rowspan[$column . $row])) {
             $temp = (string) $column;
-            ++$temp;
-            $column = (string) $temp;
+            $column = StringHelper::stringIncrement($temp);
         }
-        $this->processDomElement($child, $sheet, $row, $column, $cellContent); // ++$column above confuses Phpstan
+        $this->processDomElement($child, $sheet, $row, $column, $cellContent);
 
         // apply inline style
         $this->applyInlineStyle($sheet, $row, $column, $attributeArray);
@@ -666,16 +665,14 @@ class Html extends BaseReader
             //create merging rowspan and colspan
             $columnTo = $column;
             for ($i = 0; $i < (int) $attributeArray['colspan'] - 1; ++$i) {
-                /** @var string $columnTo */
-                ++$columnTo;
+                StringHelper::stringIncrement($columnTo);
             }
             $range = $column . $row . ':' . $columnTo . ($row + (int) $attributeArray['rowspan'] - 1);
             foreach (Coordinate::extractAllCellReferencesInRange($range) as $value) {
                 $this->rowspan[$value] = true;
             }
             $sheet->mergeCells($range);
-            //* @phpstan-ignore-next-line
-            $column = $columnTo; // ++$columnTo above confuses phpstan
+            $column = $columnTo;
         } elseif (isset($attributeArray['rowspan'])) {
             //create merging rowspan
             $range = $column . $row . ':' . $column . ($row + (int) $attributeArray['rowspan'] - 1);
@@ -687,15 +684,13 @@ class Html extends BaseReader
             //create merging colspan
             $columnTo = $column;
             for ($i = 0; $i < (int) $attributeArray['colspan'] - 1; ++$i) {
-                /** @var string $columnTo */
-                ++$columnTo;
+                StringHelper::stringIncrement($columnTo);
             }
             $sheet->mergeCells($column . $row . ':' . $columnTo . $row);
-            //* @phpstan-ignore-next-line
-            $column = $columnTo; // ++$columnTo above confuses phpstan
+            $column = $columnTo;
         }
 
-        ++$column; //* @phpstan-ignore-line
+        StringHelper::stringIncrement($column);
     }
 
     protected function processDomElement(DOMNode $element, Worksheet $sheet, int &$row, string &$column, string &$cellContent): void
@@ -934,8 +929,7 @@ class Html extends BaseReader
         } elseif (isset($attributeArray['rowspan'], $attributeArray['colspan'])) {
             $columnTo = $column;
             for ($i = 0; $i < (int) $attributeArray['colspan'] - 1; ++$i) {
-                /** @var string $columnTo */
-                ++$columnTo;
+                StringHelper::stringIncrement($columnTo);
             }
             $range = $column . $row . ':' . $columnTo . ($row + (int) $attributeArray['rowspan'] - 1);
             $cellStyle = $sheet->getStyle($range);
@@ -945,8 +939,7 @@ class Html extends BaseReader
         } elseif (isset($attributeArray['colspan'])) {
             $columnTo = $column;
             for ($i = 0; $i < (int) $attributeArray['colspan'] - 1; ++$i) {
-                /** @var string $columnTo */
-                ++$columnTo;
+                StringHelper::stringIncrement($columnTo);
             }
             $range = $column . $row . ':' . $columnTo . $row;
             $cellStyle = $sheet->getStyle($range);

--- a/src/PhpSpreadsheet/Reader/Ods.php
+++ b/src/PhpSpreadsheet/Reader/Ods.php
@@ -19,6 +19,7 @@ use PhpOffice\PhpSpreadsheet\Reader\Security\XmlScanner;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
@@ -573,7 +574,7 @@ class Ods extends BaseReader
                 }
 
                 for ($i = 0; $i < $colRepeats; ++$i) {
-                    ++$columnID;
+                    StringHelper::stringIncrement($columnID);
                 }
 
                 continue;
@@ -598,7 +599,7 @@ class Ods extends BaseReader
                     $lastRow = $rowID + $arrayRow - 1;
                     $lastCol = $columnID;
                     while ($arrayCol > 1) {
-                        ++$lastCol;
+                        StringHelper::stringIncrement($lastCol);
                         --$arrayCol;
                     }
                     $cellDataRef = "$columnID$rowID:$lastCol$lastRow";
@@ -764,7 +765,7 @@ class Ods extends BaseReader
             if ($type !== null) { // @phpstan-ignore-line
                 for ($i = 0; $i < $colRepeats; ++$i) {
                     if ($i > 0) {
-                        ++$columnID;
+                        StringHelper::stringIncrement($columnID);
                     }
 
                     if ($type !== DataType::TYPE_NULL) {
@@ -816,7 +817,7 @@ class Ods extends BaseReader
             // Merged cells
             $this->processMergedCells($cellData, $tableNs, $type, $columnID, $rowID, $spreadsheet);
 
-            ++$columnID;
+            StringHelper::stringIncrement($columnID);
         }
         $rowID += $rowRepeats;
     }
@@ -933,7 +934,7 @@ class Ods extends BaseReader
                 $spreadsheet->getActiveSheet()
                     ->getColumnDimension($tableColumnString)
                     ->setWidth($columnWidth->toUnit('cm'), 'cm');
-                ++$tableColumnString;
+                StringHelper::stringIncrement($tableColumnString);
             }
         }
         $tableColumnIndex += $rowRepeats;

--- a/src/PhpSpreadsheet/Reader/Slk.php
+++ b/src/PhpSpreadsheet/Reader/Slk.php
@@ -420,7 +420,11 @@ class Slk extends BaseReader
                 $spreadsheet->getActiveSheet()->getColumnDimension($startCol)->setWidth((float) $columnWidth);
                 do {
                     /** @var string $startCol */
-                    $spreadsheet->getActiveSheet()->getColumnDimension((string) ++$startCol)->setWidth((float) $columnWidth);
+                    $spreadsheet->getActiveSheet()
+                        ->getColumnDimension(
+                            StringHelper::stringIncrement($startCol)
+                        )
+                        ->setWidth((float) $columnWidth);
                 } while ($startCol !== $endCol);
             }
         }

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -3575,10 +3575,9 @@ class Xls extends XlsBase
     {
         $includeCellRange = false;
         $rangeBoundaries = Coordinate::getRangeBoundaries($cellRangeAddress);
-        ++$rangeBoundaries[1][0];
+        StringHelper::stringIncrement($rangeBoundaries[1][0]);
         for ($row = $rangeBoundaries[0][1]; $row <= $rangeBoundaries[1][1]; ++$row) {
-            for ($column = $rangeBoundaries[0][0]; $column != $rangeBoundaries[1][0]; ++$column) {
-                /** @var string $column */
+            for ($column = $rangeBoundaries[0][0]; $column != $rangeBoundaries[1][0]; StringHelper::stringIncrement($column)) {
                 if ($this->getReadFilter()->readCell($column, $row, $this->phpSheet->getTitle())) {
                     $includeCellRange = true;
 

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2490,10 +2490,9 @@ class Xlsx extends BaseReader
                         $lastCol = $firstCol;
                         $lastRow = $firstRow;
                     }
-                    ++$lastCol;
+                    StringHelper::stringIncrement($lastCol);
                     for ($row = $firstRow; $row <= $lastRow; ++$row) {
-                        for ($col = $firstCol; $col !== $lastCol; ++$col) {
-                            /** @var string $col */
+                        for ($col = $firstCol; $col !== $lastCol; StringHelper::stringIncrement($col)) {
                             if (!$cellCollection->has2("$col$row")) {
                                 continue;
                             }

--- a/src/PhpSpreadsheet/Reader/Xlsx/ColumnAndRowAttributes.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/ColumnAndRowAttributes.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Reader\DefaultReadFilter;
 use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use SimpleXMLElement;
 
@@ -142,9 +143,8 @@ class ColumnAndRowAttributes extends BaseParserClass
             if ($column !== null) {
                 $startColumn = Coordinate::stringFromColumnIndex((int) $column['min']);
                 $endColumn = Coordinate::stringFromColumnIndex((int) $column['max']);
-                ++$endColumn;
-                for ($columnAddress = $startColumn; $columnAddress !== $endColumn; ++$columnAddress) {
-                    /** @var string $columnAddress */
+                StringHelper::stringIncrement($endColumn);
+                for ($columnAddress = $startColumn; $columnAddress !== $endColumn; StringHelper::stringIncrement($columnAddress)) {
                     $columnAttributes[$columnAddress] = $this->readColumnRangeAttributes($column, $readDataOnly);
 
                     if ((int) ($column['max']) == 16384) {

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -17,6 +17,7 @@ use PhpOffice\PhpSpreadsheet\Reader\Xml\Style;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\SheetView;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
@@ -378,7 +379,7 @@ class Xml extends BaseReader
                         if (isset($columnVisible)) {
                             $spreadsheet->getActiveSheet()->getColumnDimension($columnID)->setVisible($columnVisible);
                         }
-                        ++$columnID;
+                        StringHelper::stringIncrement($columnID);
                         --$colspan;
                     }
                 }
@@ -412,7 +413,7 @@ class Xml extends BaseReader
                         }
 
                         if (!$this->getReadFilter()->readCell($columnID, $rowID, $worksheetName)) {
-                            ++$columnID;
+                            StringHelper::stringIncrement($columnID);
 
                             continue;
                         }
@@ -525,10 +526,9 @@ class Xml extends BaseReader
                                     ->applyFromArray($this->styles[$style]);
                             }
                         }
-                        /** @var string $columnID */
-                        ++$columnID;
+                        StringHelper::stringIncrement($columnID);
                         while ($additionalMergedCells > 0) {
-                            ++$columnID;
+                            StringHelper::stringIncrement($columnID);
                             --$additionalMergedCells;
                         }
                     }

--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -6,6 +6,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Cell\AddressRange;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Style\Conditional;
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter;
 use PhpOffice\PhpSpreadsheet\Worksheet\Table;
@@ -450,8 +451,7 @@ class ReferenceHelper
         }
         $highColumn = Coordinate::columnIndexFromString($highestDataColumn);
         for ($row = $startRow; $row <= $highestDataRow; ++$row) {
-            for ($col = $startCol, $colString = $startColString; $col <= $highColumn; ++$col, ++$colString) {
-                /** @var string $colString */
+            for ($col = $startCol, $colString = $startColString; $col <= $highColumn; ++$col, StringHelper::stringIncrement($colString)) {
                 $worksheet->getCell("$colString$row"); // create cell if it doesn't exist
             }
         }
@@ -1123,8 +1123,7 @@ class ReferenceHelper
         $endColumnId = Coordinate::stringFromColumnIndex($beforeColumn);
 
         for ($row = 1; $row <= $highestRow - 1; ++$row) {
-            for ($column = $startColumnId; $column !== $endColumnId; ++$column) {
-                /** @var string $column */
+            for ($column = $startColumnId; $column !== $endColumnId; StringHelper::stringIncrement($column)) {
                 $coordinate = $column . $row;
                 $this->clearStripCell($worksheet, $coordinate);
             }
@@ -1134,10 +1133,9 @@ class ReferenceHelper
     private function clearRowStrips(string $highestColumn, int $beforeColumn, int $beforeRow, int $numberOfRows, Worksheet $worksheet): void
     {
         $startColumnId = Coordinate::stringFromColumnIndex($beforeColumn);
-        ++$highestColumn;
+        StringHelper::stringIncrement($highestColumn);
 
-        for ($column = $startColumnId; $column !== $highestColumn; ++$column) {
-            /** @var string $column */
+        for ($column = $startColumnId; $column !== $highestColumn; StringHelper::stringIncrement($column)) {
             for ($row = $beforeRow + $numberOfRows; $row <= $beforeRow - 1; ++$row) {
                 $coordinate = $column . $row;
                 $this->clearStripCell($worksheet, $coordinate);
@@ -1217,7 +1215,10 @@ class ReferenceHelper
         $toColRef = $rangeEnd + $numberOfColumns;
 
         do {
-            $autoFilter->shiftColumn(Coordinate::stringFromColumnIndex($endColRef), Coordinate::stringFromColumnIndex($toColRef));
+            $autoFilter->shiftColumn(
+                Coordinate::stringFromColumnIndex($endColRef),
+                Coordinate::stringFromColumnIndex($toColRef)
+            );
             --$endColRef;
             --$toColRef;
         } while ($startColRef <= $endColRef);
@@ -1232,10 +1233,8 @@ class ReferenceHelper
 
         do {
             $autoFilter->shiftColumn($startColID, $toColID);
-            /** @var string $toColID */
-            ++$toColID;
-            /** @var string $startColID */
-            ++$startColID;
+            StringHelper::stringIncrement($toColID);
+            StringHelper::stringIncrement($startColID);
         } while ($startColID !== $endColID);
     }
 
@@ -1299,7 +1298,10 @@ class ReferenceHelper
         $toColRef = $rangeEnd + $numberOfColumns;
 
         do {
-            $table->shiftColumn(Coordinate::stringFromColumnIndex($endColRef), Coordinate::stringFromColumnIndex($toColRef));
+            $table->shiftColumn(
+                Coordinate::stringFromColumnIndex($endColRef),
+                Coordinate::stringFromColumnIndex($toColRef)
+            );
             --$endColRef;
             --$toColRef;
         } while ($startColRef <= $endColRef);
@@ -1314,10 +1316,8 @@ class ReferenceHelper
 
         do {
             $table->shiftColumn($startColID, $toColID);
-            /** @var string $toColID */
-            ++$toColID;
-            /** @var string $startColID */
-            ++$startColID;
+            StringHelper::stringIncrement($toColID);
+            StringHelper::stringIncrement($startColID);
         } while ($startColID !== $endColID);
     }
 

--- a/src/PhpSpreadsheet/Shared/StringHelper.php
+++ b/src/PhpSpreadsheet/Shared/StringHelper.php
@@ -729,12 +729,14 @@ class StringHelper
      *
      * @codeCoverageIgnore
      */
-    public static function stringIncrement(string &$str): void
+    public static function stringIncrement(string &$str): string
     {
         if (function_exists('str_increment')) {
             $str = str_increment($str); // @phpstan-ignore-line
         } else {
             ++$str; // @phpstan-ignore-line
         }
+
+        return $str; // @phpstan-ignore-line
     }
 }

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2926,11 +2926,9 @@ class Worksheet
                 $currentColumn = $startColumn;
                 foreach ($rowData as $cellValue) {
                     if ($cellValue !== $nullValue) {
-                        /** @var string $currentColumn */
                         $this->getCell($currentColumn . $startRow)->setValue($cellValue);
                     }
-                    /** @var string $currentColumn */
-                    ++$currentColumn;
+                    StringHelper::stringIncrement($currentColumn);
                 }
                 ++$startRow;
             }
@@ -2939,11 +2937,9 @@ class Worksheet
                 $currentColumn = $startColumn;
                 foreach ($rowData as $cellValue) {
                     if ($cellValue != $nullValue) {
-                        /** @var string $currentColumn */
                         $this->getCell($currentColumn . $startRow)->setValue($cellValue);
                     }
-                    /** @var string $currentColumn */
-                    ++$currentColumn;
+                    StringHelper::stringIncrement($currentColumn);
                 }
                 ++$startRow;
             }
@@ -3085,7 +3081,7 @@ class Worksheet
         $minColInt = $rangeStart[0];
         $maxColInt = $rangeEnd[0];
 
-        ++$maxCol;
+        StringHelper::stringIncrement($maxCol);
         /** @var array<string, bool> */
         $hiddenColumns = [];
         $nullRow = $this->buildNullRow($nullValue, $minCol, $maxCol, $returnCellRef, $ignoreHidden, $hiddenColumns);
@@ -3160,8 +3156,7 @@ class Worksheet
     ): array {
         $nullRow = [];
         $c = -1;
-        for ($col = $minCol; $col !== $maxCol; ++$col) {
-            /** @var string $col */
+        for ($col = $minCol; $col !== $maxCol; StringHelper::stringIncrement($col)) {
             if ($ignoreHidden === true && $this->columnDimensionExists($col) && $this->getColumnDimension($col)->getVisible() === false) {
                 $hiddenColumns[$col] = true;
             } else {

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -841,13 +841,12 @@ class Html extends BaseWriter
                     $totalHeight += ($height >= 0) ? $height : $defaultRowHeight;
                 }
                 $rightEdge = $brCoordinate[2];
-                ++$rightEdge;
+                StringHelper::stringIncrement($rightEdge);
                 for ($column = $tlCoordinate[2]; $column !== $rightEdge;) {
                     $width = $sheet->getColumnDimension($column)->getWidth();
                     $width = ($width < 0) ? self::DEFAULT_CELL_WIDTH_PIXELS : SharedDrawing::cellDimensionToPixels($sheet->getColumnDimension($column)->getWidth(), $this->defaultFont);
                     $totalWidth += $width;
-                    /** @var string $column */
-                    ++$column;
+                    StringHelper::stringIncrement($column);
                 }
                 $chart->setRenderedWidth($totalWidth);
                 $chart->setRenderedHeight($totalHeight);

--- a/src/PhpSpreadsheet/Writer/Pdf/Dompdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Dompdf.php
@@ -76,7 +76,7 @@ class Dompdf extends Pdf
     public function specialErrorHandler(int $errno, string $errstr, string $filename, int $lineno): bool
     {
         if ($errno === E_DEPRECATED) {
-            if (preg_match('/canonical|imagedestroy/', $errstr) === 1) {
+            if (preg_match('/canonical|imagedestroy|http_get_last_response_headers/', $errstr) === 1) {
                 return true;
             }
         }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Database/SetupTeardownDatabases.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Database/SetupTeardownDatabases.php
@@ -6,6 +6,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Database;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PHPUnit\Framework\TestCase;
@@ -150,7 +151,7 @@ class SetupTeardownDatabases extends TestCase
             foreach ($dataRow as $dataCell) {
                 $sheet->getCell("$col$row")->setValue($dataCell);
                 $maxCol = max($col, $maxCol);
-                ++$col;
+                StringHelper::stringIncrement($col);
             }
             $maxRow = $row;
             ++$row;
@@ -169,7 +170,7 @@ class SetupTeardownDatabases extends TestCase
                     $sheet->getCell("$col$row")->setValueExplicit($dataCell, DataType::TYPE_STRING);
                 }
                 $maxCol = max($col, $maxCol);
-                ++$col;
+                StringHelper::stringIncrement($col);
             }
             $maxRow = $row;
             ++$row;

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/TransposeOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/TransposeOnSpreadsheetTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
 
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class TransposeOnSpreadsheetTest extends AllSetupTeardown
@@ -20,7 +21,7 @@ class TransposeOnSpreadsheetTest extends AllSetupTeardown
         $highColumn = $sheet->getHighestDataColumn();
         $highRow = $sheet->getHighestDataRow();
         $newHighColumn = $highColumn;
-        ++$newHighColumn;
+        StringHelper::stringIncrement($newHighColumn);
         $sheet->getCell("{$newHighColumn}1")
             ->setValue("=TRANSPOSE(A1:$highColumn$highRow)");
         self::assertSame($expectedResult, $sheet->getCell("{$newHighColumn}1")->getCalculatedValue());

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AllSetupTeardown.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalcException;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PHPUnit\Framework\TestCase;
@@ -203,7 +204,7 @@ class AllSetupTeardown extends TestCase
                     $cellId = "$col$row";
                     $arrayRange = "A$row:$cellId";
                     $this->setCell($cellId, $arrayItem);
-                    ++$col;
+                    StringHelper::stringIncrement($col);
                 }
                 $formula .= "$comma$arrayRange";
                 $comma = ',';

--- a/tests/PhpSpreadsheetTests/Reader/Xls/ColourTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xls/ColourTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Xls;
 
 use PhpOffice\PhpSpreadsheet\Reader\Xls;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
 class ColourTest extends AbstractFunctional
@@ -24,7 +25,7 @@ class ColourTest extends AbstractFunctional
 
         $worksheet = $this->spreadsheet->getActiveSheet();
         for ($row = 1; $row <= 7; ++$row) {
-            for ($column = 'A'; $column !== 'J'; ++$column) {
+            for ($column = 'A'; $column !== 'J'; StringHelper::stringIncrement($column)) {
                 $cellAddress = "{$column}{$row}";
                 $colours[$cellAddress] = $worksheet->getStyle($cellAddress)->getFill()->getStartColor()->getRGB();
             }

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalIconSetTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/ConditionalIconSetTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
 
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Style\ConditionalFormatting\IconSetValues;
 use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
@@ -29,7 +30,7 @@ class ConditionalIconSetTest extends AbstractFunctional
             self::assertNotNull($iconSet);
             self::assertSame($iconSetValue, $iconSet->getIconSetType() ?? IconSetValues::ThreeTrafficLights1);
 
-            ++$columnIndex;
+            StringHelper::stringIncrement($columnIndex);
         }
 
         // icon set attributes
@@ -48,7 +49,7 @@ class ConditionalIconSetTest extends AbstractFunctional
             self::assertSame($expected['showValue'], $iconSet->getShowValue() ?? true);
             self::assertFalse($iconSet->getCustom() ?? false);
 
-            ++$columnIndex;
+            StringHelper::stringIncrement($columnIndex);
         }
 
         // cfvos
@@ -74,11 +75,11 @@ class ConditionalIconSetTest extends AbstractFunctional
                 self::assertNull($cfvo->getCellFormula());
             }
 
-            ++$columnIndex;
+            StringHelper::stringIncrement($columnIndex);
         }
 
         // unsupported icon sets
-        for ($columnIndex = 'R'; $columnIndex <= 'U'; ++$columnIndex) {
+        for ($columnIndex = 'R'; $columnIndex <= 'U'; StringHelper::stringIncrement($columnIndex)) {
             $styles = $worksheet->getConditionalStyles("{$columnIndex}2:{$columnIndex}11");
             $iconSet = $styles[0]->getIconSet();
             self::assertNull($iconSet);

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/RowBreakTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/RowBreakTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx as XlsxReader;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
@@ -32,7 +33,7 @@ class RowBreakTest extends TestCase
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
         for ($row = 1; $row < 60; ++$row) {
-            for ($column = 'A'; $column !== 'L'; ++$column) {
+            for ($column = 'A'; $column !== 'L'; StringHelper::stringIncrement($column)) {
                 $cell = $column . $row;
                 $sheet->getCell($cell)->setValue($cell);
             }
@@ -56,7 +57,7 @@ class RowBreakTest extends TestCase
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
         for ($row = 1; $row < 60; ++$row) {
-            for ($column = 'A'; $column !== 'L'; ++$column) {
+            for ($column = 'A'; $column !== 'L'; StringHelper::stringIncrement($column)) {
                 $cell = $column . $row;
                 $sheet->getCell($cell)->setValue($cell);
             }

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxTest.php
@@ -9,6 +9,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\IReader;
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Style\Conditional;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter;
@@ -59,7 +60,7 @@ class XlsxTest extends TestCase
 
         $worksheet = $spreadsheet->getActiveSheet();
         for ($row = 1; $row <= 8; $row += 2) {
-            for ($column = 'A'; $column !== 'G'; ++$column, ++$column) {
+            for ($column = 'A'; $column !== 'G'; StringHelper::stringIncrement($column), StringHelper::stringIncrement($column)) {
                 self::assertEquals(
                     $expectedColours[$row][$column],
                     $worksheet->getStyle($column . $row)->getFill()->getStartColor()->getRGB()

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoSizeTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoSizeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Worksheet\Table;
@@ -36,8 +37,8 @@ class AutoSizeTest extends TestCase
         $this->worksheet->fromArray($dataArray, null, 'A2');
 
         $toColumn = $this->worksheet->getHighestColumn();
-        ++$toColumn;
-        for ($i = 'A'; $i !== $toColumn; ++$i) {
+        StringHelper::stringIncrement($toColumn);
+        for ($i = 'A'; $i !== $toColumn; StringHelper::stringIncrement($i)) {
             $this->worksheet->getColumnDimension($i)->setAutoSize(true);
         }
     }
@@ -64,8 +65,8 @@ class AutoSizeTest extends TestCase
     {
         $columnSizes = [];
         $toColumn = $this->worksheet->getHighestColumn();
-        ++$toColumn;
-        for ($column = 'A'; $column !== $toColumn; ++$column) {
+        StringHelper::stringIncrement($toColumn);
+        for ($column = 'A'; $column !== $toColumn; StringHelper::stringIncrement($column)) {
             $columnSizes[$column] = $this->worksheet->getColumnDimension($column)->getWidth();
         }
 

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnDimension2Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnDimension2Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 
 use PhpOffice\PhpSpreadsheet\Helper\Dimension;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Html;
 use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
@@ -28,7 +29,7 @@ class ColumnDimension2Test extends AbstractFunctional
         }
         $spreadsheet->disconnectWorksheets();
         $sheet = $reloadedSpreadsheet->getActiveSheet();
-        for ($column = 'A'; $column !== 'Z'; ++$column) {
+        for ($column = 'A'; $column !== 'Z'; StringHelper::stringIncrement($column)) {
             if (in_array($column, $columns, true)) {
                 self::assertEqualsWithDelta($expectedCm, $sheet->getColumnDimension($column)->getWidth(Dimension::UOM_CENTIMETERS), 1E-3, "column $column");
             } elseif ($type === 'Xls' && $column <= 'T') {

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnIteratorTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnIteratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 
 use PhpOffice\PhpSpreadsheet\Exception as Except;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\ColumnIterator;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
@@ -38,7 +39,8 @@ class ColumnIteratorTest extends TestCase
         $counter = 0;
         foreach ($iterator as $key => $column) {
             ++$counter;
-            self::assertEquals($columnIndexResult++, $key);
+            self::assertEquals($columnIndexResult, $key);
+            StringHelper::stringIncrement($columnIndexResult);
         }
         self::assertCount($counter, self::CELL_VALUES[0]);
         $spreadsheet->disconnectWorksheets();
@@ -55,7 +57,8 @@ class ColumnIteratorTest extends TestCase
         $counter = 0;
         foreach ($iterator as $key => $column) {
             ++$counter;
-            self::assertEquals($columnIndexResult++, $key);
+            self::assertEquals($columnIndexResult, $key);
+            StringHelper::stringIncrement($columnIndexResult);
         }
         self::assertSame(3, $counter);
         $spreadsheet->disconnectWorksheets();

--- a/tests/PhpSpreadsheetTests/Worksheet/RowCellIteratorTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/RowCellIteratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 
 use PhpOffice\PhpSpreadsheet\Exception as Except;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\RowCellIterator;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
@@ -41,7 +42,8 @@ class RowCellIteratorTest extends TestCase
         $values = [];
         foreach ($iterator as $key => $RowCell) {
             $values[] = $RowCell->getValue();
-            self::assertEquals($RowCellIndexResult++, $key);
+            self::assertEquals($RowCellIndexResult, $key);
+            StringHelper::stringIncrement($RowCellIndexResult);
         }
         self::assertSame(self::CELL_VALUES[0], $values);
         $spreadsheet->disconnectWorksheets();
@@ -58,7 +60,8 @@ class RowCellIteratorTest extends TestCase
         $values = [];
         foreach ($iterator as $key => $RowCell) {
             $values[] = $RowCell->getValue();
-            self::assertEquals($RowCellIndexResult++, $key);
+            self::assertEquals($RowCellIndexResult, $key);
+            StringHelper::stringIncrement($RowCellIndexResult);
         }
         self::assertSame([220, 230, 240], $values);
         $spreadsheet->disconnectWorksheets();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,9 +39,6 @@ function strIncrement85(int $version, int $errno, string $errstr, string $filena
     if ($version < 80500 || $errno !== E_DEPRECATED) {
         return false;
     }
-    if (preg_match('/Increment on non-numeric string/', $errstr) === 1) {
-        return true;
-    }
     if (preg_match('/canonical/', $errstr) === 1 && preg_match('/mitoteam/', $filename) === 1) {
         return true;
     }


### PR DESCRIPTION
Fix #4600. String incrementation through the `++` operator is deprecated in Php 8.5. Because we make use of that operator to iterate through columns, we are particularly hard hit by that change - unaddressed, it causes over 2,000 errors in our test suite! It is, fortunately, not as difficult as I feared to correct. Replacing the `++` operator with a call to new method `StringHelper::stringIncrement` in 79 statements scattered over 31 source modules (in src, samples, test, and infra) eliminates all the messages in the test suite. It is possible that others are lurking, but I don't know a systematic way of determining if there are others. We'll stick with this for now, and deal with any others as they show up.

This PR will be applied to the master, release390, and release222 branches. It will not be applied to the release210 or release1291 branches, which will now accept security changes only.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [x] Documentation is updated as necessary

