### PR TITLE
Restore Test Disabled Due to Phpunit 10 Bug

### DIFF
--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/Issue3982Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/Issue3982Test.php
@@ -20,16 +20,18 @@ class Issue3982Test extends TestCase
      * We can mitigate the problem by changing entirely-null rows
      * to empty rows in rangeToArrayYieldRows. (uses 455MB).
      * That's a breaking change, but might be worth considering.
+     *
+     * Aha! I have narrowed the problem to self::assertCount,
+     * which has a ready substitution. I will report the problem
+     * to Phpunit if I can come up with a simpler example.
      */
     public function testLoadAllRows(): void
     {
-        if (!method_exists(TestCase::class, 'setOutputCallback')) {
-            self::markTestSkipped('Memory loop in Phpunit 10');
-        }
         $spreadsheet = IOFactory::load(self::$testbook);
         $sheet = $spreadsheet->getActiveSheet();
         $data = $sheet->toArray(null, true, false, true);
-        self::assertCount(1048576, $data);
+        $count = count($data);
+        self::assertSame(1_048_576, $count);
         $spreadsheet->disconnectWorksheets();
     }
 


### PR DESCRIPTION
Issue3982Test mysteriously ran into memory problems when we migrated from Phpunit 9 to 10. It wasn't all that critical a test, so it has been disabled ever since. I finally had some time to research, and the problem is unquestionably with Phpunit's `assertCount` test - it doesn't like something about our array. However, we can easily redo that test by using Php's native `count` function, and testing that result with `assertSame`. I have not yet succeeded at simplifying the test to a state where I am willing to report the bug, but I'll keep trying. In the meantime, the test is recoded, and can now be run successfully. No source code changes.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] workaround for Phpunit bug

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [ ] Code style is respected
- [ ] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

