### PR TITLE
Drawings for ODS

### DIFF
--- a/docs/references/features-cross-reference.md
+++ b/docs/references/features-cross-reference.md
@@ -410,6 +410,30 @@
         <td></td>
     </tr>
     <tr>
+        <td style="padding-left: 1em;">Image Above Cell</td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td style="text-align: center; color: red;">✖</td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td style="text-align: center; color: red;">✖</td>
+        <td style="text-align: center;">N/A</td>
+        <td style="text-align: center;">N/A</td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td style="padding-left: 1em;">Image In Cell</td>
+        <td style="text-align: center; color: red;">✖</td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td style="text-align: center; color: red;">✖</td>
+        <td style="text-align: center; color: red;">✖</td>
+        <td style="text-align: center; color: red;">✖</td>
+        <td style="text-align: center;">N/A</td>
+        <td style="text-align: center;">N/A</td>
+        <td style="text-align: center; color: red;">✖</td>
+        <td></td>
+    </tr>
+    <tr>
         <td style="padding-left: 0.5em;"><strong>Conditional Formatting</strong></td>
         <td style="text-align: center; color: green;">✔</td>
         <td style="text-align: center; color: green;">✔</td>
@@ -1182,7 +1206,7 @@
         <td style="text-align: center;">N/A</td>
     </tr>
     <tr>
-        <td style="padding-left: 0.5em;">Rich Text</td>
+        <td style="padding-left: 0.5em;"><strong>Rich Text</strong></td>
         <td style="text-align: center; color: green;">✔</td>
         <td style="text-align: center; color: green;">✔</td>
         <td style="text-align: center; color: red;">✖</td>
@@ -1191,13 +1215,33 @@
         <td style="text-align: center; color: green;">✔</td>
     </tr>
     <tr>
+        <td style="padding-left: 0.5em;"><strong>Image Above Cell</strong></td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td style="text-align: center;">N/A</td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td style="padding-left: 0.5em;"><strong>Image In Cell</strong></td>
+        <td style="text-align: center; color: red;">✖</td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td style="text-align: center; color: red;">✖</td>
+        <td style="text-align: center;">N/A</td>
+        <td style="text-align: center; color: red;">✖</td>
+        <td style="text-align: center; color: red;">✖</td>
+        <td></td>
+    </tr>
+    <tr>
         <td style="padding-left: 0.5em;"><strong>Conditional Formatting</strong></td>
         <td style="text-align: center; color: green;">✔</td>
         <td style="text-align: center; color: green;">✔</td>
         <td style="text-align: center; color: red;">✖</td>
         <td style="text-align: center; color: red;">✖</td>
-        <td style="text-align: center; color: red;">✖</td>
-        <td style="text-align: center; color: red;">✖</td>
+        <td style="text-align: center; color: green;">✔</td>
+        <td style="text-align: center; color: green;">✔</td>
     </tr>
     <tr>
         <td style="padding-left: 0.5em;"><strong>Array Formula<a href="#footnote8"><sup>8</sup></a></strong></td>

--- a/samples/Basic2/25_In_memory_image.php
+++ b/samples/Basic2/25_In_memory_image.php
@@ -11,10 +11,6 @@ require __DIR__ . '/../Header.php';
 $helper->log('Create new Spreadsheet object');
 $spreadsheet = new Spreadsheet();
 $sheet1 = $spreadsheet->getActiveSheet();
-$sheet1->setTitle('SheetWithData');
-$sheet1->getCell('G1')->setValue('X');
-$sheet1->getCell('E5')->setValue('Y');
-$sheet1->getCell('A8')->setValue('Z');
 
 // Set document properties
 $helper->log('Set document properties');
@@ -26,24 +22,24 @@ $spreadsheet->getProperties()->setCreator('Maarten Balliauw')
     ->setKeywords('office 2007 openxml php')
     ->setCategory('Test result file');
 
-// Generate an image
-$helper->log('Generate an image');
+$sheet1->setTitle('JpegWithData');
+$sheet1->getCell('G1')->setValue('X');
+$sheet1->getCell('E5')->setValue('Y');
+$sheet1->getCell('A8')->setValue('Z');
+$helper->log('Generate an image as jpg');
 $gdImage = imagecreatetruecolor(150, 20);
 if (!$gdImage) {
     throw new Exception('Cannot Initialize new GD image stream');
 }
-
 $textColor = imagecolorallocate($gdImage, 255, 255, 255);
 if ($textColor === false) {
     throw new Exception('imagecolorallocate failed');
 }
-imagestring($gdImage, 1, 5, 5, 'Created with PhpSpreadsheet', $textColor);
-
-// Add a drawing to the worksheet
-$helper->log('Add a drawing to the worksheet');
+imagestring($gdImage, 1, 5, 5, 'Jpeg made with PhpSpreadsheet', $textColor);
+$helper->log('Add image to the worksheet');
 $drawing = new MemoryDrawing();
-$drawing->setName('Sample image');
-$drawing->setDescription('Sample image');
+$drawing->setName('Sample JPEG image');
+$drawing->setDescription('Sample JPEG image');
 $drawing->setImageResource($gdImage);
 $drawing->setRenderingFunction(MemoryDrawing::RENDERING_JPEG);
 $drawing->setMimeType(MemoryDrawing::MIMETYPE_DEFAULT);
@@ -53,18 +49,52 @@ $drawing->setCoordinates('C5');
 
 $helper->log('Create new sheet');
 $sheet2 = $spreadsheet->createSheet();
-$sheet2->setTitle('SheetWithoutData');
-
+$sheet2->setTitle('Gif');
+$helper->log('Generate a second image as gif');
+$gdImage2 = imagecreatetruecolor(150, 20);
+if (!$gdImage2) {
+    throw new Exception('Cannot Initialize new GD image stream');
+}
+$textColor = imagecolorallocate($gdImage, 255, 255, 255);
+if ($textColor === false) {
+    throw new Exception('imagecolorallocate failed');
+}
+imagestring($gdImage2, 1, 5, 5, 'Gif made with PhpSpreadsheet', $textColor);
 // Add a drawing to the new worksheet
