### PR TITLE
Single Character Table Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org). Thia is a
 - Slightly better support for escaped characters in Xlsx Reader/Writer. [Discussion #4724](https://github.com/PHPOffice/PhpSpreadsheet/discussions/4724) [PR #4726](https://github.com/PHPOffice/PhpSpreadsheet/pull/4726)
 - CODE/UNICODE and CHAR/UNICHAR. [PR #4727](https://github.com/PHPOffice/PhpSpreadsheet/pull/4727)
 - Minor changes to TextGrid. [PR #4735](https://github.com/PHPOffice/PhpSpreadsheet/pull/4735)
+- Single-character table names. [Issue #4739](https://github.com/PHPOffice/PhpSpreadsheet/issues/4739) [PR #4740](https://github.com/PHPOffice/PhpSpreadsheet/pull/4740)
 
 ## 2025-11-24 - 5.3.0
 

--- a/src/PhpSpreadsheet/Worksheet/Table.php
+++ b/src/PhpSpreadsheet/Worksheet/Table.php
@@ -120,7 +120,7 @@ class Table implements Stringable
             if (!preg_match('/^[\p{L}_\\\]/iu', $name)) {
                 throw new PhpSpreadsheetException('The table name must begin a name with a letter, an underscore character (_), or a backslash (\)');
             }
-            if (!preg_match('/^[\p{L}_\\\][\p{L}\p{M}0-9\._]+$/iu', $name)) {
+            if (!preg_match('/^[\p{L}_\\\][\p{L}\p{M}0-9\._]*$/iu', $name)) {
                 throw new PhpSpreadsheetException('The table name contains invalid characters');
             }
 

--- a/tests/PhpSpreadsheetTests/Worksheet/Table/TableTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/Table/TableTest.php
@@ -33,7 +33,7 @@ class TableTest extends SetupTeardown
         $table = new Table(self::INITIAL_RANGE);
 
         $result = $table->setName($name);
-        self::assertEquals($expected, $result->getName());
+        self::assertSame($expected, $result->getName());
     }
 
     public static function validTableNamesProvider(): array
@@ -45,6 +45,7 @@ class TableTest extends SetupTeardown
             ['\table_3', '\table_3'],
             ["	Table_4 \n", 'Table_4'],
             ['table.5', 'table.5'],
+            'issue 4739' => ['x', 'x'],
             ['தமிழ்', 'தமிழ்'], // UTF-8 letters with combined character
         ];
     }


### PR DESCRIPTION
Fix #4739. Change `+` to `*` in regexp. Add test.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

