### PR TITLE
Navigate Cell as Cursor

### DIFF
--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -1071,4 +1071,52 @@ class Cell implements Stringable
 
         return $hidden !== Protection::PROTECTION_UNPROTECTED;
     }
+
+    /**
+     * Return cell $right positions to the right of this one.
+     */
+    public function cursorRight(int $right = 1): self
+    {
+        $row = $this->getRow();
+        $col = $this->getColumn();
+        $colIndex = Coordinate::columnIndexFromString($col);
+        $newCol = max(
+            1,
+            min($colIndex + $right, AddressRange::MAX_COLUMN_INT)
+        );
+        $newColStr = Coordinate::stringFromColumnIndex($newCol);
+
+        return $this->getWorksheet()->getCell("$newColStr$row");
+    }
+
+    /**
+     * Return cell $right positions to the left of this one.
+     */
+    public function cursorLeft(int $left = 1): self
+    {
+        return $this->cursorRight(-$left);
+    }
+
+    /**
+     * Return cell $down positions below this one.
+     */
+    public function cursorDown(int $down = 1): self
+    {
+        $row = $this->getRow();
+        $col = $this->getColumn();
+        $newRow = max(
+            1,
+            min($row + $down, AddressRange::MAX_ROW)
+        );
+
+        return $this->getWorksheet()->getCell("$col$newRow");
+    }
+
+    /**
+     * Return cell $up positions above this one.
+     */
+    public function cursorUp(int $up = 1): self
+    {
+        return $this->cursorDown(-$up);
+    }
 }

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -1090,7 +1090,7 @@ class Cell implements Stringable
     }
 
     /**
-     * Return cell $right positions to the left of this one.
+     * Return cell $left positions to the left of this one.
      */
     public function cursorLeft(int $left = 1): self
     {
@@ -1118,5 +1118,49 @@ class Cell implements Stringable
     public function cursorUp(int $up = 1): self
     {
         return $this->cursorDown(-$up);
+    }
+
+    /**
+     * Return cell at row $row in current column.
+     */
+    public function cursorRow(int $row = 1): self
+    {
+        $col = $this->getColumn();
+        $newRow = max(
+            1,
+            min($row, AddressRange::MAX_ROW)
+        );
+
+        return $this->getWorksheet()->getCell("$col$newRow");
+    }
+
+    /**
+     * Return cell at column $column in current row.
+     */
+    public function cursorColumn(string $column = 'A'): self
+    {
+        $row = $this->getRow();
+        $colIndex = Coordinate::columnIndexFromString($column);
+        $newCol = max(
+            1,
+            min($colIndex, AddressRange::MAX_COLUMN_INT)
+        );
+        $newColStr = Coordinate::stringFromColumnIndex($newCol);
+
+        return $this->getWorksheet()->getCell("$newColStr$row");
+    }
+
+    /**
+     * Return cell adjusted for Xls limits if applicable.
+     */
+    public function cursorXlsLimits(): self
+    {
+        $row = min($this->getRow(), AddressRange::MAX_ROW_XLS);
+        $column = $this->getColumn();
+        $colIndex = Coordinate::columnIndexFromString($column);
+        $newCol = min($colIndex, AddressRange::MAX_COLUMN_INT_XLS);
+        $newColStr = Coordinate::stringFromColumnIndex($newCol);
+
+        return $this->getWorksheet()->getCell("$newColStr$row");
     }
 }

--- a/tests/PhpSpreadsheetTests/Cell/CursorTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CursorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Cell;
+
+use PhpOffice\PhpSpreadsheet\Cell\AddressRange;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+class CursorTest extends TestCase
+{
+    public function testCursor(): void
+    {
+        $data = [
+            ['1a', '1b', '1c', '1d', '1e'],
+            ['2a', '2b', '2c', '2d', '2e'],
+            ['3a', '3b', '3c', '3d', '3e'],
+            ['4a', '4b', '4c', '4d', '4e'],
+            ['5a', '5b', '5c', '5d', '5e'],
+        ];
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray($data);
+        $cell = $sheet->getCell('A1')->cursorRight();
+        self::assertSame('1b', $cell->getValue());
+        $cell = $cell->cursorDown(2)->cursorLeft();
+        self::assertSame('3a', $cell->getValue());
+        $cell = $cell->cursorUp()->cursorRight(3);
+        self::assertSame('2d', $cell->getValue());
+        $cell = $cell->cursorUp(2);
+        self::assertSame('1d', $cell->getValue(), 'no move above row 1');
+        $cell = $cell->cursorLeft(5);
+        self::assertSame('1a', $cell->getValue(), 'no move to the left of column A');
+        $cell = $cell->cursorRight(AddressRange::MAX_COLUMN_INT);
+        self::assertSame(AddressRange::MAX_COLUMN . '1', $cell->getCoordinate(), 'no column beyond MAX_COLUMN_INT');
+        $cell = $cell->cursorDown(AddressRange::MAX_ROW);
+        self::assertSame(AddressRange::MAX_COLUMN . AddressRange::MAX_ROW, $cell->getCoordinate(), 'no row beyond MAX_ROW');
+        self::assertSame(
+            '4d',
+            $sheet->getCell('A2')
+                ->cursorDown(2) // takes us to A4
+                ->cursorRight(3) // takes us to D4
+                ->getValue()
+        );
+        $sheet->getCell('H5')->setValue(15)
+            ->cursorDown()->setValue(16)
+            ->cursorDown()->setValue(17);
+        self::assertSame(15, $sheet->getCell('H5')->getValue());
+        self::assertSame(16, $sheet->getCell('H6')->getValue());
+        self::assertSame(17, $sheet->getCell('H7')->getValue());
+        $spreadsheet->disconnectWorksheets();
+    }
+}

--- a/tests/PhpSpreadsheetTests/Cell/CursorTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CursorTest.php
@@ -49,6 +49,19 @@ class CursorTest extends TestCase
         self::assertSame(15, $sheet->getCell('H5')->getValue());
         self::assertSame(16, $sheet->getCell('H6')->getValue());
         self::assertSame(17, $sheet->getCell('H7')->getValue());
+
+        $cell = $sheet->getCell('H5')->cursorXlsLimits();
+        self::assertSame('H5', $cell->getCoordinate());
+        $cell = $cell->cursorRow(2);
+        self::assertSame('H2', $cell->getCoordinate());
+        $cell = $cell->cursorRow(0);
+        self::assertSame('H1', $cell->getCoordinate());
+        $cell = $cell->cursorColumn('ABC');
+        self::assertSame('ABC1', $cell->getCoordinate());
+
+        $cell = $sheet->getCell('JK71234')->cursorXlsLimits();
+        self::assertSame('IV65536', $cell->getCoordinate());
+
         $spreadsheet->disconnectWorksheets();
     }
 }


### PR DESCRIPTION
Fix #863, which went stale in 2019 and is now reopened. Add methods to `Cell` which operate in a cursor-like manner, allowing you to change to cells on the right, left, down, or up.

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary


