### PR TITLE
Ods Writer: do not convert inside string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Some earlier branches remain supported and security fixes are applied to them; i
 
 ### Fixed
 
+- Ods Writer no longer converts cell references or commas inside string literals, so `="THIS IS E1"` is written unchanged instead of as `="THIS IS [.E1]"`. [Issue #4454](https://github.com/PHPOffice/PhpSpreadsheet/issues/4454)
 - BETAINV/BETA.INV no longer abandons its search when the Beta CDF underflows to zero (wrong results for alpha above about 1080). [PR #4954](https://github.com/PHPOffice/PhpSpreadsheet/pull/4954)
 - GAMMA.INV, the GAMMA.DIST/CHISQ.DIST/F.DIST densities, and GAMMALN no longer fail or return wrong results for large shape parameters / degrees of freedom. [PR #4953](https://github.com/PHPOffice/PhpSpreadsheet/pull/4953)
 - GAMMAINV/GAMMA.INV no longer clamps upper-tail quantiles beyond alpha*beta*5. [PR #4946](https://github.com/PHPOffice/PhpSpreadsheet/pull/4946)

--- a/src/PhpSpreadsheet/Writer/Ods/Formula.php
+++ b/src/PhpSpreadsheet/Writer/Ods/Formula.php
@@ -24,15 +24,46 @@ class Formula
 
     public function convertFormula(string $formula, string $worksheetName = ''): string
     {
-        $formula = $this->convertCellReferences($formula, $worksheetName);
-        $formula = $this->convertDefinedNames($formula);
-        $formula = $this->convertFunctionNames($formula);
+        // Convert only outside of string literals, so that the text in
+        // ="THIS IS E1" is left alone rather than treated as a cell reference.
+        $converted = '';
+        foreach ($this->splitOnStringLiterals($formula) as $index => $part) {
+            if (1 === $index % 2) { // the captured string literal
+                $converted .= $part;
+
+                continue;
+            }
+
+            $part = $this->convertCellReferences($part, $worksheetName);
+            $part = $this->convertDefinedNames($part);
+            $converted .= $this->convertFunctionNames($part);
+        }
+        $formula = $converted;
 
         if (!str_starts_with($formula, '=')) {
             $formula = '=' . $formula;
         }
 
         return 'of:' . $formula;
+    }
+
+    /**
+     * Splits a formula into alternating segments outside and inside string literals,
+     * with the literals themselves at the odd offsets.
+     *
+     * A range such as A1:B2 can never be interrupted by a string literal, so every
+     * reference stays within a single segment and keeps its surrounding context.
+     *
+     * @return string[]
+     */
+    private function splitOnStringLiterals(string $formula): array
+    {
+        return Preg::split(
+            '/(' . Calculation::CALCULATION_REGEXP_STRING . ')/ui',
+            $formula,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE
+        );
     }
 
     private function convertDefinedNames(string $formula): string

--- a/tests/PhpSpreadsheetTests/Writer/Ods/Issue4454Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Ods/Issue4454Test.php
@@ -5,93 +5,52 @@ declare(strict_types=1);
 namespace PhpOffice\PhpSpreadsheetTests\Writer\Ods;
 
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
-use PhpOffice\PhpSpreadsheet\Writer\Ods as OdsWriter;
-use PHPUnit\Framework\TestCase;
+use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
-class Issue4454Test extends TestCase
+class Issue4454Test extends AbstractFunctional
 {
     /**
-     * Text inside a string literal must be left alone, while everything
-     * outside of it is still converted.
+     * Cell references and commas inside string literals must survive a round trip,
+     * while everything outside of them is still converted for Ods.
      */
-    public function testCellReferencesInStringsAreNotConverted(): void
+    public function testStringLiteralsAreNotConverted(): void
     {
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
-        $sheet->setTitle('Worksheet');
-        $sheet->setCellValue('E1', '="THIS IS E1"');
-        $sheet->setCellValue('E2', '=G1');
-        $sheet->setCellValue('E3', '=G1&"see E1 here"');
+        $sheet->getCell('A1')->setValue(1);
+        $sheet->getCell('B2')->setValue('world');
+        $sheet->getCell('G1')->setValue('hello ');
 
-        $writer = new OdsWriter($spreadsheet);
-        $data = (new OdsWriter\Content($writer))->write();
+        // Text that looks like a cell reference.
+        $sheet->getCell('E1')->setValue('="THIS IS E1"');
+        // The same, next to a reference that does need converting.
+        $sheet->getCell('E2')->setValue('=G1&"see E1 here"');
+        // A comma inside a string, which Ods separators must not touch.
+        $sheet->getCell('E3')->setValue('=IF(A1>1,"yes, really","no")');
+        // A doubled quote escapes a quote, so the reference stays inside the string.
+        $sheet->getCell('E4')->setValue('=CONCAT("a""b E1",B2)');
+        // A range, which a string literal can never interrupt.
+        $sheet->getCell('E5')->setValue('=SUM(A1:A3)');
 
-        self::assertStringContainsString('of:=&quot;THIS IS E1&quot;', $data);
-        self::assertStringContainsString('of:=[.G1]', $data);
-        self::assertStringContainsString('of:=[.G1]&amp;&quot;see E1 here&quot;', $data);
-
+        $reloadedSpreadsheet = $this->writeAndReload($spreadsheet, 'Ods');
         $spreadsheet->disconnectWorksheets();
-    }
+        $rsheet = $reloadedSpreadsheet->getActiveSheet();
 
-    /**
-     * The comma to semicolon replacement for Ods must not reach into strings either.
-     */
-    public function testCommasInStringsAreNotConverted(): void
-    {
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
-        $sheet->setTitle('Worksheet');
-        $sheet->setCellValue('A1', 1);
-        $sheet->setCellValue('B1', '=IF(A1>1,"yes, really","no")');
+        self::assertSame('="THIS IS E1"', $rsheet->getCell('E1')->getValue());
+        self::assertSame('THIS IS E1', $rsheet->getCell('E1')->getCalculatedValue());
 
-        $writer = new OdsWriter($spreadsheet);
-        $data = (new OdsWriter\Content($writer))->write();
+        self::assertSame('=G1&"see E1 here"', $rsheet->getCell('E2')->getValue());
+        self::assertSame('hello see E1 here', $rsheet->getCell('E2')->getCalculatedValue());
 
-        self::assertStringContainsString(
-            'of:=IF([.A1]&gt;1;&quot;yes, really&quot;;&quot;no&quot;)',
-            $data
-        );
+        self::assertSame('=IF(A1>1,"yes, really","no")', $rsheet->getCell('E3')->getValue());
+        self::assertSame('no', $rsheet->getCell('E3')->getCalculatedValue());
 
-        $spreadsheet->disconnectWorksheets();
-    }
+        self::assertSame('=CONCAT("a""b E1",B2)', $rsheet->getCell('E4')->getValue());
+        self::assertSame('a"b E1world', $rsheet->getCell('E4')->getCalculatedValue());
 
-    /**
-     * A doubled quote escapes a quote inside a string literal, so the reference
-     * in the middle of this one is still part of the string.
-     */
-    public function testEscapedQuotesInStringsAreHandled(): void
-    {
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
-        $sheet->setTitle('Worksheet');
-        $sheet->setCellValue('A1', '=CONCAT("a""b E1",B2)');
+        self::assertSame('=SUM(A1:A3)', $rsheet->getCell('E5')->getValue());
+        self::assertSame(1, $rsheet->getCell('E5')->getCalculatedValue());
 
-        $writer = new OdsWriter($spreadsheet);
-        $data = (new OdsWriter\Content($writer))->write();
-
-        self::assertStringContainsString(
-            'of:=CONCAT(&quot;a&quot;&quot;b E1&quot;;[.B2])',
-            $data
-        );
-
-        $spreadsheet->disconnectWorksheets();
-    }
-
-    /**
-     * Ranges are unaffected: a string literal can never interrupt one.
-     */
-    public function testRangesAreStillConverted(): void
-    {
-        $spreadsheet = new Spreadsheet();
-        $sheet = $spreadsheet->getActiveSheet();
-        $sheet->setTitle('Worksheet');
-        $sheet->setCellValue('A1', '=SUM(B1:B5)');
-
-        $writer = new OdsWriter($spreadsheet);
-        $data = (new OdsWriter\Content($writer))->write();
-
-        self::assertStringContainsString('of:=SUM([.B1:.B5])', $data);
-
-        $spreadsheet->disconnectWorksheets();
+        $reloadedSpreadsheet->disconnectWorksheets();
     }
 }

--- a/tests/PhpSpreadsheetTests/Writer/Ods/Issue4454Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Ods/Issue4454Test.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Writer\Ods;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Ods as OdsWriter;
+use PHPUnit\Framework\TestCase;
+
+class Issue4454Test extends TestCase
+{
+    /**
+     * Text inside a string literal must be left alone, while everything
+     * outside of it is still converted.
+     */
+    public function testCellReferencesInStringsAreNotConverted(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setTitle('Worksheet');
+        $sheet->setCellValue('E1', '="THIS IS E1"');
+        $sheet->setCellValue('E2', '=G1');
+        $sheet->setCellValue('E3', '=G1&"see E1 here"');
+
+        $writer = new OdsWriter($spreadsheet);
+        $data = (new OdsWriter\Content($writer))->write();
+
+        self::assertStringContainsString('of:=&quot;THIS IS E1&quot;', $data);
+        self::assertStringContainsString('of:=[.G1]', $data);
+        self::assertStringContainsString('of:=[.G1]&amp;&quot;see E1 here&quot;', $data);
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    /**
+     * The comma to semicolon replacement for Ods must not reach into strings either.
+     */
+    public function testCommasInStringsAreNotConverted(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setTitle('Worksheet');
+        $sheet->setCellValue('A1', 1);
+        $sheet->setCellValue('B1', '=IF(A1>1,"yes, really","no")');
+
+        $writer = new OdsWriter($spreadsheet);
+        $data = (new OdsWriter\Content($writer))->write();
+
+        self::assertStringContainsString(
+            'of:=IF([.A1]&gt;1;&quot;yes, really&quot;;&quot;no&quot;)',
+            $data
+        );
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    /**
+     * A doubled quote escapes a quote inside a string literal, so the reference
+     * in the middle of this one is still part of the string.
+     */
+    public function testEscapedQuotesInStringsAreHandled(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setTitle('Worksheet');
+        $sheet->setCellValue('A1', '=CONCAT("a""b E1",B2)');
+
+        $writer = new OdsWriter($spreadsheet);
+        $data = (new OdsWriter\Content($writer))->write();
+
+        self::assertStringContainsString(
+            'of:=CONCAT(&quot;a&quot;&quot;b E1&quot;;[.B2])',
+            $data
+        );
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    /**
+     * Ranges are unaffected: a string literal can never interrupt one.
+     */
+    public function testRangesAreStillConverted(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setTitle('Worksheet');
+        $sheet->setCellValue('A1', '=SUM(B1:B5)');
+
+        $writer = new OdsWriter($spreadsheet);
+        $data = (new OdsWriter\Content($writer))->write();
+
+        self::assertStringContainsString('of:=SUM([.B1:.B5])', $data);
+
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Fixes #4454

`convertFormula()` ran the cell reference, defined name and function name
conversions over the whole formula string, with nothing to tell it where a
quoted string starts. Anything inside one that looked like a reference was
rewritten:

```php
$sheet->setCellValue('E1', '="THIS IS E1"');
// written as of:="THIS IS [.E1]"
```

The `str_replace(',', ';', ...)` in `convertCellReferences()` has the same
blind spot, so the text of a string was corrupted too:

```php
$sheet->setCellValue('B1', '=IF(A1>1,"yes, really","no")');
// written as of:=IF([.A1]>1;"yes; really";"no")
```

This splits the formula on string literals and converts only the segments
outside of them, reusing `Calculation::CALCULATION_REGEXP_STRING` so that a
doubled quote keeps escaping a quote (`="a""b E1"` stays intact).

Splitting is safe for the conversion that walks offsets: a range cannot be
interrupted by a string literal — `A1:` and `:B2` can never end up in
different segments — so every reference still sees the `:` on either side of
it that `convertCellReferences()` checks for.

Three of the four added tests fail on master and pass here; the fourth covers
a range and passes either way, to catch a regression in the splitting.

Sheet-qualified references such as `='My Sheet'!A1` are unaffected, since
those are single-quoted and never match a string literal.
