### PR TITLE
Update Sheetname in Charts When Sheetname Changes

### DIFF
--- a/src/PhpSpreadsheet/Chart/Axis.php
+++ b/src/PhpSpreadsheet/Chart/Axis.php
@@ -336,7 +336,7 @@ class Axis extends Properties
     {
         parent::__clone();
         $this->majorGridlines = ($this->majorGridlines === null) ? null : clone $this->majorGridlines;
-        $this->majorGridlines = ($this->minorGridlines === null) ? null : clone $this->minorGridlines;
+        $this->minorGridlines = ($this->minorGridlines === null) ? null : clone $this->minorGridlines;
         $this->axisText = ($this->axisText === null) ? null : clone $this->axisText;
         $this->dispUnitsTitle = ($this->dispUnitsTitle === null) ? null : clone $this->dispUnitsTitle;
         $this->fillColor = clone $this->fillColor;

--- a/src/PhpSpreadsheet/Chart/DataSeries.php
+++ b/src/PhpSpreadsheet/Chart/DataSeries.php
@@ -387,7 +387,7 @@ class DataSeries
         $plotLabels = $this->plotLabel;
         $this->plotLabel = [];
         foreach ($plotLabels as $plotLabel) {
-            $this->plotLabel[] = $plotLabel;
+            $this->plotLabel[] = clone $plotLabel;
         }
         $plotCategories = $this->plotCategory;
         $this->plotCategory = [];

--- a/src/PhpSpreadsheet/Chart/PlotArea.php
+++ b/src/PhpSpreadsheet/Chart/PlotArea.php
@@ -215,10 +215,16 @@ class PlotArea
     public function __clone()
     {
         $this->layout = ($this->layout === null) ? null : clone $this->layout;
+        $this->dataTable = ($this->dataTable === null) ? null : clone $this->dataTable;
         $plotSeries = $this->plotSeries;
         $this->plotSeries = [];
         foreach ($plotSeries as $series) {
             $this->plotSeries[] = clone $series;
+        }
+        $gradientFillStops = $this->gradientFillStops;
+        $this->gradientFillStops = [];
+        foreach ($gradientFillStops as $gradientFillStop) {
+            $this->gradientFillStops[] = [$gradientFillStop[0], clone $gradientFillStop[1]];
         }
     }
 }

