### PR TITLE
Reusing Disconnected Spreadsheet

### DIFF
--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -510,6 +510,7 @@ class Spreadsheet implements JsonSerializable
             unset($worksheet);
         }
         $this->workSheetCollection = [];
+        $this->activeSheetIndex = -1;
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/ReuseDisconnectTest.php
+++ b/tests/PhpSpreadsheetTests/ReuseDisconnectTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+class ReuseDisconnectTest extends TestCase
+{
+    public function testDisconnectThenReuse(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->disconnectWorksheets();
+        self::assertSame(0, $spreadsheet->getSheetCount());
+        self::assertSame(-1, $spreadsheet->getActiveSheetIndex());
+
+        $sheet = $spreadsheet->createSheet(0);
+        self::assertSame(1, $spreadsheet->getSheetCount());
+        self::assertSame(0, $spreadsheet->getActiveSheetIndex());
+
+        // Confirm calculation engine and style supervisor are instact
+        $sheet->getCell('A1')->setValue('=1+2');
+        $sheet->getStyle('A1')->getFont()->setBold(true);
+        self::assertSame(3, $sheet->getCell('A1')->getCalculatedValue());
+        self::assertTrue(
+            $sheet->getStyle('A1')->getFont()->getBold()
+        );
+
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Throws exception if you subsequently attempt `createSheet(0)`. Fix that.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary


