### PR TITLE
Optimize large Xlsx populate and write hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Some earlier branches remain supported and security fixes are applied to them; i
 
 ### Changed
 
-- Nothing yet.
+- Performance: avoid `Worksheet::getStyle()` on every `Cell::setValueExplicit()` unless quote-prefix must change; reuse a single `getCell()` per cell in Xlsx `writeSheetData` (ignored errors + write). On a dense 40k-cell populate+save microbenchmark this cut wall time by ~36%.
 
 ### Moved
 

--- a/src/PhpSpreadsheet/Cell/Cell.php
+++ b/src/PhpSpreadsheet/Cell/Cell.php
@@ -370,16 +370,16 @@ class Cell implements Stringable
         $worksheet = $this->getWorksheet();
         $spreadsheet = $worksheet->getParent();
         if (isset($spreadsheet) && $spreadsheet->getIndex($worksheet, true) >= 0) {
-            $originalSelected = $worksheet->getSelectedCells();
-            $activeSheetIndex = $spreadsheet->getActiveSheetIndex();
-            $style = $this->getStyle();
-            $oldQuotePrefix = $style->getQuotePrefix();
+            // Avoid Worksheet::getStyle() (selection + validation) unless quotePrefix must change.
+            $oldQuotePrefix = $spreadsheet->getCellXfByIndex($this->getXfIndex())->getQuotePrefix();
             if ($oldQuotePrefix !== $quotePrefix) {
-                $style->setQuotePrefix($quotePrefix);
-            }
-            $worksheet->setSelectedCells($originalSelected);
-            if ($activeSheetIndex >= 0) {
-                $spreadsheet->setActiveSheetIndex($activeSheetIndex);
+                $originalSelected = $worksheet->getSelectedCells();
+                $activeSheetIndex = $spreadsheet->getActiveSheetIndex();
+                $this->getStyle()->setQuotePrefix($quotePrefix);
+                $worksheet->setSelectedCells($originalSelected);
+                if ($activeSheetIndex >= 0) {
+                    $spreadsheet->setActiveSheetIndex($activeSheetIndex);
+                }
             }
         }
 

--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1487,27 +1487,28 @@ class Worksheet extends WriterPart
                         $columnsInRow = explode(',', $cellsByRow[$currentRow]);
                         array_pop($columnsInRow);
                         foreach ($columnsInRow as $column) {
-                            // Write cell
                             $coord = "$column$currentRow";
-                            if ($worksheet->getCell($coord)->getIgnoredErrors()->getNumberStoredAsText()) {
+                            $pCell = $worksheet->getCell($coord);
+                            $ignoredErrors = $pCell->getIgnoredErrors();
+                            if ($ignoredErrors->getNumberStoredAsText()) {
                                 $this->numberStoredAsText .= " $coord";
                             }
-                            if ($worksheet->getCell($coord)->getIgnoredErrors()->getFormula()) {
+                            if ($ignoredErrors->getFormula()) {
                                 $this->formula .= " $coord";
                             }
-                            if ($worksheet->getCell($coord)->getIgnoredErrors()->getFormulaRange()) {
+                            if ($ignoredErrors->getFormulaRange()) {
                                 $this->formulaRange .= " $coord";
                             }
-                            if ($worksheet->getCell($coord)->getIgnoredErrors()->getTwoDigitTextYear()) {
+                            if ($ignoredErrors->getTwoDigitTextYear()) {
                                 $this->twoDigitTextYear .= " $coord";
                             }
-                            if ($worksheet->getCell($coord)->getIgnoredErrors()->getEvalError()) {
+                            if ($ignoredErrors->getEvalError()) {
                                 $this->evalError .= " $coord";
                             }
-                            if ($worksheet->getCell($coord)->getIgnoredErrors()->getMisleadingFormat()) {
+                            if ($ignoredErrors->getMisleadingFormat()) {
                                 $this->misleadingFormat .= " $coord";
                             }
-                            $this->writeCell($objWriter, $worksheet, $coord, $aFlippedStringTable);
+                            $this->writeCell($objWriter, $worksheet, $coord, $aFlippedStringTable, $pCell);
                         }
                     }
 
@@ -1709,10 +1710,10 @@ class Worksheet extends WriterPart
      * @param string $cellAddress Cell Address
      * @param string[] $flippedStringTable String table (flipped), for faster index searching
      */
-    private function writeCell(XMLWriter $objWriter, PhpspreadsheetWorksheet $worksheet, string $cellAddress, array $flippedStringTable): void
+    private function writeCell(XMLWriter $objWriter, PhpspreadsheetWorksheet $worksheet, string $cellAddress, array $flippedStringTable, ?Cell $pCell = null): void
     {
         // Cell
-        $pCell = $worksheet->getCell($cellAddress);
+        $pCell ??= $worksheet->getCell($cellAddress);
         $xfi = $pCell->getXfIndex();
         $cellValue = $pCell->getValue();
         $cellValueString = $pCell->getValueString();

--- a/tests/Benchmark/LargeXlsxWriteBenchmarkTest.php
+++ b/tests/Benchmark/LargeXlsxWriteBenchmarkTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetBenchmarks;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Benchmark populate + Xlsx save for a large dense sheet.
+ *
+ * Run with: vendor/bin/phpunit --testsuite Benchmark --filter LargeXlsxWriteBenchmark --stderr
+ */
+#[Group('benchmark')]
+class LargeXlsxWriteBenchmarkTest extends TestCase
+{
+    private const ROWS = 2000;
+
+    private const COLS = 20;
+
+    public function testPopulateAndSaveLargeSheet(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'phpspreadsheet-bench-');
+        self::assertNotFalse($tmp);
+        $filename = $tmp . '.xlsx';
+        @unlink($tmp);
+
+        $memBefore = memory_get_usage(true);
+        $start = hrtime(true);
+
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        for ($row = 1; $row <= self::ROWS; ++$row) {
+            for ($col = 1; $col <= self::COLS; ++$col) {
+                $sheet->getCell([$col, $row])->setValue("R{$row}C{$col}");
+            }
+        }
+
+        $writer = new Xlsx($spreadsheet);
+        $writer->setPreCalculateFormulas(false);
+        $writer->save($filename);
+
+        $elapsedMs = (hrtime(true) - $start) / 1e6;
+        $peakMiB = memory_get_peak_usage(true) / (1024 * 1024);
+        $deltaMiB = (memory_get_usage(true) - $memBefore) / (1024 * 1024);
+        $cellCount = self::ROWS * self::COLS;
+
+        fwrite(
+            STDERR,
+            sprintf(
+                "LargeXlsxWriteBenchmark: %d cells, %.1f ms, peak=%.1f MiB, delta=%.1f MiB, size=%.1f KiB\n",
+                $cellCount,
+                $elapsedMs,
+                $peakMiB,
+                $deltaMiB,
+                filesize($filename) / 1024
+            )
+        );
+
+        self::assertFileExists($filename);
+        self::assertGreaterThan(1000, filesize($filename));
+
+        $spreadsheet->disconnectWorksheets();
+        @unlink($filename);
+    }
+}

--- a/tests/PhpSpreadsheetTests/Cell/SetValueExplicitQuotePrefixPerfTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/SetValueExplicitQuotePrefixPerfTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Cell;
+
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PHPUnit\Framework\TestCase;
+
+class SetValueExplicitQuotePrefixPerfTest extends TestCase
+{
+    public function testQuotePrefixAppliedForLeadingEqualsString(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setSelectedCells('Z99');
+        $spreadsheet->createSheet()->setTitle('Other');
+        $spreadsheet->setActiveSheetIndex(1);
+
+        $cell = $sheet->getCell('A1');
+        $cell->setValueExplicit('=not-a-formula', DataType::TYPE_STRING);
+
+        // Read quotePrefix from the cell xf without going through Worksheet::getStyle()
+        // (which would change the selection).
+        $xf = $spreadsheet->getCellXfByIndex($sheet->getCell('A1')->getXfIndex());
+        self::assertTrue($xf->getQuotePrefix());
+        self::assertSame('Z99', $sheet->getSelectedCells());
+        self::assertSame(1, $spreadsheet->getActiveSheetIndex());
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testQuotePrefixNotAppliedForNormalString(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->getCell('A1')->setValueExplicit('hello', DataType::TYPE_STRING);
+
+        $xf = $spreadsheet->getCellXfByIndex($sheet->getCell('A1')->getXfIndex());
+        self::assertFalse($xf->getQuotePrefix());
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testQuotePrefixClearedWhenReplacingPrefixedString(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->getCell('A1')->setValueExplicit('=prefixed', DataType::TYPE_STRING);
+        self::assertTrue($spreadsheet->getCellXfByIndex($sheet->getCell('A1')->getXfIndex())->getQuotePrefix());
+
+        $sheet->getCell('A1')->setValueExplicit('plain', DataType::TYPE_STRING);
+        self::assertFalse($spreadsheet->getCellXfByIndex($sheet->getCell('A1')->getXfIndex())->getQuotePrefix());
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testNumericValueDoesNotTouchQuotePrefix(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->getCell('A1')->setValueExplicit(42, DataType::TYPE_NUMERIC);
+
+        self::assertFalse($spreadsheet->getCellXfByIndex($sheet->getCell('A1')->getXfIndex())->getQuotePrefix());
+        self::assertSame(42, $sheet->getCell('A1')->getValue());
+
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
This is:

- [ ] a bugfix
- [ ] a new feature
- [x] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [x] Documentation is updated as necessary

# Why this change is needed?

Large Xlsx generation spends a lot of time in cell population and sheet writing. A Blackfire profile of a ~167k-cell export showed heavy cost in `Cell::setValueExplicit` → `Worksheet::getStyle()` (quote-prefix handling on every value set) and repeated `getCell()` calls in `Writer\Xlsx\Worksheet::writeSheetData` (ignored-errors checks + write).

## Changes

1. **`Cell::setValueExplicit`** — read the cell’s existing quote-prefix from its xf via `getCellXfByIndex()`; call the expensive `getStyle()` / `setQuotePrefix()` path only when quote-prefix must change. Selection / active-sheet restore behavior is unchanged when that path runs.
2. **`Writer\Xlsx\Worksheet::writeSheetData`** — fetch each cell once, read ignored-errors from that instance, and pass the `Cell` into `writeCell()`. The existing comma-separated `$cellsByRow` index is kept (lower memory than an array-of-columns).

## Performance (library-only microbenchmark, PHP 8.3, opcache CLI off)

Dense string populate + Xlsx save (`setPreCalculateFormulas(false)`):

| Cells | Before | After | Delta |
|------:|-------:|------:|------:|
| 40 000 | ~764 ms | ~491 ms | **~36% faster** |
| 170 000 | ~3296 ms | ~2098 ms | **~36% faster** |

Isolated write-loop lookup pattern on 170 000 cells (7× `getCell`/cell → 1×): ~236 ms → ~98 ms.

## Tests

- New coverage for quote-prefix apply / clear / no-op paths in `setValueExplicit` (including selection / active sheet preservation when prefix changes).
- Existing Xlsx ignored-errors round-trip tests still pass.
- Optional benchmark: `vendor/bin/phpunit --testsuite Benchmark --filter LargeXlsxWriteBenchmark --stderr`
