### PR TITLE
refactor(tests): common logic in CodeTest and fix test data

### DIFF
--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CodeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CodeTest.php
@@ -19,40 +19,45 @@ class CodeTest extends AllSetupTeardown
     #[DataProvider('providerCODE')]
     public function testCODE(mixed $expectedResult, mixed $character = 'omitted'): void
     {
-        // If expected is array, 1st is for CODE, 2nd for UNICODE,
-        // 3rd is for Mac CODE if different from Windows.
-        if (is_array($expectedResult)) {
-            $expectedResult = $expectedResult[0];
-        }
-        $this->mightHaveException($expectedResult);
-        $sheet = $this->getSheet();
-        if ($character === 'omitted') {
-            $sheet->getCell('B1')->setValue('=CODE()');
-        } else {
-            $this->setCell('A1', $character);
-            $sheet->getCell('B1')->setValue('=CODE(A1)');
-        }
-        $result = $sheet->getCell('B1')->getCalculatedValue();
-        self::assertEquals($expectedResult, $result);
+        $this->runCodeTest($expectedResult, $character, false);
     }
 
     #[DataProvider('providerCODE')]
     public function testMacCODE(mixed $expectedResult, mixed $character = 'omitted'): void
     {
         CC::setMacCharacterSet();
-        // If expected is array, 1st is for CODE, 2nd for UNICODE,
-        // 3rd is for Mac CODE if different from Windows.
+        $this->runCodeTest($expectedResult, $character, true);
+    }
+
+    /**
+     * Helper method for running CODE tests.
+     *
+     * @param mixed $expectedResult Expected result (can be an array for CODE/UNICODE/Mac)
+     * @param mixed $character Symbol for testing
+     * @param bool $isMacMode Use Mac character set
+     */
+    private function runCodeTest(mixed $expectedResult, mixed $character, bool $isMacMode): void
+    {
+        // If the expected result is an array:
+        // 1st element for CODE (Windows)
+        // 2nd element for UNICODE
+        // 3rd element for Mac CODE (if different from Windows)
         if (is_array($expectedResult)) {
-            $expectedResult = $expectedResult[2] ?? $expectedResult[0];
+            $expectedResult = $isMacMode
+                ? ($expectedResult[2] ?? $expectedResult[0])
+                : $expectedResult[0];
         }
+
         $this->mightHaveException($expectedResult);
         $sheet = $this->getSheet();
+
         if ($character === 'omitted') {
             $sheet->getCell('B1')->setValue('=CODE()');
         } else {
             $this->setCell('A1', $character);
             $sheet->getCell('B1')->setValue('=CODE(A1)');
         }
+
         $result = $sheet->getCell('B1')->getCalculatedValue();
         self::assertEquals($expectedResult, $result);
     }

--- a/tests/data/Calculation/TextData/CODE.php
+++ b/tests/data/Calculation/TextData/CODE.php
@@ -64,7 +64,7 @@ return [
         'ƒ',
     ],
     [
-        [63, 0x2105],
+        [99, 0x2105, 63],
         '℅',
     ],
     [
@@ -91,5 +91,8 @@ return [
         2,
         "\x02",
     ],
-    'omitted argument' => ['exception'],
+    'omitted argument' => [
+        'exception',
+        'omitted',
+    ],
 ];


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [ ] a new feature
- [x] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

- Extract common test logic into runCodeTest() method
- Fix missing parameter in CODE test data provider
- Fix expected value for '℅' character in Windows encoding
