### PR TITLE
Improve ArrayTest structure and readability

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/ArrayTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/ArrayTest.php
@@ -8,9 +8,32 @@ use PhpOffice\PhpSpreadsheet\Calculation\Calculation;
 use PhpOffice\PhpSpreadsheet\Calculation\Functions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PHPUnit\Framework\TestCase;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class ArrayTest extends TestCase
 {
+    private string $originalArrayReturnType;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalArrayReturnType = Calculation::getArrayReturnType();
+    }
+
+    protected function tearDown(): void
+    {
+        Calculation::setArrayReturnType($this->originalArrayReturnType);
+        parent::tearDown();
+    }
+
+    private function setupMatrix(Worksheet $sheet): void
+    {
+        $sheet->setCellValue('A1', 2.0);
+        $sheet->setCellValue('A2', 0.0);
+        $sheet->setCellValue('B1', 0.0);
+        $sheet->setCellValue('B2', 1.0);
+    }
+
     public function testMultiDimensionalArrayIsFlattened(): void
     {
         $array = [
@@ -32,43 +55,87 @@ class ArrayTest extends TestCase
 
         $values = Functions::flattenArray($array);
 
+        self::assertCount(2, $values);
         self::assertIsNotArray($values[0]);
         self::assertIsNotArray($values[1]);
+        self::assertSame('PHP', $values[0]);
+        self::assertSame('Spreadsheet', $values[1]);
     }
 
-    public function testPropagateStatic(): void
+    public function testSetArrayReturnTypeWithValidValue(): void
     {
-        $oldValue = Calculation::getArrayReturnType();
-        $calculation = new Calculation();
         self::assertTrue(Calculation::setArrayReturnType(Calculation::RETURN_ARRAY_AS_ARRAY));
-        self::assertFalse(Calculation::setArrayReturnType('xxx'));
         self::assertSame(Calculation::RETURN_ARRAY_AS_ARRAY, Calculation::getArrayReturnType());
-        self::assertFalse($calculation->setArrayReturnType('xxx'));
+    }
+
+    public function testSetArrayReturnTypeWithInvalidValue(): void
+    {
+        $originalType = Calculation::getArrayReturnType();
+        self::assertFalse(Calculation::setArrayReturnType('xxx'));
+        self::assertSame($originalType, Calculation::getArrayReturnType());
+    }
+
+    public function testInstanceArrayReturnTypeInheritsFromStatic(): void
+    {
+        Calculation::setArrayReturnType(Calculation::RETURN_ARRAY_AS_ARRAY);
+        $calculation = new Calculation();
         self::assertSame(Calculation::RETURN_ARRAY_AS_ARRAY, $calculation->getInstanceArrayReturnType());
+    }
+
+    public function testInstanceArrayReturnTypeCanBeOverridden(): void
+    {
+        Calculation::setArrayReturnType(Calculation::RETURN_ARRAY_AS_ARRAY);
+        $calculation = new Calculation();
         self::assertTrue($calculation->setInstanceArrayReturnType(Calculation::RETURN_ARRAY_AS_ERROR));
         self::assertSame(Calculation::RETURN_ARRAY_AS_ARRAY, Calculation::getArrayReturnType());
         self::assertSame(Calculation::RETURN_ARRAY_AS_ERROR, $calculation->getInstanceArrayReturnType());
-        Calculation::setArrayReturnType($oldValue);
     }
 
-    public function testReturnTypes(): void
+    public function testSetInstanceArrayReturnTypeWithInvalidValue(): void
+    {
+        $calculation = new Calculation();
+        self::assertFalse($calculation->setInstanceArrayReturnType('xxx'));
+    }
+
+    public function testReturnTypeAsError(): void
     {
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
         $calculation = Calculation::getInstance($spreadsheet);
-        $sheet->setCellValue('A1', 2.0);
-        $sheet->setCellValue('A2', 0.0);
-        $sheet->setCellValue('B1', 0.0);
-        $sheet->setCellValue('B2', 1.0);
+        $this->setupMatrix($sheet);
         $sheet->setCellValue('D1', '=MINVERSE(A1:B2)');
+
         $calculation->setInstanceArrayReturnType(Calculation::RETURN_ARRAY_AS_ERROR);
         self::assertSame('#VALUE!', $sheet->getCell('D1')->getCalculatedValue());
-        $calculation->flushInstance();
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testReturnTypeAsValue(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $calculation = Calculation::getInstance($spreadsheet);
+        $this->setupMatrix($sheet);
+        $sheet->setCellValue('D1', '=MINVERSE(A1:B2)');
+
         $calculation->setInstanceArrayReturnType(Calculation::RETURN_ARRAY_AS_VALUE);
         self::assertSame(0.5, $sheet->getCell('D1')->getCalculatedValue());
-        $calculation->flushInstance();
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testReturnTypeAsArray(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $calculation = Calculation::getInstance($spreadsheet);
+        $this->setupMatrix($sheet);
+        $sheet->setCellValue('D1', '=MINVERSE(A1:B2)');
+
         $calculation->setInstanceArrayReturnType(Calculation::RETURN_ARRAY_AS_ARRAY);
         self::assertSame([[0.5, 0.0], [0.0, 1.0]], $sheet->getCell('D1')->getCalculatedValue());
+
         $spreadsheet->disconnectWorksheets();
     }
 }


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [ ] a new feature
- [x] refactoring
- [x] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

- add `setUp()` and `tearDown()` methods
- add private method `setupMatrix()` to set up test data
- improved `testMultiDimensionalArrayIsFlattened()`
- `testPropagateStatic()` is divided into separate tests
- `testReturnTypes()` is divided into separate tests

Tests have become more modular, readable, and easier to maintain. Each test verifies one specific piece of functionality.
