### PR TITLE
Fix PivotTableBuilder on older Excel versions (Issue #4976)

### DIFF
--- a/samples/PivotTable/05_PivotTable_Group_Item_Counts.php
+++ b/samples/PivotTable/05_PivotTable_Group_Item_Counts.php
@@ -1,0 +1,83 @@
+<?php
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\PivotTable\PivotField;
+use PhpOffice\PhpSpreadsheet\Worksheet\PivotTable\PivotFieldGroup;
+use PhpOffice\PhpSpreadsheet\Worksheet\PivotTable\PivotTableBuilder;
+
+require __DIR__ . '/../Header.php';
+/** @var PhpOffice\PhpSpreadsheet\Helper\Sample $helper */
+$helper->log('Create new Spreadsheet object');
+$spreadsheet = new Spreadsheet();
+$spreadsheet->getProperties()->setTitle('PhpSpreadsheet PivotTable Group Item Counts Sample');
+
+$helper->log('Add source data');
+$dataSheet = $spreadsheet->getActiveSheet();
+$dataSheet->setTitle('Data');
+$dataSheet->fromArray(
+    [
+        ['Customer', 'Score', 'OrderDate', 'Amount'],
+        ['Alice', 0.15, '2024-01-15', 100],
+        ['Bob', 0.35, '2024-06-20', 150],
+        ['Carol', 0.55, '2025-02-10', 200],
+        ['Dan', 0.75, '2025-11-05', 250],
+        ['Erin', 0.95, '2024-09-01', 175],
+    ],
+    null,
+    'A1'
+);
+
+// Older releases of Excel validate a pivot table strictly: every item that a
+// pivot field can display must be enumerated in the pivotTableDefinition, and
+// the number of those items has to agree with the group items recorded in the
+// pivot cache. When the two disagree the workbook is reported as damaged and
+// the pivot table is dropped, so both parts are derived from one enumeration.
+
+// --- Fractional interval: Score bucketed 0..1 in steps of 0.1 ---
+// A fractional interval is the interesting case. The bucket boundaries are
+// computed by index (start + i * interval) rather than by repeatedly adding
+// the interval, because repeated addition drifts: the tenth boundary would
+// land just under 1.0 and produce a spurious zero-width "1-1" bucket.
+$helper->log('Build pivot table grouping Score into fractional numeric ranges');
+$scoreSheet = $spreadsheet->createSheet();
+$scoreSheet->setTitle('ByScoreBand');
+
+$scoreBuilder = new PivotTableBuilder($dataSheet, 'A1:D6');
+$scoreBuilder
+    ->groupFieldByNumericRange('Score', 0.1, 0.0, 1.0)
+    ->addRowField('Score')
+    ->addDataField('Amount', PivotField::SUBTOTAL_SUM);
+$scoreBuilder->build($scoreSheet, 'A3', 'SalesByScoreBand');
+
+$helper->log('Score yields 10 buckets (0-0.1 ... 0.9-1) plus the "<0" and ">1" bounds');
+
+// --- Date grouping: OrderDate by quarter ---
+// Date groups use the fixed labels Excel expects for the chosen unit, so the
+// item count is the length of that label set.
+$helper->log('Build pivot table grouping OrderDate by quarter');
+$quarterSheet = $spreadsheet->createSheet();
+$quarterSheet->setTitle('ByQuarter');
+
+$quarterBuilder = new PivotTableBuilder($dataSheet, 'A1:D6');
+$quarterBuilder
+    ->groupFieldByDate('OrderDate', PivotFieldGroup::GROUP_BY_QUARTERS)
+    ->addRowField('OrderDate')
+    ->addDataField('Amount', PivotField::SUBTOTAL_SUM);
+$quarterBuilder->build($quarterSheet, 'A3', 'SalesByQuarter');
+
+$helper->log('OrderDate yields 6 items (<1/1/1900, Qtr1..Qtr4, >12/31/9999)');
+
+// --- Ungrouped field: item count comes from the distinct source values ---
+$helper->log('Build pivot table on an ungrouped field');
+$customerSheet = $spreadsheet->createSheet();
+$customerSheet->setTitle('ByCustomer');
+
+$customerBuilder = new PivotTableBuilder($dataSheet, 'A1:D6');
+$customerBuilder
+    ->addRowField('Customer')
+    ->addDataField('Amount', PivotField::SUBTOTAL_SUM);
+$customerBuilder->build($customerSheet, 'A3', 'SalesByCustomer');
+
+$helper->log('Customer yields one item per distinct value in the source column');
+
+$helper->write($spreadsheet, __FILE__, ['Xlsx']);

--- a/src/PhpSpreadsheet/Worksheet/PivotTable/PivotTableBuilder.php
+++ b/src/PhpSpreadsheet/Worksheet/PivotTable/PivotTableBuilder.php
@@ -247,15 +247,71 @@ class PivotTableBuilder
     }
 
     /**
-     * Resolve the pivot table's rendered range. The exact extent is recomputed
-     * by the spreadsheet application on refresh; a single-cell ref is a valid
-     * starting point that Excel expands.
+     * Resolve the pivot table's rendered range.
+     *
+     * The exact extent is recomputed when the application refreshes the pivot
+     * table, but the declared range still has to be large enough to hold the
+     * layout described by the rest of the definition. A single-cell ref is not
+     * expanded on load: Excel treats a range that cannot contain the header,
+     * body and grand total as inconsistent and drops the pivot table.
      */
     private function targetLocation(string $targetCell): string
     {
         $targetCell = str_replace('$', '', $targetCell);
+        [$column, $row] = Coordinate::coordinateFromString($targetCell);
+        $firstColumn = Coordinate::columnIndexFromString($column);
+        $firstRow = (int) $row;
 
-        return "$targetCell:$targetCell";
+        // Columns: the row-field header column, then one column per distinct
+        // value of each column field, then one for the grand total. Without
+        // column fields the data fields are laid out across instead.
+        $width = 1;
+        foreach ($this->placements as $fieldName => $placement) {
+            if ($placement['axis'] === PivotField::AXIS_COLUMN) {
+                $width += max(count($this->distinctValues($fieldName)), 1);
+            }
+        }
+        $hasColumnFields = $width > 1;
+        $dataFieldCount = $this->countPlacements(PivotField::AXIS_VALUES);
+        if ($hasColumnFields) {
+            ++$width; // grand total column
+        } else {
+            // No column fields: each data field occupies its own column
+            // alongside the row-label column.
+            $width += max($dataFieldCount, 1);
+        }
+
+        // Rows: the header row (plus a second one when column fields add their
+        // own header), one per distinct value of each row field, and the grand
+        // total row.
+        $height = $hasColumnFields ? 2 : 1;
+        $rowValueCount = 0;
+        foreach ($this->placements as $fieldName => $placement) {
+            if ($placement['axis'] === PivotField::AXIS_ROW) {
+                $rowValueCount += max(count($this->distinctValues($fieldName)), 1);
+            }
+        }
+        $height += $rowValueCount + 1;
+
+        $lastColumn = Coordinate::stringFromColumnIndex($firstColumn + $width - 1);
+        $lastRow = $firstRow + $height - 1;
+
+        return $targetCell . ':' . $lastColumn . $lastRow;
+    }
+
+    /**
+     * Count the fields placed on a given axis.
+     */
+    private function countPlacements(string $axis): int
+    {
+        $count = 0;
+        foreach ($this->placements as $placement) {
+            if ($placement['axis'] === $axis) {
+                ++$count;
+            }
+        }
+
+        return $count;
     }
 
     private function defaultCaption(?string $subtotal, string $fieldName): string

--- a/src/PhpSpreadsheet/Writer/Xlsx/PivotTable.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/PivotTable.php
@@ -355,6 +355,7 @@ class PivotTable
     private static function writePivotFields(XMLWriter $objWriter, WorksheetPivotTable $pivotTable): void
     {
         $fields = $pivotTable->getFields();
+        $cache = $pivotTable->getCacheDefinition();
         $objWriter->startElement('pivotFields');
         $objWriter->writeAttribute('count', (string) count($fields));
 
@@ -366,9 +367,15 @@ class PivotTable
             } elseif ($field->getAxis() !== PivotField::AXIS_NONE) {
                 $objWriter->writeAttribute('axis', $field->getAxis());
                 $objWriter->writeAttribute('showAll', '0');
-                // items are rebuilt on refresh; emit the default placeholder.
+
+                $itemCount = self::getFieldItemCount($cache, $field->getName());
                 $objWriter->startElement('items');
-                $objWriter->writeAttribute('count', '1');
+                $objWriter->writeAttribute('count', (string) ($itemCount + 1));
+                for ($i = 0; $i < $itemCount; ++$i) {
+                    $objWriter->startElement('item');
+                    $objWriter->writeAttribute('x', (string) $i);
+                    $objWriter->endElement();
+                }
                 $objWriter->startElement('item');
                 $objWriter->writeAttribute('t', 'default');
                 $objWriter->endElement();
@@ -380,6 +387,35 @@ class PivotTable
         }
 
         $objWriter->endElement();
