### PR TITLE
fix: do not trigger `Undefined array key "x"`

### DIFF
--- a/src/PhpSpreadsheet/Reader/Xml/Style.php
+++ b/src/PhpSpreadsheet/Reader/Xml/Style.php
@@ -76,7 +76,7 @@ class Style
                         break;
                     case 'Protection':
                         $locked = $hidden = null;
-                        $styleAttributesP = $styleData->attributes($namespaces['x']);
+                        $styleAttributesP = array_key_exists('x', $namespaces) ? $styleData->attributes($namespaces['x']) : [];
                         if (isset($styleAttributes['Protected'])) {
                             $locked = ((bool) (string) $styleAttributes['Protected']) ? Protection::PROTECTION_PROTECTED : Protection::PROTECTION_UNPROTECTED;
                         }

--- a/tests/PhpSpreadsheetTests/Reader/Xls/XlsTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xls/XlsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Xls;
 
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\Xls;
 use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
@@ -92,7 +93,7 @@ class XlsTest extends AbstractFunctional
     public function testLoadXlsBug1114(): void
     {
         $filename = 'tests/data/Reader/XLS/bug1114.xls';
-        $spreadsheet = \PhpOffice\PhpSpreadsheet\IOFactory::load($filename);
+        $spreadsheet = IOFactory::load($filename);
         $sheet = $spreadsheet->getActiveSheet();
         self::assertSame(1148140800.0, $sheet->getCell('B2')->getValue());
         $spreadsheet->disconnectWorksheets();

--- a/tests/PhpSpreadsheetTests/Reader/Xml/XmlTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/XmlTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Xml;
 
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Reader\Exception as ReaderException;
 use PhpOffice\PhpSpreadsheet\Reader\Xml;
 use PHPUnit\Framework\TestCase;
@@ -101,5 +102,25 @@ class XmlTest extends TestCase
         $this->expectException(ReaderException::class);
         $this->expectExceptionMessage('File "" does not exist');
         $xmlReader->load('');
+    }
+
+    /**
+     * Ensures that a PHP warning for `Undefined array key "x"` is not triggered.
+     *
+     * Relies on PHPUnit's conversion of PHP warnings, deprecations, and notices to exceptions.
+     * If that warning occurs, the test should fail.
+     */
+    public function testLoadXlsBug4669(): void
+    {
+        $filename = 'tests/data/Reader/Xml/bug4669.xml';
+
+        $reader = IOFactory::createReaderForFile($filename);
+        $reader->setReadDataOnly(true);
+
+        $spreadsheet = $reader->load($filename);
+
+        $sheet = $spreadsheet->getActiveSheet();
+        self::assertSame('Report Date', $sheet->getCell('A1')->getValue());
+        $spreadsheet->disconnectWorksheets();
     }
 }

--- a/tests/data/Reader/Xml/bug4669.xml
+++ b/tests/data/Reader/Xml/bug4669.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns:html="http://www.w3.org/TR/REC-html40" xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">
+  <Styles>
+    <Style ss:ID="Default" ss:Name="Normal">
+      <Alignment ss:Vertical="Bottom"/>
+      <Borders/>
+      <Font ss:FontName="Verdana"/>
+      <Interior/>
+      <NumberFormat/>
+      <Protection/>
+    </Style>
+    <Style ss:ID="s22">
+      <NumberFormat ss:Format="General Date"/>
+    </Style>
+    <Style ss:ID="s66">
+      <NumberFormat ss:Format="Fixed"/>
+    </Style>
+  </Styles>
+  <Worksheet ss:Name="stats by transaction_notes">
+    <Table>
+      <Row>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Report Date</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Trx Date</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Merchant</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Terminal</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Report Type</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Transition</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Report Message</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Report Info</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Status</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Merchant Transaction ID</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Unique ID</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Reference Transaction ID</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Reference Transaction Type</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Currency</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Amount (in minor currency unit)</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Card Holder</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Card Brand</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Card Number</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Email</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Country</Data>
+        </Cell>
+        <Cell ss:StyleID="Default">
+          <Data ss:Type="String">Remote IP</Data>
+        </Cell>
+      </Row>
+    </Table>
+  </Worksheet>
+</Workbook>


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

fixes https://github.com/PHPOffice/PhpSpreadsheet/issues/4668
