### PR TITLE
Tighten Up Writer Html Logic

### DIFF
--- a/src/PhpSpreadsheet/Writer/Html.php
+++ b/src/PhpSpreadsheet/Writer/Html.php
@@ -1595,7 +1595,13 @@ class Html extends BaseWriter
                     $origData2 = $cell->getValueString();
                 }
             }
-            $formatCode = $worksheet->getParentOrThrow()->getCellXfByIndex($cell->getXfIndex())->getNumberFormat()->getFormatCode();
+            $style = $worksheet->getParent()
+                ?->getCellXfByIndexOrNull(
+                    $cell->getXfIndex()
+                );
+            $formatCode = $style
+                ?->getNumberFormat()
+                ->getFormatCode();
 
             $cellData = NumberFormat::toFormattedString(
                 $origData2,
@@ -1606,9 +1612,9 @@ class Html extends BaseWriter
             if ($cellData === $origData) {
                 $cellData = htmlspecialchars($cellData, Settings::htmlEntityFlags());
             }
-            if ($worksheet->getParentOrThrow()->getCellXfByIndex($cell->getXfIndex())->getFont()->getSuperscript()) {
+            if (true === $style?->getFont()->getSuperscript()) {
                 $cellData = '<sup>' . $cellData . '</sup>';
-            } elseif ($worksheet->getParentOrThrow()->getCellXfByIndex($cell->getXfIndex())->getFont()->getSubscript()) {
+            } elseif (true === $style?->getFont()->getSubscript()) {
                 $cellData = '<sub>' . $cellData . '</sub>';
             }
         }


### PR DESCRIPTION
Fix #434, which went stale in 2018 and is now reopened. User reported a fatal error in Writer/Html. Regrettably, there is no example code/spreadsheet to illustrate the error. However, the area of code where the error happened is identified. Studying that, it was clear that the error could be avoided through the use of the nullsafe operator `?->` without any performance hit, while making the resulting code a little clearer.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