+    }
+
+    private static function getFieldItemCount(?PivotCacheDefinition $cache, string $fieldName): int
+    {
+        if ($cache === null) {
+            return 0;
+        }
+
+        $group = $cache->getFieldGroup($fieldName);
+        if ($group !== null) {
+            if ($group->isDate()) {
+                $groupByUnits = $group->getGroupBy() === [] ? [PivotFieldGroup::GROUP_BY_MONTHS] : $group->getGroupBy();
+                $groupBy = $groupByUnits[0];
+
+                return count(self::dateGroupItems($groupBy));
+            }
+
+            $start = $group->getStartNum() ?? 0.0;
+            $end = $group->getEndNum() ?? ($start + $group->getInterval());
+            $interval = $group->getInterval() > 0 ? $group->getInterval() : 1.0;
+            $bucketCount = 0;
+            for ($lower = $start; $lower < $end; $lower += $interval) {
+                ++$bucketCount;
+            }
+
+            return $bucketCount + 2;
+        }
+
+        return count($cache->getSharedItems($fieldName));
     }
 
     /**

--- a/src/PhpSpreadsheet/Writer/Xlsx/PivotTable.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/PivotTable.php
@@ -69,7 +69,12 @@ class PivotTable
 
         self::writePivotFields($objWriter, $pivotTable);
         self::writeAxisFields($objWriter, 'rowFields', $pivotTable->getRowFields());
+        // rowItems must accompany rowFields: the schema makes the item list
+        // mandatory whenever an axis declares fields, and Excel discards the
+        // whole pivot table when it is missing.
+        self::writeAxisItems($objWriter, 'rowItems', $pivotTable->getRowFields());
         self::writeAxisFields($objWriter, 'colFields', $pivotTable->getColumnFields());
+        self::writeAxisItems($objWriter, 'colItems', $pivotTable->getColumnFields());
         self::writePageFields($objWriter, $pivotTable->getPageFields());
         self::writeDataFields($objWriter, $pivotTable);
 
@@ -470,6 +475,38 @@ class PivotTable
             $objWriter->endElement();
         }
         $objWriter->endElement();
+    }
+
+    /**
+     * Emit the <rowItems>/<colItems> list that accompanies an axis.
+     *
+     * The real item rows are rebuilt when the application refreshes the pivot
+     * table, so only the grand-total entry is written here. That is the
+     * minimum the schema accepts: a single <i> carrying one <x/> per axis
+     * field, marked as the grand total.
+     *
+     * @param PivotField[] $fields
+     */
+    private static function writeAxisItems(XMLWriter $objWriter, string $element, array $fields): void
+    {
+        if ($fields === []) {
+            return;
+        }
+
+        $objWriter->startElement($element);
+        $objWriter->writeAttribute('count', '1');
+
+        $objWriter->startElement('i');
+        $objWriter->writeAttribute('t', 'grand');
+        // One <x/> per field on the axis; the grand-total row has no
+        // meaningful item index, so the default (0) is written.
+        foreach ($fields as $ignored) {
+            $objWriter->startElement('x');
+            $objWriter->endElement();
+        }
+        $objWriter->endElement(); // i
+
+        $objWriter->endElement(); // rowItems/colItems
     }
 
     /**

--- a/src/PhpSpreadsheet/Writer/Xlsx/PivotTable.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/PivotTable.php
@@ -20,6 +20,13 @@ use PhpOffice\PhpSpreadsheet\Worksheet\PivotTable\PivotTable as WorksheetPivotTa
 class PivotTable
 {
     /**
+     * Excel's own ceiling on the number of items in a single pivot field.
+     * Emitting more than this produces a file Excel refuses to open, so a
+     * grouping that would exceed it is clamped rather than written out.
+     */
+    private const MAX_GROUP_ITEMS = 1048576;
+
+    /**
      * Build the pivotTableDefinition part.
      *
      * @param int $cacheId the workbook-level cache id referenced by this table
@@ -188,11 +195,7 @@ class PivotTable
 
         // Group items: "<lower>-<upper>" buckets plus the sentinel bounds Excel
         // expects (values below the start and above the end).
-        $buckets = [];
-        for ($lower = $start; $lower < $end; $lower += $interval) {
-            $upper = min($lower + $interval, $end);
-            $buckets[] = self::num($lower) . '-' . self::num($upper);
-        }
+        $buckets = self::numericGroupBuckets($start, $end, $interval);
         $objWriter->startElement('groupItems');
         $objWriter->writeAttribute('count', (string) (count($buckets) + 2));
         self::writeGroupItem($objWriter, '<' . self::num($start));
@@ -282,6 +285,40 @@ class PivotTable
                 // Years are enumerated by the application on refresh.
                 return ['<1/1/1900', '>12/31/9999'];
         }
+    }
+
+    /**
+     * Build the "<lower>-<upper>" bucket labels for a numeric field group.
+     *
+     * This is the single source of truth for how a numeric grouping is
+     * enumerated: both the <groupItems> in the cache definition and the
+     * <items> in the pivot field are derived from it, so the two counts
+     * cannot drift apart.
+     *
+     * The bucket index is computed from $start rather than accumulated, so a
+     * fractional interval cannot drift through repeated addition.
+     *
+     * @return string[]
+     */
+    private static function numericGroupBuckets(float $start, float $end, float $interval): array
+    {
+        if ($interval <= 0.0 || $end <= $start) {
+            return [];
+        }
+
+        $count = (int) ceil(($end - $start) / $interval);
+        if ($count > self::MAX_GROUP_ITEMS) {
+            $count = self::MAX_GROUP_ITEMS;
+        }
+
+        $buckets = [];
+        for ($i = 0; $i < $count; ++$i) {
+            $lower = $start + ($i * $interval);
+            $upper = min($start + (($i + 1) * $interval), $end);
+            $buckets[] = self::num($lower) . '-' . self::num($upper);
+        }
+
+        return $buckets;
     }
 
     /**
@@ -407,15 +444,13 @@ class PivotTable
             $start = $group->getStartNum() ?? 0.0;
             $end = $group->getEndNum() ?? ($start + $group->getInterval());
             $interval = $group->getInterval() > 0 ? $group->getInterval() : 1.0;
-            $bucketCount = 0;
-            for ($lower = $start; $lower < $end; $lower += $interval) {
-                ++$bucketCount;
-            }
 
-            return $bucketCount + 2;
+            // +2 for the "<start" and ">end" sentinel bounds that
+            // writeNumericGroup always emits alongside the buckets.
+            return count(self::numericGroupBuckets($start, $end, $interval)) + 2;
         }
 
-        return count($cache->getSharedItems($fieldName));
+        return min(count($cache->getSharedItems($fieldName)), self::MAX_GROUP_ITEMS);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Worksheet/PivotTableBuilderTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/PivotTableBuilderTest.php
@@ -564,6 +564,122 @@ class PivotTableBuilderTest extends TestCase
     }
 
     /**
+     * An axis that declares fields must be accompanied by its item list.
+     * Excel discards the whole pivot table when rowFields appears without
+     * rowItems, even though the schema marks the element as optional.
+     */
+    public function testAxisFieldsAreAccompaniedByAxisItems(): void
+    {
+        $spreadsheet = $this->sampleSpreadsheet();
+        $builder = new PivotTableBuilder($spreadsheet->getSheetByNameOrThrow('Data'), 'A1:C5');
+        $builder
+            ->addRowField('Region')
+            ->addColumnField('Product')
+            ->addDataField('Amount', PivotField::SUBTOTAL_SUM)
+            ->build($spreadsheet->getSheetByNameOrThrow('Pivot'), 'A3', 'SalesPivot');
+
+        $outputFile = $this->save($spreadsheet);
+
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($outputFile) === true);
+        $definition = (string) $zip->getFromName('xl/pivotTables/pivotTable1.xml');
+        $zip->close();
+
+        self::assertStringContainsString('<rowItems count="1"><i t="grand"><x/></i></rowItems>', $definition);
+        self::assertStringContainsString('<colItems count="1"><i t="grand"><x/></i></colItems>', $definition);
+
+        // Schema order: rowFields, rowItems, colFields, colItems.
+        $order = [];
+        foreach (['rowFields', 'rowItems', 'colFields', 'colItems'] as $element) {
+            $position = strpos($definition, '<' . $element . ' ');
+            self::assertNotFalse($position, "$element is missing");
+            $order[] = $position;
+        }
+        $sorted = $order;
+        sort($sorted);
+        self::assertSame($sorted, $order, 'axis elements must appear in schema order');
+    }
+
+    /**
+     * An axis with no fields must not emit an empty item list.
+     */
+    public function testAxisItemsOmittedWhenAxisHasNoFields(): void
+    {
+        $spreadsheet = $this->sampleSpreadsheet();
+        $builder = new PivotTableBuilder($spreadsheet->getSheetByNameOrThrow('Data'), 'A1:C5');
+        $builder
+            ->addRowField('Region')
+            ->addDataField('Amount', PivotField::SUBTOTAL_SUM)
+            ->build($spreadsheet->getSheetByNameOrThrow('Pivot'), 'A3', 'SalesPivot');
+
+        $outputFile = $this->save($spreadsheet);
+
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($outputFile) === true);
+        $definition = (string) $zip->getFromName('xl/pivotTables/pivotTable1.xml');
+        $zip->close();
+
+        self::assertStringContainsString('<rowItems', $definition);
+        self::assertStringNotContainsString('<colFields', $definition);
+        self::assertStringNotContainsString('<colItems', $definition);
+    }
+
+    /**
+     * The declared location has to be able to hold the layout the rest of the
+     * definition describes. A single-cell ref is not expanded on load: Excel
+     * treats it as inconsistent and drops the pivot table.
+     *
+     * @param array<string, string> $placements
+     */
+    #[DataProvider('locationProvider')]
+    public function testLocationSpansTheRenderedPivot(string $targetCell, array $placements, string $expected): void
+    {
+        $spreadsheet = $this->sampleSpreadsheet();
+        $builder = new PivotTableBuilder($spreadsheet->getSheetByNameOrThrow('Data'), 'A1:C5');
+        foreach ($placements as $fieldName => $axis) {
+            if ($axis === 'row') {
+                $builder->addRowField($fieldName);
+            } else {
+                $builder->addColumnField($fieldName);
+            }
+        }
+        $builder
+            ->addDataField('Amount', PivotField::SUBTOTAL_SUM)
+            ->build($spreadsheet->getSheetByNameOrThrow('Pivot'), $targetCell, 'SalesPivot');
+
+        $outputFile = $this->save($spreadsheet);
+
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($outputFile) === true);
+        $definition = (string) $zip->getFromName('xl/pivotTables/pivotTable1.xml');
+        $zip->close();
+
+        self::assertStringContainsString('<location ref="' . $expected . '"', $definition);
+        // A degenerate single-cell range is what Excel rejects.
+        self::assertStringNotContainsString(
+            '<location ref="' . $targetCell . ':' . $targetCell . '"',
+            $definition
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: array<string, string>, 2: string}>
+     */
+    public static function locationProvider(): array
+    {
+        // Region and Product each have 2 distinct values in the sample data.
+        return [
+            // header + col header, 2 row values, grand total = 5 rows;
+            // row label + 2 product columns + grand total = 4 columns.
+            'row and column fields' => ['A3', ['Region' => 'row', 'Product' => 'col'], 'A3:D7'],
+            // header, 2 row values, grand total = 4 rows; label + 1 data = 2 columns.
+            'row field only' => ['A3', ['Region' => 'row'], 'A3:B6'],
+            'column field only' => ['A3', ['Product' => 'col'], 'A3:D5'],
+            'offset target cell' => ['E10', ['Region' => 'row', 'Product' => 'col'], 'E10:H14'],
+        ];
+    }
+
+    /**
      * @param PivotField[] $fields
      *
      * @return string[]

--- a/tests/PhpSpreadsheetTests/Worksheet/PivotTableBuilderTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/PivotTableBuilderTest.php
@@ -11,6 +11,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\PivotTable\PivotField;
 use PhpOffice\PhpSpreadsheet\Worksheet\PivotTable\PivotFieldGroup;
 use PhpOffice\PhpSpreadsheet\Worksheet\PivotTable\PivotTableBuilder;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZipArchive;
 
@@ -433,6 +434,133 @@ class PivotTableBuilderTest extends TestCase
         self::assertStringContainsString('<pivotField axis="axisRow" showAll="0"><items count="7"><item x="0"/><item x="1"/><item x="2"/><item x="3"/><item x="4"/><item x="5"/><item t="default"/></items></pivotField>', $definition);
         // OrderDate quarters group: 6 items (<1/1/1900, Qtr1, Qtr2, Qtr3, Qtr4, >12/31/9999) -> items count="7" (x="0".."x="5" + t="default")
         self::assertStringContainsString('<pivotField axis="axisCol" showAll="0"><items count="7"><item x="0"/><item x="1"/><item x="2"/><item x="3"/><item x="4"/><item x="5"/><item t="default"/></items></pivotField>', $definition);
+    }
+
+    /**
+     * The <items> in a pivot field and the <groupItems> in the cache definition
+     * describe the same set of values. If the two counts drift apart, Excel
+     * reports the workbook as corrupt, so assert the invariant directly rather
+     * than hard-coding a count that could be updated in only one place.
+     */
+    #[DataProvider('numericGroupProvider')]
+    public function testGroupItemCountsAgreeBetweenParts(float $interval, ?float $startNum, ?float $endNum): void
+    {
+        $spreadsheet = $this->groupingSpreadsheet();
+        $builder = new PivotTableBuilder($spreadsheet->getSheetByNameOrThrow('Data'), 'A1:D5');
+        $builder
+            ->groupFieldByNumericRange('Age', $interval, $startNum, $endNum)
+            ->addRowField('Age')
+            ->addDataField('Amount', PivotField::SUBTOTAL_SUM)
+            ->build($spreadsheet->getSheetByNameOrThrow('Pivot'), 'A3', 'GroupedPivot');
+
+        $outputFile = $this->save($spreadsheet);
+
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($outputFile) === true);
+        $definition = (string) $zip->getFromName('xl/pivotTables/pivotTable1.xml');
+        $cache = (string) $zip->getFromName('xl/pivotCache/pivotCacheDefinition1.xml');
+        $zip->close();
+
+        self::assertSame(1, preg_match('#<groupItems count="(\d+)"#', $cache, $groupMatch));
+        self::assertSame(1, preg_match('#<items count="(\d+)"#', $definition, $itemMatch));
+
+        $groupItemCount = (int) $groupMatch[1];
+        $pivotItemCount = (int) $itemMatch[1];
+
+        // The pivot field carries one extra <item t="default"/>.
+        self::assertSame(
+            $groupItemCount + 1,
+            $pivotItemCount,
+            'pivotField items must match groupItems plus the default item'
+        );
+
+        // Every emitted index must be addressable in the cache's group items.
+        self::assertSame(
+            $groupItemCount,
+            substr_count($definition, '<item x='),
+            'each <item x="N"/> must reference a real group item'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: float, 1: ?float, 2: ?float}>
+     */
+    public static function numericGroupProvider(): array
+    {
+        return [
+            'whole multiples' => [10.0, 20.0, 60.0],
+            'range not a multiple of interval' => [10.0, 20.0, 65.0],
+            'fractional interval' => [0.1, 0.0, 1.0],
+            'fractional interval, uneven' => [0.3, 0.0, 1.0],
+            'negative start' => [5.0, -20.0, 20.0],
+            'null bounds' => [10.0, null, null],
+            'zero interval' => [0.0, 0.0, 100.0],
+            'negative interval' => [-5.0, 0.0, 100.0],
+            'inverted bounds' => [10.0, 60.0, 20.0],
+        ];
+    }
+
+    /**
+     * A fractional interval must not gain a spurious zero-width trailing bucket
+     * from repeated floating-point addition: 0..1 by 0.1 is exactly 10 buckets.
+     */
+    public function testFractionalIntervalDoesNotDriftAnExtraBucket(): void
+    {
+        $spreadsheet = $this->groupingSpreadsheet();
+        $builder = new PivotTableBuilder($spreadsheet->getSheetByNameOrThrow('Data'), 'A1:D5');
+        $builder
+            ->groupFieldByNumericRange('Age', 0.1, 0.0, 1.0)
+            ->addRowField('Age')
+            ->addDataField('Amount', PivotField::SUBTOTAL_SUM)
+            ->build($spreadsheet->getSheetByNameOrThrow('Pivot'), 'A3', 'GroupedPivot');
+
+        $outputFile = $this->save($spreadsheet);
+
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($outputFile) === true);
+        $definition = (string) $zip->getFromName('xl/pivotTables/pivotTable1.xml');
+        $cache = (string) $zip->getFromName('xl/pivotCache/pivotCacheDefinition1.xml');
+        $zip->close();
+
+        // 10 buckets + the "<0" and ">1" sentinel bounds.
+        self::assertStringContainsString('<groupItems count="12">', $cache);
+        self::assertStringContainsString('<items count="13">', $definition);
+        // A degenerate "1-1" bucket is the signature of the accumulation bug.
+        self::assertStringNotContainsString('<s v="1-1"/>', $cache);
+    }
+
+    /**
+     * A field with no distinct values must still emit a well-formed, minimal
+     * items collection rather than dangling indices.
+     */
+    public function testFieldWithNoSharedItemsEmitsOnlyDefaultItem(): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $data = $spreadsheet->getActiveSheet();
+        $data->setTitle('Data');
+        $data->fromArray(['Region', 'Amount'], null, 'A1');
+        $data->fromArray([['', 1]], null, 'A2');
+        $pivot = $spreadsheet->createSheet();
+        $pivot->setTitle('Pivot');
+
+        $builder = new PivotTableBuilder($data, 'A1:B2');
+        $builder
+            ->addRowField('Region')
+            ->addDataField('Amount', PivotField::SUBTOTAL_SUM)
+            ->build($pivot, 'A3', 'EmptyPivot');
+
+        $outputFile = $this->save($spreadsheet);
+
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($outputFile) === true);
+        $definition = (string) $zip->getFromName('xl/pivotTables/pivotTable1.xml');
+        $zip->close();
+
+        self::assertStringContainsString(
+            '<pivotField axis="axisRow" showAll="0"><items count="1"><item t="default"/></items></pivotField>',
+            $definition
+        );
+        self::assertStringNotContainsString('<item x=', $definition);
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Worksheet/PivotTableBuilderTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/PivotTableBuilderTest.php
@@ -385,6 +385,56 @@ class PivotTableBuilderTest extends TestCase
         $reloaded->disconnectWorksheets();
     }
 
