### PR TITLE
Remove Phpunit9-specific Portions of Test Suite

### DIFF
--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlLoadStringTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlLoadStringTest.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Reader\Html;
 
-use PhpOffice\PhpSpreadsheet\Reader\Exception as ReaderException;
 use PhpOffice\PhpSpreadsheet\Reader\Html;
 use PHPUnit\Framework\TestCase;
 
 class HtmlLoadStringTest extends TestCase
 {
-    private static bool $alwaysTrue = true;
-
     public function testCanLoadFromString(): void
     {
         $html = '<table>
@@ -42,17 +39,7 @@ class HtmlLoadStringTest extends TestCase
         self::assertStringContainsString("\n", $cellValue);
     }
 
-    public function testLoadInvalidString(): void
-    {
-        if (method_exists($this, 'setOutputCallback')) {
-            $this->expectException(ReaderException::class);
-            $html = '<table<>';
-            (new Html())->loadFromString($html);
-        } else {
-            // The meat of this test runs in HtmlPhpunit10Test
-            self::assertTrue(self::$alwaysTrue);
-        }
-    }
+    // testLoadInvalidString moved to HtmlPhpUnit10Test
 
     public function testCanLoadFromStringIntoExistingSpreadsheet(): void
     {

--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlTest.php
@@ -21,19 +21,7 @@ class HtmlTest extends TestCase
         self::assertFalse($reader->canRead($filename));
     }
 
-    public function testBadHtml(): void
-    {
-        $filename = 'tests/data/Reader/HTML/badhtml.html';
-        $reader = new Html();
-        self::assertTrue($reader->canRead($filename));
-
-        if (method_exists($this, 'setOutputCallback')) {
-            // The meat of this test is moved to HtmlPhpunit10Test
-            // to run under all PhpUnit versions.
-            $this->expectException(ReaderException::class);
-            $reader->load($filename);
-        }
-    }
+    // testBadHtml moved to HtmlPhpunit10Test
 
     public function testNonHtml(): void
     {

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/Issue3982Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/Issue3982Test.php
@@ -13,6 +13,14 @@ class Issue3982Test extends TestCase
 {
     private static string $testbook = 'tests/data/Reader/XLSX/issue.3982.xlsx';
 
+    /**
+     * This routine comes nowhere close to out-of-memory (uses 45MB).
+     * Yet it goes out of memory in PhpUnit 10 (uses 2GB!).
+     * Works fine in PhpUnit9-.
+     * We can mitigate the problem by changing entirely-null rows
+     * to empty rows in rangeToArrayYieldRows. (uses 455MB).
+     * That's a breaking change, but might be worth considering.
+     */
     public function testLoadAllRows(): void
     {
         if (!method_exists(TestCase::class, 'setOutputCallback')) {

--- a/tests/PhpSpreadsheetTests/Shared/OLETest.php
+++ b/tests/PhpSpreadsheetTests/Shared/OLETest.php
@@ -7,7 +7,6 @@ namespace PhpOffice\PhpSpreadsheetTests\Shared;
 use PhpOffice\PhpSpreadsheet\Reader\Exception as ReaderException;
 use PhpOffice\PhpSpreadsheet\Shared\OLE;
 use PHPUnit\Framework\TestCase;
-use Throwable;
 
 class OLETest extends TestCase
 {
@@ -42,39 +41,8 @@ class OLETest extends TestCase
         self::assertSame(1024, $ole->getBlockOffset(1));
     }
 
-    public function testChainedWriteMode(): void
-    {
-        $ole = new OLE\ChainedBlockStream();
-        $openedPath = '';
-        self::assertFalse($ole->stream_open('whatever', 'w', 0, $openedPath));
-
-        // Test moved to OLEPhpunit10Test for PhpUnit 10
-        if (method_exists($this, 'setOutputCallback')) {
-            try {
-                $ole->stream_open('whatever', 'w', STREAM_REPORT_ERRORS, $openedPath);
-                self::fail('Error in statement above should be caught');
-            } catch (Throwable $e) {
-                self::assertSame('Only reading is supported', $e->getMessage());
-            }
-        }
-    }
-
-    public function testChainedBadPath(): void
-    {
-        $ole = new OLE\ChainedBlockStream();
-        $openedPath = '';
-        self::assertFalse($ole->stream_open('whatever', 'r', 0, $openedPath));
-
-        // Not sure how to do this test with PhpUnit 10
-        if (method_exists($this, 'setOutputCallback')) {
-            try {
-                $ole->stream_open('whatever', 'r', STREAM_REPORT_ERRORS, $openedPath);
-                self::fail('Error in statement above should be caught');
-            } catch (Throwable $e) {
-                self::assertSame('OLE stream not found', $e->getMessage());
-            }
-        }
-    }
+    // testChainedWriteMode moved to OLEPhpunit10Test
+    // testChainedBadPath moved to OLEPhpunit10Test
 
     public function testOleFunctions(): void
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,6 +32,4 @@ function phpunit10ErrorHandler(int $errno, string $errstr, string $filename, int
     return false; // continue error handling
 }
 
-if (!method_exists(PHPUnit\Framework\TestCase::class, 'setOutputCallback')) {
-    set_error_handler('phpunit10ErrorHandler');
-}
+set_error_handler('phpunit10ErrorHandler');


### PR DESCRIPTION
Some tests are only run under Phpunit9, but we use Phpunit10 for all supported releases. Eliminate the unused tests.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Provide an explanation of why this change is needed, with links to any Issues (if appropriate).
If this is a bugfix or a new feature, and there are no existing Issues, then please also create an issue that will make it easier to track progress with this PR.
