### PR TITLE
Don't infer cell t attribute from formula source when pre-calc is off

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1576,7 +1576,13 @@ class Worksheet extends WriterPart
     {
         $attributes = $cell->getFormulaAttributes() ?? [];
         $coordinate = $cell->getCoordinate();
-        $calculatedValue = $this->getParentWriter()->getPreCalculateFormulas() ? $cell->getCalculatedValue() : $cellValue;
+        $preCalc = $this->getParentWriter()->getPreCalculateFormulas();
+        // When pre-calc is off we have no calculated value to infer the cell type from. The
+        // previous fall-back of $cellValue (the formula source) made every formula cell write
+        // t="str" because the source is always a string — misleading for formulas that resolve
+        // to numbers/booleans. Leave $calculatedValue/$calculatedValueString null so the
+        // type-inference branches below are skipped and no t attribute is written.
+        $calculatedValue = $preCalc ? $cell->getCalculatedValue() : null;
         if ($calculatedValue === ExcelError::SPILL()) {
             $objWriter->writeAttribute('t', 'e');
             //$objWriter->writeAttribute('cm', '1'); // already added
@@ -1592,7 +1598,10 @@ class Worksheet extends WriterPart
 
             return;
         }
-        $calculatedValueString = $this->getParentWriter()->getPreCalculateFormulas() ? $cell->getCalculatedValueString() : $cellValue;
+        // Empty string (not null) so str_starts_with($calculatedValueString, '#') below stays
+        // type-correct when pre-calc is off; the surrounding writeElementIf condition guards
+        // against actually emitting <v> when there is no calculated value.
+        $calculatedValueString = $preCalc ? $cell->getCalculatedValueString() : '';
         $result = $calculatedValue;
         while (is_array($result)) {
             $result = array_shift($result);

--- a/tests/PhpSpreadsheetTests/Writer/PreCalcTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/PreCalcTest.php
@@ -108,7 +108,10 @@ class PreCalcTest extends AbstractFunctional
             $data = self::readFile($file);
             // confirm that file contains B2 pre-calculated or not as appropriate
             if ($preCalc === false) {
-                self::assertStringContainsString('<c r="B2" t="str"><f>3+A3</f></c>', $data);
+                // No t="str" when pre-calc is off: with no calculated value to inspect, the
+                // writer can no longer infer the result type from the formula source string
+                // (which is always a string). Readers compute on open per fullCalcOnLoad.
+                self::assertStringContainsString('<c r="B2"><f>3+A3</f></c>', $data);
             } else {
                 self::assertStringContainsString('<c r="B2"><f>3+A3</f><v>14</v></c>', $data);
             }


### PR DESCRIPTION
# Don't infer cell `t` attribute from formula source when pre-calc is off

## What

When `setPreCalculateFormulas(false)` is set on the Xlsx writer, every formula cell is written with `t="str"` — even when the formula evaluates to a number or boolean. This PR removes that spurious type attribute.

## Why this matters

Spreadsheet readers use the `t` attribute on a formula cell as a hint about the *result* type. Writing `t="str"` for a `=SUMIFS(...)` cell tells readers "this formula's result is a string" — which is wrong, and triggers two real failures in the wild:

1. **LibreOffice (versions before 7?) and Gnumeric** treat `t="str"` as authoritative when there is no cached `<v>`. They either skip recomputation, render the formula text literally, or surface `#NAME` errors for numeric formulas they would otherwise compute correctly.
2. **Auditors and downstream tooling** that introspect the XML get a misleading signal. A cell whose formula returns a number is declared as a string-result cell.

Internally we hit this when generating a TVA report whose Sommaire sheet uses `SUMIFS` formulas referencing a 20k+ row data sheet. With pre-calc on, PhpSpreadsheet's calc engine iterates whole-column refs to Excel's 1,048,576-row max per condition per formula and the export hangs. Disabling pre-calc unblocks the export but produces a file where every `SUMIFS` displays as `=_xlfn.sumifs(...)` returning `#NAME` because of the `t="str"` plus the formula prefix combination.

## Root cause (`src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php`, `writeCellFormula`)

```php
$calculatedValue = $this->getParentWriter()->getPreCalculateFormulas()
    ? $cell->getCalculatedValue()
    : $cellValue;          // ← formula source string when pre-calc is off
// ...
if (is_string($result)) {  // ← always true when $result derives from $cellValue
    // ...
    $objWriter->writeAttribute('t', 'str');
}
```

`$cellValue` is the formula source (e.g. `"=SUMIFS(...)"`). It is always a string, so the `is_string` branch always fires when pre-calc is off, regardless of what the formula would actually evaluate to.

## Fix

Leave `$calculatedValue` `null` (and `$calculatedValueString` empty) when pre-calc is off. The `is_string`/`is_bool` type-inference branches no longer fire and no `t` attribute is written. The `<v>` element is already correctly suppressed by the existing `getPreCalculateFormulas()` guard at the `writeElementIf` site, so no cached value is written either.

Result: cells written without pre-calc now look like

```xml
<c r="B2"><f>3+A3</f></c>
```

instead of

```xml
<c r="B2" t="str"><f>3+A3</f></c>
```

The workbook's `<calcPr fullCalcOnLoad="1" forceFullCalc="1"/>` is unchanged, so readers correctly recompute on open.

## Backwards compatibility

- Pre-calc *on* (default): no behavioural change. `$calculatedValue` still comes from `$cell->getCalculatedValue()` and the existing type-inference logic runs unchanged.
- Pre-calc *off*: cells previously wrote `t="str"` and (until very recently) `<v>0</v>`. The `<v>0</v>` was already removed in master; this PR removes the spurious `t="str"`. Readers that handled the old output continue to work, and readers that didn't (per the issues above) now do.

## Tests

- Updates `tests/PhpSpreadsheetTests/Writer/PreCalcTest.php` line 111 to expect `<c r="B2"><f>3+A3</f></c>` (no `t="str"`) when `$preCalc === false`. The Xls / Ods / Html / Csv branches are unaffected.
- Other tests asserting `t="str"` on formula cells (Issue2082Test, XlfnFunctionsTest, …) are all in pre-calc=on scenarios with `<v>...</v>` cached values, and continue to pass unchanged.
- Verified locally: full `tests/PhpSpreadsheetTests/Writer/Xlsx/` suite passes (223 tests), full `Functional/` + `Calculation/` suites pass (16,265 tests, 0 failures).

## Related

- The companion concern of `_xlfn.` prefix being added to formula cells when pre-calc is off (which causes `#NAME` in pre-7 LibreOffice / Gnumeric) is intentionally **not** addressed in this PR. The `_xlfn.` prefix is correct OOXML and would touch many more tests; it can be a separate discussion if the project wants to make that conditional too.


## More

  Commit 406988e5 — "SetCalculatedValue Avoid Casting String to Numeric (#3685)" by oleibman, 2023-08-26.                                                                                                          
                                                             
  The commit message explicitly acknowledges our exact bug:                                                                                                                                                        
                                                             
> "Reading a spreadsheet which has been created with preCalculateFormulas false will, or at least should, result in a null oldCalculatedValue. … Xlsx was actually storing 0 in this situation; that wasn't      
> precisely a problem, but it wasn't necessary and seems misleading. Xlsx Writer is changed to no longer set a value in this situation."
