### PR TITLE
Fix CFB v3 OLE writer header and DIFAT boundaries #4811

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Some earlier branches remain supported and security fixes are applied to them; i
 
 ### Fixed
 
+- Xls Writer now creates conformant CFB/DIFAT metadata at FAT-sector boundaries. [Issue #4811](https://github.com/PHPOffice/PhpSpreadsheet/issues/4811) [PR #4983](https://github.com/PHPOffice/PhpSpreadsheet/pull/4983)
 - Ods Reader/Writer Drawings. [Issue #4809](https://github.com/PHPOffice/PhpSpreadsheet/issues/4809) [PR #4956](https://github.com/PHPOffice/PhpSpreadsheet/pull/4956)
 - Ods Writer no longer converts cell references or commas inside string literals, so `="THIS IS E1"` is written unchanged instead of as `="THIS IS [.E1]"`. [Issue #4454](https://github.com/PHPOffice/PhpSpreadsheet/issues/4454) [PR #4962](https://github.com/PHPOffice/PhpSpreadsheet/pull/4962)
 - Ods Reader/Writer slight improvement for Date styles. [PR #4960](https://github.com/PHPOffice/PhpSpreadsheet/pull/4960)

--- a/src/PhpSpreadsheet/Shared/OLE/PPS/Root.php
+++ b/src/PhpSpreadsheet/Shared/OLE/PPS/Root.php
@@ -20,6 +20,7 @@ namespace PhpOffice\PhpSpreadsheet\Shared\OLE\PPS;
 // | Based on OLE::Storage_Lite by Kawai, Takanori                        |
 // +----------------------------------------------------------------------+
 //
+use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\Shared\OLE;
 use PhpOffice\PhpSpreadsheet\Shared\OLE\PPS;
 
@@ -30,14 +31,22 @@ use PhpOffice\PhpSpreadsheet\Shared\OLE\PPS;
  */
 class Root extends PPS
 {
+    private const BIG_BLOCK_SIZE = 512;
+
+    private const SMALL_BLOCK_SIZE = 64;
+
+    private const MAX_VERSION_3_STREAM_SIZE = 0x80000000;
+
+    private const MAX_REGULAR_SECTOR_COUNT = 0xFFFFFFFB;
+
     /**
      * @var resource
      */
     private $fileHandle;
 
-    private ?int $smallBlockSize = null;
+    private int $smallBlockSize = self::SMALL_BLOCK_SIZE;
 
-    private ?int $bigBlockSize = null;
+    private int $bigBlockSize = self::BIG_BLOCK_SIZE;
 
     /**
      * @param null|float|int $time_1st A timestamp
@@ -64,13 +73,9 @@ class Root extends PPS
     {
         $this->fileHandle = $fileHandle;
 
-        // Initial Setting for saving
-        $this->bigBlockSize = (int) (2 ** (
-            (isset($this->bigBlockSize)) ? self::adjust2($this->bigBlockSize) : 9
-        ));
-        $this->smallBlockSize = (int) (2 ** (
-            (isset($this->smallBlockSize)) ? self::adjust2($this->smallBlockSize) : 6
-        ));
+        // This writer implements the version-3 CFB profile only.
+        $this->bigBlockSize = self::BIG_BLOCK_SIZE;
+        $this->smallBlockSize = self::SMALL_BLOCK_SIZE;
 
         // Make an array of PPS's (for Save)
         $aList = [];
@@ -82,6 +87,7 @@ class Root extends PPS
 
         // Make Small Data string (write SBD)
         $this->_data = $this->makeSmallData($aList);
+        $this->assertVersion3StreamSize(strlen($this->_data));
 
         // Write BB
         $this->saveBigData((int) $iSBDcnt, $aList);
@@ -109,6 +115,7 @@ class Root extends PPS
         for ($i = 0; $i < $iCount; ++$i) {
             if ($raList[$i]->Type == OLE::OLE_PPS_TYPE_FILE) {
                 $raList[$i]->Size = $raList[$i]->getDataLen();
+                $this->assertVersion3StreamSize($raList[$i]->Size);
                 if ($raList[$i]->Size < OLE::OLE_DATA_SIZE_SMALL) {
                     $iSBcnt += floor($raList[$i]->Size / $this->smallBlockSize)
                         + (($raList[$i]->Size % $this->smallBlockSize) ? 1 : 0);
@@ -118,6 +125,7 @@ class Root extends PPS
                 }
             }
         }
+        $this->assertVersion3MiniStreamSize((int) $iSBcnt);
         $iSmallLen = $iSBcnt * $this->smallBlockSize;
         $iSlCnt = floor($this->bigBlockSize / OLE::OLE_LONG_INT_SIZE);
         $iSBDcnt = floor($iSBcnt / $iSlCnt) + (($iSBcnt % $iSlCnt) ? 1 : 0);
@@ -130,18 +138,16 @@ class Root extends PPS
         return [$iSBDcnt, $iBBcnt, $iPPScnt];
     }
 
-    /**
-     * Helper function for calculating a magic value for block sizes.
-     *
-     * @param int $i2 The argument
-     *
-     * @see save()
-     */
-    private static function adjust2(int $i2): float
+    private function assertVersion3StreamSize(int $size): void
     {
-        $iWk = log($i2) / log(2);
+        if ($size > self::MAX_VERSION_3_STREAM_SIZE) {
+            throw new Exception('OLE version-3 streams cannot exceed 2 GiB.');
+        }
+    }
 
-        return ($iWk > floor($iWk)) ? floor($iWk) + 1 : $iWk;
+    private function assertVersion3MiniStreamSize(int $smallBlockCount): void
+    {
+        $this->assertVersion3StreamSize($smallBlockCount * self::SMALL_BLOCK_SIZE);
     }
 
     /**
@@ -168,10 +174,14 @@ class Root extends PPS
                 ++$iAllW;
                 $iBdCntW = floor($iAllW / $iBlCnt) + (($iAllW % $iBlCnt) ? 1 : 0);
                 $iBdCnt = floor(($iAllW + $iBdCntW) / $iBlCnt) + ((($iAllW + $iBdCntW) % $iBlCnt) ? 1 : 0);
-                if ($iBdCnt <= ($iBdExL * $iBlCnt + $i1stBdL)) {
+                if ($iBdCnt <= ($iBdExL * ($iBlCnt - 1) + $i1stBdL)) {
                     break;
                 }
             }
+        }
+
+        if ($iAllW + $iBdCnt > self::MAX_REGULAR_SECTOR_COUNT) {
+            throw new Exception('OLE version-3 output exceeds the maximum sector count.');
         }
 
         // Save Header
@@ -182,7 +192,7 @@ class Root extends PPS
             . "\x00\x00\x00\x00"
             . "\x00\x00\x00\x00"
             . "\x00\x00\x00\x00"
-            . pack('v', 0x3B)
+            . pack('v', 0x3E)
             . pack('v', 0x03)
             . pack('v', -2)
             . pack('v', 9)
@@ -198,7 +208,7 @@ class Root extends PPS
             . pack('V', $iSBDcnt)
         );
         // Extra BDList Start, Count
-        if ($iBdCnt < $i1stBdL) {
+        if ($iBdCnt <= $i1stBdL) {
             fwrite(
                 $FILE,
                 pack('V', -2) // Extra BDList Start
@@ -342,7 +352,7 @@ class Root extends PPS
                 ++$iAllW;
                 $iBdCntW = floor($iAllW / $iBbCnt) + (($iAllW % $iBbCnt) ? 1 : 0);
                 $iBdCnt = floor(($iAllW + $iBdCntW) / $iBbCnt) + ((($iAllW + $iBdCntW) % $iBbCnt) ? 1 : 0);
-                if ($iBdCnt <= ($iBdExL * $iBbCnt + $i1stBdL)) {
+                if ($iBdCnt <= ($iBdExL * ($iBbCnt - 1) + $i1stBdL)) {
                     break;
                 }
             }

--- a/tests/PhpSpreadsheetTests/Shared/OLEPpsRootTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/OLEPpsRootTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpOffice\PhpSpreadsheetTests\Shared;
+
+use PhpOffice\PhpSpreadsheet\Exception;
+use PhpOffice\PhpSpreadsheet\Reader\Xls as XlsReader;
+use PhpOffice\PhpSpreadsheet\Shared\OLE;
+use PhpOffice\PhpSpreadsheet\Shared\OLE\PPS\File;
+use PhpOffice\PhpSpreadsheet\Shared\OLE\PPS\Root;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xls as XlsWriter;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class OLEPpsRootTest extends TestCase
+{
+    public function testWritesVersion3Header(): void
+    {
+        $file = tmpfile();
+        self::assertNotFalse($file);
+
+        try {
+            self::assertTrue((new Root(null, null, []))->save($file));
+            rewind($file);
+            $header = stream_get_contents($file, 512);
+
+            self::assertSame(0x003E, self::headerInteger('v', $header, 24));
+            self::assertSame(0x0003, self::headerInteger('v', $header, 26));
+            self::assertSame(9, self::headerInteger('v', $header, 30));
+            self::assertSame(6, self::headerInteger('v', $header, 32));
+        } finally {
+            fclose($file);
+        }
+    }
+
+    public function testKeeps109FatSectorsInTheHeaderDifat(): void
+    {
+        $stream = new File('LargeStream');
+        $stream->append(str_repeat('x', 13716 * 512));
+        $file = tmpfile();
+        self::assertNotFalse($file);
+
+        try {
+            self::assertTrue((new Root(null, null, [$stream]))->save($file));
+            rewind($file);
+            $header = stream_get_contents($file, 512);
+
+            self::assertSame(109, self::headerInteger('V', $header, 44));
+            self::assertSame(0xFFFFFFFE, self::headerInteger('V', $header, 68));
+            self::assertSame(0, self::headerInteger('V', $header, 72));
+        } finally {
+            fclose($file);
+        }
+    }
+
+    public function testCreatesDifatSectorFor110FatSectors(): void
+    {
+        $stream = new File('LargeStream');
+        $stream->append(str_repeat('x', 13843 * 512));
+        $file = tmpfile();
+        self::assertNotFalse($file);
+
+        try {
+            self::assertTrue((new Root(null, null, [$stream]))->save($file));
+            rewind($file);
+            $header = stream_get_contents($file, 512);
+
+            self::assertSame(110, self::headerInteger('V', $header, 44));
+            self::assertSame(13954, self::headerInteger('V', $header, 68));
+            self::assertSame(1, self::headerInteger('V', $header, 72));
+            fseek($file, (13954 + 1) * 512);
+            $difat = stream_get_contents($file, 512);
+            self::assertSame(13953, self::headerInteger('V', $difat, 0));
+            self::assertSame(0xFFFFFFFE, self::headerInteger('V', $difat, 508));
+        } finally {
+            fclose($file);
+        }
+    }
+
+    public function testCreatesTwoDifatSectorsFor237FatSectors(): void
+    {
+        $stream = new File('LargeStream');
+        $stream->append(str_repeat('x', 30096 * 512));
+        $file = tmpfile();
+        self::assertNotFalse($file);
+
+        try {
+            self::assertTrue((new Root(null, null, [$stream]))->save($file));
+            rewind($file);
+            $header = stream_get_contents($file, 512);
+
+            self::assertSame(237, self::headerInteger('V', $header, 44));
+            self::assertSame(30334, self::headerInteger('V', $header, 68));
+            self::assertSame(2, self::headerInteger('V', $header, 72));
+
+            fseek($file, (30334 + 1) * 512);
+            $firstDifat = stream_get_contents($file, 512);
+            self::assertSame(30206, self::headerInteger('V', $firstDifat, 0));
+            self::assertSame(30335, self::headerInteger('V', $firstDifat, 508));
+
+            $secondDifat = stream_get_contents($file, 512);
+            self::assertSame(30333, self::headerInteger('V', $secondDifat, 0));
+            self::assertSame(0xFFFFFFFE, self::headerInteger('V', $secondDifat, 508));
+        } finally {
+            fclose($file);
+        }
+    }
+
+    public function testRejectsStreamsLargerThanTheVersion3Limit(): void
+    {
+        $stream = new class ('TooLarge') extends File {
+            public function getDataLen(): int
+            {
+                return 0x80000001;
+            }
+        };
+        $file = tmpfile();
+        self::assertNotFalse($file);
+
+        try {
+            $this->expectException(Exception::class);
+            $this->expectExceptionMessage('OLE version-3 streams cannot exceed 2 GiB.');
+            (new Root(null, null, [$stream]))->save($file);
+        } finally {
+            fclose($file);
+        }
+    }
+
+    public function testAcceptsStreamAtTheVersion3Limit(): void
+    {
+        $method = new ReflectionMethod(Root::class, 'assertVersion3StreamSize');
+
+        self::assertNull($method->invoke(new Root(null, null, []), 0x80000000));
+    }
+
+    public function testRejectsOversizedAggregateMiniStreamBeforeWriting(): void
+    {
+        $method = new ReflectionMethod(Root::class, 'assertVersion3MiniStreamSize');
+        $root = new Root(null, null, []);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('OLE version-3 streams cannot exceed 2 GiB.');
+        $method->invoke($root, intdiv(0x80000000, 64) + 1);
+    }
+
+    public function testStoresStreamsAtTheMiniStreamBoundary(): void
+    {
+        $this->assertStreamStorage(4095, 0, 1);
+        $this->assertStreamStorage(4096, 0xFFFFFFFE, 0);
+    }
+
+    public function testXlsWriterProducesReadableVersion3Cfb(): void
+    {
+        $file = tmpfile();
+        self::assertNotFalse($file);
+        $metadata = stream_get_meta_data($file);
+        self::assertArrayHasKey('uri', $metadata);
+        self::assertIsString($metadata['uri']);
+        $path = $metadata['uri'];
+        $spreadsheet = new Spreadsheet();
+        $spreadsheet->getActiveSheet()->setCellValue('A1', 'CFB v3');
+
+        try {
+            (new XlsWriter($spreadsheet))->save($path);
+            $header = file_get_contents($path, false, null, 0, 512);
+            self::assertIsString($header);
+            self::assertSame(0x003E, self::headerInteger('v', $header, 24));
+            self::assertSame(9, self::headerInteger('v', $header, 30));
+            self::assertSame(6, self::headerInteger('v', $header, 32));
+
+            $result = (new XlsReader())->load($path);
+            self::assertSame('CFB v3', $result->getActiveSheet()->getCell('A1')->getValue());
+            $result->disconnectWorksheets();
+        } finally {
+            $spreadsheet->disconnectWorksheets();
+            fclose($file);
+        }
+    }
+
+    private function assertStreamStorage(int $length, int $firstMiniFatSector, int $miniFatSectorCount): void
+    {
+        $data = str_repeat('x', $length);
+        $stream = new File('BoundaryStream');
+        $stream->append($data);
+        $file = tmpfile();
+        self::assertNotFalse($file);
+        $metadata = stream_get_meta_data($file);
+        self::assertArrayHasKey('uri', $metadata);
+        self::assertIsString($metadata['uri']);
+        $path = $metadata['uri'];
+
+        try {
+            self::assertTrue((new Root(null, null, [$stream]))->save($file));
+            rewind($file);
+            $header = stream_get_contents($file, 512);
+            self::assertSame($firstMiniFatSector, self::headerInteger('V', $header, 60));
+            self::assertSame($miniFatSectorCount, self::headerInteger('V', $header, 64));
+
+            $ole = new OLE();
+            $ole->read($path);
+            self::assertSame(2, $ole->ppsTotal());
+            self::assertTrue($ole->isFile(1));
+            self::assertSame($data, self::getDataByName($ole, 'BoundaryStream'));
+        } finally {
+            fclose($file);
+        }
+    }
+
+    private static function headerInteger(string $format, string $header, int $offset): int
+    {
+        $value = unpack($format . 'value', substr($header, $offset));
+        self::assertIsArray($value);
+        self::assertArrayHasKey('value', $value);
+        self::assertIsInt($value['value']);
+
+        return $value['value'];
+    }
+
+    private static function getDataByName(OLE $ole, string $name): string
+    {
+        foreach ($ole->_list as $index => $pps) {
+            if ($pps->Type === OLE::OLE_PPS_TYPE_FILE && $pps->Name === $name) {
+                return $ole->getData($index, 0, $pps->Size);
+            }
+        }
+
+        self::fail("OLE stream '$name' was not found.");
+    }
+}

--- a/tests/PhpSpreadsheetTests/Shared/OLEPpsRootTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/OLEPpsRootTest.php
@@ -202,7 +202,7 @@ class OLEPpsRootTest extends TestCase
             $ole->read($path);
             self::assertSame(2, $ole->ppsTotal());
             self::assertTrue($ole->isFile(1));
-            self::assertSame($data, self::getDataByName($ole, 'BoundaryStream'));
+            self::assertSame($data, $ole->getDataByName('BoundaryStream'));
         } finally {
             fclose($file);
         }
@@ -216,16 +216,5 @@ class OLEPpsRootTest extends TestCase
         self::assertIsInt($value['value']);
 
         return $value['value'];
-    }
-
-    private static function getDataByName(OLE $ole, string $name): string
-    {
-        foreach ($ole->_list as $index => $pps) {
-            if ($pps->Type === OLE::OLE_PPS_TYPE_FILE && $pps->Name === $name) {
-                return $ole->getData($index, 0, $pps->Size);
-            }
-        }
-
-        self::fail("OLE stream '$name' was not found.");
     }
 }


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [x] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [x] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [x] Documentation is updated as necessary (no public documentation change is needed)

### Why this change is needed?

The legacy XLS writer creates a CFB/OLE version-3 container through `Shared/OLE/PPS/Root`. This PR corrects the following CFB conformance defects:

1. The writer emitted header minor version `0x003B`; it now emits `0x003E`. MS-CFB specifies `0x003E` as the version-3/4 minor version value. [MS-CFB §2.2, Compound File Header](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/05060311-bfce-4b12-874d-71fd4ce63aea)

2. The header always declared the CFB v3 512-byte-sector and 64-byte mini-sector layout, while the serializer could internally choose different power-of-two sizes. The writer is now explicitly limited to the v3 512/64-byte profile, which matches the header and the required version-3 sector shifts. [MS-CFB §2.2, Compound File Header](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/05060311-bfce-4b12-874d-71fd4ce63aea)

3. Exactly 109 FAT-sector locations fit in the header DIFAT, but the writer created an inconsistent extended-DIFAT header at that boundary: it declared zero DIFAT sectors while setting a first DIFAT sector. This is the issue reported in #4811. The writer now records `ENDOFCHAIN` and a zero DIFAT count at the 109-FAT boundary. [MS-CFB §2.5, DIFAT Sectors](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/0afa4e43-b18f-432a-9917-4f276eca7a73)

4. Extended-DIFAT capacity was calculated as 128 FAT locations per DIFAT sector. Each DIFAT sector actually has 127 FAT-sector locations and one next-DIFAT-sector pointer. The writer now correctly creates two linked DIFAT sectors for 237 FAT sectors. [MS-CFB §2.5, DIFAT Sectors](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/0afa4e43-b18f-432a-9917-4f276eca7a73)

5. The v3 writer could serialize an individual stream or aggregate root mini-stream larger than 2 GiB, even though the v3 stream-size field requires the upper 32 bits to be zero. It now rejects these layouts before writing output, and also rejects unrepresentable regular-sector counts. [MS-CFB §2.6.1, Compound File Directory Entry](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/60fe8611-66c3-496b-b70d-a504c94c9ace)

### Defect-to-code mapping

1. **Non-canonical v3 header and mismatched sector profile:** the writer previously wrote `0x003B` while allowing its internal sector sizes to be rounded to arbitrary powers of two. It now writes the canonical minor version and uses named fixed-profile constants.

   ```diff
   - $this->bigBlockSize = (int) (2 ** ((isset($this->bigBlockSize)) ? self::adjust2($this->bigBlockSize) : 9));
   - $this->smallBlockSize = (int) (2 ** ((isset($this->smallBlockSize)) ? self::adjust2($this->smallBlockSize) : 6));
   + $this->bigBlockSize = self::BIG_BLOCK_SIZE;
   + $this->smallBlockSize = self::SMALL_BLOCK_SIZE;

   - . pack('v', 0x3B)
   + . pack('v', 0x3E)
   ```

2. **Malformed 109-FAT header in #4811:** the old strict comparison treated 109 FAT sectors as requiring extended DIFAT metadata. The inclusive comparison keeps all 109 locations in the header and writes `ENDOFCHAIN` with a zero DIFAT count.

   ```diff
   - if ($iBdCnt < $i1stBdL) {
   + if ($iBdCnt <= $i1stBdL) {
       fwrite($FILE, pack('V', -2) . pack('V', 0));
   }
   ```

3. **Incorrect two-DIFAT boundary:** a 512-byte DIFAT sector contains 128 DWORDs. Its first 127 DWORDs identify FAT sectors; its final DWORD points to the next DIFAT sector. The header identifies the first 109 FAT sectors, so one DIFAT sector can identify only `109 + 127 = 236` FAT sectors. A 237-FAT file therefore needs two DIFAT sectors. The old `* $iBlCnt` calculation treated all 128 DWORDs as FAT locations and incorrectly declared one DIFAT sector sufficient; `* ($iBlCnt - 1)` reserves the chain-pointer DWORD. The identical correction in `saveBbd()` ensures the emitted DIFAT chain matches the header count.

   ```diff
   // saveHeader(): decide how many DIFAT sectors the header declares.
   - if ($iBdCnt <= ($iBdExL * $iBlCnt + $i1stBdL)) {
   + if ($iBdCnt <= ($iBdExL * ($iBlCnt - 1) + $i1stBdL)) {
         break;
     }

   // saveBbd(): use the same 127-entry capacity while writing the chain.
   - if ($iBdCnt <= ($iBdExL * $iBbCnt + $i1stBdL)) {
   + if ($iBdCnt <= ($iBdExL * ($iBbCnt - 1) + $i1stBdL)) {
         break;
     }
   ```

4. **Invalid oversized v3 stream layouts:** each file stream and the aggregate root mini-stream are checked before serialization. The maximum is inclusive at `0x80000000`, as required by CFB v3.

   ```php
   private const MAX_VERSION_3_STREAM_SIZE = 0x80000000;

   $this->assertVersion3StreamSize($raList[$i]->Size);
   $this->assertVersion3MiniStreamSize((int) $iSBcnt);

   if ($size > self::MAX_VERSION_3_STREAM_SIZE) {
       throw new Exception('OLE version-3 streams cannot exceed 2 GiB.');
   }
   ```

5. **Unrepresentable sector IDs:** after calculating the complete layout, the writer rejects a result whose regular-sector count exceeds the CFB maximum.

   ```php
   private const MAX_REGULAR_SECTOR_COUNT = 0xFFFFFFFB;

   if ($iAllW + $iBdCnt > self::MAX_REGULAR_SECTOR_COUNT) {
       throw new Exception('OLE version-3 output exceeds the maximum sector count.');
   }
   ```

New `OLEPpsRootTest` coverage verifies:

- CFB v3 header minor version and sector shifts.
- 4095-byte mini-stream and 4096-byte regular-stream boundaries, with OLE reader round-trips.
- 109 FAT sectors (header DIFAT only), 110 FAT sectors (one DIFAT sector), and 237 FAT sectors (two linked DIFAT sectors).
- Individual-stream and aggregate-mini-stream v3 size-limit rejection.
- A minimal legacy XLS writer/read-back integration path.


Validation completed:

```text
vendor/bin/phpunit --configuration phpunit.xml.dist \
  tests/PhpSpreadsheetTests/Shared/OLETest.php \
  tests/PhpSpreadsheetTests/Shared/OLEPhpunit10Test.php \
  tests/PhpSpreadsheetTests/Shared/OLEPpsRootTest.php

15 tests, 173 assertions

vendor/bin/phpcs src/PhpSpreadsheet/Shared/OLE/PPS/Root.php tests/PhpSpreadsheetTests/Shared/OLEPpsRootTest.php --report=full

vendor/bin/phpstan analyse --memory-limit=2048M src/PhpSpreadsheet/Shared/OLE/PPS/Root.php tests/PhpSpreadsheetTests/Shared/OLEPpsRootTest.php
```

### Manual verification for #4811

From the repository root, generate the reported 63,000-row fixture with a sufficiently large PHP memory limit:

```sh
php -d memory_limit=2048M -r '
require "vendor/autoload.php";

$spreadsheet = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
$sheet = $spreadsheet->setActiveSheetIndex(0);
$value = str_repeat("A", 512);

for ($row = 1; $row <= 63000; ++$row) {
    foreach (range("A", "H") as $column) {
        $sheet->setCellValue($column . $row, $value);
    }
}

(new \PhpOffice\PhpSpreadsheet\Writer\Xls($spreadsheet))->save("phpspreadsheet-issue4811-repro.xls");
$spreadsheet->disconnectWorksheets();
'
```

Inspect offsets 44, 68, and 72 in the generated CFB header. The expected values are `109` FAT sectors, `0xFFFFFFFE` (`ENDOFCHAIN`) as the first DIFAT sector, and `0` DIFAT sectors. The generated file can then be opened in Excel to verify that it no longer shows the repair dialog described in #4811.