-$helper->log('Add a drawing to the new worksheet');
+$helper->log('Add image to the new worksheet');
 $drawing = new MemoryDrawing();
-$drawing->setName('Sample image');
-$drawing->setDescription('Sample image');
-$drawing->setImageResource($gdImage);
-$drawing->setRenderingFunction(MemoryDrawing::RENDERING_JPEG);
+$drawing->setName('Sample GIF image');
+$drawing->setDescription('Sample GIF image');
+$drawing->setImageResource($gdImage2);
+$drawing->setRenderingFunction(MemoryDrawing::RENDERING_GIF);
 $drawing->setMimeType(MemoryDrawing::MIMETYPE_DEFAULT);
 $drawing->setHeight(36);
 $drawing->setWorksheet($sheet2);
+$drawing->setCoordinates('C5');
+
+$helper->log('Create a third sheet');
+$sheet3 = $spreadsheet->createSheet();
+$sheet3->setTitle('Png');
+$helper->log('Generate a third image as png');
+$gdImage3 = imagecreatetruecolor(150, 20);
+if (!$gdImage3) {
+    throw new Exception('Cannot Initialize new GD image stream');
+}
+$textColor = imagecolorallocate($gdImage3, 255, 255, 255);
+if ($textColor === false) {
+    throw new Exception('imagecolorallocate failed');
+}
+imagestring($gdImage3, 1, 5, 5, 'Png made with PhpSpreadsheet', $textColor);
+// Add a drawing to the new worksheet
+$helper->log('Add image to the new worksheet');
+$drawing = new MemoryDrawing();
+$drawing->setName('Sample PNG image');
+$drawing->setDescription('Sample PNG image');
+$drawing->setImageResource($gdImage3);
+$drawing->setRenderingFunction(MemoryDrawing::RENDERING_PNG);
+$drawing->setMimeType(MemoryDrawing::MIMETYPE_DEFAULT);
+$drawing->setHeight(36);
+$drawing->setWorksheet($sheet3);
 $drawing->setCoordinates('C5');
 
 // Save

--- a/samples/Basic2/25_In_memory_image.php
+++ b/samples/Basic2/25_In_memory_image.php
@@ -101,7 +101,7 @@ $drawing->setCoordinates('C5');
 $helper->write(
     $spreadsheet,
     __FILE__,
-    ['Xlsx', 'Html', 'Ods'],
+    ['Xlsx', 'Html', 'Ods', 'Xls'],
     false,
     function (BaseWriter $writer): void {
         if (method_exists($writer, 'writeAllSheets')) {

--- a/samples/Basic2/25_In_memory_image.php
+++ b/samples/Basic2/25_In_memory_image.php
@@ -28,7 +28,7 @@ $spreadsheet->getProperties()->setCreator('Maarten Balliauw')
 
 // Generate an image
 $helper->log('Generate an image');
-$gdImage = imagecreatetruecolor(120, 20);
+$gdImage = imagecreatetruecolor(150, 20);
 if (!$gdImage) {
     throw new Exception('Cannot Initialize new GD image stream');
 }

--- a/samples/Basic2/25_In_memory_image.php
+++ b/samples/Basic2/25_In_memory_image.php
@@ -71,7 +71,7 @@ $drawing->setCoordinates('C5');
 $helper->write(
     $spreadsheet,
     __FILE__,
-    ['Xlsx', 'Html'],
+    ['Xlsx', 'Html', 'Ods'],
     false,
     function (BaseWriter $writer): void {
         if (method_exists($writer, 'writeAllSheets')) {

--- a/samples/Basic2/27_Images_Xlsx.php
+++ b/samples/Basic2/27_Images_Xlsx.php
@@ -24,4 +24,4 @@ $sheet->getCell('G16')->setValue('BMP');
 $sheet->getStyle('G16')->getFont()->setName('Arial Black')->setBold(true);
 
 // Save
-$helper->write($spreadsheet, __FILE__);
+$helper->write($spreadsheet, __FILE__, ['Xlsx', 'Xls', 'Ods']);

--- a/src/PhpSpreadsheet/Reader/Ods.php
+++ b/src/PhpSpreadsheet/Reader/Ods.php
@@ -31,6 +31,7 @@ use PhpOffice\PhpSpreadsheet\Style\Borders;
 use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Style\Protection;
+use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Throwable;
 use XMLReader;
@@ -39,6 +40,10 @@ use ZipArchive;
 class Ods extends BaseReader
 {
     const INITIAL_FILE = 'content.xml';
+
+    private ZipArchive $zip;
+
+    private string $filename;
 
     /**
      * Create a new Ods Reader instance.
@@ -312,7 +317,8 @@ class Ods extends BaseReader
     {
         File::assertFile($filename, self::INITIAL_FILE);
 
-        $zip = new ZipArchive();
+        $this->zip = $zip = new ZipArchive();
+        $this->filename = $filename;
         $zip->open($filename);
 
         // Meta
@@ -881,6 +887,7 @@ class Ods extends BaseReader
                 }
                 // Fall through to process the cell, with per-column filter checks
             }
+            $spannedRange = '';
             if ($worksheet !== null && ($cellData->hasChildNodes() || ($cellData->nextSibling !== null)) && isset($this->allStyles[$styleName])) {
                 $spannedRange = "$columnID$rowID";
                 // the following is sufficient for ods,
@@ -977,6 +984,8 @@ class Ods extends BaseReader
                 // Filter text:p elements
                 if ($item->nodeName == 'text:p') {
                     $paragraphs[] = $item;
+                } elseif ($item->nodeName === 'draw:frame' && $worksheet !== null) {
+                    $this->processDrawFrame($spannedRange, $item, $worksheet);
                 }
             }
 
@@ -1198,6 +1207,57 @@ class Ods extends BaseReader
             StringHelper::stringIncrement($columnID);
         }
         $rowID += $rowRepeats;
+    }
+
+    private function processDrawFrame(string $spannedRange, DOMElement $item, Worksheet $worksheet): void
+    {
+        $drawName = $item->getAttribute('draw:name');
+        $svgWidth = $item->getAttribute('svg:width');
+        $svgHeight = $item->getAttribute('svg:height');
+        $styleName = $item->getAttribute('draw:style-name');
+        $drawImage = null;
+        foreach ($item->childNodes as $node) {
+            // Check if the node is a standard element tag
+            if ($node->nodeType === XML_ELEMENT_NODE && $node->nodeName === 'draw:image') {
+                /** @var DOMElement */
+                $drawImage = $node;
+
+                break;
+            }
+        }
+
+        $xlinkHref = $xlinkType = $xlinkShow = '';
+        if ($drawImage !== null) {
+            $xlinkHref = $drawImage->getAttribute('xlink:href');
+            $xlinkType = $drawImage->getAttribute('xlink:type');
+            $xlinkShow = $drawImage->getAttribute('xlink:show');
+        }
+        if (
+            $drawName !== ''
+            && Preg::isMatch('/(\d+([.]\d+)?)cm/', $svgWidth, $matchWidth)
+            && Preg::isMatch('/(\d+([.]\d+)?)cm/', $svgHeight, $matchHeight)
+            && $styleName === 'gr1'
+            && str_starts_with($xlinkHref, 'Pictures/')
+            && $xlinkType === 'simple'
+            && $xlinkShow === 'embed'
+        ) {
+            $drawing = new Drawing();
+            $drawing->setPath(
+                "zip://{$this->filename}#$xlinkHref",
+                true,
+                $this->zip,
+                false
+            );
+            $width = ((float) $matchWidth[1]) * HelperDimension::ABSOLUTE_UNITS[HelperDimension::UOM_CENTIMETERS];
+            $height = ((float) $matchHeight[1]) * HelperDimension::ABSOLUTE_UNITS[HelperDimension::UOM_CENTIMETERS];
+            if ($drawing->getPath()) {
+                $drawing->setCoordinates($spannedRange)
+                    ->setWidth((int) $width)
+                    ->setHeight((int) $height)
+                    ->setName($drawName)
+                    ->setWorksheet($worksheet);
+            }
+        }
     }
 
     private static function extractNodeName(string $key): string

--- a/src/PhpSpreadsheet/Reader/Ods.php
+++ b/src/PhpSpreadsheet/Reader/Ods.php
@@ -887,6 +887,7 @@ class Ods extends BaseReader
                 }
                 // Fall through to process the cell, with per-column filter checks
             }
+            $tempSpannedRange = "$columnID$rowID";
             $spannedRange = '';
             if ($worksheet !== null && ($cellData->hasChildNodes() || ($cellData->nextSibling !== null)) && isset($this->allStyles[$styleName])) {
                 $spannedRange = "$columnID$rowID";
@@ -985,7 +986,7 @@ class Ods extends BaseReader
                 if ($item->nodeName == 'text:p') {
                     $paragraphs[] = $item;
                 } elseif ($item->nodeName === 'draw:frame' && $worksheet !== null) {
-                    $this->processDrawFrame($spannedRange, $item, $worksheet);
+                    $this->processDrawFrame($spannedRange ?: $tempSpannedRange, $item, $worksheet);
                 }
             }
 
@@ -1234,10 +1235,10 @@ class Ods extends BaseReader
         }
         if (
             $drawName !== ''
-            && Preg::isMatch('/(\d+([.]\d+)?)cm/', $svgWidth, $matchWidth)
-            && Preg::isMatch('/(\d+([.]\d+)?)cm/', $svgHeight, $matchHeight)
-            && $styleName === 'gr1'
-            && str_starts_with($xlinkHref, 'Pictures/')
+            && Preg::isMatch('/(\d+([.]\d+)?)(cm|in)/', $svgWidth, $matchWidth)
+            && Preg::isMatch('/(\d+([.]\d+)?)(cm|in)/', $svgHeight, $matchHeight)
+            //&& $styleName === 'gr1'
+            && (str_starts_with($xlinkHref, 'Pictures/') || str_starts_with($xlinkHref, 'media/'))
             && $xlinkType === 'simple'
             && $xlinkShow === 'embed'
         ) {
@@ -1248,8 +1249,12 @@ class Ods extends BaseReader
                 $this->zip,
                 false
             );
-            $width = ((float) $matchWidth[1]) * HelperDimension::ABSOLUTE_UNITS[HelperDimension::UOM_CENTIMETERS];
-            $height = ((float) $matchHeight[1]) * HelperDimension::ABSOLUTE_UNITS[HelperDimension::UOM_CENTIMETERS];
+            $unit = [
+                'cm' => HelperDimension::ABSOLUTE_UNITS[HelperDimension::UOM_CENTIMETERS],
+                'in' => HelperDimension::ABSOLUTE_UNITS[HelperDimension::UOM_INCHES],
+            ];
+            $width = ((float) $matchWidth[1]) * $unit[$matchWidth[3]];
+            $height = ((float) $matchHeight[1]) * $unit[$matchHeight[3]];
             if ($drawing->getPath()) {
                 $drawing->setCoordinates($spannedRange)
                     ->setWidth((int) $width)

--- a/src/PhpSpreadsheet/Worksheet/RowCellIterator.php
+++ b/src/PhpSpreadsheet/Worksheet/RowCellIterator.php
@@ -142,7 +142,15 @@ class RowCellIterator extends CellIterator
     {
         do {
             ++$this->currentColumnIndex;
-        } while (($this->onlyExistingCells) && (!$this->cellCollection->has(Coordinate::stringFromColumnIndex($this->currentColumnIndex) . $this->rowIndex)) && ($this->currentColumnIndex <= $this->endColumnIndex));
+        } while (
+            $this->onlyExistingCells
+            && $this->currentColumnIndex <= $this->endColumnIndex
+            && !$this->cellCollection->has(
+                Coordinate::stringFromColumnIndex(
+                    $this->currentColumnIndex
+                ) . $this->rowIndex
+            )
+        );
     }
 
     /**
@@ -152,7 +160,15 @@ class RowCellIterator extends CellIterator
     {
         do {
             --$this->currentColumnIndex;
-        } while (($this->onlyExistingCells) && (!$this->cellCollection->has(Coordinate::stringFromColumnIndex($this->currentColumnIndex) . $this->rowIndex)) && ($this->currentColumnIndex >= $this->startColumnIndex));
+        } while (
+            $this->onlyExistingCells
+            && $this->currentColumnIndex >= $this->startColumnIndex
+            && !$this->cellCollection->has(
+                Coordinate::stringFromColumnIndex(
+                    $this->currentColumnIndex
+                ) . $this->rowIndex
+            )
+        );
     }
 
     /**
@@ -177,10 +193,28 @@ class RowCellIterator extends CellIterator
     protected function adjustForExistingOnlyRange(): void
     {
         if ($this->onlyExistingCells) {
-            while ((!$this->cellCollection->has(Coordinate::stringFromColumnIndex($this->startColumnIndex) . $this->rowIndex)) && ($this->startColumnIndex <= $this->endColumnIndex)) {
+            while (
+                $this->startColumnIndex <= $this->endColumnIndex
+                && (
+                    !$this->cellCollection->has(
+                        Coordinate::stringFromColumnIndex(
+                            $this->startColumnIndex
+                        ) . $this->rowIndex
+                    )
+                )
+            ) {
                 ++$this->startColumnIndex;
             }
-            while ((!$this->cellCollection->has(Coordinate::stringFromColumnIndex($this->endColumnIndex) . $this->rowIndex)) && ($this->endColumnIndex >= $this->startColumnIndex)) {
+            while (
+                $this->endColumnIndex >= $this->startColumnIndex
+                && (
+                    !$this->cellCollection->has(
+                        Coordinate::stringFromColumnIndex(
+                            $this->endColumnIndex
+                        ) . $this->rowIndex
+                    )
+                )
+            ) {
                 --$this->endColumnIndex;
             }
         }

--- a/src/PhpSpreadsheet/Writer/Ods.php
+++ b/src/PhpSpreadsheet/Writer/Ods.php
@@ -106,6 +106,18 @@ class Ods extends BaseWriter
 
         $this->openFileHandle($filename);
 
+        // Collect all drawings from all worksheets
+        $drawingWriter = $this->getWriterPartContent()->getDrawingWriter();
+        $drawingWriter->reset(); // Reset state
+        $sheetCount = $this->spreadSheet->getSheetCount();
+        for ($i = 0; $i < $sheetCount; ++$i) {
+            $sheet = $this->spreadSheet->getSheet($i);
+            $drawingWriter->collectDrawings($sheet);
+        }
+        $drawings = $drawingWriter->getAllImageFiles();
+        // Pass image files to MetaInf writer
+        $this->getWriterPartMetaInf()->setImageFiles($drawings);
+
         $zip = $this->createZip();
 
         $zip->addFile('META-INF/manifest.xml', $this->getWriterPartMetaInf()->write());
@@ -116,6 +128,9 @@ class Ods extends BaseWriter
         $zip->addFile('meta.xml', $this->getWriterPartmeta()->write());
         $zip->addFile('mimetype', $this->getWriterPartmimetype()->write());
         $zip->addFile('styles.xml', $this->getWriterPartstyles()->write());
+        foreach ($drawings as $imagePath => $imageContent) {
+            $zip->addFile($imagePath, $imageContent);
+        }
 
         // Close file
         try {

--- a/src/PhpSpreadsheet/Writer/Ods/Content.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Content.php
@@ -448,6 +448,7 @@ class Content extends WriterPart
         //   someone raise an issue rather than have them
         //   execute unpredictable code.
 
+        /*
         foreach ($drawingsByColumn as $column => $drawingData) {
             if ($column > $prevColumn) {
                 $this->writeCellSpan($objWriter, $column, $prevColumn);
@@ -464,6 +465,7 @@ class Content extends WriterPart
                 $prevColumn = $column;
             }
         }
+        */
     }
 
     /**

--- a/src/PhpSpreadsheet/Writer/Ods/Content.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Content.php
@@ -441,7 +441,12 @@ class Content extends WriterPart
             $prevColumn = $column;
         }
 
-        // Write any remaining drawings that don't have cells
+        // Write any remaining drawings that don't have cells.
+        // I don't know how to trigger the if condition below,
+        //   and would prefer to eliminate the code and have
+        //   someone raise an issue rather than have them
+        //   execute unpredictable code.
+        /*
         foreach ($drawingsByColumn as $column => $drawingData) {
             if ($column > $prevColumn) {
                 $this->writeCellSpan($objWriter, $column, $prevColumn);
@@ -458,6 +463,7 @@ class Content extends WriterPart
                 $prevColumn = $column;
             }
         }
+        */
     }
 
     /**

--- a/src/PhpSpreadsheet/Writer/Ods/Content.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Content.php
@@ -13,6 +13,7 @@ use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Shared\XMLWriter;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+use PhpOffice\PhpSpreadsheet\Worksheet\BaseDrawing;
 use PhpOffice\PhpSpreadsheet\Worksheet\RowCellIterator;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Writer\Ods;
@@ -26,6 +27,8 @@ class Content extends WriterPart
 {
     private Formula $formulaConvertor;
 
+    private Drawing $drawingWriter;
+
     /**
      * Set parent Ods writer.
      */
