### PR TITLE
Add listWorksheetInfo() to IReader interface (#4883)

### DIFF
--- a/src/PhpSpreadsheet/Reader/IReader.php
+++ b/src/PhpSpreadsheet/Reader/IReader.php
@@ -51,6 +51,13 @@ interface IReader
     public function canRead(string $filename): bool;
 
     /**
+     * Return worksheet info (Name, Last Column Letter, Last Column Index, Total Rows, Total Columns).
+     *
+     * @return array<int, array{worksheetName: string, lastColumnLetter: string, lastColumnIndex: int, totalRows: int, totalColumns: int, sheetState: string}>
+     */
+    public function listWorksheetInfo(string $filename): array;
+
+    /**
      * Read data only?
      *        If this is true, then the Reader will only read data values for cells, it will not read any formatting
      *           or structural information (like merges).


### PR DESCRIPTION
Fixes #4883

The listWorksheetInfo() method exists in BaseReader and all concrete reader classes (Csv, Xls, Xml, Ods, Gnumeric, Html), but was missing from the IReader interface. Users type-hinting on IReader cannot call it without a cast.