### PR TITLE
T.INV Don't Use Locale-Aware sprintf

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Statistical/Distributions/StudentT.php
+++ b/src/PhpSpreadsheet/Calculation/Statistical/Distributions/StudentT.php
@@ -281,7 +281,7 @@ class StudentT
                     + log($n / $n1 / 2 / M_PI) - 1
                         + (1 / $n1 - 1 / $n) / 6) / 2);
                 $x += $delta;
-                $round = sprintf('%.' . abs((int) (log10(abs($x)) - 4)) . 'f', $delta);
+                $round = sprintf('%.' . abs((int) (log10(abs($x)) - 4)) . 'F', $delta);
             } while (($x) && ($round != 0));
         }
 

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TDotInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TDotInvTest.php
@@ -9,9 +9,37 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class TDotInvTest extends AllSetupTeardown
 {
+    /**
+     * @var false|string
+     */
+    private $currentLocale;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->currentLocale = setlocale(LC_ALL, '0');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        if (is_string($this->currentLocale)) {
+            setlocale(LC_ALL, $this->currentLocale);
+        }
+    }
+
     #[DataProvider('providerTdotINV')]
     public function testTdotINV(mixed $expectedResult, mixed $probability, mixed $degrees): void
     {
+        $this->runTestCaseReference('T.INV', $expectedResult, $probability, $degrees);
+    }
+
+    #[DataProvider('providerTdotINV')]
+    public function testTdotINVLocale(mixed $expectedResult, mixed $probability, mixed $degrees): void
+    {
+        if (!setlocale(LC_ALL, 'fr_FR.UTF-8', 'fra_fra.utf8')) {
+            self::markTestSkipped('Unable to set locale for testing.');
+        }
         $this->runTestCaseReference('T.INV', $expectedResult, $probability, $degrees);
     }
 


### PR DESCRIPTION
Uppercase f to F, add test.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

