### PR TITLE
Use `calculateFormula` Rather Than `_calculateFormulaValue` in Tests

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateDifTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateDifTest.php
@@ -33,7 +33,7 @@ class DateDifTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DATEDIF({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -104,7 +104,7 @@ class DateDifTest extends TestCase
         } else {
             $formula = "=DATEDIF({$startDate}, {$endDate}, {$methods})";
         }
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateTest.php
@@ -53,7 +53,7 @@ class DateTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DATE({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -144,7 +144,7 @@ class DateTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=DATE({$year}, {$month}, {$day})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
@@ -211,7 +211,7 @@ class DateTest extends TestCase
         $this->expectExceptionMessage('Formulae with more than two array arguments are not supported');
 
         $formula = "=DATE({$year}, {$month}, {$day})";
-        $calculation->_calculateFormulaValue($formula);
+        $calculation->calculateFormula($formula);
     }
 
     public static function providerDateArrayException(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateValueTest.php
@@ -78,7 +78,7 @@ class DateValueTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DATEVALUE({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-8);
     }
 
@@ -182,7 +182,7 @@ class DateValueTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=DATEVALUE({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DayTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DayTest.php
@@ -46,7 +46,7 @@ class DayTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DAY({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResultExcel, $result);
     }
 
@@ -92,7 +92,7 @@ class DayTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DAY({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResultOpenOffice, $result);
     }
 
@@ -140,7 +140,7 @@ class DayTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=DAY({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/Days360Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/Days360Test.php
@@ -32,7 +32,7 @@ class Days360Test extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DAYS360({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -103,7 +103,7 @@ class Days360Test extends TestCase
         } else {
             $formula = "=DAYS360({$startDate}, {$endDate}, {$methods})";
         }
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DaysTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DaysTest.php
@@ -31,7 +31,7 @@ class DaysTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=DAYS({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -98,7 +98,7 @@ class DaysTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=DAYS({$startDate}, {$endDate})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/EDateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/EDateTest.php
@@ -47,7 +47,7 @@ class EDateTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=EDATE({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -129,7 +129,7 @@ class EDateTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=EDATE({$dateValues}, {$methods})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/EoMonthTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/EoMonthTest.php
@@ -47,7 +47,7 @@ class EoMonthTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=EOMONTH({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -128,7 +128,7 @@ class EoMonthTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=EOMONTH({$dateValues}, {$methods})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/HourTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/HourTest.php
@@ -29,7 +29,7 @@ class HourTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=HOUR({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -89,7 +89,7 @@ class HourTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=HOUR({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/IsoWeekNumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/IsoWeekNumTest.php
@@ -46,7 +46,7 @@ class IsoWeekNumTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=ISOWEEKNUM({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -120,7 +120,7 @@ class IsoWeekNumTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=ISOWEEKNUM({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/MinuteTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/MinuteTest.php
@@ -29,7 +29,7 @@ class MinuteTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=MINUTE({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -89,7 +89,7 @@ class MinuteTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=MINUTE({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/MonthTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/MonthTest.php
@@ -29,7 +29,7 @@ class MonthTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=MONTH({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -89,7 +89,7 @@ class MonthTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=MONTH({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/NetworkDaysTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/NetworkDaysTest.php
@@ -28,7 +28,7 @@ class NetworkDaysTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=NETWORKDAYS({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -93,7 +93,7 @@ class NetworkDaysTest extends TestCase
         } else {
             $formula = "=NETWORKDAYS({$startDate}, {$endDays}, {$holidays})";
         }
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/NowTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/NowTest.php
@@ -47,7 +47,7 @@ class NowTest extends TestCase
         do {
             $dtStart = new DateTimeImmutable();
             $startSecond = $dtStart->format('s');
-            $result = $calculation->_calculateFormulaValue($formula);
+            $result = $calculation->calculateFormula($formula);
             $endSecond = (new DateTimeImmutable('now'))->format('s');
         } while ($startSecond !== $endSecond);
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/SecondTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/SecondTest.php
@@ -28,7 +28,7 @@ class SecondTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=SECOND({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -88,7 +88,7 @@ class SecondTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=SECOND({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeTest.php
@@ -53,7 +53,7 @@ class TimeTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=TIME({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-12);
     }
 
@@ -129,7 +129,7 @@ class TimeTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=TIME({$hour}, {$minute}, {$second})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
@@ -196,7 +196,7 @@ class TimeTest extends TestCase
         $this->expectExceptionMessage('Formulae with more than two array arguments are not supported');
 
         $formula = "=TIME({$hour}, {$minute}, {$second})";
-        $calculation->_calculateFormulaValue($formula);
+        $calculation->calculateFormula($formula);
     }
 
     public static function providerTimeArrayException(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeValueTest.php
@@ -47,7 +47,7 @@ class TimeValueTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=TIMEVALUE({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-8);
     }
 
@@ -137,7 +137,7 @@ class TimeValueTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=TIMEVALUE({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TodayTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TodayTest.php
@@ -47,7 +47,7 @@ class TodayTest extends TestCase
         do {
             $dtStart = new DateTimeImmutable();
             $startSecond = $dtStart->format('s');
-            $result = $calculation->_calculateFormulaValue($formula);
+            $result = $calculation->calculateFormula($formula);
             $endSecond = (new DateTimeImmutable('now'))->format('s');
         } while ($startSecond !== $endSecond);
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WeekDayTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WeekDayTest.php
@@ -45,7 +45,7 @@ class WeekDayTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=WEEKDAY({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -114,7 +114,7 @@ class WeekDayTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=WEEKDAY({$dateValues}, {$styles})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WeekNumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WeekNumTest.php
@@ -46,7 +46,7 @@ class WeekNumTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=WEEKNUM({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -120,7 +120,7 @@ class WeekNumTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=WEEKNUM({$dateValues}, {$methods})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WorkDayTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WorkDayTest.php
@@ -28,7 +28,7 @@ class WorkDayTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=WORKDAY({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -92,7 +92,7 @@ class WorkDayTest extends TestCase
         } else {
             $formula = "=WORKDAY({$startDate}, {$endDays}, {$holidays})";
         }
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/YearFracTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/YearFracTest.php
@@ -29,7 +29,7 @@ class YearFracTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=YEARFRAC({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-6);
     }
 
@@ -94,7 +94,7 @@ class YearFracTest extends TestCase
         } else {
             $formula = "=YEARFRAC({$startDate}, {$endDate}, {$methods})";
         }
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/YearTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/YearTest.php
@@ -28,7 +28,7 @@ class YearTest extends TestCase
         $calculation = Calculation::getInstance();
         $formula = "=YEAR({$arguments})";
 
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 
@@ -88,7 +88,7 @@ class YearTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=YEAR({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/ErrorTypeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/ErrorTypeTest.php
@@ -6,6 +6,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Information;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ErrorTypeTest extends TestCase
@@ -16,7 +17,7 @@ class ErrorTypeTest extends TestCase
         self::assertSame(ExcelError::NA(), $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerErrorType')]
+    #[DataProvider('providerErrorType')]
     public function testErrorType(int|string $expectedResult, mixed $value): void
     {
         $result = ExcelError::type($value);
@@ -28,14 +29,14 @@ class ErrorTypeTest extends TestCase
         return require 'tests/data/Calculation/Information/ERROR_TYPE.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerErrorTypeArray')]
+    #[DataProvider('providerErrorTypeArray')]
     public function testErrorTypeArray(array $expectedResult, string $values): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ERROR.TYPE({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerErrorTypeArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsBlankTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsBlankTest.php
@@ -6,6 +6,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Information;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\Value;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IsBlankTest extends TestCase
@@ -16,7 +17,7 @@ class IsBlankTest extends TestCase
         self::assertTrue($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsBlank')]
+    #[DataProvider('providerIsBlank')]
     public function testIsBlank(bool $expectedResult, mixed $value): void
     {
         $result = Value::isBlank($value);
@@ -28,14 +29,14 @@ class IsBlankTest extends TestCase
         return require 'tests/data/Calculation/Information/IS_BLANK.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsBlankArray')]
+    #[DataProvider('providerIsBlankArray')]
     public function testIsBlankArray(array $expectedResult, string $values): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ISBLANK({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIsBlankArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsErrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsErrTest.php
@@ -6,6 +6,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Information;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ErrorValue;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IsErrTest extends TestCase
@@ -16,7 +17,7 @@ class IsErrTest extends TestCase
         self::assertFalse($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsErr')]
+    #[DataProvider('providerIsErr')]
     public function testIsErr(bool $expectedResult, mixed $value): void
     {
         $result = ErrorValue::isErr($value);
@@ -28,14 +29,14 @@ class IsErrTest extends TestCase
         return require 'tests/data/Calculation/Information/IS_ERR.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsErrArray')]
+    #[DataProvider('providerIsErrArray')]
     public function testIsErrArray(array $expectedResult, string $values): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ISERR({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIsErrArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsErrorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsErrorTest.php
@@ -6,6 +6,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Information;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ErrorValue;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IsErrorTest extends TestCase
@@ -16,7 +17,7 @@ class IsErrorTest extends TestCase
         self::assertFalse($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsError')]
+    #[DataProvider('providerIsError')]
     public function testIsError(bool $expectedResult, mixed $value): void
     {
         $result = ErrorValue::isError($value);
@@ -28,14 +29,14 @@ class IsErrorTest extends TestCase
         return require 'tests/data/Calculation/Information/IS_ERROR.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsErrorArray')]
+    #[DataProvider('providerIsErrorArray')]
     public function testIsErrorArray(array $expectedResult, string $values): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ISERROR({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIsErrorArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsEvenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsEvenTest.php
@@ -7,6 +7,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Information;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\Value;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IsEvenTest extends TestCase
@@ -17,7 +18,7 @@ class IsEvenTest extends TestCase
         self::assertSame(ExcelError::NAME(), $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsEven')]
+    #[DataProvider('providerIsEven')]
     public function testIsEven(bool|string $expectedResult, mixed $value): void
     {
         $result = Value::isEven($value);
@@ -29,14 +30,14 @@ class IsEvenTest extends TestCase
         return require 'tests/data/Calculation/Information/IS_EVEN.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsEvenArray')]
+    #[DataProvider('providerIsEvenArray')]
     public function testIsEvenArray(array $expectedResult, string $values): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ISEVEN({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIsEvenArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsFormulaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsFormulaTest.php
@@ -114,8 +114,8 @@ class IsFormulaTest extends TestCase
         $calculation = Calculation::getInstance($spreadsheet);
 
         $formula = '=ISFORMULA(A1:A7)';
-        $result = $calculation->_calculateFormulaValue($formula, 'C1', $sheet->getCell('C1'));
-        self::assertEquals([true, false, true, false, true, false, false], $result);
+        $result = $calculation->calculateFormula($formula, 'C1', $sheet->getCell('C1'));
+        self::assertSame([true, false, true, false, true, false, false], $result);
 
         $spreadsheet->disconnectWorksheets();
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsLogicalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsLogicalTest.php
@@ -6,6 +6,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Information;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\Value;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IsLogicalTest extends TestCase
@@ -16,7 +17,7 @@ class IsLogicalTest extends TestCase
         self::assertFalse($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsLogical')]
+    #[DataProvider('providerIsLogical')]
     public function testIsLogical(bool $expectedResult, mixed $value): void
     {
         $result = Value::isLogical($value);
@@ -28,14 +29,14 @@ class IsLogicalTest extends TestCase
         return require 'tests/data/Calculation/Information/IS_LOGICAL.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsLogicalArray')]
+    #[DataProvider('providerIsLogicalArray')]
     public function testIsLogicalArray(array $expectedResult, string $values): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ISLOGICAL({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIsLogicalArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsNaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsNaTest.php
@@ -6,6 +6,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Information;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ErrorValue;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IsNaTest extends TestCase
@@ -16,7 +17,7 @@ class IsNaTest extends TestCase
         self::assertFalse($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsNa')]
+    #[DataProvider('providerIsNa')]
     public function testIsNa(bool $expectedResult, mixed $value): void
     {
         $result = ErrorValue::isNa($value);
@@ -28,14 +29,14 @@ class IsNaTest extends TestCase
         return require 'tests/data/Calculation/Information/IS_NA.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsNaArray')]
+    #[DataProvider('providerIsNaArray')]
     public function testIsNaArray(array $expectedResult, string $values): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ISNA({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIsNaArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsNonTextTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsNonTextTest.php
@@ -6,6 +6,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Information;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\Value;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IsNonTextTest extends TestCase
@@ -16,7 +17,7 @@ class IsNonTextTest extends TestCase
         self::assertTrue($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsNonText')]
+    #[DataProvider('providerIsNonText')]
     public function testIsNonText(bool $expectedResult, mixed $value): void
     {
         $result = Value::isNonText($value);
@@ -28,14 +29,14 @@ class IsNonTextTest extends TestCase
         return require 'tests/data/Calculation/Information/IS_NONTEXT.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsNonTextArray')]
+    #[DataProvider('providerIsNonTextArray')]
     public function testIsNonTextArray(array $expectedResult, string $values): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ISNONTEXT({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIsNonTextArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsNumberTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsNumberTest.php
@@ -6,6 +6,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Information;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\Value;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IsNumberTest extends TestCase
@@ -16,7 +17,7 @@ class IsNumberTest extends TestCase
         self::assertFalse($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsNumber')]
+    #[DataProvider('providerIsNumber')]
     public function testIsNumber(bool $expectedResult, mixed $value): void
     {
         $result = Value::isNumber($value);
@@ -28,14 +29,14 @@ class IsNumberTest extends TestCase
         return require 'tests/data/Calculation/Information/IS_NUMBER.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsNumberArray')]
+    #[DataProvider('providerIsNumberArray')]
     public function testIsNumberArray(array $expectedResult, string $values): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ISNUMBER({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIsNumberArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsOddTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsOddTest.php
@@ -7,6 +7,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Information;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\ExcelError;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\Value;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IsOddTest extends TestCase
@@ -17,7 +18,7 @@ class IsOddTest extends TestCase
         self::assertSame(ExcelError::NAME(), $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsOdd')]
+    #[DataProvider('providerIsOdd')]
     public function testIsOdd(bool|string $expectedResult, mixed $value): void
     {
         $result = Value::isOdd($value);
@@ -29,14 +30,14 @@ class IsOddTest extends TestCase
         return require 'tests/data/Calculation/Information/IS_ODD.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsOddArray')]
+    #[DataProvider('providerIsOddArray')]
     public function testIsOddArray(array $expectedResult, string $values): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ISODD({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIsOddArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsTextTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsTextTest.php
@@ -6,6 +6,7 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Information;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Information\Value;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IsTextTest extends TestCase
@@ -16,7 +17,7 @@ class IsTextTest extends TestCase
         self::assertFalse($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsText')]
+    #[DataProvider('providerIsText')]
     public function testIsText(bool $expectedResult, mixed $value): void
     {
         $result = Value::isText($value);
@@ -28,14 +29,14 @@ class IsTextTest extends TestCase
         return require 'tests/data/Calculation/Information/IS_TEXT.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIsTextArray')]
+    #[DataProvider('providerIsTextArray')]
     public function testIsTextArray(array $expectedResult, string $values): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ISTEXT({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIsTextArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfErrorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfErrorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Logical;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class IfErrorTest extends AllSetupTeardown
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIFERROR')]
+    #[DataProvider('providerIFERROR')]
     public function testIFERROR(mixed $expectedResult, mixed ...$args): void
     {
         $this->runTestCase('IFERROR', $expectedResult, ...$args);
@@ -19,14 +20,14 @@ class IfErrorTest extends AllSetupTeardown
         return require 'tests/data/Calculation/Logical/IFERROR.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIfErrorArray')]
+    #[DataProvider('providerIfErrorArray')]
     public function testIfErrorArray(array $expectedResult, string $argument1, string $argument2): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IFERROR({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIfErrorArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfNaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfNaTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Logical;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class IfNaTest extends AllSetupTeardown
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIFNA')]
+    #[DataProvider('providerIFNA')]
     public function testIFNA(mixed $expectedResult, mixed ...$args): void
     {
         $this->runTestCase('IFNA', $expectedResult, ...$args);
@@ -19,14 +20,14 @@ class IfNaTest extends AllSetupTeardown
         return require 'tests/data/Calculation/Logical/IFNA.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIfNaArray')]
+    #[DataProvider('providerIfNaArray')]
     public function testIfNaArray(array $expectedResult, string $argument1, string $argument2): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IFNA({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIfNaArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfsTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Logical;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class IfsTest extends AllSetupTeardown
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIFS')]
+    #[DataProvider('providerIFS')]
     public function testIFS(mixed $expectedResult, mixed ...$args): void
     {
         $this->runTestCase('IFS', $expectedResult, ...$args);
@@ -19,14 +20,14 @@ class IfsTest extends AllSetupTeardown
         return require 'tests/data/Calculation/Logical/IFS.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIfsArray')]
+    #[DataProvider('providerIfsArray')]
     public function testIfsArray(array $expectedResult, string $bool1, string $argument1, string $bool2, string $argument2): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=IFS($bool1, {" . "$argument1}, $bool2, {" . "$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIfsArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/NotTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/NotTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Logical;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class NotTest extends AllSetupTeardown
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerNOT')]
+    #[DataProvider('providerNOT')]
     public function testNOT(mixed $expectedResult, mixed ...$args): void
     {
         $this->runTestCase('NOT', $expectedResult, ...$args);
@@ -19,14 +20,14 @@ class NotTest extends AllSetupTeardown
         return require 'tests/data/Calculation/Logical/NOT.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerNotArray')]
+    #[DataProvider('providerNotArray')]
     public function testNotArray(array $expectedResult, string $argument1): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=NOT({$argument1})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerNotArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/SwitchTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/SwitchTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\Logical;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SwitchTest extends AllSetupTeardown
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerSwitch')]
+    #[DataProvider('providerSwitch')]
     public function testSWITCH(mixed $expectedResult, mixed ...$args): void
     {
         $this->runTestCase('SWITCH', $expectedResult, ...$args);
@@ -19,14 +20,14 @@ class SwitchTest extends AllSetupTeardown
         return require 'tests/data/Calculation/Logical/SWITCH.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerSwitchArray')]
+    #[DataProvider('providerSwitchArray')]
     public function testIfsArray(array $expectedResult, int $expression, int $value1, string $result1, int $value2, string $result2, string $default): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=SWITCH($expression, $value1, {" . "$result1}, $value2, {" . "$result2}, {" . "$default})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerSwitchArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AddressTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AddressTest.php
@@ -6,11 +6,12 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
 
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\LookupRef;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class AddressTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerADDRESS')]
+    #[DataProvider('providerADDRESS')]
     public function testADDRESS(mixed $expectedResult, mixed ...$args): void
     {
         $result = LookupRef\Address::cell(...$args);
@@ -22,14 +23,14 @@ class AddressTest extends TestCase
         return require 'tests/data/Calculation/LookupRef/ADDRESS.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerAddressArray')]
+    #[DataProvider('providerAddressArray')]
     public function testAddressArray(array $expectedResult, string $argument1, string $argument2): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=ADDRESS({$argument1}, {$argument2}, 4)";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerAddressArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ChooseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ChooseTest.php
@@ -31,8 +31,8 @@ class ChooseTest extends TestCase
 
         $selections = implode(',', $selections);
         $formula = "=CHOOSE({$values}, {$selections})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerChooseArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnsTest.php
@@ -30,8 +30,8 @@ class ColumnsTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=COLUMNS({$argument})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerColumnsArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/HLookupTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/HLookupTest.php
@@ -109,8 +109,8 @@ class HLookupTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=HLOOKUP({$values}, {$database}, {$index}, false)";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerHLookupArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndexTest.php
@@ -7,11 +7,12 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\LookupRef\Matrix;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IndexTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerINDEX')]
+    #[DataProvider('providerINDEX')]
     public function testINDEX(mixed $expectedResult, mixed $matrix, mixed $rowNum = null, mixed $colNum = null): void
     {
         if ($rowNum === null) {
@@ -29,14 +30,14 @@ class IndexTest extends TestCase
         return require 'tests/data/Calculation/LookupRef/INDEX.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerIndexArray')]
+    #[DataProvider('providerIndexArray')]
     public function testIndexArray(array $expectedResult, string $matrix, string $rows, string $columns): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=INDEX({$matrix}, {$rows}, {$columns})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerIndexArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/LookupTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/LookupTest.php
@@ -7,11 +7,12 @@ namespace PhpOffice\PhpSpreadsheetTests\Calculation\Functions\LookupRef;
 use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\LookupRef;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class LookupTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerLOOKUP')]
+    #[DataProvider('providerLOOKUP')]
     public function testLOOKUP(mixed $expectedResult, mixed ...$args): void
     {
         $result = LookupRef\Lookup::lookup(...$args);
@@ -23,14 +24,14 @@ class LookupTest extends TestCase
         return require 'tests/data/Calculation/LookupRef/LOOKUP.php';
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('providerLookupArray')]
+    #[DataProvider('providerLookupArray')]
     public function testLookupArray(array $expectedResult, string $values, string $lookup, string $return): void
     {
         $calculation = Calculation::getInstance();
 
         $formula = "=LOOKUP({$values}, {$lookup}, {$return})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerLookupArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/MatchTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/MatchTest.php
@@ -67,7 +67,7 @@ class MatchTest extends AllSetupTeardown
         $sheet->getCell('D1')->setValue($formula);
 
         $result = $sheet->getCell('D1')->getCalculatedValue();
-        self::assertEquals($expectedResult, $result);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerMATCH(): array
@@ -81,8 +81,8 @@ class MatchTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=MATCH({$values}, {$selections}, 0)";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerMatchArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowsTest.php
@@ -30,8 +30,8 @@ class RowsTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=ROWS({$argument})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerRowsArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/VLookupTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/VLookupTest.php
@@ -52,8 +52,8 @@ class VLookupTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=VLOOKUP({$values}, {$database}, {$index}, false)";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEquals($expectedResult, $result);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerVLookupArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AbsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AbsTest.php
@@ -34,7 +34,7 @@ class AbsTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ABS({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcosTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcosTest.php
@@ -30,7 +30,7 @@ class AcosTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ACOS({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcoshTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcoshTest.php
@@ -30,7 +30,7 @@ class AcoshTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ACOSH({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcotTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcotTest.php
@@ -33,7 +33,7 @@ class AcotTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ACOT({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcothTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcothTest.php
@@ -33,7 +33,7 @@ class AcothTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ACOTH({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ArabicTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ArabicTest.php
@@ -30,7 +30,7 @@ class ArabicTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ARABIC({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AsinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AsinTest.php
@@ -30,7 +30,7 @@ class AsinTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ASIN({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AsinhTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AsinhTest.php
@@ -30,7 +30,7 @@ class AsinhTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ASINH({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/Atan2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/Atan2Test.php
@@ -31,7 +31,7 @@ class Atan2Test extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ATAN2({$argument1},{$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AtanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AtanTest.php
@@ -30,7 +30,7 @@ class AtanTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ATAN({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AtanhTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AtanhTest.php
@@ -30,7 +30,7 @@ class AtanhTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ATANH({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/BaseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/BaseTest.php
@@ -46,7 +46,7 @@ class BaseTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=BASE({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingMathTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingMathTest.php
@@ -33,7 +33,7 @@ class CeilingMathTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CEILING.MATH({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingPreciseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingPreciseTest.php
@@ -33,7 +33,7 @@ class CeilingPreciseTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CEILING.PRECISE({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingTest.php
@@ -79,7 +79,7 @@ class CeilingTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CEILING({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CombinATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CombinATest.php
@@ -35,7 +35,7 @@ class CombinATest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=COMBINA({$argument1},{$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CombinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CombinTest.php
@@ -35,7 +35,7 @@ class CombinTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=COMBIN({$argument1},{$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CosTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CosTest.php
@@ -30,7 +30,7 @@ class CosTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=COS({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CoshTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CoshTest.php
@@ -30,7 +30,7 @@ class CoshTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=COSH({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CotTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CotTest.php
@@ -33,7 +33,7 @@ class CotTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=COT({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CothTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CothTest.php
@@ -33,7 +33,7 @@ class CothTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=COTH({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CscTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CscTest.php
@@ -33,7 +33,7 @@ class CscTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CSC({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CschTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CschTest.php
@@ -33,7 +33,7 @@ class CschTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CSCH({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/DegreesTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/DegreesTest.php
@@ -34,7 +34,7 @@ class DegreesTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=DEGREES({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-12);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/EvenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/EvenTest.php
@@ -29,7 +29,7 @@ class EvenTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=EVEN({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ExpTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ExpTest.php
@@ -36,7 +36,7 @@ class ExpTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=EXP({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FactDoubleTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FactDoubleTest.php
@@ -30,7 +30,7 @@ class FactDoubleTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=FACTDOUBLE({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FactTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FactTest.php
@@ -61,7 +61,7 @@ class FactTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=FACT({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::FACT_PRECISION);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorMathTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorMathTest.php
@@ -33,7 +33,7 @@ class FloorMathTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=FLOOR.MATH({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorPreciseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorPreciseTest.php
@@ -33,7 +33,7 @@ class FloorPreciseTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=FLOOR.PRECISE({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorTest.php
@@ -79,7 +79,7 @@ class FloorTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=FLOOR({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/IntTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/IntTest.php
@@ -33,7 +33,7 @@ class IntTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=INT({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LnTest.php
@@ -36,7 +36,7 @@ class LnTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=LN({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/Log10Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/Log10Test.php
@@ -36,7 +36,7 @@ class Log10Test extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=LOG10({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LogTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LogTest.php
@@ -41,7 +41,7 @@ class LogTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=LOG({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MRoundTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MRoundTest.php
@@ -33,7 +33,7 @@ class MRoundTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=MROUND({$argument1},{$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ModTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ModTest.php
@@ -41,7 +41,7 @@ class ModTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=MOD({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/OddTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/OddTest.php
@@ -29,7 +29,7 @@ class OddTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ODD({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/PowerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/PowerTest.php
@@ -41,7 +41,7 @@ class PowerTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=POWER({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/QuotientTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/QuotientTest.php
@@ -41,7 +41,7 @@ class QuotientTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=QUOTIENT({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RadiansTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RadiansTest.php
@@ -34,7 +34,7 @@ class RadiansTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=RADIANS({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RandBetweenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RandBetweenTest.php
@@ -52,7 +52,7 @@ class RandBetweenTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=RandBetween({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertIsArray($result);
         self::assertCount($expectedRows, $result);
         self::assertIsArray($result[0]);

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RomanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RomanTest.php
@@ -30,7 +30,7 @@ class RomanTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ROMAN({$values}, {$styles})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundDownTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundDownTest.php
@@ -33,7 +33,7 @@ class RoundDownTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ROUNDDOWN({$argument1},{$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundTest.php
@@ -33,7 +33,7 @@ class RoundTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ROUND({$argument1},{$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundUpTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundUpTest.php
@@ -33,7 +33,7 @@ class RoundUpTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ROUNDUP({$argument1},{$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SecTest.php
@@ -33,7 +33,7 @@ class SecTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=SEC({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SechTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SechTest.php
@@ -33,7 +33,7 @@ class SechTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=SECH({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SeriesSumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SeriesSumTest.php
@@ -46,7 +46,7 @@ class SeriesSumTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=SERIESSUM({$x}, {$n}, {$m}, {$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SignTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SignTest.php
@@ -32,7 +32,7 @@ class SignTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=SIGN({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SinTest.php
@@ -30,7 +30,7 @@ class SinTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=SIN({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SinhTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SinhTest.php
@@ -30,7 +30,7 @@ class SinhTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=SINH({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SqrtPiTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SqrtPiTest.php
@@ -36,7 +36,7 @@ class SqrtPiTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=SQRTPI({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-12);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SqrtTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SqrtTest.php
@@ -34,7 +34,7 @@ class SqrtTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=SQRT({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TanTest.php
@@ -30,7 +30,7 @@ class TanTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=TAN({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TanhTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TanhTest.php
@@ -30,7 +30,7 @@ class TanhTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=TANH({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TruncTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TruncTest.php
@@ -33,7 +33,7 @@ class TruncTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=TRUNC({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BetaDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BetaDistTest.php
@@ -25,7 +25,7 @@ class BetaDistTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=BETADIST({$argument1}, {$argument2}, {$argument3})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BetaInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BetaInvTest.php
@@ -25,7 +25,7 @@ class BetaInvTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=BETAINV({$argument1}, {$argument2}, {$argument3})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BinomDistRangeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BinomDistRangeTest.php
@@ -29,7 +29,7 @@ class BinomDistRangeTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=BINOM.DIST.RANGE({$trials}, {$probabilities}, {$successes})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BinomDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BinomDistTest.php
@@ -29,7 +29,7 @@ class BinomDistTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=BINOMDIST({$values}, {$trials}, {$probabilities}, false)";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BinomInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BinomInvTest.php
@@ -29,7 +29,7 @@ class BinomInvTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=BINOM.INV({$trials}, {$probabilities}, {$alphas})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiDistLeftTailTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiDistLeftTailTest.php
@@ -26,7 +26,7 @@ class ChiDistLeftTailTest extends AllSetupTeardown
 
         $formula = "=CHISQ.DIST({$values}, {$degrees}, false)";
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiDistRightTailTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiDistRightTailTest.php
@@ -25,7 +25,7 @@ class ChiDistRightTailTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CHISQ.DIST.RT({$values}, {$degrees})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiInvLeftTailTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiInvLeftTailTest.php
@@ -27,10 +27,10 @@ class ChiInvLeftTailTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
         $formula = "=CHISQ.INV($probability, $degrees)";
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-8);
         $formula = "=CHISQ.DIST($result, $degrees)";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($probability, $result, 1.0e-8);
     }
 
@@ -40,7 +40,7 @@ class ChiInvLeftTailTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CHISQ.INV({$probabilities}, {$degrees})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiInvRightTailTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiInvRightTailTest.php
@@ -27,10 +27,10 @@ class ChiInvRightTailTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
         $formula = "=CHISQ.INV.RT($probability, $degrees)";
         /** @var float|int|string */
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-8);
         $formula = "=CHISQ.DIST.RT($result, $degrees)";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($probability, $result, 1.0e-8);
     }
 
@@ -40,7 +40,7 @@ class ChiInvRightTailTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CHISQ.INV.RT({$probabilities}, {$degrees})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ConfidenceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ConfidenceTest.php
@@ -25,7 +25,7 @@ class ConfidenceTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CONFIDENCE({$alpha}, {$stdDev}, {$size})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ExponDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ExponDistTest.php
@@ -25,7 +25,7 @@ class ExponDistTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=EXPONDIST({$values}, {$lambdas}, false)";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FDistTest.php
@@ -25,7 +25,7 @@ class FDistTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=F.DIST({$values}, {$u}, {$v}, false)";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FisherInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FisherInvTest.php
@@ -25,7 +25,7 @@ class FisherInvTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=FISHERINV({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FisherTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FisherTest.php
@@ -25,7 +25,7 @@ class FisherTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=FISHER({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ForecastTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ForecastTest.php
@@ -30,7 +30,7 @@ class ForecastTest extends TestCase
         $calculation = Calculation::getInstance();
 
         $formula = "=FORECAST({$testValues}, {$yValues}, {$xValues})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaDistTest.php
@@ -25,7 +25,7 @@ class GammaDistTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=GAMMA.DIST({$values}, {$alpha}, {$beta}, false)";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaInvTest.php
@@ -25,7 +25,7 @@ class GammaInvTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=GAMMA.INV({$values}, {$alpha}, {$beta})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaLnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaLnTest.php
@@ -25,7 +25,7 @@ class GammaLnTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=GAMMALN({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaTest.php
@@ -25,7 +25,7 @@ class GammaTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=GAMMA({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GaussTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GaussTest.php
@@ -25,7 +25,7 @@ class GaussTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=GAUSS({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/HypGeomDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/HypGeomDistTest.php
@@ -30,7 +30,7 @@ class HypGeomDistTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=HYPGEOMDIST({$sampleSuccesses}, {$sampleNumber}, {$populationSuccesses}, {$populationNumber})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogInvTest.php
@@ -25,7 +25,7 @@ class LogInvTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=LOGINV({$probabilities}, {$mean}, {$stdDev})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogNormDist2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogNormDist2Test.php
@@ -25,7 +25,7 @@ class LogNormDist2Test extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=LOGNORM.DIST({$values}, {$mean}, {$stdDev}, true)";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogNormDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogNormDistTest.php
@@ -25,7 +25,7 @@ class LogNormDistTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=LOGNORMDIST({$values}, {$mean}, {$stdDev})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NegBinomDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NegBinomDistTest.php
@@ -29,7 +29,7 @@ class NegBinomDistTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=NEGBINOMDIST({$failures}, {$successes}, {$probabilities})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormDistTest.php
@@ -25,7 +25,7 @@ class NormDistTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=NORMDIST({$values}, {$mean}, {$stdDev}, false)";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormInvTest.php
@@ -25,7 +25,7 @@ class NormInvTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=NORMINV({$probabilities}, {$mean}, {$stdDev})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormSDist2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormSDist2Test.php
@@ -25,7 +25,7 @@ class NormSDist2Test extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=NORM.S.DIST({$values}, true)";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormSDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormSDistTest.php
@@ -25,7 +25,7 @@ class NormSDistTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=NORMSDIST({$values})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormSInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormSInvTest.php
@@ -25,7 +25,7 @@ class NormSInvTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=NORMSINV({$probabilities})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PermutTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PermutTest.php
@@ -25,7 +25,7 @@ class PermutTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=PERMUT({$argument1},{$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PermutationATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PermutationATest.php
@@ -25,7 +25,7 @@ class PermutationATest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=PERMUTATIONA({$argument1},{$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PoissonTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PoissonTest.php
@@ -25,7 +25,7 @@ class PoissonTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=POISSON({$values}, {$mean}, false)";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/StandardizeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/StandardizeTest.php
@@ -25,7 +25,7 @@ class StandardizeTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=STANDARDIZE({$argument1}, {$argument2}, {$argument3})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TDistTest.php
@@ -25,7 +25,7 @@ class TDistTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=TDIST({$values}, {$degrees}, {$tails})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TinvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TinvTest.php
@@ -25,7 +25,7 @@ class TinvTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=TINV({$values}, {$degrees})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/WeibullTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/WeibullTest.php
@@ -25,7 +25,7 @@ class WeibullTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=WEIBULL({$values}, {$alpha}, {$beta}, false)";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ZTestTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ZTestTest.php
@@ -25,7 +25,7 @@ class ZTestTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=ZTEST({$dataSet}, {$m0})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CharTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CharTest.php
@@ -36,8 +36,8 @@ class CharTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CHAR({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerCharArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CleanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CleanTest.php
@@ -36,8 +36,8 @@ class CleanTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CLEAN({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerCleanArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CodeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CodeTest.php
@@ -36,8 +36,8 @@ class CodeTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=CODE({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerCodeArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/DollarTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/DollarTest.php
@@ -40,8 +40,8 @@ class DollarTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=DOLLAR({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerDollarArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ExactTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ExactTest.php
@@ -40,8 +40,8 @@ class ExactTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=EXACT({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerExactArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/FindTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/FindTest.php
@@ -45,8 +45,8 @@ class FindTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=FIND({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerFindArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/FixedTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/FixedTest.php
@@ -45,8 +45,8 @@ class FixedTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=FIXED({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerFixedArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LeftTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LeftTest.php
@@ -177,8 +177,8 @@ class LeftTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=LEFT({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerLeftArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LenTest.php
@@ -36,8 +36,8 @@ class LenTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=LEN({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerLenArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LowerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LowerTest.php
@@ -65,8 +65,8 @@ class LowerTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=LOWER({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerLowerArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/MidTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/MidTest.php
@@ -199,8 +199,8 @@ class MidTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=MID({$argument1}, {$argument2}, {$argument3})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerMidArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/NumberValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/NumberValueTest.php
@@ -47,7 +47,7 @@ class NumberValueTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=NumberValue({$argument1}, {$argument2}, {$argument3})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, self::NV_PRECISION);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ProperTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ProperTest.php
@@ -65,8 +65,8 @@ class ProperTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=PROPER({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerProperArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ReplaceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ReplaceTest.php
@@ -56,8 +56,8 @@ class ReplaceTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=REPLACE({$oldText}, {$start}, {$chars}, {$newText})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerReplaceArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ReptTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ReptTest.php
@@ -40,8 +40,8 @@ class ReptTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=REPT({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerReptArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/RightTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/RightTest.php
@@ -177,8 +177,8 @@ class RightTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=RIGHT({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerRightArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/SearchTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/SearchTest.php
@@ -45,8 +45,8 @@ class SearchTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=SEARCH({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerSearchArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/SubstituteTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/SubstituteTest.php
@@ -51,8 +51,8 @@ class SubstituteTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=SUBSTITUTE({$oldText}, {$fromText}, {$toText})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerSubstituteArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TTest.php
@@ -36,7 +36,7 @@ class TTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=T({$argument})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertSame($expectedResult, $result);
     }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextJoinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextJoinTest.php
@@ -42,8 +42,8 @@ class TextJoinTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=TEXTJOIN({$delimiter}, {$blanks}, {$texts})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerTextjoinArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextTest.php
@@ -40,8 +40,8 @@ class TextTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=TEXT({$argument1}, {$argument2})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerTextArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TrimTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TrimTest.php
@@ -36,8 +36,8 @@ class TrimTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=TRIM({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerTrimArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/UpperTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/UpperTest.php
@@ -65,8 +65,8 @@ class UpperTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=UPPER({$array})";
-        $result = $calculation->_calculateFormulaValue($formula);
-        self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
+        $result = $calculation->calculateFormula($formula);
+        self::assertSame($expectedResult, $result);
     }
 
     public static function providerUpperArray(): array

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ValueTest.php
@@ -49,7 +49,7 @@ class ValueTest extends AllSetupTeardown
         $calculation = Calculation::getInstance();
 
         $formula = "=VALUE({$argument})";
-        $result = $calculation->_calculateFormulaValue($formula);
+        $result = $calculation->calculateFormula($formula);
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 


### PR DESCRIPTION
They aren't quite interchangeable. Both are used in the test suite, with no indication of why one or the other. I think we'd be best off being consistent. Based on the names, I think `_calculateFormulaValue` was intended as a private, or at least internal, method, so favor `calculateFormula`. I do not intend to rename or re-categorize `_calculateFormulaValue`, just remove its usage when it isn't clearly warranted.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] test cleanup - no source change

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

