### PR TITLE
Better Support For Style Alignment Read Order

### DIFF
--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -18,6 +18,7 @@ use PhpOffice\PhpSpreadsheet\Helper\Html as HelperHtml;
 use PhpOffice\PhpSpreadsheet\Reader\Security\XmlScanner;
 use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
 use PhpOffice\PhpSpreadsheet\Style\Border;
 use PhpOffice\PhpSpreadsheet\Style\Color;
 use PhpOffice\PhpSpreadsheet\Style\Fill;
@@ -1011,6 +1012,17 @@ class Html extends BaseReader
                     $cellStyle->getFont()->setSize(
                         (float) $styleValue
                     );
+
+                    break;
+
+                case 'direction':
+                    if ($styleValue === 'rtl') {
+                        $cellStyle->getAlignment()
+                            ->setReadOrder(Alignment::READORDER_RTL);
+                    } elseif ($styleValue === 'ltr') {
+                        $cellStyle->getAlignment()
+                            ->setReadOrder(Alignment::READORDER_LTR);
+                    }
 
                     break;
 

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -1254,6 +1254,8 @@ class Xls extends XlsBase
 
                         break;
                 }
+                $readOrder = (0xC0 & ord($recordData[8])) >> 6;
+                $objStyle->getAlignment()->setReadOrder($readOrder);
 
                 // offset:  9; size: 1; Flags used for attribute groups
 

--- a/src/PhpSpreadsheet/Reader/Xml/Style/Alignment.php
+++ b/src/PhpSpreadsheet/Reader/Xml/Style/Alignment.php
@@ -55,6 +55,14 @@ class Alignment extends StyleBase
                     $style['alignment']['indent'] = $styleAttributeValue;
 
                     break;
+                case 'ReadingOrder':
+                    if ($styleAttributeValue === 'RightToLeft') {
+                        $style['alignment']['readOrder'] = AlignmentStyles::READORDER_RTL;
+                    } elseif ($styleAttributeValue === 'LeftToRight') {
+                        $style['alignment']['readOrder'] = AlignmentStyles::READORDER_LTR;
+                    }
+
+                    break;
             }
         }
 

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -1126,6 +1126,12 @@ class Html extends BaseWriter
                 $css['transform'] = "rotate({$rotation}deg)";
             }
         }
+        $direction = $alignment->getReadOrder();
+        if ($direction === Alignment::READORDER_LTR) {
+            $css['direction'] = 'ltr';
+        } elseif ($direction === Alignment::READORDER_RTL) {
+            $css['direction'] = 'rtl';
+        }
 
         return $css;
     }

--- a/src/PhpSpreadsheet/Writer/Ods/Cell/Style.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Cell/Style.php
@@ -151,6 +151,7 @@ class Style
         $vAlign = $style->getAlignment()->getVertical();
         $wrap = $style->getAlignment()->getWrapText();
         $indent = $style->getAlignment()->getIndent();
