### PR TITLE
Reduce redundant cell lookups in Xlsx writer hot path

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1714,7 +1714,6 @@ class Worksheet extends WriterPart
         // Cell
         $xfi = $pCell->getXfIndex();
         $cellValue = $pCell->getValue();
-        $cellValueString = $pCell->getValueString();
         $writeValue = $cellValue !== '' && $cellValue !== null;
         if (empty($xfi) && !$writeValue) {
             return;
@@ -1731,7 +1730,7 @@ class Worksheet extends WriterPart
         $mappedType = $pCell->getDataType();
         if ($mappedType === DataType::TYPE_FORMULA) {
             if ($this->useDynamicArrays) {
-                if (preg_match(PhpspreadsheetWorksheet::FUNCTION_LIKE_GROUPBY, $cellValueString) === 1) {
+                if (preg_match(PhpspreadsheetWorksheet::FUNCTION_LIKE_GROUPBY, $pCell->getValueString()) === 1) {
                     $tempCalc = [];
                 } else {
                     $tempCalc = $pCell->getCalculatedValue();
@@ -1760,11 +1759,11 @@ class Worksheet extends WriterPart
 
                     break;
                 case 's':            // String
-                    $this->writeCellString($objWriter, $mappedType, ($cellValue instanceof RichText) ? $cellValue : $cellValueString, $flippedStringTable);
+                    $this->writeCellString($objWriter, $mappedType, ($cellValue instanceof RichText) ? $cellValue : $pCell->getValueString(), $flippedStringTable);
 
                     break;
                 case 'f':            // Formula
-                    $this->writeCellFormula($objWriter, $cellValueString, $pCell);
+                    $this->writeCellFormula($objWriter, $pCell->getValueString(), $pCell);
 
                     break;
                 case 'n':            // Numeric
@@ -1784,7 +1783,7 @@ class Worksheet extends WriterPart
 
                     break;
                 case 'e':            // Error
-                    $this->writeCellError($objWriter, $mappedType, $cellValueString);
+                    $this->writeCellError($objWriter, $mappedType, $pCell->getValueString());
             }
         }
 

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1487,25 +1487,27 @@ class Worksheet extends WriterPart
                         foreach ($columnsInRow as $column) {
                             // Write cell
                             $coord = "$column$currentRow";
-                            if ($worksheet->getCell($coord)->getIgnoredErrors()->getNumberStoredAsText()) {
+                            $pCell = $worksheet->getCell($coord);
+                            $ignoredErrors = $pCell->getIgnoredErrors();
+                            if ($ignoredErrors->getNumberStoredAsText()) {
                                 $this->numberStoredAsText .= " $coord";
                             }
-                            if ($worksheet->getCell($coord)->getIgnoredErrors()->getFormula()) {
+                            if ($ignoredErrors->getFormula()) {
                                 $this->formula .= " $coord";
                             }
-                            if ($worksheet->getCell($coord)->getIgnoredErrors()->getFormulaRange()) {
+                            if ($ignoredErrors->getFormulaRange()) {
                                 $this->formulaRange .= " $coord";
                             }
-                            if ($worksheet->getCell($coord)->getIgnoredErrors()->getTwoDigitTextYear()) {
+                            if ($ignoredErrors->getTwoDigitTextYear()) {
                                 $this->twoDigitTextYear .= " $coord";
                             }
-                            if ($worksheet->getCell($coord)->getIgnoredErrors()->getEvalError()) {
+                            if ($ignoredErrors->getEvalError()) {
                                 $this->evalError .= " $coord";
                             }
-                            if ($worksheet->getCell($coord)->getIgnoredErrors()->getMisleadingFormat()) {
+                            if ($ignoredErrors->getMisleadingFormat()) {
                                 $this->misleadingFormat .= " $coord";
                             }
-                            $this->writeCell($objWriter, $worksheet, $coord, $aFlippedStringTable);
+                            $this->writeCell($objWriter, $pCell, $coord, $aFlippedStringTable);
                         }
                     }
 
@@ -1707,10 +1709,9 @@ class Worksheet extends WriterPart
      * @param string $cellAddress Cell Address
      * @param string[] $flippedStringTable String table (flipped), for faster index searching
      */
-    private function writeCell(XMLWriter $objWriter, PhpspreadsheetWorksheet $worksheet, string $cellAddress, array $flippedStringTable): void
+    private function writeCell(XMLWriter $objWriter, Cell $pCell, string $cellAddress, array $flippedStringTable): void
     {
         // Cell
-        $pCell = $worksheet->getCell($cellAddress);
         $xfi = $pCell->getXfIndex();
         $cellValue = $pCell->getValue();
         $cellValueString = $pCell->getValueString();

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1402,9 +1402,12 @@ class Worksheet extends WriterPart
         /** @var array<int, string> $cellsByRow */
         $cellsByRow = [];
         foreach ($worksheet->getCoordinates() as $coordinate) {
-            [$column, $row] = Coordinate::coordinateFromString($coordinate);
+            $column = '';
+            $row = 0;
+            sscanf($coordinate, '%[A-Z]%d', $column, $row);
+            /** @var int $row */
             if (!isset($cellsByRow[$row])) {
-                $pCell = $worksheet->getCell("$column$row");
+                $pCell = $worksheet->getCell($coordinate);
                 $xfi = $pCell->getXfIndex();
                 $cellValue = $pCell->getValue();
                 $writeValue = $cellValue !== '' && $cellValue !== null;


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [ ] a new feature
- [x] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

Profiling `Writer\Xlsx` on large sheets shows that most of the per-cell cost in `writeSheetData()` is not XML generation but repeated cell lookups: every written cell went through `Worksheet::getCell()` up to seven times, and each lookup pays for `Validations::validateCellAddress()`, `trimSheetFromCellReference()`, and cell collection attach/detach churn. This PR removes that redundant work in three independent, behavior-preserving steps (one commit each):

- **Fetch the cell once per coordinate.** The per-column loop in `writeSheetData()` called `$worksheet->getCell($coord)` six times for the `IgnoredErrors` checks, and `writeCell()` fetched the same cell a seventh time. The loop now fetches the `Cell` once, reads its `IgnoredErrors` instance once, and passes the `Cell` object into `writeCell()` (a private method, so the signature change is internal).
- **Compute the cell value string lazily.** `writeCell()` eagerly ran `$pCell->getValueString()` (`StringHelper::convertToString`) for every cell, but the result is only used in the string, formula, error, and dynamic-array branches. Numeric and boolean cells — typically the bulk of large sheets — no longer pay for it.
- **Replace the coordinate regex with sscanf.** The row-grouping pass over `getCoordinates()` used `Coordinate::coordinateFromString()` (a `preg_match` call) per cell just to split column and row. It now uses the same `sscanf($coordinate, '%[A-Z]%d', ...)` idiom the `Cells` collection itself uses for indexing, and passes the original coordinate string straight to `getCell()`.

Output is byte-identical: a workbook covering numeric, string, RichText, inline string, formula, boolean, error, and all `IgnoredErrors` flags produces identical XML for every zip entry before and after the change (verified by per-entry sha256).

Benchmarks (median of 5 `save()` runs, mixed 60/30/10 numeric/string/formula content, pre-calculation off, PHP 8.5):

| Scenario   | master  | this PR | delta          |
|------------|---------|---------|----------------|
| 200k cells | 6.211 s | 3.861 s | -37.8% (1.61x) |
| 20k cells  | 0.539 s | 0.410 s | -23.9% (1.31x) |

Peak memory is unchanged. The full test suite passes with no new failures, and PHPStan (level 10, full config) reports no new errors.
