### PR TITLE
Proper Output for BASE Function

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/FunctionPrefix.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/FunctionPrefix.php
@@ -66,6 +66,8 @@ class FunctionPrefix
         . '|var[.]s'
         . '|weibull[.]dist'
         . '|z[.]test'
+        // probably added with Excel 2010 but not properly documented
+        . '|base'
         // functions added with Excel 2013
         . '|acot'
         . '|acoth'

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/FunctionPrefixTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/FunctionPrefixTest.php
@@ -38,6 +38,7 @@ class FunctionPrefixTest extends TestCase
             'DAYS/NETWORKDAYS 5' => ['NETWORKDAYS(DATE(2023,1,1),TODAY(), C:C)', 'NETWORKDAYS(DATE(2023,1,1),TODAY(), C:C)'],
             'COUNTIFS reclassified as Legacy' => ['COUNTIFS()', 'COUNTIFS()'],
             'SUMIFS reclassified as Legacy' => ['SUMIFS()', 'SUMIFS()'],
+            'BASE improperly classified by MS' => ['_xlfn.BASE()', 'BASE()'],
         ];
     }
 }


### PR DESCRIPTION
Fix #4638. Microsoft does not document BASE as being introduced in Excel 2010 or later, but apparently it was.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