+        $readOrder = $style->getAlignment()->getReadOrder();
 
         $this->writer->startElement('style:table-cell-properties');
         if (!empty($vAlign) || $wrap) {
@@ -172,7 +173,7 @@ class Style
 
         $this->writer->endElement();
 
-        if ($hAlign !== '' || !empty($indent)) {
+        if ($hAlign !== '' || !empty($indent) || $readOrder === Alignment::READORDER_RTL || $readOrder === Alignment::READORDER_LTR) {
             $this->writer
                 ->startElement('style:paragraph-properties');
             if ($hAlign !== '') {
@@ -181,6 +182,11 @@ class Style
             if (!empty($indent)) {
                 $indentString = sprintf('%.4f', $indent * self::INDENT_TO_INCHES) . 'in';
                 $this->writer->writeAttribute('fo:margin-left', $indentString);
+            }
+            if ($readOrder === Alignment::READORDER_RTL) {
+                $this->writer->writeAttribute('style:writing-mode', 'rl-tb');
+            } elseif ($readOrder === Alignment::READORDER_LTR) {
+                $this->writer->writeAttribute('style:writing-mode', 'lr-tb');
             }
             $this->writer->endElement();
         }

--- a/src/PhpSpreadsheet/Writer/Xls/Xf.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Xf.php
@@ -220,8 +220,9 @@ class Xf
         $header = pack('vv', $record, $length);
 
         //BIFF8 options: identation, shrinkToFit and  text direction
-        $biff8_options = $this->style->getAlignment()->getIndent();
+        $biff8_options = $this->style->getAlignment()->getIndent() & 15;
         $biff8_options |= (int) $this->style->getAlignment()->getShrinkToFit() << 4;
+        $biff8_options |= $this->style->getAlignment()->getReadOrder() << 6;
 
         $data = pack('vvvC', $ifnt, $ifmt, $style, $align);
         $data .= pack('CCC', self::mapTextRotation((int) $this->style->getAlignment()->getTextRotation()), $biff8_options, $used_attrib);

--- a/tests/PhpSpreadsheetTests/Reader/Xml/ReadOrderTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/ReadOrderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Reader\Xml;
+
+use PhpOffice\PhpSpreadsheet\Reader\Xml as XmlReader;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class ReadOrderTest extends AbstractFunctional
+{
+    public function testReadOrder(): void
+    {
+        // Issue 850 - Xls Reader/Writer didn't support Alignment ReadOrder
+        $infile = 'tests\data\Reader\Xml\issue.850.xml';
+        $reader = new XmlReader();
+        $robj = $reader->load($infile);
+
+        $sheet0 = $robj->setActiveSheetIndex(0);
+        self::assertSame(
+            Alignment::READORDER_RTL,
+            $sheet0->getStyle('A1')->getAlignment()->getReadOrder()
+        );
+        self::assertSame(
+            Alignment::READORDER_LTR,
+            $sheet0->getStyle('A2')->getAlignment()->getReadOrder()
+        );
+        self::assertSame(
+            Alignment::READORDER_CONTEXT,
+            $sheet0->getStyle('A3')->getAlignment()->getReadOrder()
+        );
+        self::assertSame(
+            2,
+            $sheet0->getStyle('A5')->getAlignment()->getIndent()
+        );
+        $robj->disconnectWorksheets();
+    }
+}

--- a/tests/PhpSpreadsheetTests/Writer/Html/ReadOrderTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/ReadOrderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Html;
+
+use PhpOffice\PhpSpreadsheet\Reader\Html as HtmlReader;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Writer\Html as HtmlWriter;
+use PHPUnit\Framework\TestCase;
+
+class ReadOrderTest extends TestCase
+{
+    public function testInline(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', '1-' . 'منصور حسين الناصر');
+        $sheet->setCellValue('A2', '1-' . 'منصور حسين الناصر');
+        $sheet->setCellValue('A3', '1-' . 'منصور حسين الناصر');
+        $sheet->getStyle('A1')
+            ->getAlignment()->setReadOrder(Alignment::READORDER_RTL);
+        $sheet->getStyle('A2')
+            ->getAlignment()->setReadOrder(Alignment::READORDER_LTR);
+        $sheet->getStyle('A2')->getFont()->setName('Arial');
+        $sheet->getStyle('A3')->getFont()->setName('Times New Roman');
+        $writer = new HtmlWriter($spreadsheet);
+        $writer->setUseInlineCss(true);
+        $html = $writer->generateHtmlAll();
+        self::assertStringContainsString(
+            '<td class="gridlines" style="vertical-align:bottom; direction:rtl; color:#000000; font-family:\'Calibri\';',
+            $html
+        );
+        self::assertStringContainsString(
+            '<td class="gridlines" style="vertical-align:bottom; direction:ltr; color:#000000; font-family:\'Arial\';',
+            $html
+        );
+        self::assertStringContainsString(
+            '<td class="gridlines" style="vertical-align:bottom; color:#000000; font-family:\'Times New Roman\';',
+            $html
+        );
+        $spreadsheet->disconnectWorksheets();
+
+        $reader = new HtmlReader();
+        $spreadsheet2 = $reader->loadFromString($html);
+        $sheet0 = $spreadsheet2->getActiveSheet();
+        self::assertSame(
+            Alignment::READORDER_RTL,
+            $sheet0->getStyle('A1')->getAlignment()->getReadOrder()
+        );
+        self::assertSame(
+            Alignment::READORDER_LTR,
+            $sheet0->getStyle('A2')->getAlignment()->getReadOrder()
+        );
+        self::assertSame(
+            Alignment::READORDER_CONTEXT,
+            $sheet0->getStyle('A3')->getAlignment()->getReadOrder()
+        );
+        $spreadsheet2->disconnectWorksheets();
+    }
+
+    public function testNotInline(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', '1-' . 'منصور حسين الناصر');
+        $sheet->setCellValue('A2', '1-' . 'منصور حسين الناصر');
+        $sheet->setCellValue('A3', '1-' . 'منصور حسين الناصر');
+        $sheet->getStyle('A1')
+            ->getAlignment()->setReadOrder(Alignment::READORDER_RTL);
+        $sheet->getStyle('A2')
+            ->getAlignment()->setReadOrder(Alignment::READORDER_LTR);
+        $sheet->getStyle('A2')->getFont()->setName('Arial');
+        $sheet->getStyle('A3')->getFont()->setName('Times New Roman');
+        $writer = new HtmlWriter($spreadsheet);
+        $html = $writer->generateHtmlAll();
+        self::assertStringContainsString(
+            'td.style1, th.style1 { vertical-align:bottom; direction:rtl; border-bottom',
+            $html
+        );
+        self::assertStringContainsString(
+            'td.style2, th.style2 { vertical-align:bottom; direction:ltr; border-bottom',
+            $html
+        );
+        self::assertStringContainsString(
+            'td.style3, th.style3 { vertical-align:bottom; border-bottom',
+            $html
+        );
+        $spreadsheet->disconnectWorksheets();
+        // PhpSpreadsheet does not read non-inline styles
+    }
+}

--- a/tests/PhpSpreadsheetTests/Writer/Ods/ReadOrderTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Ods/ReadOrderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Ods;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Writer\Ods;
+use PhpOffice\PhpSpreadsheet\Writer\Ods\Content;
+use PHPUnit\Framework\TestCase;
+
+class ReadOrderTest extends TestCase
+{
+    public function testReadOrder(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', '1-' . 'منصور حسين الناصر');
+        $sheet->setCellValue('A2', '1-' . 'منصور حسين الناصر');
+        $sheet->setCellValue('A3', '1-' . 'منصور حسين الناصر');
+        $sheet->getStyle('A1')
+            ->getAlignment()->setReadOrder(Alignment::READORDER_RTL);
+        $sheet->getStyle('A2')
+            ->getAlignment()->setReadOrder(Alignment::READORDER_LTR);
+        $sheet->getStyle('A2')->getFont()->setName('Arial');
+        $sheet->getStyle('A3')->getFont()->setName('Times New Roman');
+        $content = new Content(new Ods($spreadsheet));
+        $xml = $content->write();
+        self::assertStringContainsString(
+            '<style:table-cell-properties style:vertical-align="bottom" style:rotation-align="none"/>'
+                . '<style:paragraph-properties style:writing-mode="rl-tb"/>'
+                . '<style:text-properties fo:color="#000000" fo:font-family="Calibri"',
+            $xml,
+            'explicit rtl direction in paragraph properties'
+        );
+        self::assertStringContainsString(
+            '<style:table-cell-properties style:vertical-align="bottom" style:rotation-align="none"/>'
+                . '<style:paragraph-properties style:writing-mode="lr-tb"/>'
+                . '<style:text-properties fo:color="#000000" fo:font-family="Arial"',
+            $xml,
+            'explicit ltr direction in paragraph properties'
+        );
+        self::assertStringContainsString(
+            '<style:table-cell-properties style:vertical-align="bottom" style:rotation-align="none"/>'
+                . '<style:text-properties fo:color="#000000" fo:font-family="Times New Roman"',
+            $xml,
+            'no paragraph properties'
+        );
+        $spreadsheet->disconnectWorksheets();
+    }
+}

--- a/tests/PhpSpreadsheetTests/Writer/Xls/ReadOrderTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/ReadOrderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xls;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class ReadOrderTest extends AbstractFunctional
+{
+    public function testBooleanLiteral(): void
+    {
+        // Issue 850 - Xls Reader/Writer didn't support Alignment ReadOrder
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', '1-' . 'منصور حسين الناصر');
+        $sheet->setCellValue('A2', '1-' . 'منصور حسين الناصر');
+        $sheet->setCellValue('A3', '1-' . 'منصور حسين الناصر');
+        $sheet->getStyle('A1')
+            ->getAlignment()->setReadOrder(Alignment::READORDER_RTL);
+        $sheet->getStyle('A2')
+            ->getAlignment()->setReadOrder(Alignment::READORDER_LTR);
+
+        $sheet->setCellValue('A5', 'hello');
+        $spreadsheet->getActiveSheet()->getStyle('A5')
+            ->getAlignment()->setIndent(2);
+
+        $robj = $this->writeAndReload($spreadsheet, 'Xls');
+        $spreadsheet->disconnectWorksheets();
+        $sheet0 = $robj->setActiveSheetIndex(0);
+        self::assertSame(
+            Alignment::READORDER_RTL,
+            $sheet0->getStyle('A1')->getAlignment()->getReadOrder()
+        );
+        self::assertSame(
+            Alignment::READORDER_LTR,
+            $sheet0->getStyle('A2')->getAlignment()->getReadOrder()
+        );
+        self::assertSame(
+            Alignment::READORDER_CONTEXT,
+            $sheet0->getStyle('A3')->getAlignment()->getReadOrder()
+        );
+        self::assertSame(
+            2,
+            $sheet0->getStyle('A5')->getAlignment()->getIndent()
+        );
+        $robj->disconnectWorksheets();
+    }
+}

--- a/tests/data/Reader/Xml/issue.850.xml
+++ b/tests/data/Reader/Xml/issue.850.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<?mso-application progid="Excel.Sheet"?>
+<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:o="urn:schemas-microsoft-com:office:office"
+ xmlns:x="urn:schemas-microsoft-com:office:excel"
+ xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:html="http://www.w3.org/TR/REC-html40">
+ <DocumentProperties xmlns="urn:schemas-microsoft-com:office:office">
+  <Title>Untitled Spreadsheet</Title>
+  <Author>Unknown Creator</Author>
+  <LastAuthor>Owen Leibman</LastAuthor>
+  <Created>2025-09-19T18:05:38Z</Created>
+  <LastSaved>2025-09-19T18:05:38Z</LastSaved>
+  <Version>16.00</Version>
+ </DocumentProperties>
+ <OfficeDocumentSettings xmlns="urn:schemas-microsoft-com:office:office">
+  <AllowPNG/>
+ </OfficeDocumentSettings>
+ <ExcelWorkbook xmlns="urn:schemas-microsoft-com:office:excel">
+  <WindowHeight>6510</WindowHeight>
+  <WindowWidth>19200</WindowWidth>
+  <WindowTopX>32767</WindowTopX>
+  <WindowTopY>32767</WindowTopY>
+  <ProtectStructure>False</ProtectStructure>
+  <ProtectWindows>False</ProtectWindows>
+ </ExcelWorkbook>
+ <Styles>
+  <Style ss:ID="Default" ss:Name="Normal">
+   <Alignment ss:Vertical="Bottom"/>
+   <Borders/>
+   <Font ss:FontName="Calibri" ss:Size="11" ss:Color="#000000"/>
+   <Interior/>
+   <NumberFormat/>
+   <Protection/>
+  </Style>
+  <Style ss:ID="s16">
+   <Alignment ss:Vertical="Bottom" ss:ReadingOrder="RightToLeft"/>
+  </Style>
+  <Style ss:ID="s17">
+   <Alignment ss:Vertical="Bottom" ss:ReadingOrder="LeftToRight"/>
+  </Style>
+  <Style ss:ID="s18">
+   <Alignment ss:Vertical="Bottom" ss:Indent="2"/>
+  </Style>
+ </Styles>
+ <Worksheet ss:Name="Worksheet">
+  <Table ss:ExpandedColumnCount="1" ss:ExpandedRowCount="5" x:FullColumns="1"
+   x:FullRows="1" ss:DefaultRowHeight="14.5">
+   <Row>
+    <Cell ss:StyleID="s16"><Data ss:Type="String">1-منصور حسين الناصر</Data></Cell>
+   </Row>
+   <Row>
+    <Cell ss:StyleID="s17"><Data ss:Type="String">1-منصور حسين الناصر</Data></Cell>
+   </Row>
+   <Row>
+    <Cell><Data ss:Type="String">1-منصور حسين الناصر</Data></Cell>
+   </Row>
+   <Row ss:Index="5">
+    <Cell ss:StyleID="s18"><Data ss:Type="String">hello</Data></Cell>
+   </Row>
+  </Table>
+  <WorksheetOptions xmlns="urn:schemas-microsoft-com:office:excel">
+   <PageSetup>
+    <Header x:Margin="0.3"/>
+    <Footer x:Margin="0.3"/>
+    <PageMargins x:Bottom="0.75" x:Left="0.7" x:Right="0.7" x:Top="0.75"/>
+   </PageSetup>
+   <Print>
+    <ValidPrinterInfo/>
+    <NoOrientation/>
+    <HorizontalResolution>600</HorizontalResolution>
+    <VerticalResolution>600</VerticalResolution>
+   </Print>
+   <Selected/>
+   <Panes>
+    <Pane>
+     <Number>3</Number>
+     <ActiveRow>4</ActiveRow>
+    </Pane>
+   </Panes>
+   <ProtectObjects>False</ProtectObjects>
+   <ProtectScenarios>False</ProtectScenarios>
+  </WorksheetOptions>
+ </Worksheet>
+</Workbook>


### PR DESCRIPTION
Fix #850 (marked stale many years ago, but now reopened). User had a typo in their script which would have caused problems no matter what. However, it exposed another problem. Style Alignment Read Order was supported only by the Xlsx Reader and Writer, but it could have been supported pretty easily for most other formats. This PR adds support for the following:

- Xls (read and write)
- Html (write, and read using inline styles). Html reader does not yet process most classes.
- Pdf (write). PhpSpreadsheet does not have a Pdf reader.
- Ods (write). PhpSpreadsheet does not yet support reading most Ods styles.
- Xml (read). PhpSpreadsheet does not have an Xml writer.
- Gnumeric (no change). It appears that the Gnumeric product does not support this attribute.
- Csv (no change). Csv does not support any styles.
- Slk (no change). Slk does not support non-Latin characters, so this attribute doesn't make sense for it.

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary


