### PR TITLE
Export only data cells/columns in toArray

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -3286,9 +3286,9 @@ class Worksheet
         $this->garbageCollect();
         $this->calculateArrays($calculateFormulas);
 
-        //    Identify the range that we need to extract from the worksheet
-        $maxCol = $this->getHighestColumn();
-        $maxRow = $this->getHighestRow();
+        // Identify the range that we need to extract from the worksheet
+        $maxCol = $this->getHighestDataColumn();
+        $maxRow = $this->getHighestDataRow();
 
         // Return
         return $this->rangeToArray("A1:{$maxCol}{$maxRow}", $nullValue, $calculateFormulas, $formatData, $returnCellRef, $ignoreHidden, $reduceArrays);

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxTest.php
@@ -11,7 +11,6 @@ use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 use PhpOffice\PhpSpreadsheet\Shared\File;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Style\Conditional;
-use PhpOffice\PhpSpreadsheet\Style\Style;
 use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter;
 use PhpOffice\PhpSpreadsheet\Worksheet\PageSetup;
 use PHPUnit\Framework\TestCase;
@@ -194,11 +193,11 @@ class XlsxTest extends TestCase
         $reader = new Xlsx();
         $reader->setReadFilter(new OddColumnReadFilter());
         $spreadsheet = $reader->load($filename);
-        $data = $spreadsheet->getActiveSheet()->toArray();
+        $data = $spreadsheet->getActiveSheet()->rangeToArray("A1:J10");
         $ref = [1.0, null, 3.0, null, 5.0, null, 7.0, null, 9.0, null];
 
         for ($i = 0; $i < 10; ++$i) {
-            self::assertEquals($ref, \array_slice($data[$i], 0, 10, true));
+            self::assertEquals($ref, $data[$i]);
         }
         $spreadsheet->disconnectWorksheets();
     }

--- a/tests/PhpSpreadsheetTests/Worksheet/ToArrayTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ToArrayTest.php
@@ -76,4 +76,20 @@ class ToArrayTest extends TestCase
         self::assertSame('start', $array[0][0]);
         self::assertSame('end', $array[0][16383]);
     }
+
+    public static function testToArrayConsidersValuesButNotFormatting(): void
+    {
+         $spreadsheet = new Spreadsheet();
+         $sheet = $spreadsheet->getActiveSheet();
+
+         $sheet->getCell('A1')->setValue('hello');
+         $array = $sheet->toArray(null, false, false, false, false);
+         self::assertSame([['hello']], $array);
+
+         // Create column dimension object that didn't exist yet
+         $sheet->getColumnDimension('C');
+         $array = $sheet->toArray(null, false, false, false, false);
+         // Yet there should be no column C in the export
+         self::assertSame([['hello']], $array);
+    }
 }


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Worksheet::toArray now calls these methods:

         $maxCol = $this->getHighestDataColumn();
         $maxRow = $this->getHighestDataRow();

instead of getHighestColumn and getHighestRow. This is to make sure that rows/columns that only have some formatting are not included. Otherwise the export would contain 16384 columns if e.g. column width setting is applied.

