### PR TITLE
First Php8.6 (Extremely Minor) Problem

### DIFF
--- a/src/PhpSpreadsheet/Shared/XMLWriter.php
+++ b/src/PhpSpreadsheet/Shared/XMLWriter.php
@@ -64,7 +64,15 @@ class XMLWriter extends \XMLWriter
         }
     }
 
-    /** @param mixed[] $data */
+    /**
+     * Unserialization is not allowed. This needs to be enforced
+     * in the class before Php8.6, but, with that release,
+     * this method is no longer needed and will not be executed.
+     *
+     * @see https://github.com/php/php-src/pull/21694
+     *
+     * @param mixed[] $data
+     */
     public function __unserialize(array $data): void
     {
         $this->tempFileName = '';

--- a/tests/PhpSpreadsheetTests/Shared/XmlWriterTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/XmlWriterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpOffice\PhpSpreadsheetTests\Shared;
 
+use Exception;
 use PhpOffice\PhpSpreadsheet\Exception as SpreadsheetException;
 use PhpOffice\PhpSpreadsheet\Shared\XMLWriter;
 use PHPUnit\Framework\TestCase;
@@ -22,10 +23,17 @@ class XmlWriterTest extends TestCase
         XMLWriter::$debugEnabled = $this->debugEnabled;
     }
 
+    protected static int $versionCheck = 80600;
+
     public function testUnserialize(): void
     {
-        $this->expectException(SpreadsheetException::class);
-        $this->expectExceptionMessage('Unserialize not permitted');
+        if (PHP_VERSION_ID >= self::$versionCheck) {
+            $this->expectException(Exception::class);
+            $this->expectExceptionMessage('Unserialization');
+        } else {
+            $this->expectException(SpreadsheetException::class);
+            $this->expectExceptionMessage('Unserialize not permitted');
+        }
         $className = XMLWriter::class;
         $classLen = strlen($className);
         $text = "O:$classLen:\"$className\":1:{";


### PR DESCRIPTION
In 8.6, XmlWriter is declared non-serializable. This changes the result of one unit test (we receive a different exception than we had expected).

This is:

- [ ] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests
- [x] Php8.6 accommodation

Checklist:

- [ ] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests (very slight result change)
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

