### PR TITLE
PHP 8.5: Prevent deprecation notices for imagedestroy

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/MemoryDrawing.php
+++ b/src/PhpSpreadsheet/Worksheet/MemoryDrawing.php
@@ -64,12 +64,7 @@ class MemoryDrawing extends BaseDrawing
 
     public function __destruct()
     {
-        if ($this->imageResource) {
-            if (\PHP_VERSION_ID < 80000) {
-                @imagedestroy($this->imageResource);
-            }
-            $this->imageResource = null;
-        }
+        $this->imageResource = null;
         $this->worksheet = null;
     }
 


### PR DESCRIPTION
`imagedestroy` is deprecated in PHP 8.5+, and hasn't been doing anything since PHP 8.0.

To prevent deprecation warnings it should therefore be called on older versions of PHP only.

See https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_no-op_functions_from_the_resource_to_object_conversion.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary