### PR TITLE
Simplified CellTest and added a helper method for styles

### DIFF
--- a/tests/PhpSpreadsheetTests/Cell/CellTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CellTest.php
@@ -115,9 +115,10 @@ class CellTest extends TestCase
     }
 
     #[DataProvider('providerSetValueExplicitException')]
-    public function testSetValueExplicitException(mixed $value, string $dataType): void
+    public function testSetValueExplicitException(mixed $value, string $dataType, string $message): void
     {
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage($message);
 
         $this->spreadsheet = new Spreadsheet();
         $cell = $this->spreadsheet->getActiveSheet()->getCell('A1');

--- a/tests/data/Cell/SetValueExplicitException.php
+++ b/tests/data/Cell/SetValueExplicitException.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 
 return [
-    'invalid numeric' => ['XYZ', DataType::TYPE_NUMERIC],
-    'invalid array' => [[], DataType::TYPE_STRING],
-    'invalid unstringable object' => [new DateTime(), DataType::TYPE_INLINE],
+    'invalid numeric' => ['XYZ', DataType::TYPE_NUMERIC, 'Invalid numeric value'],
+    'invalid array' => [[], DataType::TYPE_STRING, 'Unable to convert to string'],
+    'invalid unstringable object' => [new DateTime(), DataType::TYPE_INLINE, 'Unable to convert to string'],
 ];


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [ ] a new feature
- [x] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

- Added the `createSolidFillStyle()` method to eliminate duplication
- Simplified the `testAppliedStyleWithRange` and `testAppliedStyleSingleCell` tests
- Simplified the `testNoChangeToActiveSheet` test
- Improved code readability
