### PR TITLE
String Increments and Php8.5 - release222 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # PhpSpreadsheet
 
 [![Build Status](https://github.com/PHPOffice/PhpSpreadsheet/workflows/main/badge.svg)](https://github.com/PHPOffice/PhpSpreadsheet/actions)
-[![Code Quality](https://scrutinizer-ci.com/g/PHPOffice/PhpSpreadsheet/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/PHPOffice/PhpSpreadsheet/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/PHPOffice/PhpSpreadsheet/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/PHPOffice/PhpSpreadsheet/?branch=master)
+[![Code Coverage](https://coveralls.io/repos/github/PHPOffice/PhpSpreadsheet/badge.svg?branch=master)](https://coveralls.io/github/PHPOffice/PhpSpreadsheet?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/PHPOffice/PhpSpreadsheet)](https://packagist.org/packages/phpoffice/phpspreadsheet)
 [![Latest Stable Version](https://img.shields.io/github/v/release/PHPOffice/PhpSpreadsheet)](https://packagist.org/packages/phpoffice/phpspreadsheet)
 [![License](https://img.shields.io/github/license/PHPOffice/PhpSpreadsheet)](https://packagist.org/packages/phpoffice/phpspreadsheet)
@@ -10,6 +9,17 @@
 
 PhpSpreadsheet is a library written in pure PHP and offers a set of classes that
 allow you to read and write various spreadsheet file formats such as Excel and LibreOffice Calc.
+
+This branch (release222) is maintained (for security and some bug fixes), but it is *not* the latest version of PhpSpreadsheet, and may therefore lack features and bug fixes found in the latest version.
+
+## PHP Version Support
+
+LTS: For maintained branches, support for PHP versions will only be maintained for a period of six months beyond the
+[end of life](https://www.php.net/supported-versions) of that PHP version.
+
+Currently the required PHP minimum version is PHP __8.1__, and we [will support that version](https://www.php.net/supported-versions.php) until 30th June 2026.
+
+See the `composer.json` for other requirements.
 
 ## Installation
 

--- a/infra/LocaleGenerator.php
+++ b/infra/LocaleGenerator.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheetInfra;
 use Exception;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Column;
 use PhpOffice\PhpSpreadsheet\Worksheet\Row;
@@ -276,7 +277,7 @@ class LocaleGenerator
         $this->log("Mapping Languages for {$sheetName}:");
 
         $baseColumn = self::ENGLISH_REFERENCE_COLUMN;
-        $languagesList = $translationWorksheet->getColumnIterator(++$baseColumn);
+        $languagesList = $translationWorksheet->getColumnIterator(StringHelper::stringIncrement($baseColumn));
 
         $languageNameMap = [];
         foreach ($languagesList as $languageColumn) {

--- a/samples/Basic1/13_Calculation.php
+++ b/samples/Basic1/13_Calculation.php
@@ -1,6 +1,7 @@
 <?php
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 mt_srand(1234567890);
@@ -155,7 +156,7 @@ $spreadsheet->getActiveSheet()->setCellValue('E23', 'Mode of both ranges:')
 
 // Calculated data
 $helper->log('Calculated data');
-for ($col = 'B'; $col != 'G'; ++$col) {
+for ($col = 'B'; $col != 'G'; StringHelper::stringIncrement($col)) {
     for ($row = 14; $row <= 41; ++$row) {
         $formula = $spreadsheet->getActiveSheet()->getCell($col . $row)->getValue();
         if (

--- a/samples/Basic1/13_CalculationCyclicFormulae.php
+++ b/samples/Basic1/13_CalculationCyclicFormulae.php
@@ -1,6 +1,7 @@
 <?php
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
@@ -21,7 +22,7 @@ Calculation::getInstance($spreadsheet)->cyclicFormulaCount = 15;
 // Calculated data
 $helper->log('Calculated data');
 for ($row = 1; $row <= 2; ++$row) {
-    for ($col = 'A'; $col != 'C'; ++$col) {
+    for ($col = 'A'; $col != 'C'; StringHelper::stringIncrement($col)) {
         $formula = $spreadsheet->getActiveSheet()->getCell($col . $row)->getValue();
         if (
             is_string($formula)

--- a/samples/Basic3/39_Dropdown.php
+++ b/samples/Basic3/39_Dropdown.php
@@ -2,6 +2,7 @@
 
 use PhpOffice\PhpSpreadsheet\Cell\DataValidation;
 use PhpOffice\PhpSpreadsheet\NamedRange;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
@@ -57,7 +58,7 @@ foreach ($continents as $key => $filename) {
     $spreadsheet->getActiveSheet()
         ->setCellValue($continentColumn . ($key + 1), $continent);
 
-    ++$column;
+    StringHelper::stringIncrement($column);
 }
 
 // Hide the dropdown data

--- a/samples/ConditionalFormatting/05_Date_Comparisons.php
+++ b/samples/ConditionalFormatting/05_Date_Comparisons.php
@@ -1,5 +1,6 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Style\Color;
@@ -96,7 +97,7 @@ $spreadsheet->getActiveSheet()
     ->fromArray($dateFunctionArray, null, 'B1', true);
 $spreadsheet->getActiveSheet()
     ->fromArray($dateTitleArray, null, 'A2', true);
-for ($column = 'B'; $column !== 'L'; ++$column) {
+for ($column = 'B'; $column !== 'L'; StringHelper::stringIncrement($column)) {
     $spreadsheet->getActiveSheet()
         ->fromArray($dataArray, null, "{$column}2", true);
 }
@@ -116,7 +117,7 @@ $yellowStyle->getFont()->setColor(new Color(Color::COLOR_BLUE));
 
 // Set conditional formatting rules and styles
 $helper->log('Define conditional formatting and set styles');
-for ($column = 'B'; $column !== 'L'; ++$column) {
+for ($column = 'B'; $column !== 'L'; StringHelper::stringIncrement($column)) {
     $wizardFactory = new Wizard("{$column}2:{$column}19");
     /** @var Wizard\DateValue $dateWizard */
     $dateWizard = $wizardFactory->newRule(Wizard::DATES_OCCURRING);
@@ -139,7 +140,7 @@ for ($column = 'B'; $column !== 'L'; ++$column) {
 $helper->log('Set some additional styling for date formats');
 
 $spreadsheet->getActiveSheet()->getStyle('B:B')->getNumberFormat()->setFormatCode('ddd dd-mmm-yyyy');
-for ($column = 'A'; $column !== 'L'; ++$column) {
+for ($column = 'A'; $column !== 'L'; StringHelper::stringIncrement($column)) {
     if ($column !== 'A') {
         $spreadsheet->getActiveSheet()->getStyle("{$column}:{$column}")
             ->getNumberFormat()->setFormatCode('ddd dd-mmm-yyyy');

--- a/samples/LookupRef/VLOOKUP.php
+++ b/samples/LookupRef/VLOOKUP.php
@@ -1,5 +1,6 @@
 <?php
 
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 require __DIR__ . '/../Header.php';
@@ -40,7 +41,7 @@ $worksheet->getCell('H5')->setValue('=VLOOKUP(H3, B3:E9, 4, FALSE)');
 $worksheet->getCell('I5')->setValue('=VLOOKUP(I3, B3:E9, 4, FALSE)');
 $worksheet->getCell('J5')->setValue('=VLOOKUP(J3, B3:E9, 4, FALSE)');
 
-for ($column = 'H'; $column !== 'K'; ++$column) {
+for ($column = 'H'; $column !== 'K'; StringHelper::stringIncrement($column)) {
     for ($row = 4; $row <= 5; ++$row) {
         $cell = $worksheet->getCell("{$column}{$row}");
         $helper->log("{$column}{$row}: " . $cell->getValue() . ' => ' . $cell->getCalculatedValue());

--- a/src/PhpSpreadsheet/Calculation/Engine/Operands/StructuredReference.php
+++ b/src/PhpSpreadsheet/Calculation/Engine/Operands/StructuredReference.php
@@ -6,6 +6,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Worksheet\Table;
 use Stringable;
 
@@ -177,8 +178,8 @@ final class StructuredReference implements Operand, Stringable
         $cellReference = $cell->getCoordinate();
 
         $columns = [];
-        $lastColumn = ++$tableRange[1][0];
-        for ($column = $tableRange[0][0]; $column !== $lastColumn; ++$column) {
+        $lastColumn = StringHelper::stringIncrement($tableRange[1][0]);
+        for ($column = $tableRange[0][0]; $column !== $lastColumn; StringHelper::stringIncrement($column)) {
             $columns[$column] = $worksheet
                 ->getCell($column . ($this->headersRow ?? ($this->firstDataRow - 1)))
                 ->getCalculatedValue();

--- a/src/PhpSpreadsheet/Reader/Csv.php
+++ b/src/PhpSpreadsheet/Reader/Csv.php
@@ -446,7 +446,7 @@ class Csv extends BaseReader
                     // Set cell value
                     $sheet->getCell($columnLetter . $outRow)->setValue($rowDatum);
                 }
-                ++$columnLetter;
+                StringHelper::stringIncrement($columnLetter);
             }
             $rowData = self::getCsv($fileHandle, 0, $delimiter, $this->enclosure, $this->escapeCharacter);
             ++$currentRow;

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -15,6 +15,7 @@ use PhpOffice\PhpSpreadsheet\Exception as SpreadsheetException;
 use PhpOffice\PhpSpreadsheet\Helper\Dimension as CssDimension;
 use PhpOffice\PhpSpreadsheet\Helper\Html as HelperHtml;
 use PhpOffice\PhpSpreadsheet\Reader\Security\XmlScanner;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Border;
 use PhpOffice\PhpSpreadsheet\Style\Color;
@@ -485,7 +486,7 @@ class Html extends BaseReader
             $this->processDomElement($child, $sheet, $row, $column, $cellContent);
             $column = $this->releaseTableStartColumn();
             if ($this->tableLevel > 1) {
-                ++$column;
+                StringHelper::stringIncrement($column);
             } else {
                 ++$row;
             }
@@ -498,7 +499,7 @@ class Html extends BaseReader
     {
         if ($child->nodeName === 'col') {
             $this->applyInlineStyle($sheet, -1, $this->currentColumn, $attributeArray);
-            ++$this->currentColumn;
+            StringHelper::stringIncrement($this->currentColumn);
         } elseif ($child->nodeName === 'tr') {
             $column = $this->getTableStartColumn();
             $cellContent = '';
@@ -575,7 +576,7 @@ class Html extends BaseReader
     private function processDomElementThTd(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         while (isset($this->rowspan[$column . $row])) {
-            ++$column;
+            StringHelper::stringIncrement($column);
         }
         $this->processDomElement($child, $sheet, $row, $column, $cellContent);
 
@@ -595,7 +596,7 @@ class Html extends BaseReader
             //create merging rowspan and colspan
             $columnTo = $column;
             for ($i = 0; $i < (int) $attributeArray['colspan'] - 1; ++$i) {
-                ++$columnTo;
+                StringHelper::stringIncrement($columnTo);
             }
             $range = $column . $row . ':' . $columnTo . ($row + (int) $attributeArray['rowspan'] - 1);
             foreach (Coordinate::extractAllCellReferencesInRange($range) as $value) {
@@ -614,13 +615,13 @@ class Html extends BaseReader
             //create merging colspan
             $columnTo = $column;
             for ($i = 0; $i < (int) $attributeArray['colspan'] - 1; ++$i) {
-                ++$columnTo;
+                StringHelper::stringIncrement($columnTo);
             }
             $sheet->mergeCells($column . $row . ':' . $columnTo . $row);
             $column = $columnTo;
         }
 
-        ++$column;
+        StringHelper::stringIncrement($column);
     }
 
     protected function processDomElement(DOMNode $element, Worksheet $sheet, int &$row, string &$column, string &$cellContent): void
@@ -857,7 +858,7 @@ class Html extends BaseReader
         } elseif (isset($attributeArray['rowspan'], $attributeArray['colspan'])) {
             $columnTo = $column;
             for ($i = 0; $i < (int) $attributeArray['colspan'] - 1; ++$i) {
-                ++$columnTo;
+                StringHelper::stringIncrement($columnTo);
             }
             $range = $column . $row . ':' . $columnTo . ($row + (int) $attributeArray['rowspan'] - 1);
             $cellStyle = $sheet->getStyle($range);
@@ -867,7 +868,7 @@ class Html extends BaseReader
         } elseif (isset($attributeArray['colspan'])) {
             $columnTo = $column;
             for ($i = 0; $i < (int) $attributeArray['colspan'] - 1; ++$i) {
-                ++$columnTo;
+                StringHelper::stringIncrement($columnTo);
             }
             $range = $column . $row . ':' . $columnTo . $row;
             $cellStyle = $sheet->getStyle($range);

--- a/src/PhpSpreadsheet/Reader/Ods.php
+++ b/src/PhpSpreadsheet/Reader/Ods.php
@@ -19,6 +19,7 @@ use PhpOffice\PhpSpreadsheet\Reader\Security\XmlScanner;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
@@ -389,7 +390,9 @@ class Ods extends BaseReader
                                     $spreadsheet->getActiveSheet()
                                         ->getColumnDimension($tableColumnString)
                                         ->setWidth($columnWidth->toUnit('cm'), 'cm');
-                                    ++$tableColumnString;
+                                    StringHelper::stringIncrement(
+                                        $tableColumnString
+                                    );
                                 }
                             }
                             $tableColumnIndex += $rowRepeats;
@@ -417,7 +420,9 @@ class Ods extends BaseReader
                                         }
 
                                         for ($i = 0; $i < $colRepeats; ++$i) {
-                                            ++$columnID;
+                                            StringHelper::stringIncrement(
+                                                $columnID
+                                            );
                                         }
 
                                         continue;
@@ -591,7 +596,9 @@ class Ods extends BaseReader
                                 if ($type !== null) {
                                     for ($i = 0; $i < $colRepeats; ++$i) {
                                         if ($i > 0) {
-                                            ++$columnID;
+                                            StringHelper::stringIncrement(
+                                                $columnID
+                                            );
                                         }
 
                                         if ($type !== DataType::TYPE_NULL) {
@@ -640,7 +647,7 @@ class Ods extends BaseReader
                                 // Merged cells
                                 $this->processMergedCells($cellData, $tableNs, $type, $columnID, $rowID, $spreadsheet);
 
-                                ++$columnID;
+                                StringHelper::stringIncrement($columnID);
                             }
                             $rowID += $rowRepeats;
 

--- a/src/PhpSpreadsheet/Reader/Slk.php
+++ b/src/PhpSpreadsheet/Reader/Slk.php
@@ -406,7 +406,11 @@ class Slk extends BaseReader
                 $endCol = Coordinate::stringFromColumnIndex((int) $endCol);
                 $spreadsheet->getActiveSheet()->getColumnDimension($startCol)->setWidth((float) $columnWidth);
                 do {
-                    $spreadsheet->getActiveSheet()->getColumnDimension((string) ++$startCol)->setWidth((float) $columnWidth);
+                    $spreadsheet->getActiveSheet()
+                        ->getColumnDimension(
+                            StringHelper::stringIncrement($startCol)
+                        )
+                        ->setWidth((float) $columnWidth);
                 } while ($startCol !== $endCol);
             }
         }

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -4436,9 +4436,9 @@ class Xls extends BaseReader
         if ($this->getReadFilter() !== null) {
             $includeCellRange = false;
             $rangeBoundaries = Coordinate::getRangeBoundaries($cellRangeAddress);
-            ++$rangeBoundaries[1][0];
+            StringHelper::stringIncrement($rangeBoundaries[1][0]);
             for ($row = $rangeBoundaries[0][1]; $row <= $rangeBoundaries[1][1]; ++$row) {
-                for ($column = $rangeBoundaries[0][0]; $column != $rangeBoundaries[1][0]; ++$column) {
+                for ($column = $rangeBoundaries[0][0]; $column != $rangeBoundaries[1][0]; StringHelper::stringIncrement($column)) {
                     if ($this->getReadFilter()->readCell($column, $row, $this->phpSheet->getTitle())) {
                         $includeCellRange = true;
 

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -2370,9 +2370,9 @@ class Xlsx extends BaseReader
                         $lastCol = $firstCol;
                         $lastRow = $firstRow;
                     }
-                    ++$lastCol;
+                    StringHelper::stringIncrement($lastCol);
                     for ($row = $firstRow; $row <= $lastRow; ++$row) {
-                        for ($col = $firstCol; $col !== $lastCol; ++$col) {
+                        for ($col = $firstCol; $col !== $lastCol; StringHelper::stringIncrement($col)) {
                             if ($numberStoredAsText === '1') {
                                 $sheet->getCell("$col$row")->getIgnoredErrors()->setNumberStoredAsText(true);
                             }

--- a/src/PhpSpreadsheet/Reader/Xlsx/ColumnAndRowAttributes.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/ColumnAndRowAttributes.php
@@ -5,6 +5,7 @@ namespace PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Reader\DefaultReadFilter;
 use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use SimpleXMLElement;
 
@@ -140,8 +141,8 @@ class ColumnAndRowAttributes extends BaseParserClass
             if ($column !== null) {
                 $startColumn = Coordinate::stringFromColumnIndex((int) $column['min']);
                 $endColumn = Coordinate::stringFromColumnIndex((int) $column['max']);
-                ++$endColumn;
-                for ($columnAddress = $startColumn; $columnAddress !== $endColumn; ++$columnAddress) {
+                StringHelper::stringIncrement($endColumn);
+                for ($columnAddress = $startColumn; $columnAddress !== $endColumn; StringHelper::stringIncrement($columnAddress)) {
                     $columnAttributes[$columnAddress] = $this->readColumnRangeAttributes($column, $readDataOnly);
 
                     if ((int) ($column['max']) == 16384) {

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -17,6 +17,7 @@ use PhpOffice\PhpSpreadsheet\Reader\Xml\Style;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\SheetView;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
@@ -367,9 +368,11 @@ class Xml extends BaseReader
                             $spreadsheet->getActiveSheet()->getColumnDimension($columnID)->setWidth($columnWidth / 5.4);
                         }
                         if (isset($columnVisible)) {
-                            $spreadsheet->getActiveSheet()->getColumnDimension($columnID)->setVisible($columnVisible);
+                            $spreadsheet->getActiveSheet()
+                                ->getColumnDimension($columnID)
+                                ->setVisible($columnVisible);
                         }
-                        ++$columnID;
+                        StringHelper::stringIncrement($columnID);
                         --$colspan;
                     }
                 }
@@ -399,7 +402,7 @@ class Xml extends BaseReader
 
                         if ($this->getReadFilter() !== null) {
                             if (!$this->getReadFilter()->readCell($columnID, $rowID, $worksheetName)) {
-                                ++$columnID;
+                                StringHelper::stringIncrement($columnID);
 
                                 continue;
                             }
@@ -513,9 +516,9 @@ class Xml extends BaseReader
                                     ->applyFromArray($this->styles[$style]);
                             }
                         }
-                        ++$columnID;
+                        StringHelper::stringIncrement($columnID);
                         while ($additionalMergedCells > 0) {
-                            ++$columnID;
+                            StringHelper::stringIncrement($columnID);
                             --$additionalMergedCells;
                         }
                     }

--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -6,6 +6,7 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Cell\AddressRange;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Style\Conditional;
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter;
 use PhpOffice\PhpSpreadsheet\Worksheet\Table;
@@ -410,7 +411,7 @@ class ReferenceHelper
         }
         $highColumn = Coordinate::columnIndexFromString($highestDataColumn);
         for ($row = $startRow; $row <= $highestDataRow; ++$row) {
-            for ($col = $startCol, $colString = $startColString; $col <= $highColumn; ++$col, ++$colString) {
+            for ($col = $startCol, $colString = $startColString; $col <= $highColumn; ++$col, StringHelper::stringIncrement($colString)) {
                 $worksheet->getCell("$colString$row"); // create cell if it doesn't exist
             }
         }
@@ -999,7 +1000,7 @@ class ReferenceHelper
         $endColumnId = Coordinate::stringFromColumnIndex($beforeColumn);
 
         for ($row = 1; $row <= $highestRow - 1; ++$row) {
-            for ($column = $startColumnId; $column !== $endColumnId; ++$column) {
+            for ($column = $startColumnId; $column !== $endColumnId; StringHelper::stringIncrement($column)) {
                 $coordinate = $column . $row;
                 $this->clearStripCell($worksheet, $coordinate);
             }
@@ -1009,9 +1010,9 @@ class ReferenceHelper
     private function clearRowStrips(string $highestColumn, int $beforeColumn, int $beforeRow, int $numberOfRows, Worksheet $worksheet): void
     {
         $startColumnId = Coordinate::stringFromColumnIndex($beforeColumn);
-        ++$highestColumn;
+        StringHelper::stringIncrement($highestColumn);
 
-        for ($column = $startColumnId; $column !== $highestColumn; ++$column) {
+        for ($column = $startColumnId; $column !== $highestColumn; StringHelper::stringIncrement($column)) {
             for ($row = $beforeRow + $numberOfRows; $row <= $beforeRow - 1; ++$row) {
                 $coordinate = $column . $row;
                 $this->clearStripCell($worksheet, $coordinate);
@@ -1090,7 +1091,10 @@ class ReferenceHelper
         $toColRef = $rangeEnd + $numberOfColumns;
 
         do {
-            $autoFilter->shiftColumn(Coordinate::stringFromColumnIndex($endColRef), Coordinate::stringFromColumnIndex($toColRef));
+            $autoFilter->shiftColumn(
+                Coordinate::stringFromColumnIndex($endColRef),
+                Coordinate::stringFromColumnIndex($toColRef)
+            );
             --$endColRef;
             --$toColRef;
         } while ($startColRef <= $endColRef);
@@ -1105,8 +1109,8 @@ class ReferenceHelper
 
         do {
             $autoFilter->shiftColumn($startColID, $toColID);
-            ++$startColID;
-            ++$toColID;
+            StringHelper::stringIncrement($startColID);
+            StringHelper::stringIncrement($toColID);
         } while ($startColID !== $endColID);
     }
 
@@ -1169,7 +1173,10 @@ class ReferenceHelper
         $toColRef = $rangeEnd + $numberOfColumns;
 
         do {
-            $table->shiftColumn(Coordinate::stringFromColumnIndex($endColRef), Coordinate::stringFromColumnIndex($toColRef));
+            $table->shiftColumn(
+                Coordinate::stringFromColumnIndex($endColRef),
+                Coordinate::stringFromColumnIndex($toColRef)
+            );
             --$endColRef;
             --$toColRef;
         } while ($startColRef <= $endColRef);
@@ -1184,8 +1191,8 @@ class ReferenceHelper
 
         do {
             $table->shiftColumn($startColID, $toColID);
-            ++$startColID;
-            ++$toColID;
+            StringHelper::stringIncrement($startColID);
+            StringHelper::stringIncrement($toColID);
         } while ($startColID !== $endColID);
     }
 

--- a/src/PhpSpreadsheet/Shared/StringHelper.php
+++ b/src/PhpSpreadsheet/Shared/StringHelper.php
@@ -654,12 +654,14 @@ class StringHelper
      *
      * @codeCoverageIgnore
      */
-    public static function stringIncrement(string &$str): void
+    public static function stringIncrement(string &$str): string
     {
         if (function_exists('str_increment')) {
             $str = str_increment($str);
         } else {
             ++$str;
         }
+
+        return $str;
     }
 }

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -24,6 +24,7 @@ use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\ReferenceHelper;
 use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Shared;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Style\Color;
@@ -409,15 +410,15 @@ class Worksheet
      */
     private static function checkSheetCodeName(string $sheetCodeName): string
     {
-        $charCount = Shared\StringHelper::countCharacters($sheetCodeName);
+        $charCount = StringHelper::countCharacters($sheetCodeName);
         if ($charCount == 0) {
             throw new Exception('Sheet code name cannot be empty.');
         }
         // Some of the printable ASCII characters are invalid:  * : / \ ? [ ] and  first and last characters cannot be a "'"
         if (
             (str_replace(self::$invalidCharacters, '', $sheetCodeName) !== $sheetCodeName)
-            || (Shared\StringHelper::substring($sheetCodeName, -1, 1) == '\'')
-            || (Shared\StringHelper::substring($sheetCodeName, 0, 1) == '\'')
+            || (StringHelper::substring($sheetCodeName, -1, 1) == '\'')
+            || (StringHelper::substring($sheetCodeName, 0, 1) == '\'')
         ) {
             throw new Exception('Invalid character found in sheet code name');
         }
@@ -445,7 +446,7 @@ class Worksheet
         }
 
         // Enforce maximum characters allowed for sheet title
-        if (Shared\StringHelper::countCharacters($sheetTitle) > self::SHEET_TITLE_MAXIMUM_LENGTH) {
+        if (StringHelper::countCharacters($sheetTitle) > self::SHEET_TITLE_MAXIMUM_LENGTH) {
             throw new Exception('Maximum ' . self::SHEET_TITLE_MAXIMUM_LENGTH . ' characters allowed in sheet title.');
         }
 
@@ -868,19 +869,19 @@ class Worksheet
                 if ($this->parent->sheetNameExists($title)) {
                     // Use name, but append with lowest possible integer
 
-                    if (Shared\StringHelper::countCharacters($title) > 29) {
-                        $title = Shared\StringHelper::substring($title, 0, 29);
+                    if (StringHelper::countCharacters($title) > 29) {
+                        $title = StringHelper::substring($title, 0, 29);
                     }
                     $i = 1;
                     while ($this->parent->sheetNameExists($title . ' ' . $i)) {
                         ++$i;
                         if ($i == 10) {
-                            if (Shared\StringHelper::countCharacters($title) > 28) {
-                                $title = Shared\StringHelper::substring($title, 0, 28);
+                            if (StringHelper::countCharacters($title) > 28) {
+                                $title = StringHelper::substring($title, 0, 28);
                             }
                         } elseif ($i == 100) {
-                            if (Shared\StringHelper::countCharacters($title) > 27) {
-                                $title = Shared\StringHelper::substring($title, 0, 27);
+                            if (StringHelper::countCharacters($title) > 27) {
+                                $title = StringHelper::substring($title, 0, 27);
                             }
                         }
                     }
@@ -2031,10 +2032,10 @@ class Worksheet
      */
     protected function getTableIndexByName(string $name): ?int
     {
-        $name = Shared\StringHelper::strToUpper($name);
+        $name = StringHelper::strToUpper($name);
         foreach ($this->tableCollection as $index => $table) {
             /** @var Table $table */
-            if (Shared\StringHelper::strToUpper($table->getName()) === $name) {
+            if (StringHelper::strToUpper($table->getName()) === $name) {
                 return $index;
             }
         }
@@ -2864,7 +2865,7 @@ class Worksheet
                         $this->getCell($currentColumn . $startRow)->setValue($cellValue);
                     }
                 }
-                ++$currentColumn;
+                StringHelper::stringIncrement($currentColumn);
             }
             ++$startRow;
         }
@@ -2965,7 +2966,7 @@ class Worksheet
         $minColInt = $rangeStart[0];
         $maxColInt = $rangeEnd[0];
 
-        ++$maxCol;
+        StringHelper::stringIncrement($maxCol);
         /** @var array<string, bool> */
         $hiddenColumns = [];
         $nullRow = $this->buildNullRow($nullValue, $minCol, $maxCol, $returnCellRef, $ignoreHidden, $hiddenColumns);
@@ -3033,7 +3034,7 @@ class Worksheet
     ): array {
         $nullRow = [];
         $c = -1;
-        for ($col = $minCol; $col !== $maxCol; ++$col) {
+        for ($col = $minCol; $col !== $maxCol; StringHelper::stringIncrement($col)) {
             if ($ignoreHidden === true && $this->columnDimensionExists($col) && $this->getColumnDimension($col)->getVisible() === false) {
                 $hiddenColumns[$col] = true;
             } else {
@@ -3574,19 +3575,19 @@ class Worksheet
                 if ($this->parent->sheetCodeNameExists($codeName)) {
                     // Use name, but append with lowest possible integer
 
-                    if (Shared\StringHelper::countCharacters($codeName) > 29) {
-                        $codeName = Shared\StringHelper::substring($codeName, 0, 29);
+                    if (StringHelper::countCharacters($codeName) > 29) {
+                        $codeName = StringHelper::substring($codeName, 0, 29);
                     }
                     $i = 1;
                     while ($this->getParentOrThrow()->sheetCodeNameExists($codeName . '_' . $i)) {
                         ++$i;
                         if ($i == 10) {
-                            if (Shared\StringHelper::countCharacters($codeName) > 28) {
-                                $codeName = Shared\StringHelper::substring($codeName, 0, 28);
+                            if (StringHelper::countCharacters($codeName) > 28) {
+                                $codeName = StringHelper::substring($codeName, 0, 28);
                             }
                         } elseif ($i == 100) {
-                            if (Shared\StringHelper::countCharacters($codeName) > 27) {
-                                $codeName = Shared\StringHelper::substring($codeName, 0, 27);
+                            if (StringHelper::countCharacters($codeName) > 27) {
+                                $codeName = StringHelper::substring($codeName, 0, 27);
                             }
                         }
                     }

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -764,8 +764,8 @@ class Html extends BaseWriter
                     $totalHeight += ($height >= 0) ? $height : $defaultRowHeight;
                 }
                 $rightEdge = $brCoordinate[2];
-                ++$rightEdge;
-                for ($column = $tlCoordinate[2]; $column !== $rightEdge; ++$column) {
+                StringHelper::stringIncrement($rightEdge);
+                for ($column = $tlCoordinate[2]; $column !== $rightEdge; StringHelper::stringIncrement($column)) {
                     $width = $sheet->getColumnDimension($column)->getWidth();
                     $width = ($width < 0) ? self::DEFAULT_CELL_WIDTH_PIXELS : SharedDrawing::cellDimensionToPixels($sheet->getColumnDimension($column)->getWidth(), $this->defaultFont);
                     $totalWidth += $width;

--- a/src/PhpSpreadsheet/Writer/Pdf/Dompdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Dompdf.php
@@ -76,7 +76,7 @@ class Dompdf extends Pdf
     public function specialErrorHandler(int $errno, string $errstr, string $filename, int $lineno): bool
     {
         if ($errno === E_DEPRECATED) {
-            if (preg_match('/canonical|imagedestroy/', $errstr) === 1) {
+            if (preg_match('/canonical|imagedestroy|http_get_last_response_headers/', $errstr) === 1) {
                 return true;
             }
         }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Database/SetupTeardownDatabases.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Database/SetupTeardownDatabases.php
@@ -6,6 +6,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Database;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PHPUnit\Framework\TestCase;
@@ -141,7 +142,7 @@ class SetupTeardownDatabases extends TestCase
             foreach ($dataRow as $dataCell) {
                 $sheet->getCell("$col$row")->setValue($dataCell);
                 $maxCol = max($col, $maxCol);
-                ++$col;
+                StringHelper::stringIncrement($col);
             }
             $maxRow = $row;
             ++$row;
@@ -159,7 +160,7 @@ class SetupTeardownDatabases extends TestCase
                     $sheet->getCell("$col$row")->setValueExplicit($dataCell, DataType::TYPE_STRING);
                 }
                 $maxCol = max($col, $maxCol);
-                ++$col;
+                StringHelper::stringIncrement($col);
             }
             $maxRow = $row;
             ++$row;

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AllSetupTeardown.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AllSetupTeardown.php
@@ -7,6 +7,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Statistical;
 use PhpOffice\PhpSpreadsheet\Calculation\Exception as CalcException;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PHPUnit\Framework\TestCase;
@@ -187,7 +188,7 @@ class AllSetupTeardown extends TestCase
                     $cellId = "$col$row";
                     $arrayRange = "A$row:$cellId";
                     $this->setCell($cellId, $arrayItem);
-                    ++$col;
+                    StringHelper::stringIncrement($col);
                 }
                 $formula .= "$comma$arrayRange";
                 $comma = ',';

--- a/tests/PhpSpreadsheetTests/Reader/Xls/ColourTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xls/ColourTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Xls;
 
 use PhpOffice\PhpSpreadsheet\Reader\Xls;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
 class ColourTest extends AbstractFunctional
@@ -24,7 +25,7 @@ class ColourTest extends AbstractFunctional
 
         $worksheet = $this->spreadsheet->getActiveSheet();
         for ($row = 1; $row <= 7; ++$row) {
-            for ($column = 'A'; $column !== 'J'; ++$column) {
+            for ($column = 'A'; $column !== 'J'; StringHelper::stringIncrement($column)) {
                 $cellAddress = "{$column}{$row}";
                 $colours[$cellAddress] = $worksheet->getStyle($cellAddress)->getFill()->getStartColor()->getRGB();
             }

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/RowBreakTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/RowBreakTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Xlsx;
 
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx as XlsxReader;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
@@ -32,7 +33,7 @@ class RowBreakTest extends TestCase
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
         for ($row = 1; $row < 60; ++$row) {
-            for ($column = 'A'; $column !== 'L'; ++$column) {
+            for ($column = 'A'; $column !== 'L'; StringHelper::stringIncrement($column)) {
                 $cell = $column . $row;
                 $sheet->getCell($cell)->setValue($cell);
             }
@@ -54,7 +55,7 @@ class RowBreakTest extends TestCase
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
         for ($row = 1; $row < 60; ++$row) {
-            for ($column = 'A'; $column !== 'L'; ++$column) {
+            for ($column = 'A'; $column !== 'L'; StringHelper::stringIncrement($column)) {
                 $cell = $column . $row;
                 $sheet->getCell($cell)->setValue($cell);
             }

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxTest.php
@@ -9,6 +9,7 @@ use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\IReader;
 use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 use PhpOffice\PhpSpreadsheet\Shared\File;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Style\Conditional;
 use PhpOffice\PhpSpreadsheet\Style\Style;
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter;
@@ -58,7 +59,7 @@ class XlsxTest extends TestCase
 
         $worksheet = $spreadsheet->getActiveSheet();
         for ($row = 1; $row <= 8; $row += 2) {
-            for ($column = 'A'; $column !== 'G'; ++$column, ++$column) {
+            for ($column = 'A'; $column !== 'G'; StringHelper::stringIncrement($column), StringHelper::stringIncrement($column)) {
                 self::assertEquals(
                     $expectedColours[$row][$column],
                     $worksheet->getStyle($column . $row)->getFill()->getStartColor()->getRGB()

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoSizeTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoSizeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Worksheet\Table;
@@ -36,8 +37,8 @@ class AutoSizeTest extends TestCase
         $this->worksheet->fromArray($dataArray, null, 'A2');
 
         $toColumn = $this->worksheet->getHighestColumn();
-        ++$toColumn;
-        for ($i = 'A'; $i !== $toColumn; ++$i) {
+        StringHelper::stringIncrement($toColumn);
+        for ($i = 'A'; $i !== $toColumn; StringHelper::stringIncrement($i)) {
             $this->worksheet->getColumnDimension($i)->setAutoSize(true);
         }
     }
@@ -63,8 +64,8 @@ class AutoSizeTest extends TestCase
     {
         $columnSizes = [];
         $toColumn = $this->worksheet->getHighestColumn();
-        ++$toColumn;
-        for ($column = 'A'; $column !== $toColumn; ++$column) {
+        StringHelper::stringIncrement($toColumn);
+        for ($column = 'A'; $column !== $toColumn; StringHelper::stringIncrement($column)) {
             $columnSizes[$column] = $this->worksheet->getColumnDimension($column)->getWidth();
         }
 

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnDimension2Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnDimension2Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 
 use PhpOffice\PhpSpreadsheet\Helper\Dimension;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Html;
 use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
@@ -30,7 +31,7 @@ class ColumnDimension2Test extends AbstractFunctional
         }
         $spreadsheet->disconnectWorksheets();
         $sheet = $reloadedSpreadsheet->getActiveSheet();
-        for ($column = 'A'; $column !== 'Z'; ++$column) {
+        for ($column = 'A'; $column !== 'Z'; StringHelper::stringIncrement($column)) {
             if (in_array($column, $columns, true)) {
                 self::assertEqualsWithDelta($expectedCm, $sheet->getColumnDimension($column)->getWidth(Dimension::UOM_CENTIMETERS), 1E-3, "column $column");
             } elseif ($type === 'Xls' && $column <= 'T') {

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnIteratorTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnIteratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 
 use PhpOffice\PhpSpreadsheet\Exception as Except;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Column;
 use PhpOffice\PhpSpreadsheet\Worksheet\ColumnIterator;
@@ -39,7 +40,8 @@ class ColumnIteratorTest extends TestCase
         $counter = 0;
         foreach ($iterator as $key => $column) {
             ++$counter;
-            self::assertEquals($columnIndexResult++, $key);
+            self::assertEquals($columnIndexResult, $key);
+            StringHelper::stringIncrement($columnIndexResult);
             self::assertInstanceOf(Column::class, $column);
         }
         self::assertCount($counter, self::CELL_VALUES[0]);
@@ -57,7 +59,8 @@ class ColumnIteratorTest extends TestCase
         $counter = 0;
         foreach ($iterator as $key => $column) {
             ++$counter;
-            self::assertEquals($columnIndexResult++, $key);
+            self::assertEquals($columnIndexResult, $key);
+            StringHelper::stringIncrement($columnIndexResult);
             self::assertInstanceOf(Column::class, $column);
         }
         self::assertSame(3, $counter);

--- a/tests/PhpSpreadsheetTests/Worksheet/RowCellIteratorTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/RowCellIteratorTest.php
@@ -6,6 +6,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Exception as Except;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\RowCellIterator;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
@@ -43,7 +44,8 @@ class RowCellIteratorTest extends TestCase
         foreach ($iterator as $key => $RowCell) {
             self::assertNotNull($RowCell);
             $values[] = $RowCell->getValue();
-            self::assertEquals($RowCellIndexResult++, $key);
+            self::assertEquals($RowCellIndexResult, $key);
+            StringHelper::stringIncrement($RowCellIndexResult);
             self::assertInstanceOf(Cell::class, $RowCell);
         }
         self::assertSame(self::CELL_VALUES[0], $values);
@@ -62,7 +64,8 @@ class RowCellIteratorTest extends TestCase
         foreach ($iterator as $key => $RowCell) {
             self::assertNotNull($RowCell);
             $values[] = $RowCell->getValue();
-            self::assertEquals($RowCellIndexResult++, $key);
+            self::assertEquals($RowCellIndexResult, $key);
+            StringHelper::stringIncrement($RowCellIndexResult);
             self::assertInstanceOf(Cell::class, $RowCell);
         }
         self::assertSame([220, 230, 240], $values);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,9 +39,6 @@ function strIncrement85(int $version, int $errno, string $errstr, string $filena
     if ($version < 80500 || $errno !== E_DEPRECATED) {
         return false;
     }
-    if (preg_match('/Increment on non-numeric string/', $errstr) === 1) {
-        return true;
-    }
     if (preg_match('/canonical/', $errstr) === 1 && preg_match('/mitoteam/', $filename) === 1) {
         return true;
     }


### PR DESCRIPTION
Fix #4600. String incrementation through the `++` operator is deprecated in Php 8.5. Because we make use of that operator to iterate through columns, we are particularly hard hit by that change - unaddressed, it causes over 2,000 errors in our test suite! It is, fortunately, not as difficult as I feared to correct. Replacing the `++` operator with a call to new method `StringHelper::stringIncrement` in 79 statements scattered over 31 source modules (in src, samples, test, and infra) eliminates all the messages in the test suite. It is possible that others are lurking, but I don't know a systematic way of determining if there are others. We'll stick with this for now, and deal with any others as they show up.

This PR will be applied to the master, release390, and release222 branches. It will not be applied to the release210 or release1291 branches, which will now accept security changes only.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