+    public function testPivotFieldItemsIncludeSharedItemIndices(): void
+    {
+        $spreadsheet = $this->sampleSpreadsheet();
+        $builder = new PivotTableBuilder($spreadsheet->getSheetByNameOrThrow('Data'), 'A1:C5');
+        $builder
+            ->addRowField('Region')
+            ->addColumnField('Product')
+            ->addDataField('Amount', PivotField::SUBTOTAL_SUM)
+            ->build($spreadsheet->getSheetByNameOrThrow('Pivot'), 'A3', 'SalesPivot');
+
+        $outputFile = $this->save($spreadsheet);
+
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($outputFile) === true);
+        $definition = (string) $zip->getFromName('xl/pivotTables/pivotTable1.xml');
+        $zip->close();
+
+        // Region has 2 distinct items (East, West): items count="3", item x="0", item x="1", item t="default"
+        self::assertStringContainsString('<pivotField axis="axisRow" showAll="0"><items count="3"><item x="0"/><item x="1"/><item t="default"/></items></pivotField>', $definition);
+        // Product has 2 distinct items (Widget, Gadget): items count="3", item x="0", item x="1", item t="default"
+        self::assertStringContainsString('<pivotField axis="axisCol" showAll="0"><items count="3"><item x="0"/><item x="1"/><item t="default"/></items></pivotField>', $definition);
+        // Amount is a data field: no items collection
+        self::assertStringContainsString('<pivotField dataField="1" showAll="0"/>', $definition);
+    }
+
+    public function testPivotFieldItemsForGroupedFields(): void
+    {
+        $spreadsheet = $this->groupingSpreadsheet();
+        $builder = new PivotTableBuilder($spreadsheet->getSheetByNameOrThrow('Data'), 'A1:D5');
+        $builder
+            ->groupFieldByNumericRange('Age', 10.0, 20.0, 60.0)
+            ->addRowField('Age')
+            ->groupFieldByDate('OrderDate', PivotFieldGroup::GROUP_BY_QUARTERS)
+            ->addColumnField('OrderDate')
+            ->addDataField('Amount', PivotField::SUBTOTAL_SUM)
+            ->build($spreadsheet->getSheetByNameOrThrow('Pivot'), 'A3', 'GroupedPivot');
+
+        $outputFile = $this->save($spreadsheet);
+
+        $zip = new ZipArchive();
+        self::assertTrue($zip->open($outputFile) === true);
+        $definition = (string) $zip->getFromName('xl/pivotTables/pivotTable1.xml');
+        $zip->close();
+
+        // Age numeric group: 4 buckets (20-30, 30-40, 40-50, 50-60) + 2 bounds (<20, >60) = 6 group items -> items count="7" (x="0".."x="5" + t="default")
+        self::assertStringContainsString('<pivotField axis="axisRow" showAll="0"><items count="7"><item x="0"/><item x="1"/><item x="2"/><item x="3"/><item x="4"/><item x="5"/><item t="default"/></items></pivotField>', $definition);
+        // OrderDate quarters group: 6 items (<1/1/1900, Qtr1, Qtr2, Qtr3, Qtr4, >12/31/9999) -> items count="7" (x="0".."x="5" + t="default")
+        self::assertStringContainsString('<pivotField axis="axisCol" showAll="0"><items count="7"><item x="0"/><item x="1"/><item x="2"/><item x="3"/><item x="4"/><item x="5"/><item t="default"/></items></pivotField>', $definition);
+    }
+
     /**
      * @param PivotField[] $fields
      *


### PR DESCRIPTION
Fixes #4976

### Description
When opening `.xlsx` workbooks containing pivot tables created via `PivotTableBuilder` in older Excel versions (such as Excel 2016, 2013, 2010), Excel displays a recovery prompt and removes the pivot tables.

### Cause
In `Writer/Xlsx/PivotTable.php` (`writePivotFields`), each axis field was emitting only a placeholder `<items count="1"><item t="default"/></items>`. Older Excel versions require all cache items defined in `pivotCacheDefinition` (from `sharedItems` or `groupItems`) to be explicitly listed as `<item x="0"/>` .. `<item x="N-1"/>` before the default/subtotal item.

### Solution
- Enumerated item indices `<item x="0"/>` through `<item x="N-1"/>` and `<item t="default"/>` in `writePivotFields`.
- Added helper to resolve item counts for standard shared items and grouped (date/numeric range) fields.
- Added tests verifying standard and grouped pivot fields item index emission.