### PR TITLE
Add border color, fill opacity, and shape type to Comments (#1790)

### DIFF
--- a/src/PhpSpreadsheet/Comment.php
+++ b/src/PhpSpreadsheet/Comment.php
@@ -54,6 +54,21 @@ class Comment implements IComparable, Stringable
     private Color $fillColor;
 
     /**
+     * Comment border color.
+     */
+    private Color $borderColor;
+
+    /**
+     * Comment fill opacity.
+     */
+    private float $fillOpacity = 1.0;
+
+    /**
+     * Comment shapeType.
+     */
+    private int $shapeType = 202;
+
+    /**
      * Alignment.
      */
     private string $alignment;
@@ -80,6 +95,7 @@ class Comment implements IComparable, Stringable
         $this->author = 'Author';
         $this->text = new RichText();
         $this->fillColor = new Color('FFFFFFE1');
+        $this->borderColor = new Color(Color::COLOR_BLACK);
         $this->alignment = Alignment::HORIZONTAL_GENERAL;
         $this->backgroundImage = new Drawing();
     }
@@ -240,6 +256,42 @@ class Comment implements IComparable, Stringable
         return $this->fillColor;
     }
 
+    public function setBorderColor(Color $color): self
+    {
+        $this->borderColor = $color;
+
+        return $this;
+    }
+
+    public function getBorderColor(): Color
+    {
+        return $this->borderColor;
+    }
+
+    public function setFillOpacity(float $opacity): self
+    {
+        $this->fillOpacity = $opacity;
+
+        return $this;
+    }
+
+    public function getFillOpacity(): float
+    {
+        return $this->fillOpacity;
+    }
+
+    public function getShapeType(): int
+    {
+        return $this->shapeType;
+    }
+
+    public function setShapeType(int $shapeType): self
+    {
+        $this->shapeType = $shapeType;
+
+        return $this;
+    }
+
     public function setAlignment(string $alignment): self
     {
         $this->alignment = $alignment;
@@ -278,6 +330,9 @@ class Comment implements IComparable, Stringable
             . $this->marginTop
             . ($this->visible ? 1 : 0)
             . $this->fillColor->getHashCode()
+            . $this->borderColor->getHashCode()
+            . $this->fillOpacity
+            . $this->shapeType
             . $this->alignment
             . $this->textboxDirection
             . ($this->hasBackgroundImage() ? $this->backgroundImage->getHashCode() : '')

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1226,155 +1226,143 @@ class Xlsx extends BaseReader
                                     }
                                 }
 
-                                // later we will remove from it real vmlComments
                                 $unparsedVmlDrawings = $vmlComments;
                                 $vmlDrawingContents = [];
 
-                                // Loop through VML comments
-                                foreach ($vmlComments as $relName => $relPath) {
-                                    // Load VML comments file
-                                    $relPath = File::realpath(dirname("$dir/$fileWorksheet") . '/' . $relPath);
+                                $zipFilePath = $this->zip->filename;
 
-                                    try {
-                                        // no namespace okay - processed with Xpath
-                                        $vmlCommentsFile = $this->loadZip($relPath, '', true);
-                                        $vmlCommentsFile->registerXPathNamespace('v', Namespaces::URN_VML);
-                                    } catch (Throwable) {
-                                        //Ignore unparsable vmlDrawings. Later they will be moved from $unparsedVmlDrawings to $unparsedLoadedData
+                                foreach ($vmlComments as $relName => $relPath) {
+                                    $fullPath = File::realpath(dirname("$dir/$fileWorksheet") . '/' . $relPath);
+
+                                    if ((bool) $fullPath === false) {
                                         continue;
                                     }
 
-                                    // Locate VML drawings image relations
-                                    $drowingImages = [];
-                                    $VMLDrawingsRelations = dirname($relPath) . '/_rels/' . basename($relPath) . '.rels';
-                                    $vmlDrawingContents[$relName] = $this->getSecurityScannerOrThrow()->scan($this->getFromZipArchive($zip, $relPath));
-                                    if ($zip->locateName($VMLDrawingsRelations) !== false) {
-                                        $relsVMLDrawing = $this->loadZip($VMLDrawingsRelations, Namespaces::RELATIONSHIPS);
-                                        foreach ($relsVMLDrawing->Relationship as $elex) {
-                                            $ele = self::getAttributes($elex);
-                                            if ($ele['Type'] == Namespaces::IMAGE) {
-                                                $drowingImages[(string) $ele['Id']] = (string) $ele['Target'];
+                                    try {
+                                        $vmlCommentsFile = $this->loadZip($fullPath, '', true);
+                                        $vmlCommentsFile->registerXPathNamespace('v', Namespaces::URN_VML);
+                                    } catch (Throwable) {
+                                        continue;
+                                    }
+
+                                    $vmlDrawingContents[$relName] = $this->getSecurityScannerOrThrow()
+                                        ->scan($this->getFromZipArchive($zip, $fullPath));
+
+                                    $drawingImages = [];
+                                    $relsPath = dirname($fullPath) . '/_rels/' . basename($fullPath) . '.rels';
+
+                                    if ($zip->locateName($relsPath) !== false) {
+                                        $relsVML = $this->loadZip($relsPath, Namespaces::RELATIONSHIPS);
+                                        foreach ($relsVML->Relationship as $rel) {
+                                            $attr = self::getAttributes($rel);
+                                            if ((string) $attr['Type'] === Namespaces::IMAGE) {
+                                                $drawingImages[(string) $attr['Id']] = (string) $attr['Target'];
                                             }
                                         }
                                     }
 
                                     $shapes = self::xpathNoFalse($vmlCommentsFile, '//v:shape');
+
                                     foreach ($shapes as $shape) {
-                                        /** @var SimpleXMLElement $shape */
-                                        $vmlNamespaces = $shape->getNamespaces();
-                                        $shape->registerXPathNamespace('v', $vmlNamespaces['v'] ?? Namespaces::URN_VML);
-                                        $shape->registerXPathNamespace('x', $vmlNamespaces['x'] ?? Namespaces::URN_EXCEL);
-                                        $shape->registerXPathNamespace('o', $vmlNamespaces['o'] ?? Namespaces::URN_MSOFFICE);
+                                        $namespaces = $shape->getNamespaces();
+                                        $shape->registerXPathNamespace('x', $namespaces['x'] ?? Namespaces::URN_EXCEL);
+                                        $shape->registerXPathNamespace('o', $namespaces['o'] ?? Namespaces::URN_MSOFFICE);
+                                        $shape->registerXPathNamespace('v', $namespaces['v'] ?? Namespaces::URN_VML);
 
-                                        if (isset($shape['style'])) {
-                                            $style = (string) $shape['style'];
-                                            $fillColor = strtoupper(substr((string) $shape['fillcolor'], 1));
-                                            $column = null;
-                                            $row = null;
-                                            $textHAlign = null;
-                                            $fillImageRelId = null;
-                                            $fillImageTitle = '';
+                                        $clientDataNodes = $shape->xpath('.//x:ClientData');
+                                        if (empty($clientDataNodes)) {
+                                            continue;
+                                        }
 
-                                            $clientData = $shape->xpath('.//x:ClientData');
-                                            $textboxDirection = '';
-                                            $textboxPath = $shape->xpath('.//v:textbox');
-                                            $textbox = (string) ($textboxPath[0]['style'] ?? '');
-                                            if (Preg::isMatch('/rtl/i', $textbox)) {
-                                                $textboxDirection = Comment::TEXTBOX_DIRECTION_RTL;
-                                            } elseif (Preg::isMatch('/ltr/i', $textbox)) {
-                                                $textboxDirection = Comment::TEXTBOX_DIRECTION_LTR;
-                                            }
-                                            if (is_array($clientData) && !empty($clientData)) {
-                                                /** @var SimpleXMLElement */
-                                                $clientData = $clientData[0];
+                                        $clientData = $clientDataNodes[0];
+                                        if ((string) ($clientData['ObjectType'] ?? '') !== 'Note') {
+                                            continue;
+                                        }
 
-                                                if (isset($clientData['ObjectType']) && (string) $clientData['ObjectType'] == 'Note') {
-                                                    $clientData->registerXPathNamespace('x', $vmlNamespaces['x'] ?? Namespaces::URN_EXCEL);
-                                                    $temp = $clientData->xpath('.//x:Row');
-                                                    if (is_array($temp)) {
-                                                        $row = $temp[0];
-                                                    }
+                                        $rowNodes = $clientData->xpath('.//x:Row');
+                                        $colNodes = $clientData->xpath('.//x:Column');
 
-                                                    $temp = $clientData->xpath('.//x:Column');
-                                                    if (is_array($temp)) {
-                                                        $column = $temp[0];
-                                                    }
-                                                    $temp = $clientData->xpath('.//x:TextHAlign');
-                                                    if (!empty($temp)) {
-                                                        $textHAlign = strtolower($temp[0]);
-                                                    }
-                                                }
-                                            }
-                                            $rowx = (string) $row;
-                                            $colx = (string) $column;
-                                            if (is_numeric($rowx) && is_numeric($colx) && $textHAlign !== null) {
-                                                $docSheet->getComment([1 + (int) $colx, 1 + (int) $rowx], false)->setAlignment((string) $textHAlign);
-                                            }
-                                            if (is_numeric($rowx) && is_numeric($colx) && $textboxDirection !== '') {
-                                                $docSheet->getComment([1 + (int) $colx, 1 + (int) $rowx], false)->setTextboxDirection($textboxDirection);
-                                            }
+                                        $row = isset($rowNodes[0]) ? (int) (string)$rowNodes[0] : -1;
+                                        $col = isset($colNodes[0]) ? (int) (string)$colNodes[0] : -1;
 
-                                            $fillImageRelNode = $shape->xpath('.//v:fill/@o:relid');
-                                            if (is_array($fillImageRelNode) && !empty($fillImageRelNode)) {
-                                                /** @var SimpleXMLElement */
-                                                $fillImageRelNode = $fillImageRelNode[0];
+                                        if ($row < 0 || $col < 0) {
+                                            continue;
+                                        }
 
-                                                if (isset($fillImageRelNode['relid'])) {
-                                                    $fillImageRelId = (string) $fillImageRelNode['relid'];
-                                                }
-                                            }
+                                        $coordinate = Coordinate::stringFromColumnIndex($col + 1) . ($row + 1);
+                                        $comment = $docSheet->getComment($coordinate);
 
-                                            $fillImageTitleNode = $shape->xpath('.//v:fill/@o:title');
-                                            if (is_array($fillImageTitleNode) && !empty($fillImageTitleNode)) {
-                                                /** @var SimpleXMLElement */
-                                                $fillImageTitleNode = $fillImageTitleNode[0];
-
-                                                if (isset($fillImageTitleNode['title'])) {
-                                                    $fillImageTitle = (string) $fillImageTitleNode['title'];
-                                                }
-                                            }
-
-                                            if (($column !== null) && ($row !== null)) {
-                                                // Set comment properties
-                                                $comment = $docSheet->getComment([(int) $column + 1, (int) $row + 1]);
+                                        if (isset($shape['fillcolor'])) {
+                                            $fillColor = strtoupper(ltrim((string) $shape['fillcolor'], '#'));
+                                            if ($fillColor !== '' && ctype_xdigit($fillColor)) {
                                                 $comment->getFillColor()->setRGB($fillColor);
-                                                if (isset($fillImageRelId, $drowingImages[$fillImageRelId])) {
-                                                    $objDrawing = new \PhpOffice\PhpSpreadsheet\Worksheet\Drawing();
-                                                    $objDrawing->setName($fillImageTitle);
-                                                    $imagePath = str_replace(['../', '/xl/'], 'xl/', $drowingImages[$fillImageRelId]);
-                                                    $objDrawing->setPath(
-                                                        'zip://' . File::realpath($filename) . '#' . $imagePath,
-                                                        true,
-                                                        $zip
-                                                    );
-                                                    $comment->setBackgroundImage($objDrawing);
-                                                }
-
-                                                // Parse style
-                                                $styleArray = explode(';', str_replace(' ', '', $style));
-                                                foreach ($styleArray as $stylePair) {
-                                                    $stylePair = explode(':', $stylePair);
-
-                                                    if ($stylePair[0] == 'margin-left') {
-                                                        $comment->setMarginLeft($stylePair[1]);
-                                                    }
-                                                    if ($stylePair[0] == 'margin-top') {
-                                                        $comment->setMarginTop($stylePair[1]);
-                                                    }
-                                                    if ($stylePair[0] == 'width') {
-                                                        $comment->setWidth($stylePair[1]);
-                                                    }
-                                                    if ($stylePair[0] == 'height') {
-                                                        $comment->setHeight($stylePair[1]);
-                                                    }
-                                                    if ($stylePair[0] == 'visibility') {
-                                                        $comment->setVisible($stylePair[1] == 'visible');
-                                                    }
-                                                }
-
-                                                unset($unparsedVmlDrawings[$relName]);
                                             }
                                         }
+
+                                        if (isset($shape['strokecolor'])) {
+                                            $borderColor = strtoupper(ltrim((string) $shape['strokecolor'], '#'));
+                                            if ($borderColor !== '' && ctype_xdigit($borderColor)) {
+                                                $comment->setBorderColor(new Color($borderColor));
+                                            }
+                                        }
+
+                                        if (isset($shape['style'])) {
+                                            $styles = self::toCSSArray((string) $shape['style']);
+                                            if (isset($styles['width'])) $comment->setWidth($styles['width']);
+                                            if (isset($styles['height'])) $comment->setHeight($styles['height']);
+                                            if (isset($styles['margin-left'])) $comment->setMarginLeft($styles['margin-left']);
+                                            if (isset($styles['margin-top'])) $comment->setMarginTop($styles['margin-top']);
+                                            if (isset($styles['visibility'])) {
+                                                $comment->setVisible(strtolower($styles['visibility']) === 'visible');
+                                            }
+                                        }
+
+                                        $vNS = $namespaces['v'] ?? Namespaces::URN_VML;
+                                        $fillElement = $shape->children($vNS)->fill ?? null;
+                                        if ($fillElement && isset($fillElement['opacity'])) {
+                                            $comment->setFillOpacity((float) $fillElement['opacity']);
+                                        }
+
+                                        $textAlignNodes = $clientData->xpath('.//x:TextHAlign');
+                                        if (!empty($textAlignNodes)) {
+                                            $align = strtolower((string) $textAlignNodes[0]);
+                                            if (in_array($align, ['left', 'center', 'right'], true)) {
+                                                $comment->setAlignment($align);
+                                            }
+                                        }
+
+                                        $textboxNodes = $shape->xpath('.//v:textbox');
+                                        if (!empty($textboxNodes)) {
+                                            $tbStyle = (string) ($textboxNodes[0]['style'] ?? '');
+                                            if (str_contains($tbStyle, 'rtl')) {
+                                                $comment->setTextboxDirection(Comment::TEXTBOX_DIRECTION_RTL);
+                                            } elseif (str_contains($tbStyle, 'ltr')) {
+                                                $comment->setTextboxDirection(Comment::TEXTBOX_DIRECTION_LTR);
+                                            }
+                                        }
+
+                                        if (isset($shape['type'])) {
+                                            if (preg_match('/#_x0000_t(\d+)/', (string)$shape['type'], $m)) {
+                                                $comment->setShapeType((int) $m[1]);
+                                            }
+                                        }
+
+                                        $fillRelNodes = $shape->xpath('.//v:fill/@o:relid');
+                                        if (!empty($fillRelNodes)) {
+                                            $relId = (string) $fillRelNodes[0];
+                                            if (isset($drawingImages[$relId])) {
+                                                $imagePath = str_replace(['../', '/xl/'], 'xl/', $drawingImages[$relId]);
+                                                try {
+                                                    $drawing = new \PhpOffice\PhpSpreadsheet\Worksheet\Drawing();
+                                                    $drawing->setPath('zip://' . $zipFilePath . '#' . $imagePath, true);
+                                                    $comment->setBackgroundImage($drawing);
+                                                } catch (Throwable) {
+
+                                                }
+                                            }
+                                        }
+
+                                        unset($unparsedVmlDrawings[$relName]);
                                     }
                                 }
 

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1226,141 +1226,189 @@ class Xlsx extends BaseReader
                                     }
                                 }
 
+                                // later we will remove from it real vmlComments
                                 $unparsedVmlDrawings = $vmlComments;
                                 $vmlDrawingContents = [];
 
+                                // Loop through VML comments
                                 foreach ($vmlComments as $relName => $relPath) {
-                                    $fullPath = File::realpath(dirname("$dir/$fileWorksheet") . '/' . $relPath);
-
-                                    if (!$fullPath) {
-                                        continue;
-                                    }
+                                    // Load VML comments file
+                                    $relPath = File::realpath(dirname("$dir/$fileWorksheet") . '/' . $relPath);
 
                                     try {
-                                        $vmlCommentsFile = $this->loadZip((string) $fullPath, '', true);
+                                        // no namespace okay - processed with Xpath
+                                        $vmlCommentsFile = $this->loadZip($relPath, '', true);
+                                        $vmlCommentsFile->registerXPathNamespace('v', Namespaces::URN_VML);
                                     } catch (Throwable) {
+                                        //Ignore unparsable vmlDrawings. Later they will be moved from $unparsedVmlDrawings to $unparsedLoadedData
                                         continue;
                                     }
 
-                                    $vmlDrawingContents[$relName] = $this->getSecurityScannerOrThrow()
-                                        ->scan($this->getFromZipArchive($this->zip, (string) $fullPath));
-
-                                    $drawingImages = [];
-                                    $relsPath = dirname((string) $fullPath) . '/_rels/' . basename((string) $fullPath) . '.rels';
-
-                                    if ($this->zip->locateName($relsPath) !== false) {
-                                        $relsVML = $this->loadZip($relsPath, Namespaces::RELATIONSHIPS);
-
-                                        foreach ($relsVML->Relationship as $rel) {
-                                            $attr = self::getAttributes($rel);
-
-                                            if ((string) ($attr['Type'] ?? '') === Namespaces::IMAGE) {
-                                                $drawingImages[(string) ($attr['Id'] ?? '')] = (string) ($attr['Target'] ?? '');
+                                    // Locate VML drawings image relations
+                                    $drowingImages = [];
+                                    $VMLDrawingsRelations = dirname($relPath) . '/_rels/' . basename($relPath) . '.rels';
+                                    $vmlDrawingContents[$relName] = $this->getSecurityScannerOrThrow()->scan($this->getFromZipArchive($zip, $relPath));
+                                    if ($zip->locateName($VMLDrawingsRelations) !== false) {
+                                        $relsVMLDrawing = $this->loadZip($VMLDrawingsRelations, Namespaces::RELATIONSHIPS);
+                                        foreach ($relsVMLDrawing->Relationship as $elex) {
+                                            $ele = self::getAttributes($elex);
+                                            if ($ele['Type'] == Namespaces::IMAGE) {
+                                                $drowingImages[(string) $ele['Id']] = (string) $ele['Target'];
                                             }
                                         }
                                     }
 
-                                    $vmlCommentsFile->registerXPathNamespace('v', Namespaces::URN_VML);
                                     $shapes = self::xpathNoFalse($vmlCommentsFile, '//v:shape');
-
                                     foreach ($shapes as $shape) {
                                         /** @var SimpleXMLElement $shape */
-                                        $shape->registerXPathNamespace('v', Namespaces::URN_VML);
-                                        $shape->registerXPathNamespace('x', Namespaces::URN_EXCEL);
-                                        $shape->registerXPathNamespace('o', Namespaces::URN_MSOFFICE);
-
-                                        $clientDataNodes = $shape->xpath('x:ClientData');
-                                        $clientData = $clientDataNodes[0] ?? null;
-
-                                        if (!$clientData) {
-                                            continue;
-                                        }
-
-                                        $clientData->registerXPathNamespace('x', Namespaces::URN_EXCEL);
-
-                                        if ((string) ($clientData['ObjectType'] ?? '') !== 'Note') {
-                                            continue;
-                                        }
-
-                                        $rowNodes = $clientData->xpath('x:Row');
-                                        $colNodes = $clientData->xpath('x:Column');
-
-                                        $row = isset($rowNodes[0]) ? (int) (string) $rowNodes[0] : -1;
-                                        $col = isset($colNodes[0]) ? (int) (string) $colNodes[0] : -1;
-
-                                        if ($row < 0 || $col < 0) {
-                                            continue;
-                                        }
-
-                                        $coordinate = Coordinate::stringFromColumnIndex($col + 1) . ($row + 1);
-                                        $comment = $docSheet->getComment($coordinate);
-
-                                        if (isset($shape['fillcolor'])) {
-                                            $fillColor = strtoupper(ltrim((string) $shape['fillcolor'], '#'));
-
-                                            if ($fillColor !== '' && ctype_xdigit($fillColor)) {
-                                                $comment->getFillColor()->setRGB($fillColor);
-                                            }
-                                        }
-
-                                        if (isset($shape['strokecolor'])) {
-                                            $borderColor = strtoupper(ltrim((string) $shape['strokecolor'], '#'));
-
-                                            if ($borderColor !== '' && ctype_xdigit($borderColor)) {
-                                                $comment->setBorderColor(new Color($borderColor));
-                                            }
-                                        }
+                                        $vmlNamespaces = $shape->getNamespaces();
+                                        $shape->registerXPathNamespace('v', $vmlNamespaces['v'] ?? Namespaces::URN_VML);
+                                        $shape->registerXPathNamespace('x', $vmlNamespaces['x'] ?? Namespaces::URN_EXCEL);
+                                        $shape->registerXPathNamespace('o', $vmlNamespaces['o'] ?? Namespaces::URN_MSOFFICE);
 
                                         if (isset($shape['style'])) {
-                                            $styles = self::toCSSArray((string) $shape['style']);
+                                            $style = (string) $shape['style'];
+                                            $fillColor = strtoupper(substr((string) $shape['fillcolor'], 1));
+                                            $strokeColor = strtoupper(substr((string) $shape['strokecolor'], 1));
+                                            $column = null;
+                                            $row = null;
+                                            $textHAlign = null;
+                                            $fillImageRelId = null;
+                                            $fillImageTitle = '';
+                                            $fillOpacity = null;
+                                            $shapeType = null;
 
-                                            if (isset($styles['width']) && is_string($styles['width'])) {
-                                                $comment->setWidth($styles['width']);
+                                            // Extract shape type from type attribute (e.g., #_x0000_t203 -> 203)
+                                            $typeAttr = (string) $shape['type'];
+                                            if (Preg::isMatch('/#_x0000_t(\d+)$/', $typeAttr, $matches)) {
+                                                $shapeType = (int) $matches[1];
                                             }
-                                            if (isset($styles['height']) && is_string($styles['height'])) {
-                                                $comment->setHeight($styles['height']);
-                                            }
-                                            if (isset($styles['margin-left']) && is_string($styles['margin-left'])) {
-                                                $comment->setMarginLeft($styles['margin-left']);
-                                            }
-                                            if (isset($styles['margin-top']) && is_string($styles['margin-top'])) {
-                                                $comment->setMarginTop($styles['margin-top']);
-                                            }
-                                            if (isset($styles['visibility']) && is_string($styles['visibility'])) {
-                                                $comment->setVisible(strtolower($styles['visibility']) === 'visible');
-                                            }
-                                        }
 
-                                        $vmlNS = $shape->children(Namespaces::URN_VML);
-
-                                        if (isset($vmlNS->fill, $vmlNS->fill['opacity'])) {
-                                            $comment->setFillOpacity((float) $vmlNS->fill['opacity']);
-                                        }
-
-                                        $textAlignNodes = $clientData->xpath('x:TextHAlign');
-
-                                        if (!empty($textAlignNodes)) {
-                                            $comment->setAlignment(strtolower((string) $textAlignNodes[0]));
-                                        }
-
-                                        $fillRelNodes = $shape->xpath('v:fill/@o:relid');
-
-                                        if (!empty($fillRelNodes)) {
-                                            $relId = (string) $fillRelNodes[0];
-
-                                            if (isset($drawingImages[$relId])) {
-                                                $imagePath = str_replace(['../', '/xl/'], 'xl/', $drawingImages[$relId]);
-
-                                                try {
-                                                    $drawing = new \PhpOffice\PhpSpreadsheet\Worksheet\Drawing();
-                                                    $drawing->setPath('zip://' . $this->zip->filename . '#' . $imagePath, true);
-                                                    $comment->setBackgroundImage($drawing);
-                                                } catch (Throwable) {
+                                            // Extract fill opacity from v:fill element
+                                            $fillNode = $shape->xpath('.//v:fill');
+                                            if (is_array($fillNode) && !empty($fillNode)) {
+                                                $fillAttributes = $fillNode[0]->attributes();
+                                                if (isset($fillAttributes['opacity'])) {
+                                                    $fillOpacity = (float) $fillAttributes['opacity'];
                                                 }
                                             }
-                                        }
 
-                                        unset($unparsedVmlDrawings[$relName]);
+                                            $clientData = $shape->xpath('.//x:ClientData');
+                                            $textboxDirection = '';
+                                            $textboxPath = $shape->xpath('.//v:textbox');
+                                            $textbox = (string) ($textboxPath[0]['style'] ?? '');
+                                            if (Preg::isMatch('/rtl/i', $textbox)) {
+                                                $textboxDirection = Comment::TEXTBOX_DIRECTION_RTL;
+                                            } elseif (Preg::isMatch('/ltr/i', $textbox)) {
+                                                $textboxDirection = Comment::TEXTBOX_DIRECTION_LTR;
+                                            }
+                                            if (is_array($clientData) && !empty($clientData)) {
+                                                /** @var SimpleXMLElement */
+                                                $clientData = $clientData[0];
+
+                                                if (isset($clientData['ObjectType']) && (string) $clientData['ObjectType'] == 'Note') {
+                                                    $clientData->registerXPathNamespace('x', $vmlNamespaces['x'] ?? Namespaces::URN_EXCEL);
+                                                    $temp = $clientData->xpath('.//x:Row');
+                                                    if (is_array($temp)) {
+                                                        $row = $temp[0];
+                                                    }
+
+                                                    $temp = $clientData->xpath('.//x:Column');
+                                                    if (is_array($temp)) {
+                                                        $column = $temp[0];
+                                                    }
+                                                    $temp = $clientData->xpath('.//x:TextHAlign');
+                                                    if (!empty($temp)) {
+                                                        $textHAlign = strtolower($temp[0]);
+                                                    }
+                                                }
+                                            }
+                                            $rowx = (string) $row;
+                                            $colx = (string) $column;
+                                            if (is_numeric($rowx) && is_numeric($colx) && $textHAlign !== null) {
+                                                $docSheet->getComment([1 + (int) $colx, 1 + (int) $rowx], false)->setAlignment((string) $textHAlign);
+                                            }
+                                            if (is_numeric($rowx) && is_numeric($colx) && $textboxDirection !== '') {
+                                                $docSheet->getComment([1 + (int) $colx, 1 + (int) $rowx], false)->setTextboxDirection($textboxDirection);
+                                            }
+
+                                            $fillImageRelNode = $shape->xpath('.//v:fill/@o:relid');
+                                            if (is_array($fillImageRelNode) && !empty($fillImageRelNode)) {
+                                                /** @var SimpleXMLElement */
+                                                $fillImageRelNode = $fillImageRelNode[0];
+
+                                                if (isset($fillImageRelNode['relid'])) {
+                                                    $fillImageRelId = (string) $fillImageRelNode['relid'];
+                                                }
+                                            }
+
+                                            $fillImageTitleNode = $shape->xpath('.//v:fill/@o:title');
+                                            if (is_array($fillImageTitleNode) && !empty($fillImageTitleNode)) {
+                                                /** @var SimpleXMLElement */
+                                                $fillImageTitleNode = $fillImageTitleNode[0];
+
+                                                if (isset($fillImageTitleNode['title'])) {
+                                                    $fillImageTitle = (string) $fillImageTitleNode['title'];
+                                                }
+                                            }
+
+                                            if (($column !== null) && ($row !== null)) {
+                                                // Set comment properties
+                                                $comment = $docSheet->getComment([(int) $column + 1, (int) $row + 1]);
+                                                $comment->getFillColor()->setRGB($fillColor);
+
+                                                // Set border color
+                                                if (!empty($strokeColor)) {
+                                                    $comment->getBorderColor()->setRGB($strokeColor);
+                                                }
+
+                                                // Set fill opacity
+                                                if ($fillOpacity !== null) {
+                                                    $comment->setFillOpacity($fillOpacity);
+                                                }
+
+                                                // Set shape type
+                                                if ($shapeType !== null) {
+                                                    $comment->setShapeType($shapeType);
+                                                }
+
+                                                if (isset($fillImageRelId, $drowingImages[$fillImageRelId])) {
+                                                    $objDrawing = new \PhpOffice\PhpSpreadsheet\Worksheet\Drawing();
+                                                    $objDrawing->setName($fillImageTitle);
+                                                    $imagePath = str_replace(['../', '/xl/'], 'xl/', $drowingImages[$fillImageRelId]);
+                                                    $objDrawing->setPath(
+                                                        'zip://' . File::realpath($filename) . '#' . $imagePath,
+                                                        true,
+                                                        $zip
+                                                    );
+                                                    $comment->setBackgroundImage($objDrawing);
+                                                }
+
+                                                // Parse style
+                                                $styleArray = explode(';', str_replace(' ', '', $style));
+                                                foreach ($styleArray as $stylePair) {
+                                                    $stylePair = explode(':', $stylePair);
+
+                                                    if ($stylePair[0] == 'margin-left') {
+                                                        $comment->setMarginLeft($stylePair[1]);
+                                                    }
+                                                    if ($stylePair[0] == 'margin-top') {
+                                                        $comment->setMarginTop($stylePair[1]);
+                                                    }
+                                                    if ($stylePair[0] == 'width') {
+                                                        $comment->setWidth($stylePair[1]);
+                                                    }
+                                                    if ($stylePair[0] == 'height') {
+                                                        $comment->setHeight($stylePair[1]);
+                                                    }
+                                                    if ($stylePair[0] == 'visibility') {
+                                                        $comment->setVisible($stylePair[1] == 'visible');
+                                                    }
+                                                }
+
+                                                unset($unparsedVmlDrawings[$relName]);
+                                            }
+                                        }
                                     }
                                 }
 

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -1229,61 +1229,64 @@ class Xlsx extends BaseReader
                                 $unparsedVmlDrawings = $vmlComments;
                                 $vmlDrawingContents = [];
 
-                                $zipFilePath = $this->zip->filename;
-
                                 foreach ($vmlComments as $relName => $relPath) {
                                     $fullPath = File::realpath(dirname("$dir/$fileWorksheet") . '/' . $relPath);
 
-                                    if ((bool) $fullPath === false) {
+                                    if (!$fullPath) {
                                         continue;
                                     }
 
                                     try {
-                                        $vmlCommentsFile = $this->loadZip($fullPath, '', true);
-                                        $vmlCommentsFile->registerXPathNamespace('v', Namespaces::URN_VML);
+                                        $vmlCommentsFile = $this->loadZip((string) $fullPath, '', true);
                                     } catch (Throwable) {
                                         continue;
                                     }
 
                                     $vmlDrawingContents[$relName] = $this->getSecurityScannerOrThrow()
-                                        ->scan($this->getFromZipArchive($zip, $fullPath));
+                                        ->scan($this->getFromZipArchive($this->zip, (string) $fullPath));
 
                                     $drawingImages = [];
-                                    $relsPath = dirname($fullPath) . '/_rels/' . basename($fullPath) . '.rels';
+                                    $relsPath = dirname((string) $fullPath) . '/_rels/' . basename((string) $fullPath) . '.rels';
 
-                                    if ($zip->locateName($relsPath) !== false) {
+                                    if ($this->zip->locateName($relsPath) !== false) {
                                         $relsVML = $this->loadZip($relsPath, Namespaces::RELATIONSHIPS);
+
                                         foreach ($relsVML->Relationship as $rel) {
                                             $attr = self::getAttributes($rel);
-                                            if ((string) $attr['Type'] === Namespaces::IMAGE) {
-                                                $drawingImages[(string) $attr['Id']] = (string) $attr['Target'];
+
+                                            if ((string) ($attr['Type'] ?? '') === Namespaces::IMAGE) {
+                                                $drawingImages[(string) ($attr['Id'] ?? '')] = (string) ($attr['Target'] ?? '');
                                             }
                                         }
                                     }
 
+                                    $vmlCommentsFile->registerXPathNamespace('v', Namespaces::URN_VML);
                                     $shapes = self::xpathNoFalse($vmlCommentsFile, '//v:shape');
 
                                     foreach ($shapes as $shape) {
-                                        $namespaces = $shape->getNamespaces();
-                                        $shape->registerXPathNamespace('x', $namespaces['x'] ?? Namespaces::URN_EXCEL);
-                                        $shape->registerXPathNamespace('o', $namespaces['o'] ?? Namespaces::URN_MSOFFICE);
-                                        $shape->registerXPathNamespace('v', $namespaces['v'] ?? Namespaces::URN_VML);
+                                        /** @var SimpleXMLElement $shape */
+                                        $shape->registerXPathNamespace('v', Namespaces::URN_VML);
+                                        $shape->registerXPathNamespace('x', Namespaces::URN_EXCEL);
+                                        $shape->registerXPathNamespace('o', Namespaces::URN_MSOFFICE);
 
-                                        $clientDataNodes = $shape->xpath('.//x:ClientData');
-                                        if (empty($clientDataNodes)) {
+                                        $clientDataNodes = $shape->xpath('x:ClientData');
+                                        $clientData = $clientDataNodes[0] ?? null;
+
+                                        if (!$clientData) {
                                             continue;
                                         }
 
-                                        $clientData = $clientDataNodes[0];
+                                        $clientData->registerXPathNamespace('x', Namespaces::URN_EXCEL);
+
                                         if ((string) ($clientData['ObjectType'] ?? '') !== 'Note') {
                                             continue;
                                         }
 
-                                        $rowNodes = $clientData->xpath('.//x:Row');
-                                        $colNodes = $clientData->xpath('.//x:Column');
+                                        $rowNodes = $clientData->xpath('x:Row');
+                                        $colNodes = $clientData->xpath('x:Column');
 
-                                        $row = isset($rowNodes[0]) ? (int) (string)$rowNodes[0] : -1;
-                                        $col = isset($colNodes[0]) ? (int) (string)$colNodes[0] : -1;
+                                        $row = isset($rowNodes[0]) ? (int) (string) $rowNodes[0] : -1;
+                                        $col = isset($colNodes[0]) ? (int) (string) $colNodes[0] : -1;
 
                                         if ($row < 0 || $col < 0) {
                                             continue;
@@ -1294,6 +1297,7 @@ class Xlsx extends BaseReader
 
                                         if (isset($shape['fillcolor'])) {
                                             $fillColor = strtoupper(ltrim((string) $shape['fillcolor'], '#'));
+
                                             if ($fillColor !== '' && ctype_xdigit($fillColor)) {
                                                 $comment->getFillColor()->setRGB($fillColor);
                                             }
@@ -1301,6 +1305,7 @@ class Xlsx extends BaseReader
 
                                         if (isset($shape['strokecolor'])) {
                                             $borderColor = strtoupper(ltrim((string) $shape['strokecolor'], '#'));
+
                                             if ($borderColor !== '' && ctype_xdigit($borderColor)) {
                                                 $comment->setBorderColor(new Color($borderColor));
                                             }
@@ -1308,56 +1313,49 @@ class Xlsx extends BaseReader
 
                                         if (isset($shape['style'])) {
                                             $styles = self::toCSSArray((string) $shape['style']);
-                                            if (isset($styles['width'])) $comment->setWidth($styles['width']);
-                                            if (isset($styles['height'])) $comment->setHeight($styles['height']);
-                                            if (isset($styles['margin-left'])) $comment->setMarginLeft($styles['margin-left']);
-                                            if (isset($styles['margin-top'])) $comment->setMarginTop($styles['margin-top']);
-                                            if (isset($styles['visibility'])) {
+
+                                            if (isset($styles['width']) && is_string($styles['width'])) {
+                                                $comment->setWidth($styles['width']);
+                                            }
+                                            if (isset($styles['height']) && is_string($styles['height'])) {
+                                                $comment->setHeight($styles['height']);
+                                            }
+                                            if (isset($styles['margin-left']) && is_string($styles['margin-left'])) {
+                                                $comment->setMarginLeft($styles['margin-left']);
+                                            }
+                                            if (isset($styles['margin-top']) && is_string($styles['margin-top'])) {
+                                                $comment->setMarginTop($styles['margin-top']);
+                                            }
+                                            if (isset($styles['visibility']) && is_string($styles['visibility'])) {
                                                 $comment->setVisible(strtolower($styles['visibility']) === 'visible');
                                             }
                                         }
 
-                                        $vNS = $namespaces['v'] ?? Namespaces::URN_VML;
-                                        $fillElement = $shape->children($vNS)->fill ?? null;
-                                        if ($fillElement && isset($fillElement['opacity'])) {
-                                            $comment->setFillOpacity((float) $fillElement['opacity']);
+                                        $vmlNS = $shape->children(Namespaces::URN_VML);
+
+                                        if (isset($vmlNS->fill, $vmlNS->fill['opacity'])) {
+                                            $comment->setFillOpacity((float) $vmlNS->fill['opacity']);
                                         }
 
-                                        $textAlignNodes = $clientData->xpath('.//x:TextHAlign');
+                                        $textAlignNodes = $clientData->xpath('x:TextHAlign');
+
                                         if (!empty($textAlignNodes)) {
-                                            $align = strtolower((string) $textAlignNodes[0]);
-                                            if (in_array($align, ['left', 'center', 'right'], true)) {
-                                                $comment->setAlignment($align);
-                                            }
+                                            $comment->setAlignment(strtolower((string) $textAlignNodes[0]));
                                         }
 
-                                        $textboxNodes = $shape->xpath('.//v:textbox');
-                                        if (!empty($textboxNodes)) {
-                                            $tbStyle = (string) ($textboxNodes[0]['style'] ?? '');
-                                            if (str_contains($tbStyle, 'rtl')) {
-                                                $comment->setTextboxDirection(Comment::TEXTBOX_DIRECTION_RTL);
-                                            } elseif (str_contains($tbStyle, 'ltr')) {
-                                                $comment->setTextboxDirection(Comment::TEXTBOX_DIRECTION_LTR);
-                                            }
-                                        }
+                                        $fillRelNodes = $shape->xpath('v:fill/@o:relid');
 
-                                        if (isset($shape['type'])) {
-                                            if (preg_match('/#_x0000_t(\d+)/', (string)$shape['type'], $m)) {
-                                                $comment->setShapeType((int) $m[1]);
-                                            }
-                                        }
-
-                                        $fillRelNodes = $shape->xpath('.//v:fill/@o:relid');
                                         if (!empty($fillRelNodes)) {
                                             $relId = (string) $fillRelNodes[0];
+
                                             if (isset($drawingImages[$relId])) {
                                                 $imagePath = str_replace(['../', '/xl/'], 'xl/', $drawingImages[$relId]);
+
                                                 try {
                                                     $drawing = new \PhpOffice\PhpSpreadsheet\Worksheet\Drawing();
-                                                    $drawing->setPath('zip://' . $zipFilePath . '#' . $imagePath, true);
+                                                    $drawing->setPath('zip://' . $this->zip->filename . '#' . $imagePath, true);
                                                     $comment->setBackgroundImage($drawing);
                                                 } catch (Throwable) {
-
                                                 }
                                             }
                                         }

--- a/src/PhpSpreadsheet/Writer/Xlsx/Comments.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Comments.php
@@ -88,7 +88,7 @@ class Comments extends WriterPart
 
         // text
         $objWriter->startElement('text');
-        $this->getParentWriter()->getWriterPartstringtable()->writeRichText($objWriter, $comment->getText());
+        $this->getParentWriter()->getWriterPartStringTable()->writeRichText($objWriter, $comment->getText());
         $objWriter->endElement();
 
         $objWriter->endElement();

--- a/src/PhpSpreadsheet/Writer/Xlsx/Comments.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Comments.php
@@ -180,14 +180,18 @@ class Comments extends WriterPart
         // v:shape
         $objWriter->startElement('v:shape');
         $objWriter->writeAttribute('id', '_x0000_s' . $id);
-        $objWriter->writeAttribute('type', '#_x0000_t202');
+        $objWriter->writeAttribute('type', '#_x0000_t' . $comment->getShapeType());
         $objWriter->writeAttribute('style', 'position:absolute;margin-left:' . $comment->getMarginLeft() . ';margin-top:' . $comment->getMarginTop() . ';width:' . $comment->getWidth() . ';height:' . $comment->getHeight() . ';z-index:1;visibility:' . ($comment->getVisible() ? 'visible' : 'hidden'));
         $objWriter->writeAttribute('fillcolor', '#' . $comment->getFillColor()->getRGB());
+        $objWriter->writeAttribute('strokecolor', '#' . $comment->getBorderColor()->getRGB());
         $objWriter->writeAttribute('o:insetmode', 'auto');
 
         // v:fill
         $objWriter->startElement('v:fill');
         $objWriter->writeAttribute('color2', '#' . $comment->getFillColor()->getRGB());
+        if ($comment->getFillOpacity() < 1.0) {
+            $objWriter->writeAttribute('opacity', (string) $comment->getFillOpacity());
+        }
         if ($comment->hasBackgroundImage()) {
             $bgImage = $comment->getBackgroundImage();
             $objWriter->writeAttribute('o:relid', 'rId' . $bgImage->getImageIndex());

--- a/tests/PhpSpreadsheetTests/Functional/CommentsTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/CommentsTest.php
@@ -48,7 +48,7 @@ class CommentsTest extends AbstractFunctional
         self::assertEquals($comment, $commentClone);
         self::assertNotSame($comment, $commentClone);
         if ($format === 'Xlsx') {
-            self::assertSame('bc7bcec8f676a333dae65c945cf8dace', $comment->getHashCode(), 'changed due to addition of theme to fillColor');
+            self::assertSame('db7d24e39957b75ccd95b1bd5c7f488d', $comment->getHashCode(), 'changed due to addition of theme to fillColor');
             self::assertSame(Alignment::HORIZONTAL_GENERAL, $comment->getAlignment());
             $comment->setAlignment(Alignment::HORIZONTAL_RIGHT);
             self::assertSame(Alignment::HORIZONTAL_RIGHT, $comment->getAlignment());

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue1790Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue1790Test.php
@@ -6,6 +6,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Color;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 use PHPUnit\Framework\TestCase;
+use ZipArchive;
 
 class Issue1790Test extends TestCase
 {
@@ -23,17 +24,22 @@ class Issue1790Test extends TestCase
 
         $writer = new Xlsx($spreadsheet);
         $tempFile = tempnam(sys_get_temp_dir(), 'xlsx');
+        if ($tempFile === false) {
+            self::fail('Could not create temporary file');
+        }
         $writer->save($tempFile);
 
-        $zip = new \ZipArchive();
+        $zip = new ZipArchive();
         $zip->open($tempFile);
         $vml = $zip->getFromName('xl/drawings/vmlDrawing1.vml');
         $zip->close();
         unlink($tempFile);
 
-        $this->assertStringContainsString('fillcolor="#FF5733"', $vml);
-        $this->assertStringContainsString('strokecolor="#0000FF"', $vml);
-        $this->assertStringContainsString('opacity="0.6"', $vml);
-        $this->assertStringContainsString('type="#_x0000_t203"', $vml);
+        self::assertIsString($vml);
+
+        self::assertStringContainsString('fillcolor="#FF5733"', $vml);
+        self::assertStringContainsString('strokecolor="#0000FF"', $vml);
+        self::assertStringContainsString('opacity="0.6"', $vml);
+        self::assertStringContainsString('type="#_x0000_t203"', $vml);
     }
 }

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue1790Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue1790Test.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
 
+use PhpOffice\PhpSpreadsheet\Reader\Xlsx as XlsxReader;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Color;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
@@ -19,7 +20,6 @@ class Issue1790Test extends TestCase
         $comment->getFillColor()->setRGB('FF5733');
         $comment->setBorderColor(new Color('0000FF'));
         $comment->setFillOpacity(0.6);
-
         $comment->setShapeType(203);
 
         $writer = new Xlsx($spreadsheet);
@@ -41,5 +41,88 @@ class Issue1790Test extends TestCase
         self::assertStringContainsString('strokecolor="#0000FF"', $vml);
         self::assertStringContainsString('opacity="0.6"', $vml);
         self::assertStringContainsString('type="#_x0000_t203"', $vml);
+    }
+
+    public function testCommentStylingRoundTrip(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        $comment = $sheet->getComment('A1');
+        $comment->getFillColor()->setRGB('FF5733');
+        $comment->setBorderColor(new Color('0000FF'));
+        $comment->setFillOpacity(0.6);
+        $comment->setShapeType(203);
+        $comment->setAuthor('TestAuthor');
+        $comment->getText()->createText('Test comment text');
+
+        $writer = new Xlsx($spreadsheet);
+        $tempFile = tempnam(sys_get_temp_dir(), 'xlsx');
+        if ($tempFile === false) {
+            self::fail('Could not create temporary file');
+        }
+        $writer->save($tempFile);
+
+        $reader = new XlsxReader();
+        $loadedSpreadsheet = $reader->load($tempFile);
+        $loadedComment = $loadedSpreadsheet->getActiveSheet()->getComment('A1');
+
+        self::assertEquals('FF5733', $loadedComment->getFillColor()->getRGB());
+        self::assertEquals('0000FF', $loadedComment->getBorderColor()->getRGB());
+        self::assertEquals(0.6, $loadedComment->getFillOpacity());
+        self::assertEquals(203, $loadedComment->getShapeType());
+        self::assertEquals('TestAuthor', $loadedComment->getAuthor());
+        self::assertEquals('Test comment text', $loadedComment->getText()->getPlainText());
+
+        unlink($tempFile);
+        $spreadsheet->disconnectWorksheets();
+        $loadedSpreadsheet->disconnectWorksheets();
+    }
+
+    public function testMultipleCommentStyling(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        $comment1 = $sheet->getComment('A1');
+        $comment1->getFillColor()->setRGB('FF0000');
+        $comment1->setBorderColor(new Color('00FF00'));
+        $comment1->setFillOpacity(0.3);
+        $comment1->setShapeType(202);
+        $comment1->getText()->createText('Red comment');
+
+        $comment2 = $sheet->getComment('B2');
+        $comment2->getFillColor()->setRGB('0000FF');
+        $comment2->setBorderColor(new Color('FFFF00'));
+        $comment2->setFillOpacity(0.8);
+        $comment2->setShapeType(204);
+        $comment2->getText()->createText('Blue comment');
+
+        $writer = new Xlsx($spreadsheet);
+        $tempFile = tempnam(sys_get_temp_dir(), 'xlsx');
+        if ($tempFile === false) {
+            self::fail('Could not create temporary file');
+        }
+        $writer->save($tempFile);
+
+        $reader = new XlsxReader();
+        $loadedSpreadsheet = $reader->load($tempFile);
+        $loadedSheet = $loadedSpreadsheet->getActiveSheet();
+
+        $loadedComment1 = $loadedSheet->getComment('A1');
+        self::assertEquals('FF0000', $loadedComment1->getFillColor()->getRGB());
+        self::assertEquals('00FF00', $loadedComment1->getBorderColor()->getRGB());
+        self::assertEquals(0.3, $loadedComment1->getFillOpacity());
+        self::assertEquals(202, $loadedComment1->getShapeType());
+
+        $loadedComment2 = $loadedSheet->getComment('B2');
+        self::assertEquals('0000FF', $loadedComment2->getFillColor()->getRGB());
+        self::assertEquals('FFFF00', $loadedComment2->getBorderColor()->getRGB());
+        self::assertEquals(0.8, $loadedComment2->getFillOpacity());
+        self::assertEquals(204, $loadedComment2->getShapeType());
+
+        unlink($tempFile);
+        $spreadsheet->disconnectWorksheets();
+        $loadedSpreadsheet->disconnectWorksheets();
     }
 }

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue1790Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue1790Test.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Xlsx;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Color;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use PHPUnit\Framework\TestCase;
+
+class Issue1790Test extends TestCase
+{
+    public function testCommentStylingOutput(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $comment = $sheet->getComment('A1');
+
+        $comment->getFillColor()->setRGB('FF5733');
+        $comment->setBorderColor(new Color('0000FF'));
+        $comment->setFillOpacity(0.6);
+
+        $comment->setShapeType(203);
+
+        $writer = new Xlsx($spreadsheet);
+        $tempFile = tempnam(sys_get_temp_dir(), 'xlsx');
+        $writer->save($tempFile);
+
+        $zip = new \ZipArchive();
+        $zip->open($tempFile);
+        $vml = $zip->getFromName('xl/drawings/vmlDrawing1.vml');
+        $zip->close();
+        unlink($tempFile);
+
+        $this->assertStringContainsString('fillcolor="#FF5733"', $vml);
+        $this->assertStringContainsString('strokecolor="#0000FF"', $vml);
+        $this->assertStringContainsString('opacity="0.6"', $vml);
+        $this->assertStringContainsString('type="#_x0000_t203"', $vml);
+    }
+}


### PR DESCRIPTION
Resolved #1790 by adding shapeType and styling support for Comments. Users can now programmatically set the box shape, background color, border color, and transparency. This replaces the previously hardcoded rectangles with fully customizable comment objects. Unit tests are included to verify the VML output for all new properties.