### PR TITLE
Php8.5 Deprecates Using Null as Array Index - release222

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com)
 and this project adheres to [Semantic Versioning](https://semver.org). This is always true of the master branch. Some earlier branches, including the branch from which you are reading this file, remain supported and security fixes are applied to them; if the security fix represents a breaking change, it may have to be applied as a minor or patch version.
 
+## TBD - 2.4.2
+
+### Fixed
+
+ - Php8.5 deprecates use of null as array index. [PR #4618](https://github.com/PHPOffice/PhpSpreadsheet/pull/4618)
+
 ## 2025-09-03 - 2.4.1
 
 ### Added

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -4635,7 +4635,7 @@ class Calculation
                         return $this->raiseFormulaError($e->getMessage(), $e->getCode(), $e);
                     }
                 }
-            } elseif (!is_numeric($token) && !is_object($token) && isset(self::BINARY_OPERATORS[$token])) {
+            } elseif (!is_numeric($token) && !is_object($token) && isset($token, self::BINARY_OPERATORS[$token])) {
                 // if the token is a binary operator, pop the top two values off the stack, do the operation, and push the result back on the stack
                 //    We must have two operands, error if we don't
                 $operand2Data = $stack->pop();

--- a/src/PhpSpreadsheet/Calculation/Database/DatabaseAbstract.php
+++ b/src/PhpSpreadsheet/Calculation/Database/DatabaseAbstract.php
@@ -86,9 +86,9 @@ abstract class DatabaseAbstract
         $columnData = [];
         foreach ($database as $rowKey => $row) {
             $keys = array_keys($row);
-            $key = $keys[$field] ?? null;
+            $key = ($field === null) ? null : ($keys[$field] ?? null);
             $columnKey = $key ?? 'A';
-            $columnData[$rowKey][$columnKey] = $row[$key] ?? $defaultReturnColumnValue;
+            $columnData[$rowKey][$columnKey] = ($key === null) ? $defaultReturnColumnValue : ($row[$key] ?? $defaultReturnColumnValue);
         }
 
         return $columnData;

--- a/src/PhpSpreadsheet/Calculation/Engine/BranchPruner.php
+++ b/src/PhpSpreadsheet/Calculation/Engine/BranchPruner.php
@@ -78,7 +78,7 @@ class BranchPruner
 
     private function initialiseCondition(): void
     {
-        if (isset($this->conditionMap[$this->pendingStoreKey]) && $this->conditionMap[$this->pendingStoreKey]) {
+        if (isset($this->pendingStoreKey, $this->conditionMap[$this->pendingStoreKey]) && $this->conditionMap[$this->pendingStoreKey]) {
             $this->currentCondition = $this->pendingStoreKey;
             $stackDepth = count($this->storeKeysStack);
             if ($stackDepth > 1) {
@@ -90,7 +90,7 @@ class BranchPruner
 
     private function initialiseThen(): void
     {
-        if (isset($this->thenMap[$this->pendingStoreKey]) && $this->thenMap[$this->pendingStoreKey]) {
+        if (isset($this->pendingStoreKey, $this->thenMap[$this->pendingStoreKey]) && $this->thenMap[$this->pendingStoreKey]) {
             $this->currentOnlyIf = $this->pendingStoreKey;
         } elseif (
             isset($this->previousStoreKey, $this->thenMap[$this->previousStoreKey])
@@ -102,7 +102,7 @@ class BranchPruner
 
     private function initialiseElse(): void
     {
-        if (isset($this->elseMap[$this->pendingStoreKey]) && $this->elseMap[$this->pendingStoreKey]) {
+        if (isset($this->pendingStoreKey, $this->elseMap[$this->pendingStoreKey]) && $this->elseMap[$this->pendingStoreKey]) {
             $this->currentOnlyIfNot = $this->pendingStoreKey;
         } elseif (
             isset($this->previousStoreKey, $this->elseMap[$this->previousStoreKey])

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1227,7 +1227,7 @@ class Xlsx extends BaseReader
                                                 // Set comment properties
                                                 $comment = $docSheet->getComment([$column + 1, $row + 1]);
                                                 $comment->getFillColor()->setRGB($fillColor);
-                                                if (isset($drowingImages[$fillImageRelId])) {
+                                                if (isset($fillImageRelId, $drowingImages[$fillImageRelId])) {
                                                     $objDrawing = new \PhpOffice\PhpSpreadsheet\Worksheet\Drawing();
                                                     $objDrawing->setName($fillImageTitle);
                                                     $imagePath = str_replace(['../', '/xl/'], 'xl/', $drowingImages[$fillImageRelId]);

--- a/src/PhpSpreadsheet/Writer/Pdf/Dompdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Dompdf.php
@@ -76,7 +76,7 @@ class Dompdf extends Pdf
     public function specialErrorHandler(int $errno, string $errstr, string $filename, int $lineno): bool
     {
         if ($errno === E_DEPRECATED) {
-            if (preg_match('/canonical|imagedestroy|http_get_last_response_headers/', $errstr) === 1) {
+            if (preg_match('/canonical|imagedestroy|http_get_last_response_headers|Using null as an array offset/', $errstr) === 1) {
                 return true;
             }
         }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Rels.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Rels.php
@@ -206,7 +206,7 @@ class Rels extends WriterPart
             // (! synchronize with \PhpOffice\PhpSpreadsheet\Writer\Xlsx\Worksheet::writeDrawings)
             reset($drawingOriginalIds);
             $relPath = key($drawingOriginalIds);
-            if (isset($drawingOriginalIds[$relPath])) {
+            if (isset($relPath, $drawingOriginalIds[$relPath])) {
                 $rId = (int) (substr($drawingOriginalIds[$relPath], 3));
             }
 


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

