### PR TITLE
Removed duplicate try-catch statements

### DIFF
--- a/tests/PhpSpreadsheetTests/Helper/HandlerTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/HandlerTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Helper;
 
+use Exception;
 use PhpOffice\PhpSpreadsheet\Helper\Handler;
 use PHPUnit\Framework\TestCase;
-use Throwable;
 
 class HandlerTest extends TestCase
 {
@@ -17,61 +17,49 @@ class HandlerTest extends TestCase
 
     public function testDeprecated(): void
     {
-        try {
-            Handler::deprecated();
-            self::fail('Expected error/exception did not happen');
-        } catch (Throwable $e) {
-            self::assertStringContainsString('Invalid characters', $e->getMessage());
-        }
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/Invalid characters/');
+
+        Handler::deprecated();
     }
 
     public function testNotice(): void
     {
-        try {
-            Handler::notice('invalidtz');
-            self::fail('Expected error/exception did not happen');
-        } catch (Throwable $e) {
-            self::assertStringContainsString('Timezone', $e->getMessage());
-        }
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/Timezone/');
+
+        Handler::notice('invalidtz');
     }
 
     public function testWarning(): void
     {
-        try {
-            Handler::warning();
-            self::fail('Expected error/exception did not happen');
-        } catch (Throwable $e) {
-            self::assertStringContainsString('ailed to open stream', $e->getMessage());
-        }
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/ailed to open stream/');
+
+        Handler::warning();
     }
 
     public function testUserDeprecated(): void
     {
-        try {
-            Handler::userDeprecated();
-            self::fail('Expected error/exception did not happen');
-        } catch (Throwable $e) {
-            self::assertStringContainsString('hello', $e->getMessage());
-        }
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/hello/');
+
+        Handler::userDeprecated();
     }
 
     public function testUserNotice(): void
     {
-        try {
-            Handler::userNotice();
-            self::fail('Expected error/exception did not happen');
-        } catch (Throwable $e) {
-            self::assertStringContainsString('userNotice', $e->getMessage());
-        }
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/userNotice/');
+
+        Handler::userNotice();
     }
 
     public function testUserWarning(): void
     {
-        try {
-            Handler::userWarning();
-            self::fail('Expected error/exception did not happen');
-        } catch (Throwable $e) {
-            self::assertStringContainsString('userWarning', $e->getMessage());
-        }
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/userWarning/');
+
+        Handler::userWarning();
     }
 }


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [ ] a new feature
- [x] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

- Instead of `try-catch`, built-in PHPUnit methods are used: `expectException()` and `expectExceptionMessageMatches()`
- Instead of `Throwable`, `Exception` is used, since this is the type that is thrown in `bootstrap.php`
- The code became shorter and clearer
