### PR TITLE
First Php8.6 Deprecation

### DIFF
--- a/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
+++ b/src/PhpSpreadsheet/Writer/Pdf/Mpdf.php
@@ -40,6 +40,13 @@ class Mpdf extends Pdf
 
         //  Create PDF
         $config = ['tempDir' => $this->tempDir . '/mpdf'];
+        $restoreHandler = false;
+        if (PHP_VERSION_ID >= self::$temporaryVersionCheck) {
+            // @codeCoverageIgnoreStart
+            set_error_handler(self::specialErrorHandler(...));
+            $restoreHandler = true;
+            // @codeCoverageIgnoreEnd
+        }
         $pdf = $this->createExternalWriterInstance($config);
         $ortmp = $orientation;
         $pdf->_setPageSize($paperSize, $ortmp);
@@ -83,7 +90,28 @@ class Mpdf extends Pdf
         $str = $pdf->Output('', 'S');
         fwrite($fileHandle, $str);
 
+        if ($restoreHandler) {
+            restore_error_handler(); // @codeCoverageIgnore
+        }
         parent::restoreStateAfterSave();
+    }
+
+    protected static int $temporaryVersionCheck = 80600;
+
+    /**
+     * Temporary handler for Php8.6 mb_regex_encoding deprecation.
+     *
+     * @codeCoverageIgnore
+     */
+    public function specialErrorHandler(int $errno, string $errstr, string $filename, int $lineno): bool
+    {
+        if ($errno === E_DEPRECATED) {
+            if (preg_match('/Function mb_\w+[(][)] is deprecated since 8[.]6/', $errstr) === 1) {
+                return true;
+            }
+        }
+
+        return false; // continue error handling
     }
 
     /**


### PR DESCRIPTION
Mpdf uses soon-to-be-deprecated `mb_regex_encoding`.
https://wiki.php.net/rfc/eol-oniguruma

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] third-party deprecation

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

