### PR TITLE
Consistent HighestRow/Column After Row/Column Delete

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -2443,6 +2443,18 @@ class Worksheet
         if ($row < 1) {
             throw new Exception('Rows to be deleted should at least start from row 1.');
         }
+        if ($numberOfRows === 0) {
+            return $this;
+        }
+        if ($numberOfRows < 0) {
+            $newRow = max(1, $row + $numberOfRows + 1);
+            $numberOfRows = $row - $newRow + 1;
+            $row = $newRow;
+        }
+        $newHighestRow = $this->cachedHighestRow;
+        if ($newHighestRow >= $row) {
+            $newHighestRow = max($row - 1, $this->cachedHighestRow - $numberOfRows);
+        }
         $startRow = $row;
         $endRow = $startRow + $numberOfRows - 1;
         $removeKeys = [];
@@ -2499,6 +2511,7 @@ class Worksheet
         }
 
         $this->rowDimensions = $holdRowDimensions;
+        $this->cachedHighestRow = $newHighestRow;
 
         return $this;
     }
@@ -2537,6 +2550,19 @@ class Worksheet
             throw new Exception('Column references should not be numeric.');
         }
         $startColumnInt = Coordinate::columnIndexFromString($column);
+        if ($numberOfColumns === 0) {
+            return $this;
+        }
+        if ($numberOfColumns < 0) {
+            $newStartColumnInt = max(1, $startColumnInt + $numberOfColumns + 1);
+            $numberOfColumns = $startColumnInt - $newStartColumnInt + 1;
+            $startColumnInt = $newStartColumnInt;
+            $column = Coordinate::stringFromColumnIndex($startColumnInt);
+        }
+        $newHighestColumn = $this->cachedHighestColumn;
+        if ($newHighestColumn >= $startColumnInt) {
+            $newHighestColumn = max($startColumnInt - 1, $this->cachedHighestColumn - $numberOfColumns);
+        }
         $endColumnInt = $startColumnInt + $numberOfColumns - 1;
         $removeKeys = [];
         $addKeys = [];
@@ -2587,6 +2613,8 @@ class Worksheet
         $this->columnDimensions = $holdColumnDimensions;
 
         if ($pColumnIndex > $highestColumnIndex) {
+            $this->cachedHighestColumn = $newHighestColumn;
+
             return $this;
         }
 
@@ -2596,6 +2624,7 @@ class Worksheet
             $this->cellCollection->removeColumn($highestColumn);
             $highestColumn = Coordinate::stringFromColumnIndex(Coordinate::columnIndexFromString($highestColumn) - 1);
         }
+        $this->cachedHighestColumn = $newHighestColumn;
 
         $this->garbageCollect();
 

--- a/tests/PhpSpreadsheetTests/Worksheet/InsertTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/InsertTest.php
@@ -28,12 +28,24 @@ class InsertTest extends TestCase
         $sheet->insertNewRowBefore($currentRow, 1);
         self::assertSame(1001, $sheet->getHighestRow());
         self::assertSame(6, $sheet->getHighestDataRow());
-        self::assertTrue($sheet->getStyle('C3')->getFont()->getBold());
+        self::assertTrue(
+            $sheet->getStyle('C3')->getFont()->getBold()
+        );
         self::assertSame(11, $sheet->getCell('C3')->getValue());
-        self::assertTrue($sheet->getStyle('C4')->getFont()->getBold());
+        self::assertTrue(
+            $sheet->getStyle('C4')->getFont()->getBold()
+        );
         self::assertNull($sheet->getCell('C4')->getValue());
-        self::assertFalse($sheet->getRowDimension(1001)->getVisible());
-        self::assertTrue($sheet->getRowDimension(1000)->getVisible());
+        self::assertFalse(
+            $sheet->getRowDimension(1001)->getVisible()
+        );
+        self::assertTrue(
+            $sheet->getRowDimension(1000)->getVisible()
+        );
+        $sheet->removeRow(15, 10);
+        self::assertSame(991, $sheet->getHighestRow(), 'highest row decreases by 10');
+        $sheet->removeRow(985, 10);
+        self::assertSame(984, $sheet->getHighestRow(), 'delete range overlaps highest row so highest is now row before delete');
         $spreadsheet->disconnectWorksheets();
     }
 
@@ -56,12 +68,24 @@ class InsertTest extends TestCase
         $sheet->insertNewColumnBefore($currentColumn, 1);
         self::assertSame('ZZ', $sheet->getHighestColumn());
         self::assertSame('E', $sheet->getHighestDataColumn());
-        self::assertTrue($sheet->getStyle('C3')->getFont()->getBold());
+        self::assertTrue(
+            $sheet->getStyle('C3')->getFont()->getBold()
+        );
         self::assertSame(11, $sheet->getCell('C3')->getValue());
