### PR TITLE
Document exception in IOFactory.php

### DIFF
--- a/src/PhpSpreadsheet/IOFactory.php
+++ b/src/PhpSpreadsheet/IOFactory.php
@@ -175,6 +175,8 @@ abstract class IOFactory
      *                                 IOFactory::READER_*.
      * @param array<string, class-string<IReader>> $mergeArray supplied readers will be merged with
      *        default readers, allowing specification of a partial list.
+     *
+     * @throws Reader\Exception
      */
     public static function createReaderForFile(string $filename, ?array $readers = null, array $mergeArray = []): IReader
     {


### PR DESCRIPTION
### Why this change is needed?

It lets down stream be more strict about there exception handeling and enables tools to notify them if the behavior changes in the future.