### PR TITLE
Reject phar Protocol in Unexpected Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org). Thia is a
 
 ### Security Note
 
-- A prior change had attempted to eliminate the ability to use input files using the phar protocol. Some filenames using that protocol were not caught by the earlier change. That is now fixed. The failure to detect these files *did not* lead to a security exposure in PhpSpreadsheet. However, if you relied on "PhpSpreadsheet can read the file" as a surrogate for "it is safe to read the file's metadata", you should not do so. [PR #4876](https://github.com/PHPOffice/PhpSpreadsheet/pull/4876)
+- File::prohibitWrappers and Drawing::setPath now reject phar paths with extra leading slashes (e.g. phar:///…) that escaped the prior parse_url-based filter. No security exploit was possible even with the extra slashes. [PR #4876](https://github.com/PHPOffice/PhpSpreadsheet/pull/4876)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org). Thia is a
 
 ## TBD - 5.8.0
 
+### Security Note
+
+- A prior change had attempted to eliminate the ability to use input files using the phar protocol. Some filenames using that protocol were not caught by the earlier change. That is now fixed. The failure to detect these files *did not* lead to a security exposure in PhpSpreadsheet. However, if you relied on "PhpSpreadsheet can read the file" as a surrogate for "it is safe to read the file's metadata", you should not do so. [PR #4876](https://github.com/PHPOffice/PhpSpreadsheet/pull/4876)
+
 ### Added
 
 - Optional method to increase Calculation Engine's parsing speed. [PR #4829](https://github.com/PHPOffice/PhpSpreadsheet/pull/4829)

--- a/src/PhpSpreadsheet/Shared/File.php
+++ b/src/PhpSpreadsheet/Shared/File.php
@@ -134,10 +134,12 @@ class File
     }
 
     /**
-     * All filenames starting with protocol (e.g. phar://) are prohibited.
+     * Blocks phar:// and similar RCE-bearing wrappers.
      * Note that many protocols, including http and zip, will already
      * return false for is_file.
      * A whitelist of protocols may be added if needed in future.
+     * data: is intentionally allowed (see #4823); callers needing strict
+     * on-disk-only semantics must validate $filename themselves.
      */
     public static function prohibitWrappers(string $filename): void
     {

--- a/src/PhpSpreadsheet/Shared/File.php
+++ b/src/PhpSpreadsheet/Shared/File.php
@@ -147,7 +147,6 @@ class File
         if (
             Preg::IsMatch('~^phar://~i', $filename)
             || (Preg::isMatch('/^([\w.\s\x00-\x1f]+):/', $filename) && !Preg::isMatch('/^([\w.]+):/', $filename))
-            || Preg::isMatch('~^php://.*phar:~is', $filename)
             || Preg::isMatch('~^[\w.]+://.*phar:~is', $filename)
         ) {
             throw new Exception(

--- a/src/PhpSpreadsheet/Shared/File.php
+++ b/src/PhpSpreadsheet/Shared/File.php
@@ -147,7 +147,7 @@ class File
         if (
             Preg::IsMatch('~^phar://~i', $filename)
             || (Preg::isMatch('/^([\w\s\x00-\x1f]+):/', $filename) && !Preg::isMatch('/^([\w]+):/', $filename))
-            || Preg::isMatch('~^php://.*phar:~i', $filename)
+            || Preg::isMatch('~^php://.*phar:~is', $filename)
         ) {
             throw new Exception(
                 "Disallowed stream wrapper used for {$filename}"

--- a/src/PhpSpreadsheet/Shared/File.php
+++ b/src/PhpSpreadsheet/Shared/File.php
@@ -2,6 +2,7 @@
 
 namespace PhpOffice\PhpSpreadsheet\Shared;
 
+use Composer\Pcre\Preg;
 use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\Reader\Exception as ReaderException;
 use ZipArchive;
@@ -144,9 +145,9 @@ class File
     public static function prohibitWrappers(string $filename): void
     {
         if (
-            preg_match('~^phar://~i', $filename)
-            || (preg_match('/^([\w\s\x00-\x1f]+):/u', $filename) && !preg_match('/^([\w]+):/u', $filename))
-            || preg_match('~^php://.*phar:~i', $filename)
+            Preg::IsMatch('~^phar://~i', $filename)
+            || (Preg::isMatch('/^([\w\s\x00-\x1f]+):/', $filename) && !Preg::isMatch('/^([\w]+):/', $filename))
+            || Preg::isMatch('~^php://.*phar:~i', $filename)
         ) {
             throw new Exception(
                 "Disallowed stream wrapper used for {$filename}"

--- a/src/PhpSpreadsheet/Shared/File.php
+++ b/src/PhpSpreadsheet/Shared/File.php
@@ -146,8 +146,9 @@ class File
     {
         if (
             Preg::IsMatch('~^phar://~i', $filename)
-            || (Preg::isMatch('/^([\w\s\x00-\x1f]+):/', $filename) && !Preg::isMatch('/^([\w]+):/', $filename))
+            || (Preg::isMatch('/^([\w.\s\x00-\x1f]+):/', $filename) && !Preg::isMatch('/^([\w.]+):/', $filename))
             || Preg::isMatch('~^php://.*phar:~is', $filename)
+            || Preg::isMatch('~^[\w.]+://.*phar:~is', $filename)
         ) {
             throw new Exception(
                 "Disallowed stream wrapper used for {$filename}"

--- a/src/PhpSpreadsheet/Shared/File.php
+++ b/src/PhpSpreadsheet/Shared/File.php
@@ -143,9 +143,13 @@ class File
      */
     public static function prohibitWrappers(string $filename): void
     {
-        if (str_contains($filename, '://')) {
+        if (
+            preg_match('~^phar://~i', $filename)
+            || (preg_match('/^([\w\s\x00-\x1f]+):/u', $filename) && !preg_match('/^([\w]+):/u', $filename))
+            || preg_match('~^php://.*phar:~i', $filename)
+        ) {
             throw new Exception(
-                "Stream wrappers are not permitted as file paths: {$filename}"
+                "Disallowed stream wrapper used for {$filename}"
             );
         }
     }

--- a/src/PhpSpreadsheet/Shared/File.php
+++ b/src/PhpSpreadsheet/Shared/File.php
@@ -141,10 +141,7 @@ class File
      */
     public static function prohibitWrappers(string $filename): void
     {
-        $scheme = parse_url($filename, PHP_URL_SCHEME);
-        // strlen check > 1 to avoid issues with Windows absolute paths (e.g. C:\...), Windows quirks :)
-        // since no built-in or commonly registered PHP stream wrapper uses a single-character scheme, this should be ok, to my knowledge
-        if (is_string($scheme) && strlen($scheme) > 1) {
+        if (str_contains($filename, '://')) {
             throw new Exception(
                 "Stream wrappers are not permitted as file paths: {$filename}"
             );

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -119,8 +119,8 @@ class Drawing extends BaseDrawing
         // Check if a URL has been passed. https://stackoverflow.com/a/2058596/1252979
         } elseif (
             filter_var($path, FILTER_VALIDATE_URL)
-            || preg_match('~^phar://~i', $path)
-            || (preg_match('/^([\w\s\x00-\x1f]+):/u', $path) && !preg_match('/^([\w]+):/u', $path))
+            || Preg::isMatch('~^phar://~i', $path)
+            || (Preg::isMatch('/^([\w\s\x00-\x1f]+):/', $path) && !Preg::isMatch('/^([\w]+):/', $path))
         ) {
             if (!Preg::isMatch('/^(http|https|file|ftp|s3):/', $path)) {
                 throw new PhpSpreadsheetException('Invalid protocol for linked drawing');

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -120,7 +120,7 @@ class Drawing extends BaseDrawing
         } elseif (
             filter_var($path, FILTER_VALIDATE_URL)
             || Preg::isMatch('~^phar://~i', $path)
-            || (Preg::isMatch('/^([\w\s\x00-\x1f]+):/', $path) && !Preg::isMatch('/^([\w]+):/', $path))
+            || (Preg::isMatch('/^([\w.\s\x00-\x1f]+):/', $path) && !Preg::isMatch('/^([\w.]+):/', $path))
         ) {
             if (!Preg::isMatch('/^(http|https|file|ftp|s3):/', $path)) {
                 throw new PhpSpreadsheetException('Invalid protocol for linked drawing');

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -117,7 +117,11 @@ class Drawing extends BaseDrawing
                 }
             }
         // Check if a URL has been passed. https://stackoverflow.com/a/2058596/1252979
-        } elseif (filter_var($path, FILTER_VALIDATE_URL) || str_contains($path, '://') || (preg_match('/^([\w\s\x00-\x1f]+):/u', $path) && !preg_match('/^([\w]+):/u', $path))) {
+        } elseif (
+            filter_var($path, FILTER_VALIDATE_URL)
+            || preg_match('~^phar://~i', $path)
+            || (preg_match('/^([\w\s\x00-\x1f]+):/u', $path) && !preg_match('/^([\w]+):/u', $path))
+        ) {
             if (!Preg::isMatch('/^(http|https|file|ftp|s3):/', $path)) {
                 throw new PhpSpreadsheetException('Invalid protocol for linked drawing');
             }

--- a/src/PhpSpreadsheet/Worksheet/Drawing.php
+++ b/src/PhpSpreadsheet/Worksheet/Drawing.php
@@ -117,7 +117,7 @@ class Drawing extends BaseDrawing
                 }
             }
         // Check if a URL has been passed. https://stackoverflow.com/a/2058596/1252979
-        } elseif (filter_var($path, FILTER_VALIDATE_URL) || (preg_match('/^([\w\s\x00-\x1f]+):/u', $path) && !preg_match('/^([\w]+):/u', $path))) {
+        } elseif (filter_var($path, FILTER_VALIDATE_URL) || str_contains($path, '://') || (preg_match('/^([\w\s\x00-\x1f]+):/u', $path) && !preg_match('/^([\w]+):/u', $path))) {
             if (!Preg::isMatch('/^(http|https|file|ftp|s3):/', $path)) {
                 throw new PhpSpreadsheetException('Invalid protocol for linked drawing');
             }

--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlImage2Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlImage2Test.php
@@ -157,6 +157,7 @@ class HtmlImage2Test extends TestCase
             'mailto' => ['mailto:xyz@example.com'],
             'mailto whitespace' => ['mail to:xyz@example.com'],
             'phar' => ['phar://example.com/image.phar'],
+            'phar with 3 slashes' => ['phar:///example.com/image.phar'],
             'phar control' => ["\x14phar://example.com/image.phar"],
         ];
     }

--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlImage2Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlImage2Test.php
@@ -161,6 +161,8 @@ class HtmlImage2Test extends TestCase
             'phar with 3 slashes' => ['phar:///example.com/image.phar'],
             'phar control' => ["\x14phar://example.com/image.phar"],
             'filter with phar' => ['php://filter/read=convert.base64-encode/resource=phar:///tmp/x.Phar'],
+            'protocol with period followed by phar' => ['compress.zlib://phar:///x.phar'],
+            'protocol with period and embedded space' => ['comp ress.zlib://anything'],
         ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlImage2Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlImage2Test.php
@@ -157,8 +157,10 @@ class HtmlImage2Test extends TestCase
             'mailto' => ['mailto:xyz@example.com'],
             'mailto whitespace' => ['mail to:xyz@example.com'],
             'phar' => ['phar://example.com/image.phar'],
+            'phar mixed case' => ['Phar://example.com/image.phar'],
             'phar with 3 slashes' => ['phar:///example.com/image.phar'],
             'phar control' => ["\x14phar://example.com/image.phar"],
+            'filter with phar' => ['php://filter/read=convert.base64-encode/resource=phar:///tmp/x.Phar'],
         ];
     }
 }

--- a/tests/PhpSpreadsheetTests/Reader/NoPharTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/NoPharTest.php
@@ -19,7 +19,7 @@ class NoPharTest extends TestCase
     public function testNoPhar(string $reader): void
     {
         $this->expectException(SpreadsheetException::class);
-        $this->expectExceptionMessage('Stream wrappers are not permitted');
+        $this->expectExceptionMessage('Disallowed stream wrapper');
         $reader = new $reader();
         $reader->load('phar://anyoldname');
     }
@@ -30,10 +30,22 @@ class NoPharTest extends TestCase
     #[DataProvider('providerReaders')]
     public function testPhar3Slashes(string $reader): void
     {
-        $this->expectException(SpreadsheetException::class);
-        $this->expectExceptionMessage('Stream wrappers are not permitted');
+        $invalidProtocol = [
+            '3 slashes' => 'phar:///anyoldname',
+            'mixed case' => 'Phar:///anyoldname',
+            'embedded space' => 'ph ar://anyoldname',
+            'embedded control character' => "ph\x04ar://anyoldname",
+            'filter with phar' => 'php://filter/read=convert.base64-encode/resource=phar:///tmp/x.Phar',
+        ];
         $reader = new $reader();
-        $reader->load('phar:///anyoldname');
+        foreach ($invalidProtocol as $key => $value) {
+            try {
+                $reader->load($value);
+                self::fail("Should have thrown exception - $key");
+            } catch (SpreadsheetException $e) {
+                self::assertStringContainsString('Disallowed stream wrapper', $e->getMessage(), $key);
+            }
+        }
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Reader/NoPharTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/NoPharTest.php
@@ -25,6 +25,18 @@ class NoPharTest extends TestCase
     }
 
     /**
+     * @param class-string<IReader> $reader
+     */
+    #[DataProvider('providerReaders')]
+    public function testPhar3Slashes(string $reader): void
+    {
+        $this->expectException(SpreadsheetException::class);
+        $this->expectExceptionMessage('Stream wrappers are not permitted');
+        $reader = new $reader();
+        $reader->load('phar:///anyoldname');
+    }
+
+    /**
      * @return array<array<class-string<IReader>>>
      */
     public static function providerReaders(): array

--- a/tests/PhpSpreadsheetTests/Reader/NoPharTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/NoPharTest.php
@@ -16,26 +16,17 @@ class NoPharTest extends TestCase
      * @param class-string<IReader> $reader
      */
     #[DataProvider('providerReaders')]
-    public function testNoPhar(string $reader): void
-    {
-        $this->expectException(SpreadsheetException::class);
-        $this->expectExceptionMessage('Disallowed stream wrapper');
-        $reader = new $reader();
-        $reader->load('phar://anyoldname');
-    }
-
-    /**
-     * @param class-string<IReader> $reader
-     */
-    #[DataProvider('providerReaders')]
     public function testPhar3Slashes(string $reader): void
     {
         $invalidProtocol = [
+            'normal phar' => 'phar://anyoldname',
             '3 slashes' => 'phar:///anyoldname',
             'mixed case' => 'Phar:///anyoldname',
             'embedded space' => 'ph ar://anyoldname',
+            'leading space' => ' phar://anyoldname',
             'embedded control character' => "ph\x04ar://anyoldname",
             'filter with phar' => 'php://filter/read=convert.base64-encode/resource=phar:///tmp/x.Phar',
+            'filter with phar and newline' => "php://filter/read=convert.base64-encode/\nresource=phar:///tmp/x.Phar",
         ];
         $reader = new $reader();
         foreach ($invalidProtocol as $key => $value) {

--- a/tests/PhpSpreadsheetTests/Reader/NoPharTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/NoPharTest.php
@@ -27,6 +27,8 @@ class NoPharTest extends TestCase
             'embedded control character' => "ph\x04ar://anyoldname",
             'filter with phar' => 'php://filter/read=convert.base64-encode/resource=phar:///tmp/x.Phar',
             'filter with phar and newline' => "php://filter/read=convert.base64-encode/\nresource=phar:///tmp/x.Phar",
+            'protocol with period followed by phar' => 'compress.bzip2://phar:///x.phar',
+            'protocol with period and embedded space' => 'comp ress.zlib://anything',
         ];
         $reader = new $reader();
         foreach ($invalidProtocol as $key => $value) {


### PR DESCRIPTION
Reject `phar:///whatever` as input filename.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

