### PR TITLE
Phpstan Safe Keys

### DIFF
--- a/infra/DocumentGenerator.php
+++ b/infra/DocumentGenerator.php
@@ -17,7 +17,16 @@ class DocumentGenerator
     ];
 
     /**
-     * @param array<string, array{category: string, functionCall: string|string[], argumentCount: string, passCellReference?: bool, passByReference?: bool[], custom?: bool}> $phpSpreadsheetFunctions
+     * @param array<
+     *     array{
+     *         category: string,
+     *         functionCall: string|string[],
+     *         argumentCount: string,
+     *         passCellReference?: bool,
+     *         passByReference?: bool[],
+     *         custom?: bool
+     *    }
+     * > $phpSpreadsheetFunctions
      */
     public static function generateFunctionListByCategory($phpSpreadsheetFunctions): string
     {
@@ -89,7 +98,16 @@ class DocumentGenerator
     }
 
     /**
-     * @param array<string, array{category: string, functionCall: string|string[], argumentCount: string, passCellReference?: bool, passByReference?: bool[], custom?: bool}> $phpSpreadsheetFunctions
+     * @param array<
+     *     array{
+     *         category: string,
+     *         functionCall: string|string[],
+     *         argumentCount: string,
+     *         passCellReference?: bool,
+     *         passByReference?: bool[],
+     *         custom?: bool
+     *    }
+     * > $phpSpreadsheetFunctions
      */
     public static function generateFunctionListByName(array $phpSpreadsheetFunctions, bool $compact = false): string
     {
@@ -112,6 +130,7 @@ class DocumentGenerator
         $lastAlphabet = null;
         $lengths = $compact ? [25, 22, 37] : [25, 31, 37];
         foreach ($phpSpreadsheetFunctions as $excelFunction => $functionInfo) {
+            $excelFunction = "$excelFunction";
             if (in_array($excelFunction, self::EXCLUDED_FUNCTIONS, true)) {
                 continue;
             }

--- a/infra/LocaleGenerator.php
+++ b/infra/LocaleGenerator.php
@@ -31,7 +31,17 @@ class LocaleGenerator
 
     protected string $translationBaseFolder;
 
-    /** @var array<string, array{category: string, functionCall: string|string[], argumentCount: string, passCellReference?: bool, passByReference?: bool[], custom?: bool}> */
+    /** @var array<
+     *     array{
+     *         category: string,
+     *         functionCall: string|string[],
+     *         argumentCount: string,
+     *         passCellReference?: bool,
+     *         passByReference?: bool[],
+     *         custom?: bool
+     *    }
+     * >
+     */
     protected array $phpSpreadsheetFunctions;
 
     protected Spreadsheet $translationSpreadsheet;
@@ -55,7 +65,16 @@ class LocaleGenerator
     protected array $functionNameMap = [];
 
     /**
-     * @param array<string, array{category: string, functionCall: string|string[], argumentCount: string, passCellReference?: bool, passByReference?: bool[], custom?: bool}> $phpSpreadsheetFunctions
+     * @param array<
+     *     array{
+     *         category: string,
+     *         functionCall: string|string[],
+     *         argumentCount: string,
+     *         passCellReference?: bool,
+     *         passByReference?: bool[],
+     *         custom?: bool
+     *     }
+     * > $phpSpreadsheetFunctions
      */
     public function __construct(
         string $translationBaseFolder,

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -27,6 +27,7 @@ parameters:
         - tests/PhpSpreadsheetTests/Writer/Xlsx/ArrayFunctions2Test.php
     parallel:
         processTimeout: 300.0
+    reportUnsafeArrayStringKeyCasting: prevent
     ignoreErrors:
         # Accept a bit anything for assert methods
         - '~^Parameter \#2 .* of static method PHPUnit\\Framework\\Assert\:\:assert\w+\(\) expects .*, .* given\.$~'

--- a/src/PhpSpreadsheet/Calculation/Calculation.php
+++ b/src/PhpSpreadsheet/Calculation/Calculation.php
@@ -99,7 +99,7 @@ class Calculation extends CalculationLocale
     /**
      * Cache of parsed formula tokens, keyed by the raw formula string.
      *
-     * @var array<string, array<mixed>|bool>
+     * @var array<array<mixed>|bool>
      */
     private array $formulaTokenCache = [];
 
@@ -2849,6 +2849,7 @@ class Calculation extends CalculationLocale
         $returnValue = [];
         $phpSpreadsheetFunctions = &self::getFunctionsAddress();
         foreach ($phpSpreadsheetFunctions as $functionName => $function) {
+            $functionName = "$functionName";
             if ($this->isImplemented($functionName)) {
                 $returnValue[] = $functionName;
             }

--- a/src/PhpSpreadsheet/Calculation/CalculationBase.php
+++ b/src/PhpSpreadsheet/Calculation/CalculationBase.php
@@ -7,7 +7,16 @@ class CalculationBase
     /**
      * Get a list of all implemented functions as an array of function objects.
      *
-     * @return array<string, array{category: string, functionCall: string|string[], argumentCount: string, passCellReference?: bool, passByReference?: bool[], custom?: bool}>
+     * @return array<
+     *     array{
+     *         category: string,
+     *         functionCall: string|string[],
+     *         argumentCount: string,
+     *         passCellReference?: bool,
+     *         passByReference?: bool[],
+     *         custom?: bool
+     *     }
+     * >
      */
     public static function getFunctions(): array
     {
@@ -17,7 +26,7 @@ class CalculationBase
     /**
      * Get address of list of all implemented functions as an array of function objects.
      *
-     * @return array<string, array<string, mixed>>
+     * @return array<array<string, mixed>>
      */
     protected static function &getFunctionsAddress(): array
     {
@@ -25,7 +34,14 @@ class CalculationBase
     }
 
     /**
-     * @param array{category: string, functionCall: string|string[], argumentCount: string, passCellReference?: bool, passByReference?: bool[], custom?: bool} $value
+     * @param array{
+     *     category: string,
+     *     functionCall: string|string[],
+     *     argumentCount: string,
+     *     passCellReference?: bool,
+     *     passByReference?: bool[],
+     *     custom?: bool
+     * } $value
      */
     public static function addFunction(string $key, array $value): bool
     {

--- a/src/PhpSpreadsheet/Calculation/Engine/Operands/StructuredReference.php
+++ b/src/PhpSpreadsheet/Calculation/Engine/Operands/StructuredReference.php
@@ -175,7 +175,7 @@ final class StructuredReference implements Operand, Stringable
     }
 
     /**
-     * @param array{array{string, int}, array{string, int}} $tableRange
+     * @param array{array{non-decimal-int-string, int}, array{non-decimal-int-string, int}} $tableRange
      *
      * @return mixed[]
      */
@@ -187,7 +187,7 @@ final class StructuredReference implements Operand, Stringable
         $columns = [];
         $lastColumn = StringHelper::stringIncrement($tableRange[1][0]);
         for ($column = $tableRange[0][0]; $column !== $lastColumn; StringHelper::stringIncrement($column)) {
-            /** @var string $column */
+            /** @var non-decimal-int-string $column */
             $columns[$column] = $worksheet
                 ->getCell($column . ($this->headersRow ?? ($this->firstDataRow - 1)))
                 ->getCalculatedValue();

--- a/src/PhpSpreadsheet/Calculation/Engineering/ConvertUOM.php
+++ b/src/PhpSpreadsheet/Calculation/Engineering/ConvertUOM.php
@@ -473,7 +473,7 @@ class ConvertUOM
      *
      * @param ?string $category The group whose units of measure you want to retrieve
      *
-     * @return array<string, list<array<string, string>>>
+     * @return array<list<array<string>>>
      */
     public static function getConversionCategoryUnitDetails(?string $category = null): array
     {

--- a/src/PhpSpreadsheet/Calculation/FunctionArray.php
+++ b/src/PhpSpreadsheet/Calculation/FunctionArray.php
@@ -7,7 +7,16 @@ class FunctionArray extends CalculationBase
     /**
      * Array of functions usable on Spreadsheet.
      *
-     * @var array<string, array{category: string, functionCall: string|string[], argumentCount: string, passCellReference?: bool, passByReference?: bool[], custom?: bool}>
+     * @var array<
+     *     array{
+     *         category: string,
+     *         functionCall: string|string[],
+     *         argumentCount: string,
+     *         passCellReference?: bool,
+     *         passByReference?: bool[],
+     *         custom?: bool
+     *     }
+     * >
      */
     protected static array $phpSpreadsheetFunctions = [ // @phpstan-ignore-line
         'ABS' => [

--- a/src/PhpSpreadsheet/Calculation/Functions.php
+++ b/src/PhpSpreadsheet/Calculation/Functions.php
@@ -353,12 +353,16 @@ class Functions
         return (string) preg_replace('/:[\w\$]+$/', '', $coordinate);
     }
 
+    /**
+     * @return non-decimal-int-string
+     */
     public static function trimSheetFromCellReference(string $coordinate): string
     {
         if (str_contains($coordinate, '!')) {
             $coordinate = substr($coordinate, strrpos($coordinate, '!') + 1);
         }
 
+        /** @var non-decimal-int-string */
         return $coordinate;
     }
 

--- a/src/PhpSpreadsheet/Calculation/LookupRef/VLookup.php
+++ b/src/PhpSpreadsheet/Calculation/LookupRef/VLookup.php
@@ -51,6 +51,7 @@ class VLookup extends LookupBase
         if (!$notExactMatch) {
             /** @var callable $callable */
             $callable = [self::class, 'vlookupSort'];
+            /** @var array<int, mixed> $lookupArray */
             uasort($lookupArray, $callable);
         }
 

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -126,6 +126,8 @@ class Cell implements Stringable
      * Get cell coordinate column.
      *
      * @throws SpreadsheetException
+     *
+     * @return non-decimal-int-string
      */
     public function getColumn(): string
     {
@@ -156,6 +158,8 @@ class Cell implements Stringable
      * Get cell coordinate.
      *
      * @throws SpreadsheetException
+     *
+     * @return non-decimal-int-string
      */
     public function getCoordinate(): string
     {
@@ -169,6 +173,7 @@ class Cell implements Stringable
             throw new SpreadsheetException('Coordinate no longer exists');
         }
 
+        /** @var non-decimal-int-string */
         return $coordinate;
     }
 
@@ -507,7 +512,7 @@ class Cell implements Stringable
                                         }
                                     }
                                 }
-                                /** @var string $newColumn */
+                                /** @var non-decimal-int-string $newColumn */
                                 StringHelper::stringIncrement($newColumn);
                             }
                             ++$newRow;
@@ -539,14 +544,16 @@ class Cell implements Stringable
                             $ref = $oldAttributesRef;
                             if (preg_match('/^([A-Z]{1,3})([0-9]{1,7})(:([A-Z]{1,3})([0-9]{1,7}))?$/', $ref, $matches) === 1) {
                                 if (isset($matches[5])) {
-                                    $minCol = $matches[1];
+                                    /** @var non-decimal-int-string */
+                                    $minCol = "{$matches[1]}";
                                     $minRow = (int) $matches[2];
+                                    /** @var non-decimal-int-string */
                                     $maxCol = $matches[4];
                                     StringHelper::stringIncrement($maxCol);
                                     $maxRow = (int) $matches[5];
                                     for ($row = $minRow; $row <= $maxRow; ++$row) {
                                         for ($col = $minCol; $col !== $maxCol; StringHelper::stringIncrement($col)) {
-                                            /** @var string $col */
+                                            /** @var non-decimal-int-string $col */
                                             if ("$col$row" !== $coordinate) {
                                                 $thisworksheet->getCell("$col$row")->setValue(null);
                                             }

--- a/src/PhpSpreadsheet/Cell/Coordinate.php
+++ b/src/PhpSpreadsheet/Cell/Coordinate.php
@@ -30,15 +30,17 @@ abstract class Coordinate
      *
      * @param string $cellAddress eg: 'A1'
      *
-     * @return array{0: string, 1: string} Array containing column and row (indexes 0 and 1)
+     * @return array{0: non-decimal-int-string, 1: string} Array containing column and row (indexes 0 and 1)
      */
     public static function coordinateFromString(string $cellAddress): array
     {
         if (preg_match(self::A1_COORDINATE_REGEX, $cellAddress, $matches)) {
             $row = (int) ltrim($matches['row'], '$');
+            /** @var non-decimal-int-string */
+            $matchesCol = "{$matches['col']}";
             // reluctantly allow row 0 due to regression problems
             if (/*$row > 0 &&*/ $row <= AddressRange::MAX_ROW) {
-                return [$matches['col'], $matches['row']];
+                return [$matchesCol, $matches['row']];
             }
         } elseif (self::coordinateIsRange($cellAddress)) {
             throw new Exception('Cell coordinate string can not be a range of cells');
@@ -54,11 +56,12 @@ abstract class Coordinate
      *
      * @param string $coordinates eg: 'A1', '$B$12'
      *
-     * @return array{0: int, 1: int, 2: string} Array containing column and row index, and column string
+     * @return array{0: int, 1: int, 2: non-decimal-int-string} Array containing column and row index, and column string
      */
     public static function indexesFromString(string $coordinates): array
     {
         [$column, $row] = self::coordinateFromString($coordinates);
+        /** @var non-decimal-int-string */
         $column = ltrim($column, '$');
 
         return [
@@ -280,9 +283,9 @@ abstract class Coordinate
     /**
      * Calculate range boundaries.
      *
-     * @param string $range Cell range, Single Cell, Row/Column Range (e.g. A1:A1, B2, B:C, 2:3)
+     * @param non-decimal-int-string $range Cell range, Single Cell, Row/Column Range (e.g. A1:A1, B2, B:C, 2:3)
      *
-     * @return array{array{string, int}, array{string, int}} Range coordinates [Start Cell, End Cell]
+     * @return array{array{non-decimal-int-string, int}, array{non-decimal-int-string, int}} Range coordinates [Start Cell, End Cell]
      *                    where Start Cell and End Cell are arrays [Column ID, Row Number]
      */
     public static function getRangeBoundaries(string $range): array
@@ -456,10 +459,12 @@ abstract class Coordinate
      * String from column index.
      *
      * @param int|numeric-string $columnIndex Column index (A = 1)
+     *
+     * @return non-decimal-int-string
      */
     public static function stringFromColumnIndex(int|string $columnIndex, bool $tolerateZero = false): string
     {
-        /** @var string[] */
+        /** @var non-decimal-int-string[] */
         static $indexCache = [];
         $columnIndex2 = (int) $columnIndex;
         if ($columnIndex2 === 0 && $tolerateZero) {
@@ -481,6 +486,7 @@ abstract class Coordinate
             $indexCache[$columnIndex] = $base26;
         }
 
+        /** @var non-decimal-int-string[] $indexCache */
         return $indexCache[$columnIndex];
     }
 
@@ -489,7 +495,7 @@ abstract class Coordinate
      *
      * @param string $cellRange Range: e.g. 'A1' or 'A1:C10' or 'A1:E10,A20:E25' or 'A1:E5 C3:G7' or 'A1:C1,A3:C3 B1:C3'
      *
-     * @return string[] Array containing single cell references
+     * @return non-decimal-int-string[] Array containing single cell references
      */
     public static function extractAllCellReferencesInRange(string $cellRange): array
     {
@@ -525,6 +531,7 @@ abstract class Coordinate
         $cellList = array_merge(...$cells); //* @phpstan-ignore-line
         // Unsure how to satisfy phpstan in line above
 
+        /** @var non-decimal-int-string[] */
         $retVal = array_map(
             fn (string $cellAddress) => ($worksheet !== '') ? "{$quoted}{$worksheet}{$quoted}!{$cellAddress}" : $cellAddress,
             self::sortCellReferenceArray($cellList)
@@ -688,13 +695,14 @@ abstract class Coordinate
      *
      *    [ 'A1:A3' => 'x', 'A4' => 'y' ]
      *
-     * @param array<string, mixed> $coordinateCollection associative array mapping coordinates to values
+     * @param array<non-decimal-int-string, mixed> $coordinateCollection associative array mapping coordinates to values
      *
      * @return array<string, mixed> associative array mapping coordinate ranges to values
      */
     public static function mergeRangesInCollection(array $coordinateCollection): array
     {
         $hashedValues = [];
+        /** @var array<non-decimal-int-string, mixed> */
         $mergedCoordCollection = [];
 
         foreach ($coordinateCollection as $coord => $value) {
@@ -725,6 +733,7 @@ abstract class Coordinate
             sort($hashedValue->rows);
             $rowStart = null;
             $rowEnd = null;
+            /** @var array<int, non-decimal-int-string> */
             $ranges = [];
 
             foreach ($hashedValue->rows as $row) {
@@ -758,6 +767,7 @@ abstract class Coordinate
             }
         }
 
+        /** @var array<non-decimal-int-string, mixed>  $mergedCoordCollection */
         return $mergedCoordCollection;
     }
 

--- a/src/PhpSpreadsheet/Chart/Axis.php
+++ b/src/PhpSpreadsheet/Chart/Axis.php
@@ -54,7 +54,7 @@ class Axis extends Properties
     /**
      * Axis Options.
      *
-     * @var array<string, null|string>
+     * @var array<null|string>
      */
     private array $axisOptions = [
         'minimum' => null,

--- a/src/PhpSpreadsheet/Collection/Cells.php
+++ b/src/PhpSpreadsheet/Collection/Cells.php
@@ -29,6 +29,8 @@ class Cells
 
     /**
      * Coordinate of the currently active Cell.
+     *
+     * @var null|non-decimal-int-string
      */
     private ?string $currentCoordinate = null;
 
@@ -53,7 +55,7 @@ class Cells
     /**
      * Index keys cache to avoid recalculating on large arrays.
      *
-     * @var null|string[]
+     * @var null|non-decimal-int-string[]
      */
     private ?array $indexKeysCache = null;
 
@@ -144,22 +146,22 @@ class Cells
     /**
      * Get a list of all cell coordinates currently held in the collection.
      *
-     * @return string[]
+     * @return non-decimal-int-string[]
      */
     public function getCoordinates(): array
     {
         // Build or rebuild index keys cache
         if ($this->indexKeysCache === null) {
-            $this->indexKeysCache = array_keys($this->index);
+            $this->indexKeysCache = array_keys($this->index); // @phpstan-ignore-line
         }
 
-        return $this->indexKeysCache;
+        return $this->indexKeysCache; // @phpstan-ignore-line
     }
 
     /**
      * Get a sorted list of all cell coordinates currently held in the collection by row and column.
      *
-     * @return string[]
+     * @return non-decimal-int-string[]
      */
     public function getSortedCoordinates(): array
     {
@@ -174,10 +176,10 @@ class Cells
 
         // Build or rebuild index keys cache
         if ($this->indexKeysCache === null) {
-            $this->indexKeysCache = array_keys($this->index);
+            $this->indexKeysCache = array_keys($this->index); // @phpstan-ignore-line
         }
 
-        return $this->indexKeysCache;
+        return $this->indexKeysCache; // @phpstan-ignore-line
     }
 
     /**
@@ -204,6 +206,8 @@ class Cells
 
     /**
      * Return the cell coordinate of the currently active cell object.
+     *
+     * @return null|non-decimal-int-string
      */
     public function getCurrentCoordinate(): ?string
     {
@@ -212,14 +216,18 @@ class Cells
 
     /**
      * Return the column coordinate of the currently active cell object.
+     *
+     * @return non-decimal-int-string
      */
     public function getCurrentColumn(): string
     {
         $column = 0;
         $row = '';
         sscanf($this->currentCoordinate ?? '', '%[A-Z]%d', $column, $row);
+        /** @var non-decimal-int-string */
+        $temp = "$column";
 
-        return (string) $column;
+        return $temp;
     }
 
     /**
@@ -237,7 +245,7 @@ class Cells
     /**
      * Get highest worksheet column and highest row that have cell records.
      *
-     * @return array{row: int, column: string} Highest column name and highest row number
+     * @return array{row: int, column: non-decimal-int-string} Highest column name and highest row number
      */
     public function getHighestRowAndColumn(): array
     {
@@ -262,7 +270,7 @@ class Cells
      * @param null|int|string $row Return the highest column for the specified row,
      *                    or the highest column of any row if no row number is passed
      *
-     * @return string Highest column name
+     * @return non-decimal-int-string Highest column name
      */
     public function getHighestColumn($row = null): string
     {
@@ -433,7 +441,7 @@ class Cells
     /**
      * Add or update a cell identified by its coordinate into the collection.
      *
-     * @param string $cellCoordinate Coordinate of the cell to update
+     * @param non-decimal-int-string $cellCoordinate Coordinate of the cell to update
      * @param Cell $cell Cell to update
      */
     public function add(string $cellCoordinate, Cell $cell): Cell
@@ -462,7 +470,7 @@ class Cells
     /**
      * Get cell at a specific coordinate.
      *
-     * @param string $cellCoordinate Coordinate of the cell
+     * @param non-decimal-int-string $cellCoordinate Coordinate of the cell
      *
      * @return null|Cell Cell that was found, or null if not found
      */

--- a/src/PhpSpreadsheet/Collection/Cells.php
+++ b/src/PhpSpreadsheet/Collection/Cells.php
@@ -43,7 +43,7 @@ class Cells
      * An index of existing cells. int pointer to the coordinate (0-base-indexed row * 16,384 + 1-base indexed column)
      *    indexed by their coordinate.
      *
-     * @var int[]
+     * @var array<non-decimal-int-string, int>
      */
     private array $index = [];
 
@@ -55,14 +55,14 @@ class Cells
     /**
      * Index keys cache to avoid recalculating on large arrays.
      *
-     * @var null|non-decimal-int-string[]
+     * @var null|array<int, non-decimal-int-string>
      */
     private ?array $indexKeysCache = null;
 
     /**
      * Index values cache to avoid recalculating on large arrays.
      *
-     * @var null|int[]
+     * @var null|array<int, int>
      */
     private ?array $indexValuesCache = null;
 
@@ -146,22 +146,22 @@ class Cells
     /**
      * Get a list of all cell coordinates currently held in the collection.
      *
-     * @return non-decimal-int-string[]
+     * @return array<int, non-decimal-int-string>
      */
     public function getCoordinates(): array
     {
         // Build or rebuild index keys cache
         if ($this->indexKeysCache === null) {
-            $this->indexKeysCache = array_keys($this->index); // @phpstan-ignore-line
+            $this->indexKeysCache = array_keys($this->index);
         }
 
-        return $this->indexKeysCache; // @phpstan-ignore-line
+        return $this->indexKeysCache;
     }
 
     /**
      * Get a sorted list of all cell coordinates currently held in the collection by row and column.
      *
-     * @return non-decimal-int-string[]
+     * @return array<int, non-decimal-int-string>
      */
     public function getSortedCoordinates(): array
     {
@@ -176,16 +176,16 @@ class Cells
 
         // Build or rebuild index keys cache
         if ($this->indexKeysCache === null) {
-            $this->indexKeysCache = array_keys($this->index); // @phpstan-ignore-line
+            $this->indexKeysCache = array_keys($this->index);
         }
 
-        return $this->indexKeysCache; // @phpstan-ignore-line
+        return $this->indexKeysCache;
     }
 
     /**
      * Get a sorted list of all cell coordinates currently held in the collection by index (16384*row+column).
      *
-     * @return int[]
+     * @return array<non-decimal-int-strint, int>
      */
     public function getSortedCoordinatesInt(): array
     {

--- a/src/PhpSpreadsheet/HashTable.php
+++ b/src/PhpSpreadsheet/HashTable.php
@@ -10,7 +10,7 @@ class HashTable
     /**
      * HashTable elements.
      *
-     * @var array<string, T>
+     * @var array<T>
      */
     protected array $items = [];
 

--- a/src/PhpSpreadsheet/IOFactory.php
+++ b/src/PhpSpreadsheet/IOFactory.php
@@ -259,6 +259,7 @@ abstract class IOFactory
     /**
      * Register a writer with its type and class name.
      *
+     * @param non-decimal-int-string $writerType
      * @param class-string<IWriter> $writerClass
      */
     public static function registerWriter(string $writerType, string $writerClass): void
@@ -274,6 +275,7 @@ abstract class IOFactory
     /**
      * Register a reader with its type and class name.
      *
+     * @param non-decimal-int-string $readerType
      * @param class-string<IReader> $readerClass
      */
     public static function registerReader(string $readerType, string $readerClass): void

--- a/src/PhpSpreadsheet/Reader/Html.php
+++ b/src/PhpSpreadsheet/Reader/Html.php
@@ -260,9 +260,14 @@ class Html extends BaseReader
 
     protected int $tableLevel = 0;
 
-    /** @var string[] */
+    /** @var non-decimal-int-string[] */
     protected array $nestedColumn = ['A'];
 
+    /**
+     * @param non-decimal-int-string $column
+     *
+     * @return non-decimal-int-string
+     */
     protected function setTableStartColumn(string $column): string
     {
         if ($this->tableLevel == 0) {
@@ -274,11 +279,13 @@ class Html extends BaseReader
         return $this->nestedColumn[$this->tableLevel];
     }
 
+    /** @return non-decimal-int-string */
     protected function getTableStartColumn(): string
     {
         return $this->nestedColumn[$this->tableLevel];
     }
 
+    /** @return non-decimal-int-string */
     protected function releaseTableStartColumn(): string
     {
         --$this->tableLevel;
@@ -337,7 +344,9 @@ class Html extends BaseReader
                     }
 
                     //catching the Exception and ignoring the invalid data types
-                    $hyperlink = $sheet->hyperlinkExists($column . $row) ? $sheet->getHyperlink($column . $row) : null;
+                    /** @var non-decimal-int-string */
+                    $temp = "$column$row";
+                    $hyperlink = $sheet->hyperlinkExists($temp) ? $sheet->getHyperlink($temp) : null;
 
                     try {
                         if (isset($attributeArray['data-formula'])) {
@@ -360,14 +369,18 @@ class Html extends BaseReader
                     } catch (SpreadsheetException) {
                         $sheet->setCellValue($column . $row, $cellContent);
                     }
-                    $sheet->setHyperlink($column . $row, $hyperlink);
+                    /** @var non-decimal-int-string */
+                    $temp = "$column$row";
+                    $sheet->setHyperlink($temp, $hyperlink);
                 } else {
+                    /** @var non-decimal-int-string */
+                    $temp = "$column$row";
                     $hyperlink = null;
-                    if ($sheet->hyperlinkExists($column . $row)) {
-                        $hyperlink = $sheet->getHyperlink($column . $row);
+                    if ($sheet->hyperlinkExists($temp)) {
+                        $hyperlink = $sheet->getHyperlink($temp);
                     }
-                    $sheet->setCellValue($column . $row, $attributeArray['data-value'] ?? $cellContent);
-                    $sheet->setHyperlink($column . $row, $hyperlink);
+                    $sheet->setCellValue($temp, $attributeArray['data-value'] ?? $cellContent);
+                    $sheet->setHyperlink($temp, $hyperlink);
                 }
                 $this->dataArray[$row][$column] = $cellContent; // @phpstan-ignore-line
             }
@@ -406,6 +419,11 @@ class Html extends BaseReader
         return $cellContent;
     }
 
+    /**
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementBody(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child): void
     {
         $attributeArray = [];
@@ -425,7 +443,12 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementTitle(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         if ($child->nodeName === 'title') {
@@ -445,7 +468,12 @@ class Html extends BaseReader
 
     private const SPAN_ETC = ['span', 'div', 'font', 'i', 'em', 'strong', 'b'];
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementSpanEtc(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         if (in_array((string) $child->nodeName, self::SPAN_ETC, true)) {
@@ -474,7 +502,12 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementHr(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         if ($child->nodeName === 'hr') {
@@ -487,7 +520,12 @@ class Html extends BaseReader
         $this->processDomElementBr($sheet, $row, $column, $cellContent, $child, $attributeArray);
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementBr(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         if ($child->nodeName === 'br' || $child->nodeName === 'hr') {
@@ -505,7 +543,12 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementA(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         if ($child->nodeName === 'a') {
@@ -532,7 +575,12 @@ class Html extends BaseReader
 
     private const H1_ETC = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ol', 'ul', 'p'];
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementH1Etc(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         if (in_array((string) $child->nodeName, self::H1_ETC, true)) {
@@ -561,7 +609,12 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementLi(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         if ($child->nodeName === 'li') {
@@ -583,7 +636,12 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementImg(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         if ($child->nodeName === 'img') {
@@ -593,9 +651,15 @@ class Html extends BaseReader
         }
     }
 
+    /** @var non-decimal-int-string */
     private string $currentColumn = 'A';
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementTable(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         if ($child->nodeName === 'table') {
@@ -629,7 +693,12 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementTr(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         if ($child->nodeName === 'col') {
@@ -650,7 +719,12 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementThTdOther(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         if ($child->nodeName !== 'td' && $child->nodeName !== 'th') {
@@ -660,7 +734,10 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     */
     private function processDomElementBgcolor(Worksheet $sheet, int $row, string $column, array $attributeArray): void
     {
         if (isset($attributeArray['bgcolor'])) {
@@ -675,7 +752,10 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     */
     private function processDomElementWidth(Worksheet $sheet, string $column, array $attributeArray): void
     {
         if (isset($attributeArray['width'])) {
@@ -691,7 +771,10 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     */
     private function processDomElementAlign(Worksheet $sheet, int $row, string $column, array $attributeArray): void
     {
         if (isset($attributeArray['align'])) {
@@ -699,7 +782,10 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     */
     private function processDomElementVAlign(Worksheet $sheet, int $row, string $column, array $attributeArray): void
     {
         if (isset($attributeArray['valign'])) {
@@ -707,7 +793,10 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     */
     private function processDomElementDataFormat(Worksheet $sheet, int $row, string $column, array $attributeArray): void
     {
         if (isset($attributeArray['data-format'])) {
@@ -715,7 +804,12 @@ class Html extends BaseReader
         }
     }
 
-    /** @param string[] $attributeArray */
+    /**
+     * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     private function processDomElementThTd(Worksheet $sheet, int &$row, string &$column, string &$cellContent, DOMElement $child, array &$attributeArray): void
     {
         while (isset($this->rowspan[$column . $row])) {
@@ -769,6 +863,11 @@ class Html extends BaseReader
         StringHelper::stringIncrement($column);
     }
 
+    /**
+     * @param non-decimal-int-string $column
+     *
+     * @param-out non-decimal-int-string $column
+     */
     protected function processDomElement(DOMNode $element, Worksheet $sheet, int &$row, string &$column, string &$cellContent): void
     {
         foreach ($element->childNodes as $child) {
@@ -1015,6 +1114,7 @@ class Html extends BaseReader
      * - Implement to other properties, such as border
      *
      * @param string[] $attributeArray
+     * @param non-decimal-int-string $column
      */
     private function applyInlineStyle(Worksheet &$sheet, int $row, string $column, array $attributeArray): void
     {

--- a/src/PhpSpreadsheet/Reader/Ods.php
+++ b/src/PhpSpreadsheet/Reader/Ods.php
@@ -258,7 +258,7 @@ class Ods extends BaseReader
         return $this->loadIntoExisting($filename, $spreadsheet);
     }
 
-    /** @var array<string,
+    /** @var array<
      *  array{
      *     font?:array{
      *       autoColor?: true,

--- a/src/PhpSpreadsheet/Reader/Slk.php
+++ b/src/PhpSpreadsheet/Reader/Slk.php
@@ -349,6 +349,8 @@ class Slk extends BaseReader
         $this->addFormats($spreadsheet, $formatStyle, $row, $column);
         $this->addFonts($spreadsheet, $fontStyle, $row, $column);
         $this->addStyle($spreadsheet, $styleData, $row, $column);
+        /** @var non-decimal-int-string $startCol */
+        /** @var non-decimal-int-string $endCol */
         $this->addWidth($spreadsheet, $columnWidth, $startCol, $endCol);
     }
 
@@ -411,6 +413,10 @@ class Slk extends BaseReader
         }
     }
 
+    /**
+     * @param non-decimal-int-string $startCol
+     * @param non-decimal-int-string $endCol
+     */
     private function addWidth(Spreadsheet $spreadsheet, string $columnWidth, string $startCol, string $endCol): void
     {
         if ($columnWidth > '') {
@@ -422,7 +428,7 @@ class Slk extends BaseReader
                 $endCol = Coordinate::stringFromColumnIndex((int) $endCol);
                 $spreadsheet->getActiveSheet()->getColumnDimension($startCol)->setWidth((float) $columnWidth);
                 do {
-                    /** @var string $startCol */
+                    /** @var non-decimal-int-string $startCol */
                     $spreadsheet->getActiveSheet()
                         ->getColumnDimension(
                             StringHelper::stringIncrement($startCol)

--- a/src/PhpSpreadsheet/Reader/Xls.php
+++ b/src/PhpSpreadsheet/Reader/Xls.php
@@ -3598,6 +3598,7 @@ class Xls extends XlsBase
         return $selectedCells;
     }
 
+    /** @param non-decimal-int-string $cellRangeAddress */
     private function includeCellRangeFiltered(string $cellRangeAddress): bool
     {
         $includeCellRange = false;
@@ -3636,7 +3637,7 @@ class Xls extends XlsBase
         if ($this->version == self::XLS_BIFF8 && !$this->readDataOnly) {
             $cellRangeAddressList = Xls\Biff8::readBIFF8CellRangeAddressList($recordData);
             foreach ($cellRangeAddressList['cellRangeAddresses'] as $cellRangeAddress) {
-                /** @var string $cellRangeAddress */
+                /** @var non-decimal-int-string $cellRangeAddress */
                 if (
                     (str_contains($cellRangeAddress, ':'))
                     && ($this->includeCellRangeFiltered($cellRangeAddress))

--- a/src/PhpSpreadsheet/Reader/Xls/DataValidationHelper.php
+++ b/src/PhpSpreadsheet/Reader/Xls/DataValidationHelper.php
@@ -212,6 +212,7 @@ class DataValidationHelper extends Xls
             $objValidation->setPrompt($prompt);
             $objValidation->setFormula1($formula1);
             $objValidation->setFormula2($formula2);
+            /** @var non-decimal-int-string $cellRange */
             $xls->phpSheet->setDataValidation($cellRange, $objValidation);
         }
     }

--- a/src/PhpSpreadsheet/Reader/Xlsx.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx.php
@@ -701,7 +701,11 @@ class Xlsx extends BaseReader
                                 }
                             }
                             foreach ($this->styleReader->getFontCharsets() as $fontName => $charset) {
-                                $excel->addFontCharset($fontName, $charset);
+                                /** @var non-decimal-int-string $fontName */
+                                $excel->addFontCharset(
+                                    $fontName,
+                                    $charset
+                                );
                             }
                             if ($addingFirstCellXf) {
                                 $excel->removeCellXfByIndex(0); // remove the default style
@@ -1382,7 +1386,7 @@ class Xlsx extends BaseReader
                                 if ($unparsedVmlDrawings) {
                                     foreach ($unparsedVmlDrawings as $rId => $relPath) {
                                         /** @var mixed[][][] $unparsedLoadedData */
-                                        $rId = substr($rId, 3); // rIdXXX
+                                        $rId = substr("$rId", 3); // rIdXXX
                                         /** @var mixed[][] */
                                         $unparsedVmlDrawing = &$unparsedLoadedData['sheets'][$docSheet->getCodeName()]['vmlDrawings'];
                                         $unparsedVmlDrawing[$rId] = [];
@@ -2394,7 +2398,7 @@ class Xlsx extends BaseReader
         /** @var mixed[][] */
         $unparsedCtrlProps = &$unparsedLoadedData['sheets'][$docSheet->getCodeName()]['ctrlProps'];
         foreach ($ctrlProps as $rId => $ctrlProp) {
-            $rId = substr($rId, 3); // rIdXXX
+            $rId = substr("$rId", 3); // rIdXXX
             $unparsedCtrlProps[$rId] = [];
             $unparsedCtrlProps[$rId]['filePath'] = self::dirAdd("$dir/$fileWorksheet", $ctrlProp['Target']);
             $unparsedCtrlProps[$rId]['relFilePath'] = (string) $ctrlProp['Target'];
@@ -2426,7 +2430,7 @@ class Xlsx extends BaseReader
         /** @var mixed[][] */
         $unparsedPrinterSettings = &$unparsedLoadedData['sheets'][$docSheet->getCodeName()]['printerSettings'];
         foreach ($sheetPrinterSettings as $rId => $printerSettings) {
-            $rId = substr($rId, 3); // rIdXXX
+            $rId = substr("$rId", 3); // rIdXXX
             if (!str_ends_with($rId, 'ps')) {
                 $rId = $rId . 'ps'; // rIdXXX, add 'ps' suffix to avoid identical resource identifier collision with unparsed vmlDrawing
             }
@@ -2638,8 +2642,11 @@ class Xlsx extends BaseReader
                         $lastCol = $firstCol;
                         $lastRow = $firstRow;
                     }
+                    /** @var non-decimal-int-string */
+                    $lastCol = "$lastCol";
                     StringHelper::stringIncrement($lastCol);
                     for ($row = $firstRow; $row <= $lastRow; ++$row) {
+                        /** @var non-decimal-int-string $col */
                         for ($col = $firstCol; $col !== $lastCol; StringHelper::stringIncrement($col)) {
                             if (!$cellCollection->has2("$col$row")) {
                                 continue;

--- a/src/PhpSpreadsheet/Reader/Xlsx/ConditionalStyles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/ConditionalStyles.php
@@ -81,9 +81,10 @@ class ConditionalStyles
         }
     }
 
-    /** @return array<string, array<int, Conditional>> */
+    /** @return array<non-decimal-int-string, array<int, Conditional>> */
     private function readConditionalsFromExt(SimpleXMLElement $extLst): array
     {
+        /** @var array<non-decimal-int-string, array<int, Conditional>> */
         $conditionals = [];
         if (!isset($extLst->ext)) {
             return $conditionals;
@@ -106,7 +107,9 @@ class ConditionalStyles
                     continue;
                 }
 
-                $sqref = (string) $extFormattingRangeXml->sqref;
+                $sqrefx = (string) $extFormattingRangeXml->sqref;
+                /** @var non-decimal-int-string */
+                $sqref = "$sqrefx";
                 $extCfRuleXml = $extFormattingXml->cfRule;
 
                 $attributes = $extCfRuleXml->attributes();

--- a/src/PhpSpreadsheet/Reader/Xlsx/DataValidations.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/DataValidations.php
@@ -36,7 +36,9 @@ class DataValidations
         }
         foreach ($this->worksheetXml->dataValidations->dataValidation as $dataValidation) {
             // Uppercase coordinate
-            $range = strtoupper((string) $dataValidation['sqref']);
+            $rangex = strtoupper((string) $dataValidation['sqref']);
+            /** @var non-decimal-int-string */
+            $range = "$rangex";
             $docValidation = new DataValidation();
             $docValidation->setType((string) $dataValidation['type']);
             $docValidation->setErrorStyle((string) $dataValidation['errorStyle']);

--- a/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
+++ b/src/PhpSpreadsheet/Reader/Xlsx/Styles.php
@@ -98,7 +98,9 @@ class Styles extends BaseParserClass
                 $charsetAttr = $this->getStyleAttributes($fontStyleXml->charset);
                 if (isset($charsetAttr['val'])) {
                     $charsetVal = (int) $charsetAttr['val'];
-                    $this->fontCharsets[$fontStyle->getName()] = $charsetVal;
+                    /** @var non-decimal-int-string */
+                    $fontName = $fontStyle->getName();
+                    $this->fontCharsets[$fontName] = $charsetVal;
                 }
             }
         }

--- a/src/PhpSpreadsheet/Reader/Xml.php
+++ b/src/PhpSpreadsheet/Reader/Xml.php
@@ -526,17 +526,19 @@ class Xml extends BaseReader
                             }
 
                             $hyperlink = null;
-                            if ($spreadsheet->getActiveSheet()->hyperlinkExists($columnID . $rowID)) {
-                                $hyperlink = $spreadsheet->getActiveSheet()->getHyperlink($columnID . $rowID);
+                            /** @var non-decimal-int-string */
+                            $targetCell = "$columnID$rowID";
+                            if ($spreadsheet->getActiveSheet()->hyperlinkExists($targetCell)) {
+                                $hyperlink = $spreadsheet->getActiveSheet()->getHyperlink($targetCell);
                             }
                             $spreadsheet->getActiveSheet()
-                                ->getCell($columnID . $rowID)
+                                ->getCell($targetCell)
                                 ->setValueExplicit(
                                     $hasCalculatedValue ? $cellDataFormula : $cellValue,
                                     $type
                                 );
                             $spreadsheet->getActiveSheet()
-                                ->setHyperlink($columnID . $rowID, $hyperlink);
+                                ->setHyperlink($targetCell, $hyperlink);
                             if ($hasCalculatedValue) {
                                 $spreadsheet->getActiveSheet()->getCell($columnID . $rowID)->setCalculatedValue($cellValue, $originalType === DataType::TYPE_NUMERIC);
                             }

--- a/src/PhpSpreadsheet/Reader/Xml/DataValidations.php
+++ b/src/PhpSpreadsheet/Reader/Xml/DataValidations.php
@@ -172,6 +172,7 @@ class DataValidations
                 }
             }
 
+            /** @var non-decimal-int-string $combinedCells */
             $sheet->setDataValidation($combinedCells, $validation);
         }
     }

--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -197,7 +197,9 @@ class ReferenceHelper
             } elseif ($cellAddress !== $newReference) {
                 $worksheet->setHyperlink($cellAddress, null);
                 if ($newReference) {
-                    $worksheet->setHyperlink($newReference, $value); // @phpstan-ignore-line
+                    /** @var non-decimal-int-string */
+                    $temp = $newReference;
+                    $worksheet->setHyperlink($temp, $value);
                 }
             }
         }
@@ -1173,8 +1175,9 @@ class ReferenceHelper
 
         for ($row = 1; $row <= $highestRow - 1; ++$row) {
             for ($column = $startColumnId; $column !== $endColumnId; StringHelper::stringIncrement($column)) {
-                $coordinate = $column . $row;
-                $this->clearStripCell($worksheet, $coordinate); // @phpstan-ignore-line
+                /** @var non-decimal-int-string */
+                $coordinate = "$column$row";
+                $this->clearStripCell($worksheet, $coordinate);
             }
         }
     }
@@ -1187,8 +1190,9 @@ class ReferenceHelper
 
         for ($column = $startColumnId; $column !== $highestColumn; StringHelper::stringIncrement($column)) {
             for ($row = $beforeRow + $numberOfRows; $row <= $beforeRow - 1; ++$row) {
-                $coordinate = $column . $row;
-                $this->clearStripCell($worksheet, $coordinate); // @phpstan-ignore-line
+                /** @var non-decimal-int-string */
+                $coordinate = "$column$row";
+                $this->clearStripCell($worksheet, $coordinate);
             }
         }
     }

--- a/src/PhpSpreadsheet/ReferenceHelper.php
+++ b/src/PhpSpreadsheet/ReferenceHelper.php
@@ -128,8 +128,8 @@ class ReferenceHelper
     {
         $aBreaks = $worksheet->getBreaks();
         ($numberOfColumns > 0 || $numberOfRows > 0)
-            ? uksort($aBreaks, [self::class, 'cellReverseSort'])
-            : uksort($aBreaks, [self::class, 'cellSort']);
+            ? uksort($aBreaks, self::cellReverseSort(...))
+            : uksort($aBreaks, self::cellSort(...));
 
         foreach ($aBreaks as $cellAddress => $value) {
             /** @var CellReferenceHelper */
@@ -185,8 +185,8 @@ class ReferenceHelper
     {
         $aHyperlinkCollection = $worksheet->getHyperlinkCollection();
         ($numberOfColumns > 0 || $numberOfRows > 0)
-            ? uksort($aHyperlinkCollection, [self::class, 'cellReverseSort'])
-            : uksort($aHyperlinkCollection, [self::class, 'cellSort']);
+            ? uksort($aHyperlinkCollection, self::cellReverseSort(...))
+            : uksort($aHyperlinkCollection, self::cellSort(...));
 
         foreach ($aHyperlinkCollection as $cellAddress => $value) {
             $newReference = $this->updateCellReference($cellAddress);
@@ -197,7 +197,7 @@ class ReferenceHelper
             } elseif ($cellAddress !== $newReference) {
                 $worksheet->setHyperlink($cellAddress, null);
                 if ($newReference) {
-                    $worksheet->setHyperlink($newReference, $value);
+                    $worksheet->setHyperlink($newReference, $value); // @phpstan-ignore-line
                 }
             }
         }
@@ -214,8 +214,8 @@ class ReferenceHelper
     {
         $aStyles = $worksheet->getConditionalStylesCollection();
         ($numberOfColumns > 0 || $numberOfRows > 0)
-            ? uksort($aStyles, [self::class, 'cellReverseSort'])
-            : uksort($aStyles, [self::class, 'cellSort']);
+            ? uksort($aStyles, self::cellReverseSort(...))
+            : uksort($aStyles, self::cellSort(...));
 
         foreach ($aStyles as $cellAddress => $cfRules) {
             $worksheet->removeConditionalStyles($cellAddress);
@@ -255,8 +255,8 @@ class ReferenceHelper
     {
         $aDataValidationCollection = $worksheet->getDataValidationCollection();
         ($numberOfColumns > 0 || $numberOfRows > 0)
-            ? uksort($aDataValidationCollection, [self::class, 'cellReverseSort'])
-            : uksort($aDataValidationCollection, [self::class, 'cellSort']);
+            ? uksort($aDataValidationCollection, self::cellReverseSort(...))
+            : uksort($aDataValidationCollection, self::cellSort(...));
 
         foreach ($aDataValidationCollection as $cellAddress => $dataValidation) {
             $formula = $dataValidation->getFormula1();
@@ -292,6 +292,7 @@ class ReferenceHelper
                 $newReference .= $separator . $this->updateCellReference($addressPart);
                 $separator = ' ';
             }
+            /** @var non-decimal-int-string $newReference */
             if ($cellAddress !== $newReference) {
                 $worksheet->setDataValidation($newReference, $dataValidation);
                 $worksheet->setDataValidation($cellAddress, null);
@@ -353,7 +354,9 @@ class ReferenceHelper
                 $outArray = [];
                 foreach ($extracted as $cellAddress) {
                     if (!$cellReferenceHelper->cellAddressInDeleteRange($cellAddress)) {
-                        $outArray[$this->updateCellReference($cellAddress)] = 'x';
+                        /** @var non-decimal-int-string */
+                        $temp = $this->updateCellReference($cellAddress);
+                        $outArray[$temp] = 'x';
                     }
                 }
                 $outArray2 = Coordinate::mergeRangesInCollection($outArray);
@@ -1171,11 +1174,12 @@ class ReferenceHelper
         for ($row = 1; $row <= $highestRow - 1; ++$row) {
             for ($column = $startColumnId; $column !== $endColumnId; StringHelper::stringIncrement($column)) {
                 $coordinate = $column . $row;
-                $this->clearStripCell($worksheet, $coordinate);
+                $this->clearStripCell($worksheet, $coordinate); // @phpstan-ignore-line
             }
         }
     }
 
+    /** @param non-decimal-int-string $highestColumn */
     private function clearRowStrips(string $highestColumn, int $beforeColumn, int $beforeRow, int $numberOfRows, Worksheet $worksheet): void
     {
         $startColumnId = Coordinate::stringFromColumnIndex($beforeColumn);
@@ -1184,11 +1188,12 @@ class ReferenceHelper
         for ($column = $startColumnId; $column !== $highestColumn; StringHelper::stringIncrement($column)) {
             for ($row = $beforeRow + $numberOfRows; $row <= $beforeRow - 1; ++$row) {
                 $coordinate = $column . $row;
-                $this->clearStripCell($worksheet, $coordinate);
+                $this->clearStripCell($worksheet, $coordinate); // @phpstan-ignore-line
             }
         }
     }
 
+    /** @param non-decimal-int-string $coordinate */
     private function clearStripCell(Worksheet $worksheet, string $coordinate): void
     {
         $worksheet->removeConditionalStyles($coordinate);

--- a/src/PhpSpreadsheet/Shared/StringHelper.php
+++ b/src/PhpSpreadsheet/Shared/StringHelper.php
@@ -787,6 +787,12 @@ class StringHelper
      * Php introduced str_increment with Php8.3,
      * but didn't issue deprecation notices till 8.5.
      *
+     * @param non-decimal-int-string $str
+     *
+     * @param-out non-decimal-int-string $str
+     *
+     * @return non-decimal-int-string
+     *
      * @codeCoverageIgnore
      */
     public static function stringIncrement(string &$str): string

--- a/src/PhpSpreadsheet/Spreadsheet.php
+++ b/src/PhpSpreadsheet/Spreadsheet.php
@@ -185,6 +185,7 @@ class Spreadsheet implements JsonSerializable
     ];
 
     /**
+     * @param non-decimal-int-string $fontName
      * @param int $charset uses any value from Shared\Font,
      *    but defaults to ARABIC because that is the only known
      *    charset for which this declaration might be needed

--- a/src/PhpSpreadsheet/Worksheet/ColumnCellIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/ColumnCellIterator.php
@@ -117,7 +117,9 @@ class ColumnCellIterator extends CellIterator
      */
     public function current(): ?Cell
     {
-        $cellAddress = Coordinate::stringFromColumnIndex($this->columnIndex) . $this->currentRow;
+        $temp = Coordinate::stringFromColumnIndex($this->columnIndex) . $this->currentRow;
+        /** @var non-decimal-int-string */
+        $cellAddress = "$temp";
 
         return $this->cellCollection->has($cellAddress)
             ? $this->cellCollection->get($cellAddress)

--- a/src/PhpSpreadsheet/Worksheet/PageBreak.php
+++ b/src/PhpSpreadsheet/Worksheet/PageBreak.php
@@ -10,6 +10,7 @@ class PageBreak
 {
     private int $breakType;
 
+    /** @var non-decimal-int-string */
     private string $coordinate;
 
     private int $maxColOrRow;
@@ -30,6 +31,7 @@ class PageBreak
         return $this->breakType;
     }
 
+    /** @return non-decimal-int-string */
     public function getCoordinate(): string
     {
         return $this->coordinate;
@@ -50,6 +52,7 @@ class PageBreak
         return Coordinate::indexesFromString($this->coordinate)[1];
     }
 
+    /** @return non-decimal-int-string */
     public function getColumnString(): string
     {
         return Coordinate::indexesFromString($this->coordinate)[2];

--- a/src/PhpSpreadsheet/Worksheet/RowCellIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/RowCellIterator.php
@@ -116,7 +116,9 @@ class RowCellIterator extends CellIterator
      */
     public function current(): ?Cell
     {
-        $cellAddress = Coordinate::stringFromColumnIndex($this->currentColumnIndex) . $this->rowIndex;
+        $temp = Coordinate::stringFromColumnIndex($this->currentColumnIndex) . $this->rowIndex;
+        /** @var non-decimal-int-string */
+        $cellAddress = "$temp";
 
         return $this->cellCollection->has($cellAddress)
             ? $this->cellCollection->get($cellAddress)

--- a/src/PhpSpreadsheet/Worksheet/Table.php
+++ b/src/PhpSpreadsheet/Worksheet/Table.php
@@ -31,6 +31,8 @@ class Table implements Stringable
 
     /**
      * Table Range.
+     *
+     * @var non-decimal-int-string
      */
     private string $range = '';
 
@@ -259,6 +261,8 @@ class Table implements Stringable
 
     /**
      * Get Table Range.
+     *
+     * @return non-decimal-int-string
      */
     public function getRange(): string
     {
@@ -296,7 +300,9 @@ class Table implements Stringable
             throw new PhpSpreadsheetException('The table range must be at least 1 column and row');
         }
 
-        $this->range = $range;
+        /** @var non-decimal-int-string */
+        $rangetemp = "$range";
+        $this->range = $rangetemp;
         $this->autoFilter->setRange($range);
 
         //    Discard any column rules that are no longer valid within this range

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -92,7 +92,7 @@ class Worksheet
     /**
      * Collection of column dimensions.
      *
-     * @var ColumnDimension[]
+     * @var array<non-decimal-int-string, ColumnDimension>
      */
     private array $columnDimensions = [];
 
@@ -167,21 +167,21 @@ class Worksheet
     /**
      * Conditional styles. Indexed by cell coordinate, e.g. 'A1'.
      *
-     * @var Conditional[][]
+     * @var array<non-decimal-int-string, Conditional[]>
      */
     private array $conditionalStylesCollection = [];
 
     /**
      * Collection of row breaks.
      *
-     * @var PageBreak[]
+     * @var array<non-decimal-int-string, PageBreak>
      */
     private array $rowBreaks = [];
 
     /**
      * Collection of column breaks.
      *
-     * @var PageBreak[]
+     * @var array<non-decimal-int-string, PageBreak>
      */
     private array $columnBreaks = [];
 
@@ -296,7 +296,7 @@ class Worksheet
     /**
      * Hyperlinks. Indexed by cell coordinate, e.g. 'A1'.
      *
-     * @var Hyperlink[]
+     * @var array<non-decimal-int-string, Hyperlink>
      */
     private array $hyperlinkCollection = [];
 
@@ -304,7 +304,7 @@ class Worksheet
      * Data validation objects. Indexed by cell coordinate, e.g. 'A1'.
      * Index can include ranges, and multiple cells/ranges.
      *
-     * @var DataValidation[]
+     * @var array<non-decimal-int-string, DataValidation>
      */
     private array $dataValidationCollection = [];
 
@@ -644,6 +644,7 @@ class Worksheet
             $newColumnDimensions[$objColumnDimension->getColumnIndex()] = $objColumnDimension;
         }
 
+        /** @var array<non-decimal-int-string, ColumnDimension> $newColumnDimensions */
         $this->columnDimensions = $newColumnDimensions;
 
         return $this;
@@ -720,6 +721,7 @@ class Worksheet
 
             // loop through all cells in the worksheet
             foreach ($this->getCoordinates(false) as $coordinate) {
+                /** @var non-decimal-int-string $coordinate */
                 $cell = $this->getCellOrNull($coordinate);
 
                 if ($cell !== null && isset($autoSizes[$this->cellCollection->getCurrentColumn()])) {
@@ -791,7 +793,7 @@ class Worksheet
                 if ($width == -1) {
                     $width = $this->getDefaultColumnDimension()->getWidth();
                 }
-                $this->getColumnDimension($columnIndex)->setWidth($width);
+                $this->getColumnDimension("$columnIndex")->setWidth($width);
             }
             $this->activePane = $holdActivePane;
         }
@@ -1062,7 +1064,7 @@ class Worksheet
      * @param null|int|string $row Return the data highest column for the specified row,
      *                                     or the highest column of any row if no row number is passed
      *
-     * @return string Highest column name
+     * @return non-decimal-int-string Highest column name
      */
     public function getHighestColumn($row = null): string
     {
@@ -1079,7 +1081,7 @@ class Worksheet
      * @param null|int|string $row Return the highest data column for the specified row,
      *                                     or the highest data column of any row if no row number is passed
      *
-     * @return string Highest column name that contains data
+     * @return non-decimal-int-string Highest column name that contains data
      */
     public function getHighestDataColumn($row = null): string
     {
@@ -1196,6 +1198,7 @@ class Worksheet
 
         /** @var Worksheet $sheet */
         [$sheet, $finalCoordinate] = $this->getWorksheetAndCoordinate($cellAddress);
+        /** @var non-decimal-int-string $finalCoordinate */
         $cell = $sheet->getCellCollection()->get($finalCoordinate);
 
         return $cell ?? $sheet->createNewCell($finalCoordinate);
@@ -1256,7 +1259,7 @@ class Worksheet
     /**
      * Get an existing cell at a specific coordinate, or null.
      *
-     * @param string $coordinate Coordinate of the cell, eg: 'A1'
+     * @param non-decimal-int-string $coordinate Coordinate of the cell, eg: 'A1'
      *
      * @return null|Cell Cell that was found or null
      */
@@ -1273,7 +1276,7 @@ class Worksheet
     /**
      * Create a new cell at the specified coordinate.
      *
-     * @param string $coordinate Coordinate of the cell
+     * @param non-decimal-int-string $coordinate Coordinate of the cell
      *
      * @return Cell Cell that was created
      *              WARNING: Because the cell collection can be cached to reduce memory, it only allows one
@@ -1381,7 +1384,9 @@ class Worksheet
 
         // Fetch dimensions
         if (!isset($this->columnDimensions[$column])) {
-            $this->columnDimensions[$column] = new ColumnDimension($column);
+            /** @var non-decimal-int-string */
+            $temp = "$column";
+            $this->columnDimensions[$temp] = new ColumnDimension($temp);
 
             $columnIndex = Coordinate::columnIndexFromString($column);
             if ($this->cachedHighestColumn < $columnIndex) {
@@ -1605,7 +1610,7 @@ class Worksheet
     /**
      * Get collection of conditional styles.
      *
-     * @return Conditional[][]
+     * @return array<non-decimal-int-string, Conditional[]>
      */
     public function getConditionalStylesCollection(): array
     {
@@ -1622,7 +1627,7 @@ class Worksheet
      */
     public function setConditionalStyles(string $coordinate, array $styles): static
     {
-        $this->conditionalStylesCollection[strtoupper($coordinate)] = $styles;
+        $this->conditionalStylesCollection[strtoupper($coordinate)] = $styles; // @phpstan-ignore-line
 
         return $this;
     }
@@ -1735,7 +1740,7 @@ class Worksheet
     /**
      * Get breaks.
      *
-     * @return int[]
+     * @return array<non-decimal-int-string, int>
      */
     public function getBreaks(): array
     {
@@ -2584,6 +2589,7 @@ class Worksheet
         $objReferenceHelper = ReferenceHelper::getInstance();
         $objReferenceHelper->insertNewBefore($column . '1', -$numberOfColumns, 0, $this);
 
+        /** @var array<non-decimal-int-string, ColumnDimension> $holdColumnDimensions */
         $this->columnDimensions = $holdColumnDimensions;
 
         if ($pColumnIndex > $highestColumnIndex) {
@@ -2957,7 +2963,6 @@ class Worksheet
         // Loop through $source
         if ($strictNullComparison) {
             foreach ($source as $rowData) {
-                /** @var string */
                 $currentColumn = $startColumn;
                 foreach ($rowData as $cellValue) {
                     if ($cellValue !== $nullValue) {
@@ -3143,7 +3148,7 @@ class Worksheet
         $maxColInt = $rangeEnd[0];
 
         StringHelper::stringIncrement($maxCol);
-        /** @var array<string, bool> */
+        /** @var array<non-decimal-int-string, bool> */
         $hiddenColumns = [];
         $nullRow = $this->buildNullRow($nullValue, $minCol, $maxCol, $returnCellRef, $ignoreHidden, $hiddenColumns);
         $hideColumns = !empty($hiddenColumns);
@@ -3193,7 +3198,9 @@ class Worksheet
                     $col = Coordinate::stringFromColumnIndex($thisCol);
                     if ($hideColumns === false || !isset($hiddenColumns[$col])) {
                         $columnRef = $returnCellRef ? $col : ($thisCol - $minColInt);
-                        $cell = $this->cellCollection->get("{$col}{$thisRow}");
+                        /** @var non-decimal-int-string */
+                        $temp = "{$col}{$thisRow}";
+                        $cell = $this->cellCollection->get($temp);
                         if ($cell !== null) {
                             $value = $this->cellToArray($cell, $calculateFormulas, $formatData, $nullValue, lessFloatPrecision: $lessFloatPrecision, oldCalculatedValue: $oldCalculatedValue);
                             if ($reduceArrays) {
@@ -3218,13 +3225,13 @@ class Worksheet
      * Prepare a row data filled with null values to deduplicate the memory areas for empty rows.
      *
      * @param mixed $nullValue Value returned in the array entry if a cell doesn't exist
-     * @param string $minCol Start column of the range
-     * @param string $maxCol End column of the range
+     * @param non-decimal-int-string $minCol Start column of the range
+     * @param non-decimal-int-string $maxCol End column of the range
      * @param bool $returnCellRef False - Return a simple array of rows and columns indexed by number counting from zero
      *                              True - Return rows and columns indexed by their actual row and column IDs
      * @param bool $ignoreHidden False - Return values for rows/columns even if they are defined as hidden.
      *                             True - Don't return values for rows/columns that are defined as hidden.
-     * @param array<string, bool> $hiddenColumns
+     * @param array<non-decimal-int-string, bool> $hiddenColumns
      *
      * @return mixed[]
      */
@@ -3482,7 +3489,7 @@ class Worksheet
     /**
      * Get hyperlink.
      *
-     * @param string $cellCoordinate Cell coordinate to get hyperlink for, eg: 'A1'
+     * @param non-decimal-int-string $cellCoordinate Cell coordinate to get hyperlink for, eg: 'A1'
      */
     public function getHyperlink(string $cellCoordinate): Hyperlink
     {
@@ -3501,7 +3508,7 @@ class Worksheet
     /**
      * Set hyperlink.
      *
-     * @param string $cellCoordinate Cell coordinate to insert hyperlink, eg: 'A1'
+     * @param non-decimal-int-string $cellCoordinate Cell coordinate to insert hyperlink, eg: 'A1'
      *
      * @return $this
      */
@@ -3524,7 +3531,7 @@ class Worksheet
     /**
      * Hyperlink at a specific coordinate exists?
      *
-     * @param string $coordinate eg: 'A1'
+     * @param non-decimal-int-string $coordinate eg: 'A1'
      */
     public function hyperlinkExists(string $coordinate): bool
     {
@@ -3534,7 +3541,7 @@ class Worksheet
     /**
      * Get collection of hyperlinks.
      *
-     * @return Hyperlink[]
+     * @return array<non-decimal-int-string, Hyperlink>
      */
     public function getHyperlinkCollection(): array
     {
@@ -3544,7 +3551,7 @@ class Worksheet
     /**
      * Get data validation.
      *
-     * @param string $cellCoordinate Cell coordinate to get data validation for, eg: 'A1'
+     * @param non-decimal-int-string $cellCoordinate Cell coordinate to get data validation for, eg: 'A1'
      */
     public function getDataValidation(string $cellCoordinate): DataValidation
     {
@@ -3579,7 +3586,7 @@ class Worksheet
     /**
      * Set data validation.
      *
-     * @param string $cellCoordinate Cell coordinate to insert data validation, eg: 'A1'
+     * @param non-decimal-int-string $cellCoordinate Cell coordinate to insert data validation, eg: 'A1'
      *
      * @return $this
      */
@@ -3625,7 +3632,7 @@ class Worksheet
     /**
      * Get collection of data validations.
      *
-     * @return DataValidation[]
+     * @return array<non-decimal-int-string, DataValidation>
      */
     public function getDataValidationCollection(): array
     {
@@ -3655,6 +3662,7 @@ class Worksheet
 
         $rangeBlocks = explode(' ', $range);
         foreach ($rangeBlocks as &$rangeSet) {
+            /** @var non-decimal-int-string $rangeSet */
             $rangeBoundaries = Coordinate::getRangeBoundaries($rangeSet);
 
             if (Coordinate::columnIndexFromString($rangeBoundaries[0][0]) > $maxCol) {

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -1627,7 +1627,10 @@ class Worksheet
      */
     public function setConditionalStyles(string $coordinate, array $styles): static
     {
-        $this->conditionalStylesCollection[strtoupper($coordinate)] = $styles; // @phpstan-ignore-line
+        $temp1 = strtoupper($coordinate);
+        /** @var non-decimal-int-string */
+        $temp2 = "$temp1";
+        $this->conditionalStylesCollection[$temp2] = $styles;
 
         return $this;
     }

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -1519,8 +1519,10 @@ class Html extends BaseWriter
         } else {
             $cssClass = [];
         }
+        /** @var non-decimal-int-string */
+        $temp = "$coordinate";
 
-        return [$cell, $cssClass, $coordinate]; // @phpstan-ignore-line
+        return [$cell, $cssClass, $temp];
     }
 
     private function generateRowCellDataValueRich(RichText $richText, ?Font $defaultFont = null): string

--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -631,9 +631,10 @@ class Html extends BaseWriter
                             $rowData[$column] = ($sheet->getCellCollection()->has($cellAddress)) ? $cellAddress : '';
                         }
                         ++$column;
-                        /** @var string $colStr */
+                        /** @var non-decimal-int-string $colStr */
                         StringHelper::stringIncrement($colStr);
                     }
+                    /** @var array<int, non-decimal-int-string> $rowData */
                     $html .= $this->generateRow($sheet, $rowData, $row - 1, $cellType);
                 }
 
@@ -1504,7 +1505,11 @@ class Html extends BaseWriter
         return $html;
     }
 
-    /** @return array{null|''|Cell, array{}|string, non-empty-string} */
+    /**
+     * @param non-decimal-int-string $cellAddress
+     *
+     * @return array{null|''|Cell, array{}|string, non-decimal-int-string}
+     */
     private function generateRowCellCss(Worksheet $worksheet, string $cellAddress, int $row, int $columnNumber): array
     {
         $cell = ($cellAddress > '') ? $worksheet->getCellCollection()->get($cellAddress) : '';
@@ -1515,7 +1520,7 @@ class Html extends BaseWriter
             $cssClass = [];
         }
 
-        return [$cell, $cssClass, $coordinate];
+        return [$cell, $cssClass, $coordinate]; // @phpstan-ignore-line
     }
 
     private function generateRowCellDataValueRich(RichText $richText, ?Font $defaultFont = null): string
@@ -1896,7 +1901,7 @@ class Html extends BaseWriter
     /**
      * Generate row.
      *
-     * @param array<int, string> $values Array containing cells in a row
+     * @param array<int, non-decimal-int-string> $values Array containing cells in a row
      * @param int $row Row number (0-based)
      * @param string $cellType eg: 'td'
      */

--- a/src/PhpSpreadsheet/Writer/Ods/Cell/Style.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Cell/Style.php
@@ -27,7 +27,7 @@ class Style
 
     private XMLWriter $writer;
 
-    /** @var array<string, callable> */
+    /** @var array<callable> */
     private array $additionalNumberFormats;
 
     /** @param array<string, callable> $additionalNumberFormats */
@@ -403,7 +403,7 @@ class Style
 
     private int $numFmtIndex = 199;
 
-    /** @var array<string, string> */
+    /** @var array<string> */
     private array $numFmtIndexes = [];
 
     private function writeNumFmt(string $numFmt): void

--- a/src/PhpSpreadsheet/Writer/Xls/Parser.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Parser.php
@@ -100,14 +100,14 @@ class Parser
     /**
      * Array of external sheets.
      *
-     * @var array<string, int>
+     * @var array<int>
      */
     private array $externalSheets;
 
     /**
      * Array of sheet references in the form of REF structures.
      *
-     * @var array<int|string, int|string>
+     * @var array<int|string>
      */
     public array $references;
 

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -113,7 +113,7 @@ class Worksheet extends BIFFwriter
     /**
      * Reference to the array containing all the unique strings in the workbook.
      *
-     * @var array<string, int>
+     * @var array<int>
      */
     private array $stringTable;
 
@@ -526,6 +526,7 @@ class Worksheet extends BIFFwriter
     /** @deprecated 5.6.0 Use AddressRange::MAX_ROW_XLS */
     public const MAX_XLS_ROW = AddressRange::MAX_ROW_XLS;
 
+    /** @param non-decimal-int-string $exploded */
     private static function limitRange(string $exploded): string
     {
         $retVal = '';
@@ -555,6 +556,7 @@ class Worksheet extends BIFFwriter
         foreach ($this->phpSheet->getConditionalStylesCollection() as $key => $value) {
             $keyExplode = explode(',', Coordinate::resolveUnionAndIntersection($key));
             foreach ($keyExplode as $exploded) {
+                /** @var non-decimal-int-string $exploded */
                 $range = self::limitRange($exploded);
                 if ($range !== '') {
                     $arrConditionalStyles[$range] = $value;
@@ -2785,7 +2787,7 @@ class Worksheet extends BIFFwriter
 
                 // cell range address list
                 $data .= pack('v', 0x0001);
-                $data .= $this->writeBIFF8CellRangeAddressFixed($cellCoordinate);
+                $data .= $this->writeBIFF8CellRangeAddressFixed("$cellCoordinate");
 
                 $length = strlen($data);
                 $header = pack('vv', $record, $length);

--- a/src/PhpSpreadsheet/Writer/Xlsx/Comments.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Comments.php
@@ -55,7 +55,7 @@ class Comments extends WriterPart
         // Loop through authors
         $objWriter->startElement('authors');
         foreach ($authors as $author => $index) {
-            $objWriter->writeElement('author', $author);
+            $objWriter->writeElement('author', "$author");
         }
         $objWriter->endElement();
 
@@ -77,7 +77,7 @@ class Comments extends WriterPart
      *
      * @param string $cellReference Cell reference
      * @param Comment $comment Comment
-     * @param array<string, int> $authors Array of authors
+     * @param array<int> $authors Array of authors
      */
     private function writeComment(XMLWriter $objWriter, string $cellReference, Comment $comment, array $authors): void
     {

--- a/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
@@ -260,6 +260,7 @@ class CoordinateTest extends TestCase
         return require 'tests/data/CellRangeDimension.php';
     }
 
+    /** @param non-decimal-int-string $rangeSet */
     #[DataProvider('providerGetRangeBoundaries')]
     public function testGetRangeBoundaries(mixed $expectedResult, string $rangeSet): void
     {
@@ -330,7 +331,7 @@ class CoordinateTest extends TestCase
         return [['Z1:A1'], ['A4:A1'], ['B1:A1'], ['AA1:Z1']];
     }
 
-    /** @param array<string, mixed> $rangeSets */
+    /** @param array<non-decimal-int-string, mixed> $rangeSets */
     #[DataProvider('providerMergeRangesInCollection')]
     public function testMergeRangesInCollection(mixed $expectedResult, array $rangeSets): void
     {

--- a/tests/PhpSpreadsheetTests/DocumentGeneratorTest.php
+++ b/tests/PhpSpreadsheetTests/DocumentGeneratorTest.php
@@ -19,7 +19,18 @@ class DocumentGeneratorTest extends TestCase
 
     private static bool $succeededByCategory = false;
 
-    /** @param array<string, array{category: string, functionCall: array<string>|string, argumentCount: string, passCellReference?: bool, passByReference?: array<bool>, custom?: bool}> $phpSpreadsheetFunctions */
+    /**
+     * @param array<
+     *     array{
+     *         category: string,
+     *         functionCall: string|string[],
+     *         argumentCount: string,
+     *         passCellReference?: bool,
+     *         passByReference?: bool[],
+     *         custom?: bool
+     *    }
+     * > $phpSpreadsheetFunctions
+     */
     #[DataProvider('providerGenerateFunctionListByName')]
     public function testGenerateFunctionListByName(array $phpSpreadsheetFunctions, string $expected): void
     {
@@ -27,7 +38,18 @@ class DocumentGeneratorTest extends TestCase
         self::$succeededByName = true;
     }
 
-    /** @param array<string, array{category: string, functionCall: array<string>|string, argumentCount: string, passCellReference?: bool, passByReference?: array<bool>, custom?: bool}> $phpSpreadsheetFunctions */
+    /**
+     * @param array<
+     *     array{
+     *         category: string,
+     *         functionCall: string|string[],
+     *         argumentCount: string,
+     *         passCellReference?: bool,
+     *         passByReference?: bool[],
+     *         custom?: bool
+     *    }
+     * > $phpSpreadsheetFunctions
+     */
     #[DataProvider('providerGenerateFunctionListByCategory')]
     public function testGenerateFunctionListByCategory(array $phpSpreadsheetFunctions, string $expected): void
     {

--- a/tests/PhpSpreadsheetTests/Reader/Xls/DataValidationTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xls/DataValidationTest.php
@@ -11,7 +11,10 @@ use PHPUnit\Framework\TestCase;
 
 class DataValidationTest extends TestCase
 {
-    /** @param mixed[] $expectedRule */
+    /**
+     * @param non-decimal-int-string $expectedRange
+     * @param mixed[] $expectedRule
+     */
     #[DataProvider('dataValidationProvider')]
     public function testDataValidation(string $expectedRange, array $expectedRule): void
     {

--- a/tests/PhpSpreadsheetTests/Worksheet/CloneTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/CloneTest.php
@@ -24,7 +24,6 @@ class CloneTest extends TestCase
         } else {
             $sheet2 = clone $sheet1;
         }
-        $sheet2 = clone $sheet1;
         $sheet2->getCell('A1')->setValue(20);
         self::assertSame(0, $spreadsheet->getIndex($sheet1));
         $idx = $spreadsheet->getIndex($sheet2, true);

--- a/tests/PhpSpreadsheetTests/Worksheet/CloneTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/CloneTest.php
@@ -7,15 +7,23 @@ namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
 use PhpOffice\PhpSpreadsheet\Exception as SpreadsheetException;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class CloneTest extends TestCase
 {
-    public function testUnattachedIndex(): void
+    #[DataProvider('providerCopyClone')]
+    public function testUnattachedIndex(string $type): void
     {
         $spreadsheet = new Spreadsheet();
         $sheet1 = $spreadsheet->getActiveSheet();
         $sheet1->getCell('A1')->setValue(10);
+        $sheet1->getCell('A2')->setValue(30);
+        if ($type === 'copy') {
+            $sheet2 = $sheet1->copy();
+        } else {
+            $sheet2 = clone $sheet1;
+        }
         $sheet2 = clone $sheet1;
         $sheet2->getCell('A1')->setValue(20);
         self::assertSame(0, $spreadsheet->getIndex($sheet1));
@@ -27,7 +35,17 @@ class CloneTest extends TestCase
         self::assertSame(1, $idx);
         self::assertSame(10, $spreadsheet->getSheet(0)->getCell('A1')->getValue());
         self::assertSame(20, $spreadsheet->getSheet(1)->getCell('A1')->getValue());
+        self::assertSame(30, $spreadsheet->getSheet(0)->getCell('A2')->getValue());
+        self::assertSame(30, $spreadsheet->getSheet(1)->getCell('A2')->getValue());
         $spreadsheet->disconnectWorksheets();
+    }
+
+    public static function providerCopyClone(): array
+    {
+        return [
+            ['copy'],
+            ['clone'],
+        ];
     }
 
     public function testGetCloneIndex(): void

--- a/tests/PhpSpreadsheetTests/Worksheet/ShrinkRangeToFitTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ShrinkRangeToFitTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+class ShrinkRangeToFitTest extends TestCase
+{
+    public static function testToArray(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->getCell('B2')->setValue(1);
+        $sheet->getCell('E10')->setValue(2);
+        $testArray = [
+            'C3:F12' => 'C3:E10',
+            'C3:D12' => 'C3:D10',
+            'C3:D9' => 'C3:D9',
+            'A1:B2 C3:D4' => 'A1:B2 C3:D4',
+            'A1:B11 C3:D4' => 'A1:B10 C3:D4',
+            'A1:B2 C3:F12' => 'A1:B2 C3:E10',
+            'A1:B11 C3:F12' => 'A1:B10 C3:E10',
+            // In both of the following, the range
+            //    isn't merely shrunk - it has moved.
+            // This doesn't seem right, although I am
+            //    hard-pressed to come up with an alternative,
+            //    and not willing to make a breaking change,
+            //    even to code which probably isn't used much.
+            'A11:B12' => 'A10:B10',
+            'G1:H4' => 'E1:E4',
+        ];
+        foreach ($testArray as $input => $expectedOutput) {
+            $output = $sheet->shrinkRangeToFit($input);
+            self::assertSame($expectedOutput, $output, $input);
+        }
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Phpstan 2.2 adds type-safe protection for array keys, which Php may convert from string to int. I suppose it can be useful to us for arrays indexed by column or cell address. The initial conversion for PhpSpreadsheet to make use of it is a bit of a pain, but it's done. It requires the use of more `@var` annotations than I would like. Also several cases where, even though `$x` is known to be a string, `$y="$x"` works out much better than `$y=$x`. And the occasional less precise use of `array<whatever>` instead of `array<string, whatever>` when we truly don't care if the key might be converted to int.

Almost all of this change is done in comments (doc blocks and annotations), but there are some small code changes.

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] using new feature in 3rd party software

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