--- a/src/PhpSpreadsheet/Worksheet/Worksheet.php
+++ b/src/PhpSpreadsheet/Worksheet/Worksheet.php
@@ -343,7 +343,9 @@ class Worksheet
     {
         // Set parent and title
         $this->parent = $parent;
-        $this->setTitle($title, false);
+        // Chart collection must be set before title
+        $this->chartCollection = new ArrayObject();
+        $this->setTitle($title, false, changeChartSheetNames: false);
         // setTitle can change $pTitle
         $this->setCodeName($this->getTitle());
         $this->setSheetState(self::SHEETSTATE_VISIBLE);
@@ -361,8 +363,6 @@ class Worksheet
         $this->drawingCollection = new ArrayObject();
         // In Cell Drawing collection
         $this->inCellDrawingCollection = new ArrayObject();
-        // Chart collection
-        $this->chartCollection = new ArrayObject();
         // Protection
         $this->protection = new Protection();
         // Default row dimension
@@ -901,7 +901,7 @@ class Worksheet
      *
      * @return $this
      */
-    public function setTitle(string $title, bool $updateFormulaCellReferences = true, bool $validate = true): static
+    public function setTitle(string $title, bool $updateFormulaCellReferences = true, bool $validate = true, bool $changeChartSheetNames = true): static
     {
         // Is this a 'rename' or not?
         if ($this->getTitle() == $title) {
@@ -954,8 +954,59 @@ class Worksheet
                 ReferenceHelper::getInstance()->updateNamedFormulae($this->parent, $oldTitle, $newTitle);
             }
         }
+        if ($changeChartSheetNames) {
+            $this->changeChartSheetNames($oldTitle, $title);
+        }
 
         return $this;
+    }
+
+    private function changeChartSheetNames(string $oldTitle, string $title): void
+    {
+        $worksheets = [$this];
+        if ($this->parent !== null) {
+            $sheets = $this->parent->getAllSheets();
+            if (in_array($this, $sheets, true)) {
+                $worksheets = $sheets;
+            }
+        }
+        $titleq = "'$title'!";
+        $oldTitleq1 = preg_quote("'$oldTitle'!");
+        $oldTitleq2 = preg_quote("$oldTitle!");
+        $preg1 = "/$oldTitleq1|\\b$oldTitleq2/";
+        foreach ($worksheets as $sheet) {
+            foreach ($sheet->getChartCollection() as $chart) {
+                foreach (($chart->getPlotArea()?->getPlotGroup() ?? []) as $plotGroup) {
+                    foreach ($plotGroup->getPlotCategories() as $plotCategory) {
+                        $dataSource = (string) $plotCategory->getDataSource();
+                        $dataSource2 = Preg::replace($preg1, $titleq, $dataSource);
+                        if ($dataSource2 !== $dataSource) {
+                            $plotCategory->setDataSource(
+                                $dataSource2
+                            );
+                        }
+                    }
+                    foreach ($plotGroup->getPlotLabels() as $plotLabel) {
+                        $dataSource = (string) $plotLabel->getDataSource();
+                        $dataSource2 = Preg::replace($preg1, $titleq, $dataSource);
+                        if ($dataSource2 !== $dataSource) {
+                            $plotLabel->setDataSource(
+                                $dataSource2
+                            );
+                        }
+                    }
+                    foreach ($plotGroup->getPlotValues() as $plotValue) {
+                        $dataSource = (string) $plotValue->getDataSource();
+                        $dataSource2 = Preg::replace($preg1, $titleq, $dataSource);
+                        if ($dataSource2 !== $dataSource) {
+                            $plotValue->setDataSource(
+                                $dataSource2
+                            );
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/tests/PhpSpreadsheetTests/Chart/Charts32ScatterTest.php
+++ b/tests/PhpSpreadsheetTests/Chart/Charts32ScatterTest.php
@@ -457,7 +457,9 @@ class Charts32ScatterTest extends AbstractFunctional
         $file = self::DIRECTORY . '32readwriteScatterChart9.xlsx';
         $reader = new XlsxReader();
         $reader->setIncludeCharts(true);
-        $spreadsheet = $reader->load($file);
+        $oldspreadsheet = $reader->load($file);
+        $spreadsheet = clone $oldspreadsheet;
+        $oldspreadsheet->disconnectWorksheets();
         $sheet = $spreadsheet->getActiveSheet();
         self::assertSame(1, $sheet->getChartCount());
         /** @var callable */

--- a/tests/PhpSpreadsheetTests/Worksheet/ChartsAndRenamedSheetsTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ChartsAndRenamedSheetsTest.php
@@ -1,0 +1,452 @@
+<?php
+
+namespace PhpOffice\PhpSpreadsheetTests\Worksheet;
+
+use PhpOffice\PhpSpreadsheet\Chart\Chart;
+use PhpOffice\PhpSpreadsheet\Chart\DataSeries;
+use PhpOffice\PhpSpreadsheet\Chart\DataSeriesValues;
+use PhpOffice\PhpSpreadsheet\Chart\Legend;
+use PhpOffice\PhpSpreadsheet\Chart\PlotArea;
+use PhpOffice\PhpSpreadsheet\Chart\Title;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PHPUnit\Framework\TestCase;
+
+class ChartsAndRenamedSheetsTest extends TestCase
+{
+    public function testRenameSheet(): void
+    {
+        // Create a Spreadsheet
+        $spreadsheet = new Spreadsheet();
+        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheetName = 'Worksheet';
+        $worksheet->setTitle($worksheetName);
+        $worksheet->fromArray(
+            [
+                ['', 2010, 2011, 2012],
+                ['Q1', 12, 15, 21],
+                ['Q2', 56, 73, 86],
+                ['Q3', 52, 61, 69],
+                ['Q4', 30, 32, 0],
+            ]
+        );
+
+        $testSheet1 = $spreadsheet->createSheet();
+        $testSheet1Name = 'TestSheet1';
+        $testSheet1->setTitle($testSheet1Name);
+        // Create a Chart
+        $dataSeriesLabels = [
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_STRING,
+                $worksheetName . '!$B$1',
+                null,
+                1
+            ), // 2010
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_STRING,
+                $worksheetName . '!$C$1',
+                null,
+                1
+            ), // 2011
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_STRING,
+                $worksheetName . '!$D$1',
+                null,
+                1
+            ), // 2012
+        ];
+        $xAxisTickValues = [
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_STRING,
+                $worksheetName . '!$A$2:$A$5',
+                null,
+                4
+            ), // Q1 to Q4
+        ];
+        $dataSeriesValues = [
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_NUMBER,
+                $worksheetName . '!$B$2:$B$5',
+                null,
+                4
+            ),
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_NUMBER,
+                $worksheetName . '!$C$2:$C$5',
+                null,
+                4
+            ),
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_NUMBER,
+                $worksheetName . '!$D$2:$D$5',
+                null,
+                4
+            ),
+        ];
+        $series = new DataSeries(
+            DataSeries::TYPE_BARCHART, // plotType
+            DataSeries::GROUPING_STACKED, // plotGrouping
+            range(0, count($dataSeriesValues) - 1), // plotOrder
+            $dataSeriesLabels, // plotLabel
+            $xAxisTickValues, // plotCategory
+            $dataSeriesValues        // plotValues
+        );
+        $series->setPlotDirection(DataSeries::DIRECTION_BAR);
+        $plotArea = new PlotArea(null, [$series]);
+        $legend = new Legend(Legend::POSITION_RIGHT, null, false);
+        $title = new Title('Test Chart');
+        $yAxisLabel = new Title('Value ($k)');
+        $chartName = 'Chart 1';
+        $chart = new Chart(
+            $chartName, // name
+            $title, // title
+            $legend, // legend
+            $plotArea, // plotArea
+            true, // plotVisibleOnly
+            DataSeries::EMPTY_AS_GAP, // displayBlanksAs
+            null, // xAxisLabel
+            $yAxisLabel  // yAxisLabel
+        );
+        $chart->setTopLeftPosition('A7');
+        $chart->setBottomRightPosition('H20');
+        $testSheet1->addChart($chart);
+
+        // Duplicate the Worksheet
+        $testSheet2 = $spreadsheet->duplicateWorksheetByTitle($testSheet1Name);
+        $testSheet2Name = 'TestSheet2';
+        $testSheet2->setTitle($testSheet2Name);
+
+        $newName = 'Renamed';
+        $worksheet->setTitle($newName);
+
+        // Chart 1 on TestSheet1 and Chart 1 on TestSheet2 should not be the same object
+        $chartOne = $testSheet1->getChartByNameOrThrow($chartName);
+        $chartTwo = $testSheet2->getChartByNameOrThrow($chartName);
+        self::assertNotSame($chartOne, $chartTwo);
+
+        $assertion1 = $assertion2 = $assertion3 = false;
+        foreach (($chartOne->getPlotArea()?->getPlotGroup() ?? []) as $plotGroup) {
+            foreach ($plotGroup->getPlotCategories() as $plotCategory) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotCategory->getDataSource(), true, true);
+                self::assertSame($newName, $sheetTitle[0]);
+                $assertion1 = true;
+            }
+            foreach ($plotGroup->getPlotLabels() as $plotLabel) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotLabel->getDataSource(), true, true);
+                self::assertSame($newName, $sheetTitle[0]);
+                $assertion2 = true;
+            }
+            foreach ($plotGroup->getPlotValues() as $plotValue) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotValue->getDataSource(), true, true);
+                self::assertSame($newName, $sheetTitle[0]);
+                $assertion3 = true;
+            }
+        }
+        self::assertTrue($assertion1);
+        self::assertTrue($assertion2);
+        self::assertTrue($assertion3);
+
+        $assertion1 = $assertion2 = $assertion3 = false;
+        foreach (($chartTwo->getPlotArea()?->getPlotGroup() ?? []) as $plotGroup) {
+            foreach ($plotGroup->getPlotCategories() as $plotCategory) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotCategory->getDataSource(), true, true);
+                self::assertSame($newName, $sheetTitle[0]);
+                $assertion1 = true;
+            }
+            foreach ($plotGroup->getPlotLabels() as $plotLabel) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotLabel->getDataSource(), true, true);
+                self::assertSame($newName, $sheetTitle[0]);
+                $assertion2 = true;
+            }
+            foreach ($plotGroup->getPlotValues() as $plotValue) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotValue->getDataSource(), true, true);
+                self::assertSame($newName, $sheetTitle[0]);
+                $assertion3 = true;
+            }
+        }
+        self::assertTrue($assertion1);
+        self::assertTrue($assertion2);
+        self::assertTrue($assertion3);
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testSingleSheet(): void
+    {
+        // Create a Spreadsheet
+        $spreadsheet = new Spreadsheet();
+        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheetName = 'Worksheet';
+        $worksheet->setTitle($worksheetName);
+        $worksheet->fromArray(
+            [
+                ['', 2010, 2011, 2012],
+                ['Q1', 12, 15, 21],
+                ['Q2', 56, 73, 86],
+                ['Q3', 52, 61, 69],
+                ['Q4', 30, 32, 0],
+            ]
+        );
+
+        // Create a Chart
+        $dataSeriesLabels = [
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_STRING,
+                $worksheetName . '!$B$1',
+                null,
+                1
+            ), // 2010
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_STRING,
+                $worksheetName . '!$C$1',
+                null,
+                1
+            ), // 2011
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_STRING,
+                $worksheetName . '!$D$1',
+                null,
+                1
+            ), // 2012
+        ];
+        $xAxisTickValues = [
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_STRING,
+                $worksheetName . '!$A$2:$A$5',
+                null,
+                4
+            ), // Q1 to Q4
+        ];
+        $dataSeriesValues = [
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_NUMBER,
+                $worksheetName . '!$B$2:$B$5',
+                null,
+                4
+            ),
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_NUMBER,
+                $worksheetName . '!$C$2:$C$5',
+                null,
+                4
+            ),
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_NUMBER,
+                $worksheetName . '!$D$2:$D$5',
+                null,
+                4
+            ),
+        ];
+        $series = new DataSeries(
+            DataSeries::TYPE_BARCHART, // plotType
+            DataSeries::GROUPING_STACKED, // plotGrouping
+            range(0, count($dataSeriesValues) - 1), // plotOrder
+            $dataSeriesLabels, // plotLabel
+            $xAxisTickValues, // plotCategory
+            $dataSeriesValues        // plotValues
+        );
+        $series->setPlotDirection(DataSeries::DIRECTION_BAR);
+        $plotArea = new PlotArea(null, [$series]);
+        $legend = new Legend(Legend::POSITION_RIGHT, null, false);
+        $title = new Title('Test Chart');
+        $yAxisLabel = new Title('Value ($k)');
+        $chartName = 'Chart 1';
+        $chart = new Chart(
+            $chartName, // name
+            $title, // title
+            $legend, // legend
+            $plotArea, // plotArea
+            true, // plotVisibleOnly
+            DataSeries::EMPTY_AS_GAP, // displayBlanksAs
+            null, // xAxisLabel
+            $yAxisLabel  // yAxisLabel
+        );
+        $chart->setTopLeftPosition('A7');
+        $chart->setBottomRightPosition('H20');
+        $worksheet->addChart($chart);
+
+        $newName = 'New Name';
+        $worksheet->setTitle($newName);
+
+        $chartOne = $worksheet->getChartByNameOrThrow($chartName);
+
+        $assertion1 = $assertion2 = $assertion3 = false;
+        foreach (($chartOne->getPlotArea()?->getPlotGroup() ?? []) as $plotGroup) {
+            foreach ($plotGroup->getPlotCategories() as $plotCategory) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotCategory->getDataSource(), true, true);
+                self::assertSame($newName, $sheetTitle[0]);
+                $assertion1 = true;
+            }
+            foreach ($plotGroup->getPlotLabels() as $plotLabel) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotLabel->getDataSource(), true, true);
+                self::assertSame($newName, $sheetTitle[0]);
+                $assertion2 = true;
+            }
+            foreach ($plotGroup->getPlotValues() as $plotValue) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotValue->getDataSource(), true, true);
+                self::assertSame($newName, $sheetTitle[0]);
+                $assertion3 = true;
+            }
+        }
+        self::assertTrue($assertion1);
+        self::assertTrue($assertion2);
+        self::assertTrue($assertion3);
+
+        $spreadsheet->disconnectWorksheets();
+    }
+
+    public function testCloneSheet(): void
+    {
+        // Create a Spreadsheet
+        $spreadsheet = new Spreadsheet();
+        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheetName = 'Worksheet';
+        $worksheet->setTitle($worksheetName);
+        $worksheet->fromArray(
+            [
+                ['', 2010, 2011, 2012],
+                ['Q1', 12, 15, 21],
+                ['Q2', 56, 73, 86],
+                ['Q3', 52, 61, 69],
+                ['Q4', 30, 32, 0],
+            ]
+        );
+
+        $testSheet1 = $worksheet;
+        $testSheet1Name = $worksheetName;
+        // Create a Chart
+        $dataSeriesLabels = [
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_STRING,
+                $worksheetName . '!$B$1',
+                null,
+                1
+            ), // 2010
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_STRING,
+                $worksheetName . '!$C$1',
+                null,
+                1
+            ), // 2011
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_STRING,
+                $worksheetName . '!$D$1',
+                null,
+                1
+            ), // 2012
+        ];
+        $xAxisTickValues = [
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_STRING,
+                $worksheetName . '!$A$2:$A$5',
+                null,
+                4
+            ), // Q1 to Q4
+        ];
+        $dataSeriesValues = [
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_NUMBER,
+                $worksheetName . '!$B$2:$B$5',
+                null,
+                4
+            ),
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_NUMBER,
+                $worksheetName . '!$C$2:$C$5',
+                null,
+                4
+            ),
+            new DataSeriesValues(
+                DataSeriesValues::DATASERIES_TYPE_NUMBER,
+                $worksheetName . '!$D$2:$D$5',
+                null,
+                4
+            ),
+        ];
+        $series = new DataSeries(
+            DataSeries::TYPE_BARCHART, // plotType
+            DataSeries::GROUPING_STACKED, // plotGrouping
+            range(0, count($dataSeriesValues) - 1), // plotOrder
+            $dataSeriesLabels, // plotLabel
+            $xAxisTickValues, // plotCategory
+            $dataSeriesValues        // plotValues
+        );
+        $series->setPlotDirection(DataSeries::DIRECTION_BAR);
+        $plotArea = new PlotArea(null, [$series]);
+        $legend = new Legend(Legend::POSITION_RIGHT, null, false);
+        $title = new Title('Test Chart');
+        $yAxisLabel = new Title('Value ($k)');
+        $chartName = 'Chart 1';
+        $chart = new Chart(
+            $chartName, // name
+            $title, // title
+            $legend, // legend
+            $plotArea, // plotArea
+            true, // plotVisibleOnly
+            DataSeries::EMPTY_AS_GAP, // displayBlanksAs
+            null, // xAxisLabel
+            $yAxisLabel  // yAxisLabel
+        );
+        $chart->setTopLeftPosition('A7');
+        $chart->setBottomRightPosition('H20');
+        $testSheet1->addChart($chart);
+
+        // Duplicate the Worksheet
+        $testSheet2 = $spreadsheet->duplicateWorksheetByTitle($testSheet1Name);
+        $testSheet2Name = 'TestSheet2';
+        $testSheet2->setTitle($testSheet2Name);
+
+        $newName = 'Renamed';
+        $worksheet->setTitle($newName);
+
+        // Chart 1 on TestSheet1 and Chart 1 on TestSheet2 should not be the same object
+        $chartOne = $testSheet1->getChartByNameOrThrow($chartName);
+        $chartTwo = $testSheet2->getChartByNameOrThrow($chartName);
+        self::assertNotSame($chartOne, $chartTwo);
+
+        $assertion1 = $assertion2 = $assertion3 = false;
+        foreach (($chartOne->getPlotArea()?->getPlotGroup() ?? []) as $plotGroup) {
+            foreach ($plotGroup->getPlotCategories() as $plotCategory) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotCategory->getDataSource(), true, true);
+                self::assertSame($newName, $sheetTitle[0]);
+                $assertion1 = true;
+            }
+            foreach ($plotGroup->getPlotLabels() as $plotLabel) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotLabel->getDataSource(), true, true);
+                self::assertSame($newName, $sheetTitle[0]);
+                $assertion2 = true;
+            }
+            foreach ($plotGroup->getPlotValues() as $plotValue) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotValue->getDataSource(), true, true);
+                self::assertSame($newName, $sheetTitle[0]);
+                $assertion3 = true;
+            }
+        }
+        self::assertTrue($assertion1);
+        self::assertTrue($assertion2);
+        self::assertTrue($assertion3);
+
+        $assertion1 = $assertion2 = $assertion3 = false;
+        // Chart 2 sheetnames should point to sheet2 so should remain unchanged
+        foreach (($chartTwo->getPlotArea()?->getPlotGroup() ?? []) as $plotGroup) {
+            foreach ($plotGroup->getPlotCategories() as $plotCategory) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotCategory->getDataSource(), true, true);
+                self::assertSame($testSheet2Name, $sheetTitle[0]);
+                $assertion1 = true;
+            }
+            foreach ($plotGroup->getPlotLabels() as $plotLabel) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotLabel->getDataSource(), true, true);
+                self::assertSame($testSheet2Name, $sheetTitle[0]);
+                $assertion2 = true;
+            }
+            foreach ($plotGroup->getPlotValues() as $plotValue) {
+                $sheetTitle = Worksheet::extractSheetTitle($plotValue->getDataSource(), true, true);
+                self::assertSame($testSheet2Name, $sheetTitle[0]);
+                $assertion3 = true;
+            }
+        }
+        self::assertTrue($assertion1);
+        self::assertTrue($assertion2);
+        self::assertTrue($assertion3);
+        $spreadsheet->disconnectWorksheets();
+    }
+}


### PR DESCRIPTION
Fix #744 (marked stale in 2019, but now reopened). The fix draws heavily on the work of @guillaume-ro-fr in PR #745, which was closed because of a unit test error which is no longer possible, and because it was targeted to a branch which no longer existed.

Changing a worksheet name can wind up invalidating charts. To fix this: when a worksheet name changes, inspect all the charts in the spreadsheet (the old PR changed only the current worksheet) and change worksheet references from the old name to the new one.

During testing, found and corrected some minor problems with cloning some Chart objects.

This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [x] Changes are covered by unit tests
  - [x] Changes are covered by existing unit tests
  - [x] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

