### PR TITLE
Update APCu cache documentation example

### DIFF
--- a/docs/topics/memory_saving.md
+++ b/docs/topics/memory_saving.md
@@ -53,19 +53,24 @@ details, but here are a few suggestions that should get you started.
 
 ### APCu
 
-Require the packages into your project:
+Require Symfony Cache in your project:
 
 ```sh
-composer require cache/simple-cache-bridge cache/apcu-adapter
+composer require symfony/cache
 ```
+
+You must also install and enable the APCu PHP extension for your environment.
 
 Configure PhpSpreadsheet with something like:
 
 ```php
-$pool = new \Cache\Adapter\Apcu\ApcuCachePool();
-$simpleCache = new \Cache\Bridge\SimpleCache\SimpleCacheBridge($pool);
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Psr16Cache;
 
-\PhpOffice\PhpSpreadsheet\Settings::setCache($simpleCache);
+$apcuAdapter = new ApcuAdapter();
+$cache = new Psr16Cache($apcuAdapter);
+
+\PhpOffice\PhpSpreadsheet\Settings::setCache($cache);
 ```
 
 ### Redis


### PR DESCRIPTION
This PR updates the APCu example in the memory saving documentation.

The current documentation recommends `cache/simple-cache-bridge` and `cache/apcu-adapter`. This PR updates the APCu example to use Symfony Cache with `ApcuAdapter` and `Psr16Cache`.

## Changes

- Replaced the old APCu package recommendation
- Added a Symfony Cache based APCu example
- Mentioned that the APCu PHP extension must be installed and enabled

Fixes #3908.