@@ -34,6 +37,7 @@ class Content extends WriterPart
         parent::__construct($writer);
 
         $this->formulaConvertor = new Formula($this->getParentWriter()->getSpreadsheet()->getDefinedNames());
+        $this->drawingWriter = new Drawing($writer);
     }
 
     /**
@@ -115,6 +119,14 @@ class Content extends WriterPart
     }
 
     /**
+     * Get drawing writer instance.
+     */
+    public function getDrawingWriter(): Drawing
+    {
+        return $this->drawingWriter;
+    }
+
+    /**
      * Write sheets.
      */
     private function writeSheets(XMLWriter $objWriter): void
@@ -156,11 +168,27 @@ class Content extends WriterPart
     {
         $spanRow = 0;
         $rows = $sheet->getRowIterator();
+
+        // Build a map of drawings by their row position
+        /** @var array<int, array<int, array{drawing: BaseDrawing, index: int}>> */
+        $drawingsByRow = [];
+        $drawingIndex = 0;
+        foreach ($sheet->getDrawingCollection() as $drawing) {
+            ++$drawingIndex;
+            $coordinates = Coordinate::coordinateFromString($drawing->getCoordinates());
+            $row = (int) $coordinates[1];
+            if (!isset($drawingsByRow[$row])) {
+                $drawingsByRow[$row] = [];
+            }
+            $drawingsByRow[$row][] = ['drawing' => $drawing, 'index' => $drawingIndex];
+        }
+
         foreach ($rows as $row) {
             $cellIterator = $row->getCellIterator(iterateOnlyExistingCells: true);
             $cellIterator->rewind();
             $rowStyleExists = $sheet->rowDimensionExists($row->getRowIndex()) && $sheet->getRowDimension($row->getRowIndex())->getRowHeight() > 0;
-            if ($cellIterator->valid() || $rowStyleExists) {
+            $rowIndex = $row->getRowIndex();
+            if ($cellIterator->valid() || $rowStyleExists || isset($drawingsByRow[$rowIndex])) {
                 if ($spanRow) {
                     $objWriter->startElement('table:table-row');
                     $objWriter->writeAttribute(
@@ -174,15 +202,15 @@ class Content extends WriterPart
                 if ($rowStyleExists) {
                     $objWriter->writeAttribute(
                         'table:style-name',
-                        sprintf('%s_%d_%d', Style::ROW_STYLE_PREFIX, $sheetIndex, $row->getRowIndex())
+                        sprintf('%s_%d_%d', Style::ROW_STYLE_PREFIX, $sheetIndex, $rowIndex)
                     );
-                } elseif ($sheet->getDefaultRowDimension()->getRowHeight() > 0.0 && !$sheet->getRowDimension($row->getRowIndex())->getCustomFormat()) {
+                } elseif ($sheet->getDefaultRowDimension()->getRowHeight() > 0.0 && !$sheet->getRowDimension($rowIndex)->getCustomFormat()) {
                     $objWriter->writeAttribute(
                         'table:style-name',
                         sprintf('%s%d', Style::ROW_STYLE_PREFIX, $sheetIndex)
                     );
                 }
-                $this->writeCells($objWriter, $cellIterator);
+                $this->writeCells($objWriter, $cellIterator, $drawingsByRow, $rowIndex, $sheet);
                 $objWriter->endElement();
             } else {
                 ++$spanRow;
@@ -192,10 +220,20 @@ class Content extends WriterPart
 
     /**
      * Write cells of the specified row.
+     *
+     * @param array<int, array<int, array{drawing: BaseDrawing, index: int}>> $drawingsByRow
      */
-    private function writeCells(XMLWriter $objWriter, RowCellIterator $cells): void
+    private function writeCells(XMLWriter $objWriter, RowCellIterator $cells, array $drawingsByRow, int $rowIndex, Worksheet $sheet): void
     {
         $prevColumn = -1;
+        // Get drawings for this row
+        $rowDrawings = $drawingsByRow[$rowIndex] ?? [];
+        $drawingsByColumn = [];
+        foreach ($rowDrawings as $drawingData) {
+            $coordinates = Coordinate::coordinateFromString($drawingData['drawing']->getCoordinates());
+            $column = Coordinate::columnIndexFromString($coordinates[0]) - 1;
+            $drawingsByColumn[$column] = $drawingData;
+        }
         foreach ($cells as $cell) {
             /** @var Cell $cell */
             $column = Coordinate::columnIndexFromString($cell->getColumn()) - 1;
@@ -386,9 +424,39 @@ class Content extends WriterPart
 
                     break;
             }
+
+            // Write drawing if it belongs to this cell
+            if (isset($drawingsByColumn[$column])) {
+                $drawingData = $drawingsByColumn[$column];
+                $this->drawingWriter->writeDrawingFrame(
+                    $objWriter,
+                    $drawingData['drawing'],
+                    $drawingData['index'],
+                    $sheet->getTitle()
+                );
+            }
+
             Comment::write($objWriter, $cell);
             $objWriter->endElement();
             $prevColumn = $column;
+        }
+
+        // Write any remaining drawings that don't have cells
+        foreach ($drawingsByColumn as $column => $drawingData) {
+            if ($column > $prevColumn) {
+                $this->writeCellSpan($objWriter, $column, $prevColumn);
+                $objWriter->startElement('table:table-cell');
+
+                $this->drawingWriter->writeDrawingFrame(
+                    $objWriter,
+                    $drawingData['drawing'],
+                    $drawingData['index'],
+                    $sheet->getTitle()
+                );
+
+                $objWriter->endElement();
+                $prevColumn = $column;
+            }
         }
     }
 

--- a/src/PhpSpreadsheet/Writer/Ods/Content.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Content.php
@@ -29,6 +29,8 @@ class Content extends WriterPart
 
     private Drawing $drawingWriter;
 
+    private int $drawingIndex = 0;
+
     /**
      * Set parent Ods writer.
      */
@@ -172,15 +174,14 @@ class Content extends WriterPart
         // Build a map of drawings by their row position
         /** @var array<int, array<int, array{drawing: BaseDrawing, index: int}>> */
         $drawingsByRow = [];
-        $drawingIndex = 0;
         foreach ($sheet->getDrawingCollection() as $drawing) {
-            ++$drawingIndex;
+            ++$this->drawingIndex;
             $coordinates = Coordinate::coordinateFromString($drawing->getCoordinates());
             $row = (int) $coordinates[1];
             if (!isset($drawingsByRow[$row])) {
                 $drawingsByRow[$row] = [];
             }
-            $drawingsByRow[$row][] = ['drawing' => $drawing, 'index' => $drawingIndex];
+            $drawingsByRow[$row][] = ['drawing' => $drawing, 'index' => $this->drawingIndex];
         }
 
         foreach ($rows as $row) {
@@ -446,7 +447,7 @@ class Content extends WriterPart
         //   and would prefer to eliminate the code and have
         //   someone raise an issue rather than have them
         //   execute unpredictable code.
-        /*
+
         foreach ($drawingsByColumn as $column => $drawingData) {
             if ($column > $prevColumn) {
                 $this->writeCellSpan($objWriter, $column, $prevColumn);
@@ -463,7 +464,6 @@ class Content extends WriterPart
                 $prevColumn = $column;
             }
         }
-        */
     }
 
     /**

--- a/src/PhpSpreadsheet/Writer/Ods/Drawing.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Drawing.php
@@ -18,7 +18,9 @@ class Drawing extends WriterPart
     private int $imageCounter = 0;
 
     /**
-     * Required by WriterPart abstract class.
+     * Required by WriterPart abstract class, but unused.
+     *
+     * @codeCoverageIgnore
      */
     public function write(): string
     {
@@ -62,46 +64,31 @@ class Drawing extends WriterPart
                     $this->imageFiles[$imagePath] = $imageContents;
                 }
             } elseif ($drawing instanceof MemoryDrawing) {
+                $renderingFunction = $drawing->getRenderingFunction();
                 $extension = 'png';
-                switch ($drawing->getRenderingFunction()) {
-                    case MemoryDrawing::RENDERING_JPEG:
-                        $extension = 'jpg';
-
-                        break;
-                    case MemoryDrawing::RENDERING_GIF:
-                        $extension = 'gif';
-
-                        break;
+                if ($renderingFunction === MemoryDrawing::RENDERING_JPEG) {
+                    $extension = 'jpg';
+                } elseif ($renderingFunction === MemoryDrawing::RENDERING_GIF) {
+                    $extension = 'gif';
                 }
 
-                ob_start();
                 $gdImage = $drawing->getImageResource();
                 if ($gdImage !== null) {
-                    switch ($drawing->getRenderingFunction()) {
-                        case MemoryDrawing::RENDERING_JPEG:
-                            imagejpeg($gdImage);
-
-                            break;
-                        case MemoryDrawing::RENDERING_GIF:
-                            imagegif($gdImage);
-
-                            break;
-                        //case MemoryDrawing::RENDERING_PNG:
-                        default:
-                            imagepng($gdImage);
-
-                            break;
+                    ob_start();
+                    if ($renderingFunction === MemoryDrawing::RENDERING_JPEG) {
+                        imagejpeg($gdImage);
+                    } elseif ($renderingFunction === MemoryDrawing::RENDERING_GIF) {
+                        imagegif($gdImage);
+                    } else {
+                        imagepng($gdImage);
                     }
-                    $imageContents = ob_get_contents();
-                    ob_end_clean();
+                    $imageContents = ob_get_clean();
 
                     if ($imageContents !== false && $imageContents !== '') {
                         $imagePath = "Pictures/image{$this->imageCounter}.{$extension}";
                         $drawings[$imagePath] = $imageContents;
                         $this->imageFiles[$imagePath] = $imageContents;
                     }
-                } else {
-                    ob_end_clean();
                 }
             }
         }
@@ -128,15 +115,11 @@ class Drawing extends WriterPart
         if ($drawing instanceof WorksheetDrawing) {
             $extension = $drawing->getExtension();
         } elseif ($drawing instanceof MemoryDrawing) {
-            switch ($drawing->getRenderingFunction()) {
-                case MemoryDrawing::RENDERING_JPEG:
-                    $extension = 'jpg';
-
-                    break;
-                case MemoryDrawing::RENDERING_GIF:
-                    $extension = 'gif';
-
-                    break;
+            $renderingFunction = $drawing->getRenderingFunction();
+            if ($renderingFunction === MemoryDrawing::RENDERING_JPEG) {
+                $extension = 'jpg';
+            } elseif ($renderingFunction === MemoryDrawing::RENDERING_GIF) {
+                $extension = 'gif';
             }
         }
 

--- a/src/PhpSpreadsheet/Writer/Ods/Drawing.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Drawing.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheet\Writer\Ods;
+
+use PhpOffice\PhpSpreadsheet\Helper\Dimension;
+use PhpOffice\PhpSpreadsheet\Shared\XMLWriter;
+use PhpOffice\PhpSpreadsheet\Worksheet\BaseDrawing;
+use PhpOffice\PhpSpreadsheet\Worksheet\Drawing as WorksheetDrawing;
+use PhpOffice\PhpSpreadsheet\Worksheet\MemoryDrawing;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+class Drawing extends WriterPart
+{
+    /** @var array<string, string> Image files to be added to ODS */
+    private array $imageFiles = [];
+
+    /** @var int Counter for image numbering */
+    private int $imageCounter = 0;
+
+    /**
+     * Required by WriterPart abstract class.
+     */
+    public function write(): string
+    {
+        return '';
+    }
+
+    /**
+     * Reset the drawing writer state.
+     */
+    public function reset(): void
+    {
+        $this->imageFiles = [];
+        $this->imageCounter = 0;
+    }
+
+    /**
+     * Collect all drawings from a worksheet and prepare image files.
+     *
+     * @return array<string, string> Array of drawing image files [path => content]
+     */
+    public function collectDrawings(Worksheet $worksheet): array
+    {
+        $drawingCollection = $worksheet->getDrawingCollection();
+
+        if (count($drawingCollection) === 0) {
+            return [];
+        }
+
+        $drawings = [];
+        foreach ($drawingCollection as $drawing) {
+            ++$this->imageCounter;
+
+            if ($drawing instanceof WorksheetDrawing) {
+                $filename = $drawing->getPath();
+                $filename = str_replace('\\', '/', $filename);
+                $imageContents = @file_get_contents($filename);
+                if ($imageContents !== false) {
+                    $extension = $drawing->getExtension();
+                    $imagePath = "Pictures/image{$this->imageCounter}.{$extension}";
+                    $drawings[$imagePath] = $imageContents;
+                    $this->imageFiles[$imagePath] = $imageContents;
+                }
+            } elseif ($drawing instanceof MemoryDrawing) {
+                $extension = 'png';
+                switch ($drawing->getRenderingFunction()) {
+                    case MemoryDrawing::RENDERING_JPEG:
+                        $extension = 'jpg';
+
+                        break;
+                    case MemoryDrawing::RENDERING_GIF:
+                        $extension = 'gif';
+
+                        break;
+                }
+
+                ob_start();
+                $gdImage = $drawing->getImageResource();
+                if ($gdImage !== null) {
+                    switch ($drawing->getRenderingFunction()) {
+                        case MemoryDrawing::RENDERING_JPEG:
+                            imagejpeg($gdImage);
+
+                            break;
+                        case MemoryDrawing::RENDERING_GIF:
+                            imagegif($gdImage);
+
+                            break;
+                        //case MemoryDrawing::RENDERING_PNG:
+                        default:
+                            imagepng($gdImage);
+
+                            break;
+                    }
+                    $imageContents = ob_get_contents();
+                    ob_end_clean();
+
+                    if ($imageContents !== false && $imageContents !== '') {
+                        $imagePath = "Pictures/image{$this->imageCounter}.{$extension}";
+                        $drawings[$imagePath] = $imageContents;
+                        $this->imageFiles[$imagePath] = $imageContents;
+                    }
+                } else {
+                    ob_end_clean();
+                }
+            }
+        }
+
+        return $drawings;
+    }
+
+    /**
+     * Get all collected image files.
+     *
+     * @return array<string, string>
+     */
+    public function getAllImageFiles(): array
+    {
+        return $this->imageFiles;
+    }
+
+    /**
+     * Write drawing frames in content.xml within a table cell.
+     */
+    public function writeDrawingFrame(XMLWriter $objWriter, BaseDrawing $drawing, int $imageIndex, string $sheetTitle): void
+    {
+        $extension = 'png';
+        if ($drawing instanceof WorksheetDrawing) {
+            $extension = $drawing->getExtension();
+        } elseif ($drawing instanceof MemoryDrawing) {
+            switch ($drawing->getRenderingFunction()) {
+                case MemoryDrawing::RENDERING_JPEG:
+                    $extension = 'jpg';
+
+                    break;
+                case MemoryDrawing::RENDERING_GIF:
+                    $extension = 'gif';
+
+                    break;
+            }
+        }
+
+        // Calculate dimensions in cm (ODS uses cm, PhpSpreadsheet uses pixels)
+        // 1 pixel = 0.0264583333 cm (at 96 DPI)
+        $widthCm = round($drawing->getWidth() / Dimension::ABSOLUTE_UNITS[Dimension::UOM_CENTIMETERS], 4);
+        $heightCm = round($drawing->getHeight() / Dimension::ABSOLUTE_UNITS[Dimension::UOM_CENTIMETERS], 4);
+
+        // Write draw:frame
+        $objWriter->startElement('draw:frame');
+        $objWriter->writeAttribute('draw:name', $drawing->getName() ?: "Image {$imageIndex}");
+        $objWriter->writeAttribute('draw:z-index', (string) $imageIndex);
+        $objWriter->writeAttribute('svg:width', "{$widthCm}cm");
+        $objWriter->writeAttribute('svg:height', "{$heightCm}cm");
+        $objWriter->writeAttribute('draw:style-name', 'gr1');
+
+        // Write draw:image
+        $objWriter->startElement('draw:image');
+        $objWriter->writeAttribute('xlink:href', "Pictures/image{$imageIndex}.{$extension}");
+        $objWriter->writeAttribute('xlink:type', 'simple');
+        $objWriter->writeAttribute('xlink:show', 'embed');
+        $objWriter->writeAttribute('xlink:actuate', 'onLoad');
+
+        // Empty text element required by ODS spec
+        $objWriter->startElement('text:p');
+        $objWriter->endElement(); // text:p
+
+        $objWriter->endElement(); // draw:image
+        $objWriter->endElement(); // draw:frame
+    }
+}

--- a/src/PhpSpreadsheet/Writer/Ods/MetaInf.php
+++ b/src/PhpSpreadsheet/Writer/Ods/MetaInf.php
@@ -6,6 +6,15 @@ use PhpOffice\PhpSpreadsheet\Shared\XMLWriter;
 
 class MetaInf extends WriterPart
 {
+    /** @var array<string, string> */
+    private array $imageFiles = [];
+
+    /** @param array<string, string> $imageFiles */
+    public function setImageFiles(array $imageFiles): void
+    {
+        $this->imageFiles = $imageFiles;
+    }
+
     /**
      * Write META-INF/manifest.xml to XML format.
      *
@@ -53,6 +62,25 @@ class MetaInf extends WriterPart
         $objWriter->writeAttribute('manifest:full-path', 'styles.xml');
         $objWriter->writeAttribute('manifest:media-type', 'text/xml');
         $objWriter->endElement();
+
+        // Add manifest entries for all image files
+        foreach ($this->imageFiles as $imagePath => $imageContent) {
+            $objWriter->startElement('manifest:file-entry');
+            $objWriter->writeAttribute('manifest:full-path', $imagePath);
+
+            // Determine MIME type based on extension
+            $extension = strtolower(pathinfo($imagePath, PATHINFO_EXTENSION));
+            $mimeType = match ($extension) {
+                'png' => 'image/png',
+                'jpg', 'jpeg' => 'image/jpeg',
+                'gif' => 'image/gif',
+                default => 'application/octet-stream',
+            };
+
+            $objWriter->writeAttribute('manifest:media-type', $mimeType);
+            $objWriter->endElement(); // manifest:file-entry
+        }
+
         $objWriter->endElement();
 
         return $objWriter->getData();

--- a/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xls/Worksheet.php
@@ -484,6 +484,9 @@ class Worksheet extends BIFFwriter
             [$column, $row] = Coordinate::indexesFromString($coordinate);
 
             $url = $hyperlink->getUrl();
+            if ($url === '') {
+                continue;
+            }
             if ($url[0] === '#') {
                 $url = "internal:$url";
             } elseif (str_starts_with($url, 'sheet://')) {

--- a/tests/PhpSpreadsheetTests/Writer/Ods/DrawingTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Ods/DrawingTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Ods;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Drawing;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
+
+class DrawingTest extends AbstractFunctional
+{
+    public function testDrawing(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        // Add a drawing to the worksheet
+        $drawing = new Drawing();
+        $drawing->setName('Letters B, M, and P');
+        $drawing->setDescription('Handwritten B, M, and P');
+        $drawing->setPath('samples/images/bmp.bmp');
+        $drawing->setWorksheet($sheet);
+        $drawing->setCoordinates('A1');
+
+        $drawing = new Drawing();
+        $drawing->setName('Letters G, I, and F');
+        $drawing->setDescription('Handwritten G, I, and F');
+        $drawing->setPath('samples/images/gif.gif');
+        $drawing->setWorksheet($sheet);
+        $drawing->setCoordinates('E5');
+
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Ods');
+        $spreadsheet->disconnectWorksheets();
+        $worksheet = $reloadedSpreadsheet->getActiveSheet();
+        $drawings = $worksheet->getDrawingCollection();
+        self::assertCount(2, $drawings);
+
+        $drawing = $drawings[0] ?? null;
+        self::assertInstanceOf(Drawing::class, $drawing);
+        // original width is 123, some loss of precision due to rounding
+        self::assertGreaterThanOrEqual(120, $drawing->getWidth());
+        self::assertLessThanOrEqual(126, $drawing->getWidth());
+        // original height is 81
+        self::assertGreaterThanOrEqual(78, $drawing->getHeight());
+        self::assertLessThanOrEqual(84, $drawing->getHeight());
+        self::assertSame('Letters B, M, and P', $drawing->getName());
+        self::assertSame('A1', $drawing->getCoordinates());
+
+        $drawing = $drawings[1] ?? null;
+        self::assertInstanceOf(Drawing::class, $drawing);
+        // original width is 163, some loss of precision due to rounding
+        self::assertGreaterThanOrEqual(160, $drawing->getWidth());
+        self::assertLessThanOrEqual(166, $drawing->getWidth());
+        // original height is 121
+        self::assertGreaterThanOrEqual(118, $drawing->getHeight());
+        self::assertLessThanOrEqual(124, $drawing->getHeight());
+        self::assertSame('Letters G, I, and F', $drawing->getName());
+        self::assertSame('E5', $drawing->getCoordinates());
+
+        $reloadedSpreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Fix #4809. This initial work for this PR was done by @xxltomcat-ux in PR #4812. That PR needed some work, and was accidentally closed in a manner that caused all its work to be lost. As compared with that version, this version corrects a write bug when Ods output is added to 27_Images_Xlsx, adds limited support for Read, and adds some tests (more are probably needed). What follows here is the original description from the closed PR.

# Summary

Currently, the ODS writer in PhpSpreadsheet does not support exporting images. Images (Drawing or MemoryDrawing objects) are completely ignored in ODS exports, though they work correctly for XLSX. This issue proposes and provides a full implementation to add support for image/drawing export in ODS, bringing feature parity with the XLSX writer.

# Problem

- ODS exports silently drop images and worksheet graphics
- This is a required feature for interoperability with LibreOffice/OpenOffice users

# Key Implementation:

- Update: Writer/Ods.php to collect/package images into the export ZIP
- Update: Writer/Ods/Content.php to integrate images into content.xml and table cells
- New: Writer/Ods/Drawing.php to manage extraction & XML for worksheet images (Drawing & MemoryDrawing)
- Update: Writer/Ods/MetaInf.php to list all Pictures/ images in the manifest
- Update: Reader/Ods.php to read drawing-related Xml and add those which meet certain criteria to spreadsheet.

# Features

- Exports all worksheet images (Drawing, MemoryDrawing)
- Embeds images in Pictures/ directory inside ODS
- Writes <draw:frame> and <draw:image> elements linked to cell positions
- Updates META-INF/manifest.xml with all images
- Handles cell/row mapping & coordinates
- Supports PNG, JPEG, GIF, BMP

This is:

- [ ] a bugfix
- [x] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [x] Documentation is updated as necessary

