### PR TITLE
Offer Tcpdf Interface Which Throws Exception Rather than Die

### DIFF
--- a/src/PhpSpreadsheet/Writer/Pdf/Tcpdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Tcpdf.php
@@ -30,7 +30,13 @@ class Tcpdf extends Pdf
      */
     protected function createExternalWriterInstance(string $orientation, string $unit, $paperSize): \TCPDF
     {
+        $this->defines();
+
         return new \TCPDF($orientation, $unit, $paperSize);
+    }
+
+    protected function defines(): void
+    {
     }
 
     /**

--- a/src/PhpSpreadsheet/Writer/Pdf/TcpdfNoDie.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/TcpdfNoDie.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Writer\Pdf;
+
+class TcpdfNoDie extends Tcpdf
+{
+    /**
+     * By default, Tcpdf will die sometimes rather than throwing exception.
+     * And this is controlled by a defined constant in the global namespace,
+     * not by an instance property. Ugh!
+     * Using this class instead of the class which it extends will probably
+     * be suitable for most users. But not for those who have customized
+     * their config file. Which is why this isn't the default, so that
+     * there is no breaking change for those users.
+     * Note that if both Tcpdf and TcpdfNoDie are used in the same process,
+     * the first one used "wins" the battle of the defines.
+     */
+    protected function defines(): void
+    {
+        if (!defined('K_TCPDF_EXTERNAL_CONFIG')) {
+            define('K_TCPDF_EXTERNAL_CONFIG', true);
+        }
+        if (!defined('K_TCPDF_THROW_EXCEPTION_ERROR')) {
+            define('K_TCPDF_THROW_EXCEPTION_ERROR', true);
+        }
+    }
+}

--- a/tests/PhpSpreadsheetTests/Writer/Tcpdf/NoDieTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Tcpdf/NoDieTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Tcpdf;
+
+use Exception;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Pdf\TcpdfNoDie;
+use PHPUnit\Framework\Attributes;
+
+// Separate processes because of global defined names
+#[Attributes\RunTestsInSeparateProcesses]
+class NoDieTest extends \PHPUnit\Framework\TestCase
+{
+    private Spreadsheet $spreadsheet;
+
+    protected function setUp(): void
+    {
+        $this->spreadsheet = new Spreadsheet();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->spreadsheet);
+    }
+
+    public function testExceptionRatherThanDie(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Could not include font definition file');
+        $sheet = $this->spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'cell');
+        $writer = new TcpdfNoDie($this->spreadsheet);
+        $writer->setFont('xyz');
+        $writer->save('php://memory');
+    }
+}


### PR DESCRIPTION
By default, TCPDF will die sometimes rather than throwing exception. And this is controlled by a defined constant in the global namespace, not by an instance property. Ugh! Using this class instead of the class which it extends will probably be suitable for most users. But not for those who have customized their config file. Which is why this isn't the default, so that there is no breaking change for those users. Note that if both Tcpdf and TcpdfNoDie are used in the same process, the first one used "wins" the battle of the defines.

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