-        self::assertTrue($sheet->getStyle('D3')->getFont()->getBold());
+        self::assertTrue(
+            $sheet->getStyle('D3')->getFont()->getBold()
+        );
         self::assertNull($sheet->getCell('D3')->getValue());
-        self::assertFalse($sheet->getColumnDimension('ZZ')->getVisible());
-        self::assertTrue($sheet->getColumnDimension('ZY')->getVisible());
+        self::assertFalse(
+            $sheet->getColumnDimension('ZZ')->getVisible()
+        );
+        self::assertTrue(
+            $sheet->getColumnDimension('ZY')->getVisible()
+        );
+        $sheet->removeColumn('G', 5);
+        self::assertSame('ZU', $sheet->getHighestColumn(), 'ZZ moved over 5 columns');
+        $sheet->removeColumn('ZR', 5);
+        self::assertSame('ZQ', $sheet->getHighestColumn(), 'delete range overlaps highest column so new highest is one before deleted columns');
         $spreadsheet->disconnectWorksheets();
     }
 
@@ -97,7 +121,9 @@ class InsertTest extends TestCase
         ]);
         $sheet->getCell('XFD1')->setValue('lastcol');
         $sheet->insertNewColumnBefore('D', 4);
-        self::assertFalse($sheet->getCellCollection()->has('XFH1'));
+        self::assertFalse(
+            $sheet->getCellCollection()->has('XFH1')
+        );
         $spreadsheet->disconnectWorksheets();
     }
 }

--- a/tests/PhpSpreadsheetTests/Worksheet/RemoveTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/RemoveTest.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Color;
 use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class RemoveTest extends TestCase
@@ -85,5 +86,63 @@ class RemoveTest extends TestCase
         }
 
         $spreadsheet->disconnectWorksheets();
+    }
+
+    /**
+     * @param array<array<int, int>> $expectedArray
+     */
+    #[DataProvider('providerColumnEdgeCases')]
+    public function testColumnEdgeCases(string $start, int $num, array $expectedArray, string $expectedHighestColumn): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $sheet->removeColumn($start, $num);
+        self::assertSame($expectedArray, $sheet->toArray(formatData: false));
+        self::assertSame($expectedHighestColumn, $sheet->getHighestColumn());
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    /**
+     * @return array<string, array{string, int, int[][], string}>
+     */
+    public static function providerColumnEdgeCases(): array
+    {
+        return [
+            'remove positive cols' => ['E', 2, [[1, 2, 3, 4, 7, 8, 9, 10]], 'H'],
+            'remove negative cols' => ['E', -2, [[1, 2, 3, 6, 7, 8, 9, 10]], 'H'],
+            'remove zero cols' => ['E', 0, [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]], 'J'],
+            'remove cols above highest' => ['T', 2, [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]], 'J'],
+        ];
+    }
+
+    /**
+     * @param array<int, list<int>> $expectedArray
+     */
+    #[DataProvider('providerRowEdgeCases')]
+    public function testRowEdgeCases(int $start, int $num, array $expectedArray, int $expectedHighestRow): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray([[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]]);
+        $sheet->removeRow($start, $num);
+        self::assertSame($expectedArray, $sheet->toArray(formatData: false));
+        self::assertSame($expectedHighestRow, $sheet->getHighestRow());
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    /**
+     * @return array<string, array{int, int, array<int, list<int>>, int}>
+     */
+    public static function providerRowEdgeCases(): array
+    {
+        return [
+            'remove positive rows' => [5, 2, [[1], [2], [3], [4], [7], [8], [9], [10]], 8],
+            'remove negative rows' => [5, -2, [[1], [2], [3], [6], [7], [8], [9], [10]], 8],
+            'remove zero rows' => [5, 0, [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]], 10],
+            'remove rows above highest' => [20, 2, [[1], [2], [3], [4], [5], [6], [7], [8], [9], [10]], 10],
+        ];
     }
 }


### PR DESCRIPTION
Fix #943, which went stale a long time ago, and is now reopened. I believe that the specific problem in that issue was actually mostly resolved some time ago. However, `highestRow/Column` produces questionable results when the delete range overlaps the highest row/column. That is fixed by this PR.

In addition, `removeRow/Column` allow the specification of a non-negative value for `numberOfRows/Columns`. But the expected results in those cases are not defined, and the actual results probably do not meet user expectations. I believe that very few, if any, users are taking advantage of this "feature", but we may as well straighten it out. For 0 rows/columns, I think it makes perfect sense to do nothing. As for negative - if `removeRow(5, 2)` says to remove 2 rows *starting* with 5, I think `removeRow(5, -2)` ought to remove (up to) 2 rows *ending* with 5. The undefined behaviors are changed to act as described in this paragraph.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

