### PR TITLE
Fix phpstan issues by making Escher generic

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,30 +7,6 @@ parameters:
 			path: src/PhpSpreadsheet/Calculation/LookupRef/Sort.php
 
 		-
-			message: '#^Cannot call method getAllSpContainers\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xls/LoadSpreadsheet.php
-
-		-
-			message: '#^Cannot call method getBSECollection\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xls/LoadSpreadsheet.php
-
-		-
-			message: '#^Cannot call method getBstoreContainer\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xls/LoadSpreadsheet.php
-
-		-
-			message: '#^Cannot call method getSpgrContainer\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/PhpSpreadsheet/Reader/Xls/LoadSpreadsheet.php
-
-		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1

--- a/src/PhpSpreadsheet/Reader/Xls/Escher.php
+++ b/src/PhpSpreadsheet/Reader/Xls/Escher.php
@@ -12,6 +12,9 @@ use PhpOffice\PhpSpreadsheet\Shared\Escher\DggContainer\BstoreContainer;
 use PhpOffice\PhpSpreadsheet\Shared\Escher\DggContainer\BstoreContainer\BSE;
 use PhpOffice\PhpSpreadsheet\Shared\Escher\DggContainer\BstoreContainer\BSE\Blip;
 
+/**
+ * @template T of BSE|BstoreContainer|DgContainer|DggContainer|\PhpOffice\PhpSpreadsheet\Shared\Escher|SpContainer|SpgrContainer
+ */
 class Escher
 {
     const DGGCONTAINER = 0xF000;
@@ -50,11 +53,15 @@ class Escher
 
     /**
      * The object to be returned by the reader. Modified during load.
+     *
+     * @var T
      */
     private BSE|BstoreContainer|DgContainer|DggContainer|\PhpOffice\PhpSpreadsheet\Shared\Escher|SpContainer|SpgrContainer $object;
 
     /**
      * Create a new Escher instance.
+     *
+     * @param T $object
      */
     public function __construct(BSE|BstoreContainer|DgContainer|DggContainer|\PhpOffice\PhpSpreadsheet\Shared\Escher|SpContainer|SpgrContainer $object)
     {
@@ -84,6 +91,8 @@ class Escher
 
     /**
      * Load Escher stream data. May be a partial Escher stream.
+     *
+     * @return T
      */
     public function load(string $data): BSE|BstoreContainer|DgContainer|DggContainer|\PhpOffice\PhpSpreadsheet\Shared\Escher|SpContainer|SpgrContainer
     {

--- a/src/PhpSpreadsheet/Reader/Xls/LoadSpreadsheet.php
+++ b/src/PhpSpreadsheet/Reader/Xls/LoadSpreadsheet.php
@@ -435,7 +435,7 @@ class LoadSpreadsheet extends Xls
 
                 // get all spContainers in one long array, so they can be mapped to OBJ records
                 /** @var SpContainer[] $allSpContainers */
-                $allSpContainers = method_exists($escherWorksheet, 'getDgContainer') ? $escherWorksheet->getDgContainer()->getSpgrContainer()->getAllSpContainers() : [];
+                $allSpContainers = $escherWorksheet->getDgContainerOrThrow()->getSpgrContainerOrThrow()->getAllSpContainers();
             }
 
             // treat OBJ records
@@ -497,7 +497,7 @@ class LoadSpreadsheet extends Xls
 
                             if ($escherWorkbook) {
                                 /** @var BSE[] */
-                                $BSECollection = method_exists($escherWorkbook, 'getDggContainer') ? $escherWorkbook->getDggContainer()->getBstoreContainer()->getBSECollection() : [];
+                                $BSECollection = $escherWorkbook->getDggContainerOrThrow()->getBstoreContainerOrThrow()->getBSECollection();
                                 $BSE = $BSECollection[$BSEindex - 1];
                                 $blipType = $BSE->getBlipType();
 

--- a/src/PhpSpreadsheet/Shared/Escher.php
+++ b/src/PhpSpreadsheet/Shared/Escher.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheet\Shared;
 
+use PhpOffice\PhpSpreadsheet\Exception as SpreadsheetException;
+
 class Escher
 {
     /**
@@ -23,6 +25,14 @@ class Escher
     }
 
     /**
+     * Get Drawing Group Container.
+     */
+    public function getDggContainerOrThrow(): Escher\DggContainer
+    {
+        return $this->dggContainer ?? throw new SpreadsheetException('dggContainer is unexpectedly null');
+    }
+
+    /**
      * Set Drawing Group Container.
      */
     public function setDggContainer(Escher\DggContainer $dggContainer): Escher\DggContainer
@@ -36,6 +46,14 @@ class Escher
     public function getDgContainer(): ?Escher\DgContainer
     {
         return $this->dgContainer;
+    }
+
+    /**
+     * Get Drawing Container.
+     */
+    public function getDgContainerOrThrow(): Escher\DgContainer
+    {
+        return $this->dgContainer ?? throw new SpreadsheetException('dgContainer is unexpectedly null');
     }
 
     /**

--- a/src/PhpSpreadsheet/Shared/Escher/DggContainer.php
+++ b/src/PhpSpreadsheet/Shared/Escher/DggContainer.php
@@ -2,6 +2,8 @@
 
 namespace PhpOffice\PhpSpreadsheet\Shared\Escher;
 
+use PhpOffice\PhpSpreadsheet\Exception as SpreadsheetException;
+
 class DggContainer
 {
     /**
@@ -92,6 +94,14 @@ class DggContainer
     public function getBstoreContainer(): ?DggContainer\BstoreContainer
     {
         return $this->bstoreContainer;
+    }
+
+    /**
+     * Get BLIP Store Container.
+     */
+    public function getBstoreContainerOrThrow(): DggContainer\BstoreContainer
+    {
+        return $this->bstoreContainer ?? throw new SpreadsheetException('bstoreContainer is unexpectedly null');
     }
 
     /**


### PR DESCRIPTION
This is:

- [X] refactoring

Checklist:

- [ ] Changes are covered by unit tests
  - [X] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [X] Code style is respected
- [X] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Extra checks are currently needed on the result of the `Escher::load` method, as its not clear what the return type becomes.

By making this class generic, we allow to infer the return type from the constructor argument, for static analysis tools.

Additional `get...OrThrow` methods have been added, to throw more precise errors, rather than Fail due to a method call on null.
